### PR TITLE
Added a ValueType trait to TypeInfo.

### DIFF
--- a/include/ADIOSTypes.h
+++ b/include/ADIOSTypes.h
@@ -116,6 +116,7 @@ struct TypeInfo<T, typename std::enable_if<std::is_integral<T>::value>::type>
 {
     using IOType =
         typename FixedWidthInt<sizeof(T), std::is_signed<T>::value>::Type;
+    using ValueType = T;
 };
 
 template <typename T>
@@ -123,6 +124,7 @@ struct TypeInfo<T,
                 typename std::enable_if<std::is_floating_point<T>::value>::type>
 {
     using IOType = T;
+    using ValueType = T;
 };
 
 template <typename T>
@@ -130,6 +132,7 @@ struct TypeInfo<T, typename std::enable_if<std::is_same<
                        T, std::complex<typename T::value_type>>::value>::type>
 {
     using IOType = T;
+    using ValueType = typename T::value_type;
 };
 
 } // end namespace adios


### PR DESCRIPTION
This will allow for generic template functions that can deal with
complex types using thier underlying value types.  So rather than have to split definitions like:
```
template<T> T foo(const T&);
template<T> T foo(const std::complex<T>&);
```
to handle the case where an std::complex<float> should use a float
return value, you can now use a single signature:
```
template<T> TypeInfo<T>::ValueType foo(const T&);
```