### PR TITLE
Creat single adios target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ if(ADIOS_USE_MPI)
 endif()
 option(ADIOS_USE_BZip2 "Enable support for BZip2 transforms" OFF)
 option(ADIOS_USE_ADIOS1 "Enable support for the ADIOS 1 engine" OFF)
+option(ADIOS_USE_HDF5 "Enable support for the HDF5 engine" OFF)
 
 # DataMan is not a user-settable option.  It will always be enabled if the
 # platform supports it.
@@ -137,5 +138,5 @@ message("    MPI:     ${ADIOS_USE_MPI}")
 message("    BZip2:   ${ADIOS_USE_BZip2}")
 message("    ADIOS1:  ${ADIOS_USE_ADIOS1}")
 message("    DataMan: ${ADIOS_USE_DataMan}")
-message("    HDF5: ${ADIOS_USE_PHDF5}")
+message("    HDF5:    ${ADIOS_USE_HDF5}")
 message("")

--- a/cmake/FindADIOS1.cmake
+++ b/cmake/FindADIOS1.cmake
@@ -244,20 +244,20 @@ endif()
 # handles the REQUIRED, QUIET and version-related arguments for find_package
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ADIOS1
-    REQUIRED_VARS ADIOS1_LIBRARY_PATH ADIOS1_DEPENDENCY_LIBRARIES ADIOS1_INCLUDE_DIRS
-    VERSION_VAR ADIOS1_VERSION
+    REQUIRED_VARS
+      ADIOS1_LIBRARY_PATH ADIOS1_DEPENDENCY_LIBRARIES ADIOS1_INCLUDE_DIRS
+    VERSION_VAR
+      ADIOS1_VERSION
 )
 
 ##########################################################################
 # Add target and dependencies to ADIOS2
 ##########################################################################
-#message(STATUS "ADIOS1 Find ended with ${ADIOS1_FOUND}")
-    if(ADIOS1_FOUND AND NOT TARGET adios1::adios)
-      message(STATUS "Add library ADIOS1 to the build")
-      add_library(adios1::adios UNKNOWN IMPORTED)
-      set_target_properties(adios1::adios PROPERTIES
-        IMPORTED_LOCATION "${ADIOS1_LIBRARY_PATH}"
-        INTERFACE_LINK_LIBRARIES "${ADIOS1_DEPENDENCY_LIBRARIES}"
-        INTERFACE_INCLUDE_DIRECTORIES "${ADIOS1_INCLUDE_DIRS}"
-      )
-    endif()
+if(ADIOS1_FOUND AND NOT TARGET adios1::adios)
+  add_library(adios1::adios UNKNOWN IMPORTED)
+  set_target_properties(adios1::adios PROPERTIES
+    IMPORTED_LOCATION "${ADIOS1_LIBRARY_PATH}"
+    INTERFACE_LINK_LIBRARIES "${ADIOS1_DEPENDENCY_LIBRARIES}"
+    INTERFACE_INCLUDE_DIRECTORIES "${ADIOS1_INCLUDE_DIRS}"
+  )
+endif()

--- a/examples/heatTransfer/read/CMakeLists.txt
+++ b/examples/heatTransfer/read/CMakeLists.txt
@@ -15,13 +15,6 @@ if(ADIOS_USE_MPI)
     target_link_libraries(heatTransfer_read_adios1
       adios1::adios ${MPI_C_LIBRARIES}
     )
-
-    if(ADIOS_BUILD_TESTING)
-      add_test(
-        NAME Example::heatTransfer::read::adios1
-        COMMAND heatRead_adios1
-      )
-    endif()
   endif()
 endif()
 

--- a/examples/heatTransfer/write/CMakeLists.txt
+++ b/examples/heatTransfer/write/CMakeLists.txt
@@ -17,13 +17,6 @@ if(ADIOS_USE_MPI)
   )
   target_link_libraries(heatTransfer_write_adios2 adios2 ${MPI_C_LIBRARIES})
 
-  if(ADIOS_BUILD_TESTING)
-    add_test(
-      NAME Example::heatTransfer::write::adios2
-      COMMAND heatTransfer_write_adios2
-    )
-  endif()
-
   if(ADIOS_USE_ADIOS1)
     find_package(ADIOS1 REQUIRED)
     find_package(MPI COMPONENTS C REQUIRED)
