### PR TITLE
Fix FindDataMan.cmake missing include.

### DIFF
--- a/cmake/FindDataMan.cmake
+++ b/cmake/FindDataMan.cmake
@@ -51,6 +51,7 @@ if(NOT DataMan_FOUND)
   find_library(DataMan_LIBRARY dataman ${_DataMan_LIBRARY_HINT})
   unset(_DataMan_LIBRARY_HINT)
 
+  include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(DataMan
     FOUND_VAR DataMan_FOUND
     REQUIRED_VARS


### PR DESCRIPTION
FindPackageHandleStandardArgs needs to be included in every find module
that the find_package_handle_standard_args is used.  I was getting
transitively included by othger find modules before but when all other
options are turned off except DataMan, it's missing.  This ensures it's
always included before calling find_package_handle_standard_args.