### PR TITLE
Makes missing xml file permissive

### DIFF
--- a/source/adios2/helper/adiosString.cpp
+++ b/source/adios2/helper/adiosString.cpp
@@ -20,15 +20,13 @@
 namespace adios2
 {
 
-std::string FileToString(const std::string &fileName)
+std::string FileToString(const std::string &fileName) noexcept
 {
     std::ifstream fileStream(fileName);
 
     if (!fileStream)
     {
-        throw std::invalid_argument(
-            "ERROR: file " + fileName +
-            " could not be opened. Check permissions or existence\n");
+        return std::string(); // empty string
     }
 
     std::ostringstream fileSS;

--- a/source/adios2/helper/adiosString.h
+++ b/source/adios2/helper/adiosString.h
@@ -27,7 +27,7 @@ namespace adios2
  * @param fileName of text file
  * @return file contents in a string
  */
-std::string FileToString(const std::string &fileName);
+std::string FileToString(const std::string &fileName) noexcept;
 
 /**
  * Transforms a vector to a map of parameters


### PR DESCRIPTION
If file doesn't exist, continue with run
Fixed bug if space before and after "=" in: \<tag attribute1= "value1" \>"

To do: need to discuss policy for config files, xml config files still experimental