@@ -40,12 +33,5 @@ if(ADIOS_USE_MPI)
     target_link_libraries(heatTransfer_write_adios1
       adios1::adios ${MPI_C_LIBRARIES}
     )
-
-    if(ADIOS_BUILD_TESTING)
-      add_test(
-        NAME Example::heatTransfer::write::adios1
-        COMMAND heatTransfer_write_adios1
-      )
-    endif()
   endif()
 endif()

--- a/examples/heatTransfer/write/main.cpp
+++ b/examples/heatTransfer/write/main.cpp
@@ -10,9 +10,7 @@
  *     Author: Norbert Podhorszki
  *
  */
-#define OMPI_SKIP_MPICXX 1 // workaround for OpenMPI forcing C++ bindings
 #include <mpi.h>
-#undef OMPI_SKIP_MPICXX
 
 #include <iostream>
 #include <memory>

--- a/examples/hello/CMakeLists.txt
+++ b/examples/hello/CMakeLists.txt
@@ -15,6 +15,6 @@ if(ADIOS_USE_DataMan)
   add_subdirectory(datamanWriter)
 endif()
 
-if(ADIOS_USE_PHDF5)
+if(ADIOS_USE_HDF5)
   add_subdirectory(hdf5Writer)
 endif()

--- a/examples/hello/adios1Writer/CMakeLists.txt
+++ b/examples/hello/adios1Writer/CMakeLists.txt
@@ -5,10 +5,16 @@
 
 if(ADIOS_USE_MPI)
   find_package(MPI COMPONENTS C REQUIRED)
+
   add_executable(hello_adios1Writer helloADIOS1Writer.cpp)
   target_include_directories(hello_adios1Writer PRIVATE ${MPI_C_INCLUDE_PATH})
-  target_link_libraries(hello_adios1Writer adios2 ${MPI_C_LIBRARIES})
+  target_link_libraries(hello_adios1Writer ${MPI_C_LIBRARIES})
+else()
+  add_executable(hello_adios1Writer helloADIOS1Writer_nompi.cpp)
+endif()
+target_link_libraries(hello_adios1Writer adios2)
+
+if(ADIOS_BUILD_TESTING)
+  add_test( NAME Example::hello::adios1::write COMMAND hello_adios1Writer)
 endif()
 
-add_executable(hello_adios1Writer_nompi helloADIOS1Writer_nompi.cpp)
-target_link_libraries(hello_adios1Writer_nompi adios2)

--- a/examples/hello/adios1Writer/helloADIOS1Writer.cpp
+++ b/examples/hello/adios1Writer/helloADIOS1Writer.cpp
@@ -11,9 +11,7 @@
 #include <iostream>
 #include <vector>
 
-#define OMPI_SKIP_MPICXX 1 // workaround for OpenMPI forcing C++ bindings
 #include <mpi.h>
-#undef OMPI_SKIP_MPICXX
 
 #include "ADIOS_CPP.h"
 

--- a/examples/hello/bpWriter/CMakeLists.txt
+++ b/examples/hello/bpWriter/CMakeLists.txt
@@ -3,21 +3,17 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-add_executable(hello_bpWriter_nompi helloBPWriter_nompi.cpp)
-target_link_libraries(hello_bpWriter_nompi adios2_nompi)
-
-if(ADIOS_BUILD_TESTING)
-  add_test( NAME Example::hello::bpWriter_nompi COMMAND hello_bpWriter_nompi)
-endif()
-
 if(ADIOS_USE_MPI)
   find_package(MPI COMPONENTS C REQUIRED)
+
   add_executable(hello_bpWriter helloBPWriter.cpp)
   target_include_directories(hello_bpWriter PRIVATE ${MPI_C_INCLUDE_PATH})
-  target_link_libraries(hello_bpWriter adios2 ${MPI_C_LIBRARIES})
-
-  if(ADIOS_BUILD_TESTING)
-    add_test( NAME Example::hello::bpWriter COMMAND hello_bpWriter)
-  endif()
+  target_link_libraries(hello_bpWriter ${MPI_C_LIBRARIES})
+else()
+  add_executable(hello_bpWriter helloBPWriter_nompi.cpp)
 endif()
