### PR TITLE
Solve Issue #171, bug when using threaded operations

### DIFF
--- a/examples/hello/bpFlushWriter/helloBPFlushWriter.cpp
+++ b/examples/hello/bpFlushWriter/helloBPFlushWriter.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
     /** Application variable */
-    std::vector<float> myFloats(100);
+    std::vector<float> myFloats(1000000); //~ 4 MB
     const std::size_t Nx = myFloats.size();
 
     try
@@ -38,7 +38,11 @@ int main(int argc, char *argv[])
          * Parameters, Transports, and Execution: Engines */
         adios2::IO &bpIO = adios.DeclareIO("BPFile_N2N_Flush");
         bpIO.SetEngine("BPFileWriter");
-        // bpIO.SetParameters( )
+
+        //        bpIO.SetParameters({{"MaxBufferSize", "9Mb"},
+        //                            {"BufferGrowthFactor", "1.5"},
+        //                            {"Threads", "2"}});
+        //        bpIO.AddTransport("File", {{"ProfileUnits", "Microseconds"}});
 
         /** global array : name, { shape (total) }, { start (local) }, { count
          * (local) }, all are constant dimensions */
@@ -54,8 +58,13 @@ int main(int argc, char *argv[])
                 "ERROR: bpWriter not created at Open\n");
         }
 
-        /** Write variable for buffering */
-        bpWriter->Write<float>(bpFloats, myFloats.data());
+        for (unsigned int t = 0; t < 100; ++t)
+        {
+            /** values to time step */
+            myFloats.assign(myFloats.size(), t);
+            /** Write variable for buffering */
+            bpWriter->Write<float>(bpFloats, myFloats.data());
+        }
 
         /** Create bp file, engine becomes unreachable after this*/
         bpWriter->Close();

--- a/source/adios2/helper/adiosMath.inl
+++ b/source/adios2/helper/adiosMath.inl
@@ -60,7 +60,7 @@ template <class T>
 void GetMinMaxThreads(const T *values, const size_t size, T &min, T &max,
                       const unsigned int threads) noexcept
 {
-    if (threads == 1)
+    if (threads == 1 || threads > size)
     {
         GetMinMax(values, size, min, max);
         return;

--- a/source/adios2/toolkit/format/bp1/BP1Base.cpp
+++ b/source/adios2/toolkit/format/bp1/BP1Base.cpp
@@ -57,6 +57,10 @@ void BP1Base::InitParameters(const Params &parameters)
         {
             InitParameterMaxBufferSize(value);
         }
+        else if (key == "Threads")
+        {
+            InitParameterThreads(value);
+        }
         else if (key == "Verbose")
         {
             InitParameterVerbose(value);
@@ -274,6 +278,38 @@ void BP1Base::InitParameterMaxBufferSize(const std::string value)
     {
         m_MaxBufferSize = static_cast<size_t>(std::stoul(number) * factor);
     }
+}
+
+void BP1Base::InitParameterThreads(const std::string value)
+{
+    int threads = -1;
+
+    if (m_DebugMode)
+    {
+        bool success = true;
+
+        try
+        {
+            threads = std::stoi(value);
+        }
+        catch (std::exception &e)
+        {
+            success = false;
+        }
+
+        if (!success || threads < 1)
+        {
+            throw std::invalid_argument(
+                "ERROR: value in Threads=value in IO SetParameters must be "
+                "an integer >= 1 (default), in call to Open\n");
+        }
+    }
+    else
+    {
+        threads = std::stoi(value);
+    }
+
+    m_Threads = static_cast<unsigned int>(threads);
 }
 
 void BP1Base::InitParameterVerbose(const std::string value)

--- a/source/adios2/toolkit/format/bp1/BP1Base.h
+++ b/source/adios2/toolkit/format/bp1/BP1Base.h
@@ -251,9 +251,13 @@ protected:
     /** set initial buffer size */
     void InitParameterInitBufferSize(const std::string value);
 
-    /** unlimited (default), set max buffer size in Gb or Mb
+    /** default = DefaultMaxBufferSize in ADIOSTypes.h, set max buffer size in
+     * Gb or Mb
      *  max_buffer_size=100Mb or  max_buffer_size=1Gb */
     void InitParameterMaxBufferSize(const std::string value);
+
+    /** Set available number of threads for vector operations */
+    void InitParameterThreads(const std::string value);
 
     /** verbose file level=0 (default) */
     void InitParameterVerbose(const std::string value);

--- a/source/adios2/toolkit/format/bp1/BP1Writer.cpp
+++ b/source/adios2/toolkit/format/bp1/BP1Writer.cpp
@@ -192,7 +192,8 @@ std::string BP1Writer::GetRankProfilingLog(
     std::string timeDate(profiler.Timers.at("buffering").m_LocalTimeDate);
     timeDate.pop_back();
 
-    rankLog += "'date_and_time': '" + timeDate + "', " + "'bytes': " +
+    rankLog += "'date_and_time': '" + timeDate + "', 'threads': " +
+               std::to_string(m_Threads) + ", 'bytes': " +
                std::to_string(profiler.Bytes.at("buffering")) + ", ";
     lf_WriterTimer(rankLog, profiler.Timers.at("buffering"));
 


### PR DESCRIPTION
Replace std::copy with std::memcpy in std::thread
Added threads to profiling.log
Limiting the use of threads


TO DO: 
large scale runs to enforce threads policy
adding example with SetParameters (needs to be fixed)