### PR TITLE
Stop mpidummy contamination

### DIFF
--- a/source/adios2/ADIOS.cpp
+++ b/source/adios2/ADIOS.cpp
@@ -17,8 +17,8 @@
 #include <sstream>
 #include <utility>
 
-#include "adios2/ADIOSMacros.h"
 #include "adios2/ADIOSMPI.h"
+#include "adios2/ADIOSMacros.h"
 #include "adios2/core/adiosFunctions.h"
 #include "adios2/engine/bp/BPFileReader.h"
 #include "adios2/engine/bp/BPFileWriter.h"

--- a/source/adios2/ADIOS.cpp
+++ b/source/adios2/ADIOS.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "adios2/ADIOSMacros.h"
+#include "adios2/ADIOSMPI.h"
 #include "adios2/core/adiosFunctions.h"
 #include "adios2/engine/bp/BPFileReader.h"
 #include "adios2/engine/bp/BPFileWriter.h"
@@ -41,17 +42,14 @@ namespace adios
 {
 
 ADIOS::ADIOS(const Verbose verbose, const bool debugMode)
-: m_DebugMode{debugMode}
+: ADIOS("", MPI_COMM_SELF, verbose, debugMode)
 {
-    InitMPI();
 }
 
 ADIOS::ADIOS(const std::string config, const Verbose verbose,
              const bool debugMode)
-: m_ConfigFile(config), m_DebugMode(debugMode)
+: ADIOS(config, MPI_COMM_SELF, verbose, debugMode)
 {
-    InitMPI();
-    // InitXML( m_ConfigFile, m_MPIComm, m_DebugMode, m_Transforms );
 }
 
 ADIOS::ADIOS(const std::string configFile, MPI_Comm mpiComm,
@@ -64,9 +62,8 @@ ADIOS::ADIOS(const std::string configFile, MPI_Comm mpiComm,
 }
 
 ADIOS::ADIOS(MPI_Comm mpiComm, const Verbose verbose, const bool debugMode)
-: m_MPIComm(mpiComm), m_DebugMode(debugMode)
+: ADIOS("", mpiComm, verbose, debugMode)
 {
-    InitMPI();
 }
 
 // ADIOS::~ADIOS() {}

--- a/source/adios2/ADIOS.h
+++ b/source/adios2/ADIOS.h
@@ -21,9 +21,9 @@
 /// \endcond
 
 #include "adios2/ADIOSConfig.h"
+#include "adios2/ADIOSMPICommOnly.h"
 #include "adios2/ADIOSMacros.h"
 #include "adios2/ADIOSTypes.h"
-#include "adios2/ADIOSMPICommOnly.h"
 #include "adios2/core/Method.h"
 #include "adios2/core/Support.h"
 #include "adios2/core/Transform.h"

--- a/source/adios2/ADIOS.h
+++ b/source/adios2/ADIOS.h
@@ -23,7 +23,7 @@
 #include "adios2/ADIOSConfig.h"
 #include "adios2/ADIOSMacros.h"
 #include "adios2/ADIOSTypes.h"
-#include "adios2/ADIOS_MPI.h"
+#include "adios2/ADIOSMPICommOnly.h"
 #include "adios2/core/Method.h"
 #include "adios2/core/Support.h"
 #include "adios2/core/Transform.h"
@@ -45,7 +45,7 @@ public:
      * Passed from parallel constructor, MPI_Comm is a pointer itself.
      *  Public as called from C
      */
-    MPI_Comm m_MPIComm = MPI_COMM_SELF;
+    MPI_Comm m_MPIComm;
 
     int m_RankMPI = 0; ///< current MPI rank process
     int m_SizeMPI = 1; ///< current MPI processes size

--- a/source/adios2/ADIOSMPI.h
+++ b/source/adios2/ADIOSMPI.h
@@ -1,0 +1,17 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+
+#ifndef ADIOS2_ADIOSMPI_H_
+#define ADIOS2_ADIOSMPI_H_
+
+#include "adios2/ADIOSConfig.h"
+
+#ifdef ADIOS2_HAVE_MPI
+#include <mpi.h>
+#else
+#include "adios2/mpidummy.h"
+#endif
+
+#endif /* ADIOS2_ADIOSMPI_H_ */

--- a/source/adios2/ADIOSMPICommOnly.h
+++ b/source/adios2/ADIOSMPICommOnly.h
@@ -3,15 +3,18 @@
  * accompanying file Copyright.txt for details.
  */
 
-#ifndef ADIOS2_ADIOS_MPI_H_
-#define ADIOS2_ADIOS_MPI_H_
+#ifndef ADIOS2_ADIOSMPICOMMONLY_H_
+#define ADIOS2_ADIOSMPICOMMONLY_H_
 
 #include "adios2/ADIOSConfig.h"
 
 #ifdef ADIOS2_HAVE_MPI
 #include <mpi.h>
 #else
-#include "adios2/mpidummy.h"
+namespace adios
+{
+    using MPI_Comm = int;
+} // end namespace adios
 #endif
 
-#endif /* ADIOS2_ADIOS_MPI_H_ */
+#endif /* ADIOS2_ADIOSMPICOMMONLY_H_ */

--- a/source/adios2/ADIOSMPICommOnly.h
+++ b/source/adios2/ADIOSMPICommOnly.h
@@ -13,7 +13,7 @@
 #else
 namespace adios
 {
-    using MPI_Comm = int;
+using MPI_Comm = int;
 } // end namespace adios
 #endif
 

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 
 install(
   FILES
-    ADIOS.h ADIOS.inl ADIOSMacros.h ADIOS_MPI.h ADIOSTypes.h mpidummy.h
+    ADIOS.h ADIOS.inl ADIOSMacros.h ADIOS_MPI.h ADIOSTypes.h ADIOSMPICommOnly.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/adios2
 )
 install(

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -12,6 +12,7 @@
 
 #include <ios> //std::ios_base::failure
 
+#include "adios2/ADIOSMPI.h"
 #include "adios2/core/Support.h"
 #include "adios2/core/adiosFunctions.h"
 

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -24,7 +24,7 @@
 #include "adios2/ADIOS.h"
 #include "adios2/ADIOSConfig.h"
 #include "adios2/ADIOSTypes.h"
-#include "adios2/ADIOS_MPI.h"
+#include "adios2/ADIOSMPICommOnly.h"
 #include "adios2/core/Capsule.h"
 #include "adios2/core/Method.h"
 #include "adios2/core/Transform.h"
@@ -52,7 +52,7 @@ class Engine
 {
 
 public:
-    MPI_Comm m_MPIComm = MPI_COMM_SELF;
+    MPI_Comm m_MPIComm;
 
     const std::string m_EngineType; ///< from derived class
     const std::string m_Name;       ///< name used for this engine

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -23,8 +23,8 @@
 
 #include "adios2/ADIOS.h"
 #include "adios2/ADIOSConfig.h"
-#include "adios2/ADIOSTypes.h"
 #include "adios2/ADIOSMPICommOnly.h"
+#include "adios2/ADIOSTypes.h"
 #include "adios2/core/Capsule.h"
 #include "adios2/core/Method.h"
 #include "adios2/core/Transform.h"

--- a/source/adios2/core/Transport.cpp
+++ b/source/adios2/core/Transport.cpp
@@ -12,6 +12,8 @@
 
 #include <utility>
 
+#include "adios2/ADIOSMPI.h"
+
 namespace adios
 {
 

--- a/source/adios2/core/Transport.h
+++ b/source/adios2/core/Transport.h
@@ -17,7 +17,7 @@
 /// \endcond
 
 #include "adios2/ADIOSConfig.h"
-#include "adios2/ADIOS_MPI.h"
+#include "adios2/ADIOSMPICommOnly.h"
 #include "adios2/core/IOChrono.h"
 
 namespace adios
@@ -32,7 +32,7 @@ public:
     std::string m_AccessMode; ///< from Open
     bool m_IsOpen = false;
 
-    MPI_Comm m_MPIComm = MPI_COMM_SELF;
+    MPI_Comm m_MPIComm;
 
     int m_RankMPI = 0;              ///< current MPI rank process
     int m_SizeMPI = 1;              ///< current MPI processes size

--- a/source/adios2/core/adiosFunctions.cpp
+++ b/source/adios2/core/adiosFunctions.cpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 #include <thread> //std::thread
 
+#include "adios2/ADIOSMPI.h"
 #include "adios2/core/Support.h"
 
 #ifdef ADIOS2_HAVE_BZIP2

--- a/source/adios2/core/adiosFunctions.h
+++ b/source/adios2/core/adiosFunctions.h
@@ -20,7 +20,7 @@
 /// \endcond
 
 #include "adios2/ADIOSConfig.h"
-#include "adios2/ADIOS_MPI.h"
+#include "adios2/ADIOSMPICommOnly.h"
 #include "adios2/core/Transform.h"
 
 namespace adios

--- a/source/adios2/engine/adios1/ADIOS1Reader.h
+++ b/source/adios2/engine/adios1/ADIOS1Reader.h
@@ -15,11 +15,21 @@
 
 #include <iostream> //this must go away
 
-#include <adios_read_v2.h>
-
 #include "adios2/ADIOSConfig.h"
 #include "adios2/capsule/heap/STLVector.h"
 #include "adios2/core/Engine.h"
+
+// Fake out the include guard from ADIOS1's mpidummy.h to prevent it from
+// getting included
+#ifdef _NOMPI
+#define __MPI_DUMMY_H__
+#define MPI_Comm int
+#endif
+#include <adios_read_v2.h>
+#ifdef _NOMPI
+#undef MPI_Comm
+#undef __MPI_DUMMY_H__
+#endif
 
 namespace adios
 {

--- a/source/adios2/engine/adios1/ADIOS1Writer.h
+++ b/source/adios2/engine/adios1/ADIOS1Writer.h
@@ -13,10 +13,20 @@
 #ifndef ADIOS2_ENGINE_ADIOS1_ADIOS1WRITER_H_
 #define ADIOS2_ENGINE_ADIOS1_ADIOS1WRITER_H_
 
-#include <adios.h>
-
 #include "adios2/ADIOSConfig.h"
 #include "adios2/core/Engine.h"
+
+// Fake out the include guard from ADIOS1's mpidummy.h to prevent it from
+// getting included
+#ifdef _NOMPI
+#define __MPI_DUMMY_H__
+#define MPI_Comm int
+#endif
+#include <adios.h>
+#ifdef _NOMPI
+#undef MPI_Comm
+#undef __MPI_DUMMY_H__
+#endif
 
 namespace adios
 {

--- a/source/adios2/engine/dataman/DataManWriter.cpp
+++ b/source/adios2/engine/dataman/DataManWriter.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "DataManWriter.h"
+#include "DataManWriter.tcc"
 
 #include <iostream> //needs to go away, this is just for demo purposes
 

--- a/source/adios2/engine/dataman/DataManWriter.h
+++ b/source/adios2/engine/dataman/DataManWriter.h
@@ -127,56 +127,7 @@ private:
                      const std::map<std::string, std::string> &mdtmParameters);
 
     template <class T>
-    void WriteVariableCommon(Variable<T> &variable, const T *values)
-    {
-        // here comes your magic at Writing now variable.m_UserValues has the
-        // data
-        // passed by the user
-        // set variable
-        variable.m_AppValues = values;
-        m_WrittenVariables.insert(variable.m_Name);
-
-        // This part will go away, this is just to monitor variables per rank
-
-        json jmsg;
-        jmsg["doid"] = m_Name;
-        jmsg["var"] = variable.m_Name;
-        jmsg["dtype"] = GetType<T>();
-        jmsg["putshape"] = variable.m_LocalDimensions;
-        if (variable.m_GlobalDimensions.size() == 0)
-            variable.m_GlobalDimensions = variable.m_LocalDimensions;
-        jmsg["varshape"] = variable.m_GlobalDimensions;
-        if (variable.m_Offsets.size() == 0)
-            variable.m_Offsets.assign(variable.m_LocalDimensions.size(), 0);
-        jmsg["offset"] = variable.m_Offsets;
-        jmsg["timestep"] = 0;
-        m_Man.put(values, jmsg);
-
-        if (m_DoMonitor)
-        {
-            MPI_Barrier(m_MPIComm);
-            std::cout << "I am hooked to the DataMan library\n";
-            std::cout << "putshape " << variable.m_LocalDimensions.size()
-                      << std::endl;
-            std::cout << "varshape " << variable.m_GlobalDimensions.size()
-                      << std::endl;
-            std::cout << "offset " << variable.m_Offsets.size() << std::endl;
-            for (int i = 0; i < m_SizeMPI; ++i)
-            {
-                if (i == m_RankMPI)
-                {
-                    std::cout << "Rank: " << m_RankMPI << "\n";
-                    variable.Monitor(std::cout);
-                    std::cout << std::endl;
-                }
-                else
-                {
-                    sleep(1);
-                }
-            }
-            MPI_Barrier(m_MPIComm);
-        }
-    }
+    void WriteVariableCommon(Variable<T> &variable, const T *values);
 };
 
 } // end namespace adios

--- a/source/adios2/engine/dataman/DataManWriter.tcc
+++ b/source/adios2/engine/dataman/DataManWriter.tcc
@@ -1,0 +1,75 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * DataMan.h
+ *
+ *  Created on: Jan 10, 2017
+ *      Author: wfg
+ */
+
+#ifndef ADIOS2_ENGINE_DATAMAN_DATAMAN_WRITER_TCC_
+#define ADIOS2_ENGINE_DATAMAN_DATAMAN_WRITER_TCC_
+
+#include "DataManWriter.h"
+
+#include "adios2/ADIOSMPI.h"
+
+namespace adios
+{
+
+template <class T>
+void DataManWriter::WriteVariableCommon(Variable<T> &variable, const T *values)
+{
+    // here comes your magic at Writing now variable.m_UserValues has the
+    // data
+    // passed by the user
+    // set variable
+    variable.m_AppValues = values;
+    m_WrittenVariables.insert(variable.m_Name);
+
+    // This part will go away, this is just to monitor variables per rank
+
+    json jmsg;
+    jmsg["doid"] = m_Name;
+    jmsg["var"] = variable.m_Name;
+    jmsg["dtype"] = GetType<T>();
+    jmsg["putshape"] = variable.m_LocalDimensions;
+    if (variable.m_GlobalDimensions.size() == 0)
+        variable.m_GlobalDimensions = variable.m_LocalDimensions;
+    jmsg["varshape"] = variable.m_GlobalDimensions;
+    if (variable.m_Offsets.size() == 0)
+        variable.m_Offsets.assign(variable.m_LocalDimensions.size(), 0);
+    jmsg["offset"] = variable.m_Offsets;
+    jmsg["timestep"] = 0;
+    m_Man.put(values, jmsg);
+
+    if (m_DoMonitor)
+    {
+        MPI_Barrier(m_MPIComm);
+        std::cout << "I am hooked to the DataMan library\n";
+        std::cout << "putshape " << variable.m_LocalDimensions.size()
+                  << std::endl;
+        std::cout << "varshape " << variable.m_GlobalDimensions.size()
+                  << std::endl;
+        std::cout << "offset " << variable.m_Offsets.size() << std::endl;
+        for (int i = 0; i < m_SizeMPI; ++i)
+        {
+            if (i == m_RankMPI)
+            {
+                std::cout << "Rank: " << m_RankMPI << "\n";
+                variable.Monitor(std::cout);
+                std::cout << std::endl;
+            }
+            else
+            {
+                sleep(1);
+            }
+        }
+        MPI_Barrier(m_MPIComm);
+    }
+}
+
+} // end namespace adios
+
+#endif /* ADIOS2_ENGINE_DATAMAN_DATAMAN_WRITER_H_ */

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -12,6 +12,7 @@
 
 #include <iostream> //needs to go away, this is just for demo purposes
 
+#include "adiso2/ADIOSMPI.h"
 #include "adios2/core/Support.h"
 #include "adios2/core/adiosFunctions.h" //CSVToVector
 

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -12,9 +12,9 @@
 
 #include <iostream> //needs to go away, this is just for demo purposes
 
-#include "adiso2/ADIOSMPI.h"
 #include "adios2/core/Support.h"
 #include "adios2/core/adiosFunctions.h" //CSVToVector
+#include "adiso2/ADIOSMPI.h"
 
 namespace adios
 {

--- a/source/adios2/engine/hdf5/HDF5WriterP.h
+++ b/source/adios2/engine/hdf5/HDF5WriterP.h
@@ -13,7 +13,7 @@
 #define ADIOS2_ENGINE_HDF5_HDF5WRITERP_H__
 
 #include "adios2/ADIOSConfig.h"
-#include "adios2/ADIOS_MPI.h"
+#include "adios2/ADIOSMPICommOnly.h"
 #include "adios2/capsule/heap/STLVector.h"
 #include "adios2/core/Engine.h"
 

--- a/source/adios2/transport/file/MPI_File.h
+++ b/source/adios2/transport/file/MPI_File.h
@@ -12,7 +12,7 @@
 #define ADIOS2_TRANSPORT_FILE_MPI_FILE_H_
 
 #include "adios2/ADIOSConfig.h"
-#include "adios2/ADIOS_MPI.h"
+#include "adios2/ADIOSMPICommOnly.h"
 
 namespace adios
 {

--- a/source/adios2/utilities/format/bp1/BP1Aggregator.cpp
+++ b/source/adios2/utilities/format/bp1/BP1Aggregator.cpp
@@ -14,6 +14,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include "adios2/ADIOSMPI.h"
+
 namespace adios
 {
 namespace format
@@ -25,8 +27,6 @@ BP1Aggregator::BP1Aggregator(MPI_Comm mpiComm, const bool debugMode)
     MPI_Comm_rank(m_MPIComm, &m_RankMPI);
     MPI_Comm_size(m_MPIComm, &m_SizeMPI);
 }
-
-BP1Aggregator::~BP1Aggregator() {}
 
 void BP1Aggregator::WriteProfilingLog(const std::string fileName,
                                       const std::string &rankLog)

--- a/source/adios2/utilities/format/bp1/BP1Aggregator.h
+++ b/source/adios2/utilities/format/bp1/BP1Aggregator.h
@@ -16,7 +16,7 @@
 /// \endcond
 
 #include "adios2/ADIOSConfig.h"
-#include "adios2/ADIOS_MPI.h"
+#include "adios2/ADIOSMPICommOnly.h"
 
 namespace adios
 {
@@ -30,9 +30,9 @@ class BP1Aggregator
 {
 
 public:
-    MPI_Comm m_MPIComm = MPI_COMM_SELF; ///< MPI communicator from Engine
-    int m_RankMPI = 0;                  ///< current MPI rank process
-    int m_SizeMPI = 1;                  ///< current MPI processes size
+    MPI_Comm m_MPIComm; ///< MPI communicator from Engine
+    int m_RankMPI = 0;  ///< current MPI rank process
+    int m_SizeMPI = 1;  ///< current MPI processes size
 
     /**
      * Unique constructor
@@ -40,7 +40,7 @@ public:
      */
     BP1Aggregator(MPI_Comm mpiComm, const bool debugMode = false);
 
-    ~BP1Aggregator();
+    ~BP1Aggregator() = default;
 
     /**
      * Function that aggregates and writes (from rank = 0) profiling.log in

--- a/source/adios2/utilities/format/bp1/BP1Base.cpp
+++ b/source/adios2/utilities/format/bp1/BP1Base.cpp
@@ -10,6 +10,7 @@
 
 #include "BP1Base.h"
 
+#include "adios2/ADIOSMPI.h"
 #include "adios2/core/adiosFunctions.h"
 
 namespace adios

--- a/source/adios2/utilities/format/bp1/BP1Base.h
+++ b/source/adios2/utilities/format/bp1/BP1Base.h
@@ -19,7 +19,7 @@
 /// \endcond
 
 #include "adios2/ADIOSConfig.h"
-#include "adios2/ADIOS_MPI.h"
+#include "adios2/ADIOSMPICommOnly.h"
 #include "adios2/core/Transport.h"
 
 namespace adios


### PR DESCRIPTION
@pnorbert @williamfgc This should let us kill off mpidummy.h from public interface and restrict it to internal use only.