+target_link_libraries(hello_bpWriter adios2)
 
+if(ADIOS_BUILD_TESTING)
+  add_test( NAME Example::hello::bp::write COMMAND hello_bpWriter)
+endif()

--- a/examples/hello/datamanReader/CMakeLists.txt
+++ b/examples/hello/datamanReader/CMakeLists.txt
@@ -3,26 +3,17 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-add_executable(hello_datamanReader_nompi helloDataManReader_nompi.cpp)
-target_link_libraries(hello_datamanReader_nompi adios2_nompi)
-
-if(ADIOS_BUILD_TESTING)
-  add_test(
-    NAME Example::hello::datamanReader_nompi
-    COMMAND hello_datamanReader_nompi
-  )
-endif()
-
 if(ADIOS_USE_MPI)
   find_package(MPI COMPONENTS C REQUIRED)
 
   add_executable(hello_datamanReader helloDataManReader.cpp)
-  target_link_libraries(hello_datamanReader adios2)
   target_include_directories(hello_datamanReader PRIVATE ${MPI_C_INCLUDE_PATH})
-  target_link_libraries(hello_datamanReader adios2 ${MPI_C_LIBRARIES})
-
-  if(ADIOS_BUILD_TESTING)
-    add_test(NAME Example::hello::datamanReader COMMAND hello_datamanReader)
-  endif()
+  target_link_libraries(hello_datamanReader ${MPI_C_LIBRARIES})
+else()
+  add_executable(hello_datamanReader helloDataManReader_nompi.cpp)
 endif()
-  
+target_link_libraries(hello_datamanReader adios2)
+
+if(ADIOS_BUILD_TESTING)
+  add_test(NAME Example::hello::dataman::read COMMAND hello_datamanReader)
+endif()

--- a/examples/hello/datamanWriter/CMakeLists.txt
+++ b/examples/hello/datamanWriter/CMakeLists.txt
@@ -3,26 +3,17 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-add_executable(hello_datamanWriter_nompi helloDataManWriter_nompi.cpp)
-target_link_libraries(hello_datamanWriter_nompi adios2_nompi)
-
-if(ADIOS_BUILD_TESTING)
-  add_test(
-    NAME Example::hello::datamanWriter_nompi
-    COMMAND hello_datamanWriter_nompi
-  )
-endif()
-
 if(ADIOS_USE_MPI)
   find_package(MPI COMPONENTS C REQUIRED)
   
   add_executable(hello_datamanWriter helloDataManWriter.cpp)
-  target_link_libraries(hello_datamanWriter adios2)
   target_include_directories(hello_datamanWriter PRIVATE ${MPI_C_INCLUDE_PATH})
-  target_link_libraries(hello_datamanWriter adios2 ${MPI_C_LIBRARIES})
-
-  if(ADIOS_BUILD_TESTING)
-    add_test(NAME Example::hello::datamanWriter COMMAND hello_datamanWriter)
-  endif()
+  target_link_libraries(hello_datamanWriter ${MPI_C_LIBRARIES})
+else()
+  add_executable(hello_datamanWriter helloDataManWriter_nompi.cpp)
 endif()
+target_link_libraries(hello_datamanWriter adios2)
 
+if(ADIOS_BUILD_TESTING)
+  add_test(NAME Example::hello::dataman::write COMMAND hello_datamanWriter)
+endif()

--- a/examples/hello/hdf5Writer/CMakeLists.txt
+++ b/examples/hello/hdf5Writer/CMakeLists.txt
@@ -3,28 +3,17 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-#add_executable(hello_hdf5Writer_nompi helloHDF5Writer_nompi.cpp)
-message("    HDF5:   ${HDF5_INCLUDE_DIRS}")
-include_directories(${HDF5_INCLUDE_DIRS})
-#target_link_libraries(hello_hdf5Writer_nompi adios2_nompi)
-
-if(ADIOS_BUILD_TESTING)
-  #add_test(
-  #  NAME Example::hello::hdf5Writer_nompi
-  #  COMMAND hello_hdf5Writer_nompi
-  #)
-endif()
-
 if(ADIOS_USE_MPI)
   find_package(MPI COMPONENTS C REQUIRED)
 
   add_executable(hello_hdf5Writer helloHDF5Writer.cpp)
