### PR TITLE
Allow json.hpp to be used with gcc 4.8.5

### DIFF
--- a/source/dataman/json.hpp
+++ b/source/dataman/json.hpp
@@ -63,7 +63,7 @@ SOFTWARE.
     "unsupported Clang version - see https://github.com/nlohmann/json#supported-compilers"
 #endif
 #elif defined(__GNUC__)
-#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
+#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40805
 #error                                                                         \
     "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"
 #endif


### PR DESCRIPTION
There are a few issues with this that prevent it from being accepted upstream but it's fine for how we use it.