### PR TITLE
added direct callback mode to dataman receiver to bypass cache

### DIFF
--- a/examples/groupless/multistep/reader_allsteps.cpp
+++ b/examples/groupless/multistep/reader_allsteps.cpp
@@ -191,7 +191,9 @@ int main(int argc, char *argv[])
         if (rank == 0)
             Print2DArray(Nparts, vNparts->GetNSteps(), Nwriters, "Nparts");
         Delete2DArray(Nparts);
+#ifdef ADIOS2_HAVE_MPI
         MPI_Barrier(MPI_COMM_WORLD);
+#endif
 
         /*
          * GlobalArrayFixedDims
@@ -227,19 +229,28 @@ int main(int argc, char *argv[])
         vGlobalArrayFixedDims->SetStepSelection(
             0, vGlobalArrayFixedDims->GetNSteps());
         bpReader->Read<double>(*vGlobalArrayFixedDims, GlobalArrayFixedDims[0]);
+#ifdef ADIOS2_HAVE_MPI
         MPI_Barrier(MPI_COMM_WORLD);
         MPI_Status status;
+#endif
+
         int token = 0;
+#ifdef ADIOS2_HAVE_MPI
         if (rank > 0)
             MPI_Recv(&token, 1, MPI_INT, rank - 1, 0, MPI_COMM_WORLD, &status);
         std::cout << "Rank " << rank << " read start = " << start
                   << " count = " << count << std::endl;
+#endif
         Print2DArray(GlobalArrayFixedDims, vGlobalArrayFixedDims->GetNSteps(),
                      count, "GlobalArrayFixedDims");
+#ifdef ADIOS2_HAVE_MPI
         if (rank < nproc - 1)
             MPI_Send(&token, 1, MPI_INT, rank + 1, 0, MPI_COMM_WORLD);
+#endif
         Delete2DArray(GlobalArrayFixedDims);
+#ifdef ADIOS2_HAVE_MPI
         MPI_Barrier(MPI_COMM_WORLD);
+#endif
 
         /*
          * LocalArrayFixedDims
@@ -256,7 +267,9 @@ int main(int argc, char *argv[])
         }
         std::cout << "LocalArrayFixedDims is irregular. Cannot read this "
                      "variable yet...\n";
+#ifdef ADIOS2_HAVE_MPI
         MPI_Barrier(MPI_COMM_WORLD);
+#endif
 
         /*
          * LocalArrayFixedDimsJoined
@@ -282,7 +295,9 @@ int main(int argc, char *argv[])
                          vLocalArrayFixedDimsJoined->m_Shape[0],
                          "LocalArrayFixedDimsJoined");
         Delete2DArray(LocalArrayFixedDimsJoined);
+#ifdef ADIOS2_HAVE_MPI
         MPI_Barrier(MPI_COMM_WORLD);
+#endif
 
         /*
          * GlobalArray which changes size over time
@@ -299,7 +314,9 @@ int main(int argc, char *argv[])
                 "dimension is supposed to be adios::IrregularDim indicating an "
                 "Irregular array\n");
         }
+#ifdef ADIOS2_HAVE_MPI
         MPI_Barrier(MPI_COMM_WORLD);
+#endif
 
         // Close file/stream
         bpReader->Close();

--- a/source/dataman/MdtmMan.cpp
+++ b/source/dataman/MdtmMan.cpp
@@ -154,7 +154,7 @@ void MdtmMan::on_recv(json a_jmsg)
     // for flush
     if (jqueue.front()["operation"] == "flush")
     {
-        callback();
+        callback_cache();
         jqueue.pop();
         vqueue.pop();
         iqueue.pop();
@@ -222,7 +222,17 @@ void MdtmMan::on_recv(json a_jmsg)
                         auto_transform(vqueue.front(), a_jmsg);
                     }
                 }
-                m_cache.put(vqueue.front().data(), jmsg);
+
+                if (a_jmsg["varshape"] == a_jmsg["putshape"])
+                {
+                    std::cout << "callback_direct \n";
+                    callback_direct(vqueue.front().data(), jmsg);
+                }
+                else
+                {
+                    m_cache.put(vqueue.front().data(), jmsg);
+                }
+
                 jqueue.pop();
                 vqueue.pop();
                 iqueue.pop();

--- a/source/dataman/StreamMan.h
+++ b/source/dataman/StreamMan.h
@@ -31,7 +31,8 @@ public:
 protected:
     void *zmq_context = NULL;
     CacheMan m_cache;
-    int callback();
+    int callback_direct(const void *a_data, json &a_jmsg);
+    int callback_cache();
 
     std::string m_get_mode = "callback";
     std::string m_stream_mode;

--- a/source/dataman/ZmqMan.h
+++ b/source/dataman/ZmqMan.h
@@ -28,7 +28,7 @@ public:
     std::string name() { return "ZmqMan"; }
 
 private:
-    void *zmq_data = NULL;
+    void *zmq_data = nullptr;
 };
 
 extern "C" DataManBase *getMan() { return new ZmqMan; }


### PR DESCRIPTION
@pnorbert I have fixed a few MPI macro problems in examples/groupless/multistep/reader_allsteps.cpp. Sorry about touching your file but otherwise it does not compile. Please have a look and see if the changes are fine. 