-  target_link_libraries(hello_hdf5Writer adios2)
   target_include_directories(hello_hdf5Writer PRIVATE ${MPI_C_INCLUDE_PATH})
-  target_link_libraries(hello_hdf5Writer adios2 ${MPI_C_LIBRARIES})
-
-  if(ADIOS_BUILD_TESTING)
-    add_test(NAME Example::hello::hdf5Writer COMMAND hello_hdf5Writer)
-  endif()
+  target_link_libraries(hello_hdf5Writer ${MPI_C_LIBRARIES})
+else()
+  add_executable(hello_hdf5Writer helloHDF5Writer_nompi.cpp)
 endif()
+target_link_libraries(hello_hdf5Writer adios2)
 
+if(ADIOS_BUILD_TESTING)
+  add_test(NAME Example::hello::hdf5::write COMMAND hello_hdf5Writer)
+endif()

--- a/examples/hello/hdf5Writer/helloHDF5Writer_nompi.cpp
+++ b/examples/hello/hdf5Writer/helloHDF5Writer_nompi.cpp
@@ -1,0 +1,130 @@
+/*
+ * HDF5Writer.cpp
+ *
+ *  Created on: March 20, 2017
+ *      Author: Junmin
+ */
+
+#include <iostream>
+#include <vector>
+
+#include "ADIOS_CPP.h"
+
+int main(int argc, char *argv[])
+{
+    const bool adiosDebug = true;
+    adios::ADIOS adios(adios::Verbose::INFO, adiosDebug);
+
+    // Application variable
+    const std::size_t intDim1 = 4;
+    const std::size_t intDim2 = 3;
+    std::vector<int> myInts = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21};
+
+    std::vector<double> myDoubles = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    const std::size_t Nx = myDoubles.size();
+
+    std::vector<std::complex<float>> myCFloats;
+    const std::size_t CFloatSize = 3;
+    myCFloats.reserve(CFloatSize);
+    myCFloats.emplace_back(1, 3);
+    myCFloats.emplace_back(2, 2);
+    myCFloats.emplace_back(3, 1);
+
+    std::vector<std::complex<double>> myCDoubles;
+    const std::size_t CDoubleSize = 3;
+    myCDoubles.reserve(CDoubleSize);
+    myCDoubles.emplace_back(1, 3);
+    myCDoubles.emplace_back(2, 2);
+    myCDoubles.emplace_back(3, 1);
+
+    std::size_t doubleVCount = Nx / size;
+    std::size_t floatCount = CFloatSize / size;
+    std::size_t intCountDim1 = intDim1 / size;
+
+    std::size_t doubleVOffset = rank * doubleVCount;
+    std::size_t floatOffset = rank * floatCount;
+    std::size_t intOffsetDim1 = rank * intCountDim1;
+    std::size_t intOffsetDim2 = 0;
+
+    if ((size > 1) && (rank == size - 1))
+    {
+        doubleVCount = Nx - rank * (Nx / size);
+        floatCount = CFloatSize - rank * (CFloatSize / size);
+        intCountDim1 = intDim1 - rank * (intDim1 / size);
+    }
+
+    try
+    {
+        // Define variable and local size
+        // auto& ioMyDoubles = adios.DefineVariable<double>( "myDoubles", {Nx},
+        // {Nx} );
+        // auto& ioMyCFloats = adios.DefineVariable<std::complex<float>>(
+        // "myCFloats", {3}, {3} );
+        // auto& ioMyInts = adios.DefineVariable<int>( "myInts", {4,3}, {4,3} );
+
+        auto &ioMyDoubles = adios.DefineVariable<double>(
+            "myDoubles", {doubleVCount}, {Nx}, {doubleVOffset});
+        auto &ioMyCFloats = adios.DefineVariable<std::complex<float>>(
+            "myCFloats", {floatCount}, {3}, {floatOffset});
+        auto &ioMyCDoubles = adios.DefineVariable<std::complex<double>>(
+            "myCDoubles", {floatCount}, {3}, {floatOffset});
+        auto &ioMyInts =
+            adios.DefineVariable<int>("myInts", {intCountDim1, intDim2}, {4, 3},
+                                      {intOffsetDim1, intOffsetDim2});
+
+        // Define method for engine creation, it is basically straight-forward
+        // parameters
+        adios::Method &HDF5Settings =
+            adios.DeclareMethod("HDF5Writer"); // default method type is Writer
+        HDF5Settings.SetParameters("chunck=yes", "collectiveIO=yes");
+        // HDF5Settings.AddTransport( "Mdtm", "localIP=128.0.0.0.1",
+        // "remoteIP=128.0.0.0.2", "tolerances=1,2,3" );
+
+        // Create engine smart pointer to HDF5 Engine due to polymorphism,
+        // Open returns a smart pointer to Engine containing the Derived class
+        // HDF5
+        auto HDF5Writer = adios.Open("test.bp", "w", HDF5Settings);
+
+        if (HDF5Writer == nullptr)
+            throw std::ios_base::failure(
+                "ERROR: failed to create HDF5 I/O engine at Open\n");
+
+        HDF5Writer->Write(ioMyDoubles, myDoubles.data() +
+                                           doubleVOffset); // Base class Engine
+                                                           // own the Write<T>
+                                                           // that will call
+                                                           // overloaded Write
+                                                           // from Derived
+        HDF5Writer->Write(ioMyInts,
+                          myInts.data() + (intOffsetDim1 * intDim2 * rank));
+        HDF5Writer->Write(ioMyCFloats, myCFloats.data());
+        HDF5Writer->Write(ioMyCDoubles, myCDoubles.data());
+        HDF5Writer->Close();
+    }
+    catch (std::invalid_argument &e)
+    {
+        if (rank == 0)
+        {
+            std::cout << "Invalid argument exception, STOPPING PROGRAM\n";
+            std::cout << e.what() << "\n";
+        }
+    }
+    catch (std::ios_base::failure &e)
+    {
+        if (rank == 0)
+        {
+            std::cout << "System exception, STOPPING PROGRAM\n";
+            std::cout << e.what() << "\n";
+        }
+    }
+    catch (std::exception &e)
+    {
+        if (rank == 0)
+        {
+            std::cout << "Exception, STOPPING PROGRAM\n";
+            std::cout << e.what() << "\n";
+        }
+    }
+
+    return 0;
+}

