### PR TITLE
Remove ADIOS.tcc from the CMakeLists.txt

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------#
 
 add_library(adios2
-  ADIOS.cpp ADIOS.tcc ADIOS_inst.cpp
+  ADIOS.cpp ADIOS_inst.cpp
   #ADIOS_C.cpp
 
   capsule/heap/STLVector.cpp


### PR DESCRIPTION
This was leftover from a previous branch and has been moved into
includes.