--- a/examples/hello/timeBP/CMakeLists.txt
+++ b/examples/hello/timeBP/CMakeLists.txt
@@ -3,24 +3,17 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-add_executable(hello_timeBPWriter_nompi timeBPWriter_nompi.cpp)
-target_link_libraries(hello_timeBPWriter_nompi adios2_nompi)
-
-if(ADIOS_BUILD_TESTING)
-  add_test(
-    NAME Example::hello::timeBPWriter_nompi
-    COMMAND hello_timeBPWriter_nompi
-  )
-endif()
-
 if(ADIOS_USE_MPI)
   find_package(MPI COMPONENTS C REQUIRED)
-  add_executable(hello_timeBPWriter timeBPWriter.cpp)
-  target_link_libraries(hello_timeBPWriter adios2)
-  target_include_directories(hello_timeBPWriter PRIVATE ${MPI_C_INCLUDE_PATH})
-  target_link_libraries(hello_timeBPWriter adios2 ${MPI_C_LIBRARIES})
 
-  if(ADIOS_BUILD_TESTING)
-    add_test(NAME Example::hello::timeBPWriter COMMAND hello_timeBPWriter)
-  endif()
+  add_executable(hello_timeBPWriter timeBPWriter.cpp)
+  target_include_directories(hello_timeBPWriter PRIVATE ${MPI_C_INCLUDE_PATH})
+  target_link_libraries(hello_timeBPWriter ${MPI_C_LIBRARIES})
+else()
+  add_executable(hello_timeBPWriter timeBPWriter_nompi.cpp)
+endif()
+target_link_libraries(hello_timeBPWriter adios2)
+
+if(ADIOS_BUILD_TESTING)
+  add_test(NAME Example::hello::timeBP::write COMMAND hello_timeBPWriter)
 endif()

--- a/include/engine/adios1/ADIOS1Writer.h
+++ b/include/engine/adios1/ADIOS1Writer.h
@@ -18,13 +18,7 @@
 namespace adios
 {
 
-#ifndef ADIOS_HAVE_MPI
-#define _NOMPI
-#endif
 #include "adios.h" // this is adios 1.x header file
-#ifndef ADIOS_HAVE_MPI
-#undef _NOMPI
-#endif
 
 class ADIOS1Writer : public Engine
 {

--- a/source/ADIOS.cpp
+++ b/source/ADIOS.cpp
@@ -36,11 +36,9 @@
 #include "engine/adios1/ADIOS1Writer.h"
 #endif
 
-#ifdef ADIOS_HAVE_PHDF5 // external dependencies
-#ifdef ADIOS_HAVE_MPI
+#ifdef ADIOS_HAVE_HDF5 // external dependencies
 #include "engine/hdf5/HDF5ReaderP.h"
 #include "engine/hdf5/HDF5WriterP.h"
-#endif
 #endif
 namespace adios
 {
@@ -194,7 +192,7 @@ std::shared_ptr<Engine> ADIOS::Open(const std::string &name,
     }
     else if (type == "HDF5Writer") // -junmin
     {
-#if defined(ADIOS_HAVE_PHDF5) && defined(ADIOS_HAVE_MPI)
+#ifdef ADIOS_HAVE_HDF5
         return std::make_shared<HDF5Writer>(*this, name, accessMode, mpiComm,
                                             method);
 #else

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -74,7 +74,7 @@ else()
 endif()
 
 if(ADIOS_USE_ADIOS1)
-  if(ADIOS_HAVE_MPI)
+  if(ADIOS_USE_MPI)
     find_package(ADIOS1 REQUIRED)
   else()
     find_package(ADIOS1 COMPONENTS sequential REQUIRED)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -90,8 +90,10 @@ endif()
 
 if(ADIOS_USE_HDF5)
   find_package(HDF5 REQUIRED)
-  if(ADIOS_USE_MPI AND NOT HDF5_IS_PARALLEL)
-    message(FATAL_ERROR "A sequential version of HDF5 was detected but the parallel version of ADIOS requires a parallel HDF5.")
+  if(ADIOS_USE_MPI AND (NOT HDF5_IS_PARALLEL))
+    message(FATAL_ERROR "A sequential version of HDF5 was detected but the parallel version of ADIOS is being built, which requires a parallel HDF5.")
+  elseif((NOT ADIOS_USE_MPI) AND HDF5_IS_PARALLEL)
+    message(FATAL_ERROR "A parallel version of HDF5 was detected but the sequential version of ADIOS is being built, which requires a sequential HDF5.")
   endif()
 
   target_include_directories(adios2 PRIVATE ${HDF5_INCLUDE_DIRS})

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -3,107 +3,102 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
   
-set(adios2_targets adios2_nompi)
-if(ADIOS_USE_MPI)
-  list(APPEND adios2_targets adios2)
-endif()
+add_library(adios2
+  ADIOS.cpp ADIOS.tcc
+  #ADIOS_C.cpp
   
-foreach(adios2_target IN LISTS adios2_targets)
-  add_library(${adios2_target}
-    ADIOS.cpp ADIOS.tcc
-    #ADIOS_C.cpp
+  capsule/heap/STLVector.cpp
+  capsule/shmem/ShmSystemV.cpp
   
-    capsule/heap/STLVector.cpp
-    capsule/shmem/ShmSystemV.cpp
+  core/Capsule.cpp
+  core/Engine.cpp
+  core/Method.cpp
+  core/Support.cpp
+  core/Transform.cpp
+  core/Transport.cpp
   
-    core/Capsule.cpp
-    core/Engine.cpp
-    core/Method.cpp
-    core/Support.cpp
-    core/Transform.cpp
-    core/Transport.cpp
-  
-    engine/bp/BPFileReader.cpp
-    engine/bp/BPFileWriter.cpp
+  engine/bp/BPFileReader.cpp
+  engine/bp/BPFileWriter.cpp
 
-    utilities/format/bp1/BP1Base.cpp
-    utilities/format/bp1/BP1Aggregator.cpp
-    utilities/format/bp1/BP1Writer.cpp
+  utilities/format/bp1/BP1Base.cpp
+  utilities/format/bp1/BP1Aggregator.cpp
+  utilities/format/bp1/BP1Writer.cpp
     
-    utilities/profiling/iochrono/Timer.cpp
+  utilities/profiling/iochrono/Timer.cpp
+
+  functions/adiosFunctions.cpp
   
-    functions/adiosFunctions.cpp
+  transport/file/FStream.cpp
+  transport/file/FileDescriptor.cpp
+  transport/file/FilePointer.cpp
+    
+  utilities/format/bp1/BP1Base.cpp
+  utilities/format/bp1/BP1Aggregator.cpp
+  utilities/format/bp1/BP1Writer.cpp
+  utilities/format/bp1/BP1Writer.tcc
+    
+  utilities/profiling/iochrono/Timer.cpp
+)
+target_include_directories(adios2
+  PUBLIC ${ADIOS_SOURCE_DIR}/include
+)
   
-    transport/file/FStream.cpp
-    transport/file/FileDescriptor.cpp
-    transport/file/FilePointer.cpp
-    
-    utilities/format/bp1/BP1Base.cpp
-    utilities/format/bp1/BP1Aggregator.cpp
-    utilities/format/bp1/BP1Writer.cpp
-    utilities/format/bp1/BP1Writer.tcc
-    
-    utilities/profiling/iochrono/Timer.cpp
+if(ADIOS_USE_DataMan)
+  target_sources(adios2 PRIVATE
+    engine/dataman/DataManReader.cpp
+    engine/dataman/DataManWriter.cpp
+    transport/wan/MdtmMan.cpp
+    utilities/realtime/dataman/DataManBase.cpp
+    utilities/realtime/dataman/DataMan.cpp
   )
-  target_include_directories(${adios2_target}
-    PUBLIC ${ADIOS_SOURCE_DIR}/include
-  )
-  
-  if(ADIOS_USE_DataMan)
-    target_sources(${adios2_target} PRIVATE
-      engine/dataman/DataManReader.cpp
-      engine/dataman/DataManWriter.cpp
-      transport/wan/MdtmMan.cpp
-      utilities/realtime/dataman/DataManBase.cpp
-      utilities/realtime/dataman/DataMan.cpp
-    )
-    target_compile_definitions(${adios2_target} PRIVATE ADIOS_HAVE_DATAMAN)
-    target_link_libraries(${adios2_target} PRIVATE ${CMAKE_DL_LIBS})
-  endif()
-
-  
-  if(ADIOS_USE_BZip2)
-    find_package(BZip2 REQUIRED)
-    target_sources(${adios2_target} PRIVATE transform/BZip2.cpp)
-    target_compile_definitions(${adios2_target} PRIVATE ADIOS_HAVE_BZIP2)
-    target_link_libraries(${adios2_target} PRIVATE BZip2::BZip2)
-  endif()
-endforeach()
-
-target_sources(adios2_nompi PRIVATE mpidummy.cpp)
-if(CMAKE_CXX_COMPILER_WRAPPER STREQUAL CrayPrgEnv)
-  target_compile_options(adios2_nompi PRIVATE --cray-bypass-pkgconfig)
+  target_compile_definitions(adios2 PRIVATE ADIOS_HAVE_DATAMAN)
+  target_link_libraries(adios2 PRIVATE ${CMAKE_DL_LIBS})
 endif()
+
+  
+if(ADIOS_USE_BZip2)
+  find_package(BZip2 REQUIRED)
+  target_sources(adios2 PRIVATE transform/BZip2.cpp)
+  target_compile_definitions(adios2 PRIVATE ADIOS_HAVE_BZIP2)
+  target_link_libraries(adios2 PRIVATE BZip2::BZip2)
+endif()
+
 
 if(ADIOS_USE_MPI)
   find_package(MPI COMPONENTS C REQUIRED)
   target_include_directories(adios2 PUBLIC ${MPI_C_INCLUDE_PATH})
   target_compile_definitions(adios2 PUBLIC ADIOS_HAVE_MPI)
   target_link_libraries(adios2 PUBLIC ${MPI_C_LIBRARIES})
+else()
+  target_sources(adios2 PRIVATE mpidummy.cpp)
+endif()
 
-  if(ADIOS_USE_ADIOS1)
+if(ADIOS_USE_ADIOS1)
+  if(ADIOS_HAVE_MPI)
     find_package(ADIOS1 REQUIRED)
-    target_sources(adios2 PRIVATE
-      engine/adios1/ADIOS1Reader.cpp
-      engine/adios1/ADIOS1Writer.cpp
-    )
-    target_compile_definitions(adios2 PRIVATE ADIOS_HAVE_ADIOS1)
-    target_link_libraries(adios2 PRIVATE adios1::adios)
+  else()
+    find_package(ADIOS1 COMPONENTS sequential REQUIRED)
   endif()
 
-  if(ADIOS_USE_PHDF5)
-    find_package(HDF5 REQUIRED)
-    message("    HDF5 ROOT:   ${HDF5_ROOT}")
-    message("    HDF5 include:   ${HDF5_INCLUDE_DIRS}   is paralle? ${HDF5_IS_PARALLEL}")
+  target_sources(adios2 PRIVATE
+    engine/adios1/ADIOS1Reader.cpp
+    engine/adios1/ADIOS1Writer.cpp
+  )
+  target_compile_definitions(adios2 PRIVATE ADIOS_HAVE_ADIOS1)
+  target_link_libraries(adios2 PRIVATE adios1::adios)
+endif()
 
-    target_include_directories(adios2 PRIVATE ${HDF5_INCLUDE_DIRS})
-
-    target_sources(adios2 PRIVATE
-      engine/hdf5/HDF5ReaderP.cpp
-      engine/hdf5/HDF5WriterP.cpp
-    )
-    target_compile_definitions(adios2 PRIVATE ADIOS_HAVE_PHDF5)
-    target_link_libraries(adios2 PRIVATE ${HDF5_C_LIBRARIES})
+if(ADIOS_USE_HDF5)
+  find_package(HDF5 REQUIRED)
+  if(ADIOS_USE_MPI AND NOT HDF5_IS_PARALLEL)
+    message(FATAL_ERROR "A sequential version of HDF5 was detected but the parallel version of ADIOS requires a parallel HDF5.")
   endif()
 
+  target_include_directories(adios2 PRIVATE ${HDF5_INCLUDE_DIRS})
+  target_sources(adios2 PRIVATE
+    engine/hdf5/HDF5ReaderP.cpp
+    engine/hdf5/HDF5WriterP.cpp
+  )
+  target_compile_definitions(adios2 PRIVATE ADIOS_HAVE_HDF5)
+  target_link_libraries(adios2 PRIVATE ${HDF5_C_LIBRARIES})
 endif()

--- a/source/engine/hdf5/HDF5WriterP.cpp
+++ b/source/engine/hdf5/HDF5WriterP.cpp
@@ -78,7 +78,9 @@ void HDF5Writer::Init()
 
     _plist_id = H5Pcreate(H5P_FILE_ACCESS);
 
+#ifdef ADIOS_HAVE_MPI
     H5Pset_fapl_mpio(_plist_id, m_MPIComm, MPI_INFO_NULL);
+#endif
 
     /*
      * Create a new file collectively and release property list identifier.
@@ -340,8 +342,9 @@ void HDF5Writer::UseHDFWrite(Variable<T> &variable, const T *values,
     //  Create property list for collective dataset write.
 
     _plist_id = H5Pcreate(H5P_DATASET_XFER);
+#ifdef ADIOS_HAVE_MPI
     H5Pset_dxpl_mpio(_plist_id, H5FD_MPIO_COLLECTIVE);
-
+#endif
     herr_t status;
 
     status =


### PR DESCRIPTION
This creates a single ADIOS target instead of both an MPI and serial target in the same build.  This is primarily motivated by the various incompatibilities that arise when both serial and parallel versions of dependencies exist in the runtime environment at the same time.  Most HPC module environments actually explicitly prohibit this.  With this change, the MPI and serial library versions will need to be done in two separate builds.  Similarly, all the dependencies (HDF5, NetCDF, etc.) that have both a parallel and serial version available will need to use their serial version for the serial build and their parallel version for the MPI build.