### PR TITLE
Solve Issue #180 Modified file transports to enable write loop in size > 2Gb

### DIFF
--- a/examples/experimental/multistep/reader_allsteps.cpp
+++ b/examples/experimental/multistep/reader_allsteps.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
             bpReaderSettings.SetEngine(
                 "ADIOS1Reader"); // BP is the default engine
             // see only one step at a time
-            bpReaderSettings.SetParameters({"OpenAsFile=yes"});
+            bpReaderSettings.SetParameters({{"OpenAsFile", "yes"}});
         }
 
         // Create engine smart pointer due to polymorphism,

--- a/examples/experimental/multistep/writer_multistep.cpp
+++ b/examples/experimental/multistep/writer_multistep.cpp
@@ -74,11 +74,15 @@ int main(int argc, char *argv[])
             bpWriterSettings.AddTransport("file"
 #ifdef ADIOS2_HAVE_MPI
                                           ,
-                                          { "library=MPI-IO" }
+                                          {
+                                              {
+                                                  "library", "MPI-IO"
+                                              }
+                                          }
 #endif
                                           );
             // Passing parameters to the engine
-            bpWriterSettings.SetParameters({"have_metadata_file=yes"});
+            bpWriterSettings.SetParameters({{"have_metadata_file", "yes"}});
             // number of aggregators
             // bpWriterSettings.SetParameters("Aggregation", (nproc + 1) / 2);
         }

--- a/examples/hello/bpWriter/helloBPWriter_nompi.cpp
+++ b/examples/hello/bpWriter/helloBPWriter_nompi.cpp
@@ -29,6 +29,7 @@ int main(int argc, char *argv[])
         /*** IO class object: settings and factory of Settings: Variables,
          * Parameters, Transports, and Execution: Engines */
         adios2::IO &bpIO = adios.DeclareIO("BPFile_N2N");
+        bpIO.AddTransport("File", {{"Library", "stdio"}});
 
         /** global array: name, { shape (total dimensions) }, { start (local) },
          * { count (local) }, all are constant dimensions */

--- a/source/adios2/ADIOSTypes.h
+++ b/source/adios2/ADIOSTypes.h
@@ -155,6 +155,9 @@ constexpr size_t DefaultInitialBufferSize(16384);
 constexpr size_t DefaultMaxBufferSize(16777216);
 /** default buffer growth factor (from STL vector = 2.) */
 constexpr float DefaultBufferGrowthFactor(2.);
+/** default size for writing/reading files using POSIX/fstream/stdio write
+ *  1Gb - 1Kb (tolerance)*/
+constexpr size_t DefaultMaxFileBatchSize(1024 * 1024 * 1024 - 1024);
 
 // adios alias values and types
 constexpr bool DebugON = true;

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -47,17 +47,17 @@ void IO::SetParameters(const Params &parameters) { m_Parameters = parameters; }
 
 const Params &IO::GetParameters() const { return m_Parameters; }
 
-unsigned int IO::AddTransport(const std::string type,
-                              const std::vector<std::string> &parametersVector)
-{
-    Params parametersMap(BuildParametersMap(parametersVector, m_DebugMode));
-    return AddTransportCommon(type, parametersMap);
-}
-
 unsigned int IO::AddTransport(const std::string type, const Params &parameters)
 {
     Params parametersMap(parameters);
-    return AddTransportCommon(type, parametersMap);
+    if (m_DebugMode)
+    {
+        CheckTransportType(type);
+    }
+
+    parametersMap["transport"] = type;
+    m_TransportsParameters.push_back(parametersMap);
+    return static_cast<unsigned int>(m_TransportsParameters.size() - 1);
 }
 
 VariableCompound &IO::GetVariableCompound(const std::string &name)
@@ -235,18 +235,6 @@ std::shared_ptr<Engine> IO::Open(const std::string &name,
 }
 
 // PRIVATE Functions
-unsigned int IO::AddTransportCommon(const std::string type, Params &parameters)
-{
-    if (m_DebugMode)
-    {
-        CheckTransportType(type);
-    }
-
-    parameters["transport"] = type;
-    m_TransportsParameters.push_back(parameters);
-    return static_cast<unsigned int>(m_TransportsParameters.size() - 1);
-}
-
 unsigned int IO::GetVariableIndex(const std::string &name) const
 {
     if (m_DebugMode)

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -93,14 +93,11 @@ public:
     const Params &GetParameters() const;
 
     /**
-     * Adds a transport and its parameters for the method
-     * @param type must be a supported transport type under /include/transport
-     * @param args list of parameters for a transport with format
-     * "parameter1=value1", ..., "parameterN=valueN"
+     * Adds a transport and its parameters for the IO Engine
+     * @param type must be a supported transport type
+     * @param params acceptable parameters for a particular transport
+     * @return
      */
-    unsigned int AddTransport(const std::string type,
-                              const std::vector<std::string> &paramsVector);
-
     unsigned int AddTransport(const std::string type,
                               const Params &params = Params());
 
@@ -250,14 +247,6 @@ private:
     std::map<std::string, double> m_AttributesNumeric;
 
     std::set<std::string> m_EngineNames;
-
-    /**
-     * Called from AddTransport overloads
-     * @param type
-     * @param parameters
-     * @return transport index
-     */
-    unsigned int AddTransportCommon(const std::string type, Params &parameters);
 
     /** Gets the internal reference to a variable map for type T
      *  This function is specialized in IO.tcc */

--- a/source/adios2/toolkit/format/bp1/BP1Base.cpp
+++ b/source/adios2/toolkit/format/bp1/BP1Base.cpp
@@ -22,6 +22,8 @@ BP1Base::BP1Base(MPI_Comm mpiComm, const bool debugMode)
 : m_HeapBuffer(debugMode), m_BP1Aggregator(mpiComm, debugMode),
   m_DebugMode(debugMode)
 {
+    // default
+    m_Profiler.IsActive = true;
 }
 
 void BP1Base::InitParameters(const Params &parameters)

--- a/source/adios2/toolkit/profiling/iochrono/IOChrono.h
+++ b/source/adios2/toolkit/profiling/iochrono/IOChrono.h
@@ -43,8 +43,8 @@ struct IOChrono
     /** Create byte tracking counter for each process*/
     std::unordered_map<std::string, size_t> Bytes;
 
-    /** flag to determine if IOChrono object is used */
-    bool IsActive = true;
+    /** flag to determine if IOChrono object is being used */
+    bool IsActive = false;
 };
 
 } // end namespace profiling

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -25,6 +25,8 @@ Transport::Transport(const std::string type, const std::string library,
 
 void Transport::InitProfiler(const OpenMode openMode, const TimeUnit timeUnit)
 {
+    m_Profiler.IsActive = true;
+
     m_Profiler.Timers.emplace(std::make_pair(
         "open", profiling::Timer("open", TimeUnit::Microseconds, m_DebugMode)));
 
@@ -51,8 +53,6 @@ void Transport::InitProfiler(const OpenMode openMode, const TimeUnit timeUnit)
     m_Profiler.Timers.emplace(
         "close",
         profiling::Timer("close", TimeUnit::Microseconds, m_DebugMode));
-
-    m_Profiler.IsActive = true;
 }
 
 void Transport::SetBuffer(char * /*buffer*/, size_t /*size*/)

--- a/source/adios2/toolkit/transport/file/FilePointer.h
+++ b/source/adios2/toolkit/transport/file/FilePointer.h
@@ -11,9 +11,8 @@
 #ifndef ADIOS2_TOOLKIT_TRANSPORT_FILE_FILEPOINTER_H_
 #define ADIOS2_TOOLKIT_TRANSPORT_FILE_FILEPOINTER_H_
 
-#include <stdio.h> // FILE*
+#include <cstdio> // FILE*
 
-#include "adios2/ADIOSConfig.h"
 #include "adios2/toolkit/transport/Transport.h"
 
 namespace adios2
@@ -40,13 +39,13 @@ public:
 
     void Write(const char *buffer, size_t size) final;
 
-    void Flush();
+    void Flush() final;
 
-    void Close();
+    void Close() final;
 
 private:
     /** C File pointer */
-    FILE *m_File = nullptr; // NULL or nullptr?
+    std::FILE *m_File = nullptr; // NULL or nullptr?
 };
 
 } // end namespace transport

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -9,6 +9,15 @@ if(NOT ADIOS2_HAVE_MPI)
 
   add_executable(TestBPWriteRead TestBPWriteRead.cpp)
   target_link_libraries(TestBPWriteRead adios2 gtest adios1::adios)
+  
+  add_executable(TestBPWriteReadstdio TestBPWriteReadstdio.cpp)
+  target_link_libraries(TestBPWriteReadstdio adios2 gtest adios1::adios)
+
+  add_executable(TestBPWriteReadfstream TestBPWriteReadfstream.cpp)
+  target_link_libraries(TestBPWriteReadfstream adios2 gtest adios1::adios)
+  
 
   gtest_add_tests(TARGET TestBPWriteRead)
+  gtest_add_tests(TARGET TestBPWriteReadstdio)
+  gtest_add_tests(TARGET TestBPWriteReadfstream)
 endif()

--- a/testing/adios2/engine/bp/TestBPWriteReadfstream.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadfstream.cpp
@@ -1,0 +1,712 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+#include <adios_read.h>
+
+#include <gtest/gtest.h>
+
+#include "../SmallTestData.h"
+
+class BPWriteReadTest : public ::testing::Test
+{
+public:
+    BPWriteReadTest() = default;
+
+    SmallTestData m_TestData;
+};
+
+//******************************************************************************
+// 1D 1x8 test data
+//******************************************************************************
+
+// ADIOS2 write, native ADIOS1 read
+TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8fstream)
+{
+    std::string fname = "ADIOS2BPWriteADIOS1Read1D8fstream.bp";
+
+    // Write test data using ADIOS2
+    {
+        adios2::ADIOS adios(true);
+        adios2::IO &io = adios.DeclareIO("TestIO");
+
+        // Declare 1D variables
+        {
+            auto &var_i8 =
+                io.DefineVariable<char>("i8", {}, {}, adios2::Dims{8});
+            auto &var_i16 =
+                io.DefineVariable<short>("i16", {}, {}, adios2::Dims{8});
+            auto &var_i32 =
+                io.DefineVariable<int>("i32", {}, {}, adios2::Dims{8});
+            auto &var_i64 =
+                io.DefineVariable<long>("i64", {}, {}, adios2::Dims{8});
+            auto &var_u8 =
+                io.DefineVariable<unsigned char>("u8", {}, {}, adios2::Dims{8});
+            auto &var_u16 = io.DefineVariable<unsigned short>("u16", {}, {},
+                                                              adios2::Dims{8});
+            auto &var_u32 =
+                io.DefineVariable<unsigned int>("u32", {}, {}, adios2::Dims{8});
+            auto &var_u64 = io.DefineVariable<unsigned long>("u64", {}, {},
+                                                             adios2::Dims{8});
+            auto &var_r32 =
+                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{8});
+            auto &var_r64 =
+                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{8});
+        }
+
+        // Create the BP Engine
+        io.SetEngine("BPFileWriter");
+        io.AddTransport("File", {{"Library", "fstream"}});
+
+        auto engine = io.Open(fname, adios2::OpenMode::Write);
+        ASSERT_NE(engine.get(), nullptr);
+
+        for (size_t step = 0; step < 3; ++step)
+        {
+            // Retrieve the variables that previously went out of scope
+            auto &var_i8 = io.GetVariable<char>("i8");
+            auto &var_i16 = io.GetVariable<short>("i16");
+            auto &var_i32 = io.GetVariable<int>("i32");
+            auto &var_i64 = io.GetVariable<long>("i64");
+            auto &var_u8 = io.GetVariable<unsigned char>("u8");
+            auto &var_u16 = io.GetVariable<unsigned short>("u16");
+            auto &var_u32 = io.GetVariable<unsigned int>("u32");
+            auto &var_u64 = io.GetVariable<unsigned long>("u64");
+            auto &var_r32 = io.GetVariable<float>("r32");
+            auto &var_r64 = io.GetVariable<double>("r64");
+
+            // Write each one
+            engine->Write(var_i8, m_TestData.I8.data() + step);
+            engine->Write(var_i16, m_TestData.I16.data() + step);
+            engine->Write(var_i32, m_TestData.I32.data() + step);
+            engine->Write(var_i64, m_TestData.I64.data() + step);
+            engine->Write(var_u8, m_TestData.U8.data() + step);
+            engine->Write(var_u16, m_TestData.U16.data() + step);
+            engine->Write(var_u32, m_TestData.U32.data() + step);
+            engine->Write(var_u64, m_TestData.U64.data() + step);
+            engine->Write(var_r32, m_TestData.R32.data() + step);
+            engine->Write(var_r64, m_TestData.R64.data() + step);
+
+            // Advance to the next time step
+            engine->Advance();
+        }
+
+        // Close the file
+        engine->Close();
+    }
+
+// Read test data using ADIOS1
+#ifdef ADIOS2_HAVE_MPI
+    // Read everything from rank 0
+    int rank;
+    MPI_Comm_rank();
+    if (rank == 0)
+#endif
+    {
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+                               "verbose=3");
+
+        // Open the file for reading
+        ADIOS_FILE *f =
+            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
+                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        ASSERT_NE(f, nullptr);
+
+        // Check the variables exist
+        ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
+        ASSERT_NE(var_i8, nullptr);
+        ASSERT_EQ(var_i8->ndim, 1);
+        ASSERT_EQ(var_i8->dims[0], 8);
+        ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
+        ASSERT_NE(var_i16, nullptr);
+        ASSERT_EQ(var_i16->ndim, 1);
+        ASSERT_EQ(var_i16->dims[0], 8);
+        ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
+        ASSERT_NE(var_i32, nullptr);
+        ASSERT_EQ(var_i32->ndim, 1);
+        ASSERT_EQ(var_i32->dims[0], 8);
+        ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
+        ASSERT_NE(var_i64, nullptr);
+        ASSERT_EQ(var_i64->ndim, 1);
+        ASSERT_EQ(var_i64->dims[0], 8);
+        ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
+        ASSERT_NE(var_u8, nullptr);
+        ASSERT_EQ(var_u8->ndim, 1);
+        ASSERT_EQ(var_u8->dims[0], 8);
+        ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
+        ASSERT_NE(var_u16, nullptr);
+        ASSERT_EQ(var_u16->ndim, 1);
+        ASSERT_EQ(var_u16->dims[0], 8);
+        ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
+        ASSERT_NE(var_u32, nullptr);
+        ASSERT_EQ(var_u32->ndim, 1);
+        ASSERT_EQ(var_u32->dims[0], 8);
+        ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
+        ASSERT_NE(var_u64, nullptr);
+        ASSERT_EQ(var_u64->ndim, 1);
+        ASSERT_EQ(var_u64->dims[0], 8);
+        ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
+        ASSERT_NE(var_r32, nullptr);
+        ASSERT_EQ(var_r32->ndim, 1);
+        ASSERT_EQ(var_r32->dims[0], 8);
+        ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
+        ASSERT_NE(var_r64, nullptr);
+        ASSERT_EQ(var_r64->ndim, 1);
+        ASSERT_EQ(var_r64->dims[0], 8);
+
+        std::array<char, 8> I8;
+        std::array<int16_t, 8> I16;
+        std::array<int32_t, 8> I32;
+        std::array<int64_t, 8> I64;
+        std::array<unsigned char, 8> U8;
+        std::array<uint16_t, 8> U16;
+        std::array<uint32_t, 8> U32;
+        std::array<uint64_t, 8> U64;
+        std::array<float, 8> R32;
+        std::array<double, 8> R64;
+
+        uint64_t start[1] = {0};
+        uint64_t count[1] = {8};
+        ADIOS_SELECTION *sel = adios_selection_boundingbox(1, start, count);
+
+        // Read stuff
+        for (size_t t = 0; t < 3; ++t)
+        {
+            // Read the current step
+            adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
+            adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
+            adios_schedule_read_byid(f, sel, var_i32->varid, t, 1, I32.data());
+            adios_schedule_read_byid(f, sel, var_i64->varid, t, 1, I64.data());
+            adios_schedule_read_byid(f, sel, var_u8->varid, t, 1, U8.data());
+            adios_schedule_read_byid(f, sel, var_u16->varid, t, 1, U16.data());
+            adios_schedule_read_byid(f, sel, var_u32->varid, t, 1, U32.data());
+            adios_schedule_read_byid(f, sel, var_u64->varid, t, 1, U64.data());
+            adios_schedule_read_byid(f, sel, var_r32->varid, t, 1, R32.data());
+            adios_schedule_read_byid(f, sel, var_r64->varid, t, 1, R64.data());
+            adios_perform_reads(f, 1);
+
+            // Check if it's correct
+            for (size_t i = 0; i < 8; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
+                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
+                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
+                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
+                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
+                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
+                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
+                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
+                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
+                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+            }
+        }
+
+        adios_selection_delete(sel);
+
+        // Cleanup variable structures
+        adios_free_varinfo(var_i8);
+        adios_free_varinfo(var_i16);
+        adios_free_varinfo(var_i32);
+        adios_free_varinfo(var_i64);
+        adios_free_varinfo(var_u8);
+        adios_free_varinfo(var_u16);
+        adios_free_varinfo(var_u32);
+        adios_free_varinfo(var_u64);
+        adios_free_varinfo(var_r32);
+        adios_free_varinfo(var_r64);
+
+        // Cleanup file
+        adios_read_close(f);
+    }
+}
+
+// ADIOS2 write, ADIOS2 read
+TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead1D8fstream)
+{
+    std::string fname = "ADIOS2BPWriteADIOS2BPRead1D8fstream.bp";
+
+    ASSERT_TRUE(false) << "ADIOS2 read API is not yet implemented";
+}
+
+//******************************************************************************
+// 2D 2x4 test data
+//******************************************************************************
+
+// ADIOS2 write, native ADIOS1 read
+TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4fstream)
+{
+    std::string fname = "ADIOS2BPWriteADIOS1Read2D2x4Testfstream.bp";
+
+    // Write test data using ADIOS2
+    {
+        adios2::ADIOS adios(true);
+        adios2::IO &io = adios.DeclareIO("TestIO");
+
+        // Declare 1D variables
+        {
+            auto &var_i8 =
+                io.DefineVariable<char>("i8", {}, {}, adios2::Dims{2, 4});
+            auto &var_i16 =
+                io.DefineVariable<short>("i16", {}, {}, adios2::Dims{2, 4});
+            auto &var_i32 =
+                io.DefineVariable<int>("i32", {}, {}, adios2::Dims{2, 4});
+            auto &var_i64 =
+                io.DefineVariable<long>("i64", {}, {}, adios2::Dims{2, 4});
+            auto &var_u8 = io.DefineVariable<unsigned char>("u8", {}, {},
+                                                            adios2::Dims{2, 4});
+            auto &var_u16 = io.DefineVariable<unsigned short>(
+                "u16", {}, {}, adios2::Dims{2, 4});
+            auto &var_u32 = io.DefineVariable<unsigned int>("u32", {}, {},
+                                                            adios2::Dims{2, 4});
+            auto &var_u64 = io.DefineVariable<unsigned long>(
+                "u64", {}, {}, adios2::Dims{2, 4});
+            auto &var_r32 =
+                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{2, 4});
+            auto &var_r64 =
+                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{2, 4});
+        }
+
+        // Create the BP Engine
+        io.SetEngine("BPFileWriter");
+        io.AddTransport("file", {{"Library", "fstream"}});
+
+        auto engine = io.Open(fname, adios2::OpenMode::Write);
+        ASSERT_NE(engine.get(), nullptr);
+
+        for (size_t step = 0; step < 3; ++step)
+        {
+            // Retrieve the variables that previously went out of scope
+            auto &var_i8 = io.GetVariable<char>("i8");
+            auto &var_i16 = io.GetVariable<short>("i16");
+            auto &var_i32 = io.GetVariable<int>("i32");
+            auto &var_i64 = io.GetVariable<long>("i64");
+            auto &var_u8 = io.GetVariable<unsigned char>("u8");
+            auto &var_u16 = io.GetVariable<unsigned short>("u16");
+            auto &var_u32 = io.GetVariable<unsigned int>("u32");
+            auto &var_u64 = io.GetVariable<unsigned long>("u64");
+            auto &var_r32 = io.GetVariable<float>("r32");
+            auto &var_r64 = io.GetVariable<double>("r64");
+
+            // Write each one
+            engine->Write(var_i8, m_TestData.I8.data() + step);
+            engine->Write(var_i16, m_TestData.I16.data() + step);
+            engine->Write(var_i32, m_TestData.I32.data() + step);
+            engine->Write(var_i64, m_TestData.I64.data() + step);
+            engine->Write(var_u8, m_TestData.U8.data() + step);
+            engine->Write(var_u16, m_TestData.U16.data() + step);
+            engine->Write(var_u32, m_TestData.U32.data() + step);
+            engine->Write(var_u64, m_TestData.U64.data() + step);
+            engine->Write(var_r32, m_TestData.R32.data() + step);
+            engine->Write(var_r64, m_TestData.R64.data() + step);
+
+            // Advance to the next time step
+            engine->Advance();
+        }
+
+        // Close the file
+        engine->Close();
+    }
+
+// Read test data using ADIOS1
+#ifdef ADIOS2_HAVE_MPI
+    // Read everything from rank 0
+    int rank;
+    MPI_Comm_rank();
+    if (rank == 0)
+#endif
+    {
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+                               "verbose=3");
+
+        // Open the file for reading
+        ADIOS_FILE *f =
+            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
+                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        ASSERT_NE(f, nullptr);
+
+        // Check the variables exist
+        ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
+        ASSERT_NE(var_i8, nullptr);
+        ASSERT_EQ(var_i8->ndim, 2);
+        ASSERT_EQ(var_i8->dims[0], 2);
+        ASSERT_EQ(var_i8->dims[1], 4);
+        ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
+        ASSERT_NE(var_i16, nullptr);
+        ASSERT_EQ(var_i16->ndim, 2);
+        ASSERT_EQ(var_i16->dims[0], 2);
+        ASSERT_EQ(var_i16->dims[1], 4);
+        ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
+        ASSERT_NE(var_i32, nullptr);
+        ASSERT_EQ(var_i32->ndim, 2);
+        ASSERT_EQ(var_i32->dims[0], 2);
+        ASSERT_EQ(var_i32->dims[1], 4);
+        ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
+        ASSERT_NE(var_i64, nullptr);
+        ASSERT_EQ(var_i64->ndim, 2);
+        ASSERT_EQ(var_i64->dims[0], 2);
+        ASSERT_EQ(var_i64->dims[1], 4);
+        ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
+        ASSERT_NE(var_u8, nullptr);
+        ASSERT_EQ(var_u8->ndim, 2);
+        ASSERT_EQ(var_u8->dims[0], 2);
+        ASSERT_EQ(var_u8->dims[1], 4);
+        ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
+        ASSERT_NE(var_u16, nullptr);
+        ASSERT_EQ(var_u16->ndim, 2);
+        ASSERT_EQ(var_u16->dims[0], 2);
+        ASSERT_EQ(var_u16->dims[1], 4);
+        ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
+        ASSERT_NE(var_u32, nullptr);
+        ASSERT_EQ(var_u32->ndim, 2);
+        ASSERT_EQ(var_u32->dims[0], 2);
+        ASSERT_EQ(var_u32->dims[1], 4);
+        ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
+        ASSERT_NE(var_u64, nullptr);
+        ASSERT_EQ(var_u64->ndim, 2);
+        ASSERT_EQ(var_u64->dims[0], 2);
+        ASSERT_EQ(var_u64->dims[1], 4);
+        ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
+        ASSERT_NE(var_r32, nullptr);
+        ASSERT_EQ(var_r32->ndim, 2);
+        ASSERT_EQ(var_r32->dims[0], 2);
+        ASSERT_EQ(var_r32->dims[1], 4);
+        ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
+        ASSERT_NE(var_r64, nullptr);
+        ASSERT_EQ(var_r64->ndim, 2);
+        ASSERT_EQ(var_r64->dims[0], 2);
+        ASSERT_EQ(var_r64->dims[1], 4);
+
+        std::array<char, 8> I8;
+        std::array<int16_t, 8> I16;
+        std::array<int32_t, 8> I32;
+        std::array<int64_t, 8> I64;
+        std::array<unsigned char, 8> U8;
+        std::array<uint16_t, 8> U16;
+        std::array<uint32_t, 8> U32;
+        std::array<uint64_t, 8> U64;
+        std::array<float, 8> R32;
+        std::array<double, 8> R64;
+
+        uint64_t start[2] = {0, 0};
+        uint64_t count[2] = {2, 4};
+        ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
+
+        // Read stuff
+        for (size_t t = 0; t < 3; ++t)
+        {
+            // Read the current step
+            adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
+            adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
+            adios_schedule_read_byid(f, sel, var_i32->varid, t, 1, I32.data());
+            adios_schedule_read_byid(f, sel, var_i64->varid, t, 1, I64.data());
+            adios_schedule_read_byid(f, sel, var_u8->varid, t, 1, U8.data());
+            adios_schedule_read_byid(f, sel, var_u16->varid, t, 1, U16.data());
+            adios_schedule_read_byid(f, sel, var_u32->varid, t, 1, U32.data());
+            adios_schedule_read_byid(f, sel, var_u64->varid, t, 1, U64.data());
+            adios_schedule_read_byid(f, sel, var_r32->varid, t, 1, R32.data());
+            adios_schedule_read_byid(f, sel, var_r64->varid, t, 1, R64.data());
+            adios_perform_reads(f, 1);
+
+            // Check if it's correct
+            for (size_t i = 0; i < 8; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
+                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
+                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
+                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
+                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
+                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
+                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
+                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
+                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
+                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+            }
+        }
+
+        adios_selection_delete(sel);
+
+        // Cleanup variable structures
+        adios_free_varinfo(var_i8);
+        adios_free_varinfo(var_i16);
+        adios_free_varinfo(var_i32);
+        adios_free_varinfo(var_i64);
+        adios_free_varinfo(var_u8);
+        adios_free_varinfo(var_u16);
+        adios_free_varinfo(var_u32);
+        adios_free_varinfo(var_u64);
+        adios_free_varinfo(var_r32);
+        adios_free_varinfo(var_r64);
+
+        // Cleanup file
+        adios_read_close(f);
+    }
+}
+
+// ADIOS2 write, ADIOS2 read
+TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead2D2x4fstream)
+{
+    std::string fname = "ADIOS2BPWriteADIOS2BPRead2D2x4Testfstream.bp";
+
+    ASSERT_TRUE(false) << "ADIOS2 read API is not yet implemented";
+}
+
+//******************************************************************************
+// 2D 4x2 test data
+//******************************************************************************
+
+// ADIOS2 write, native ADIOS1 read
+TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2fstream)
+{
+    std::string fname = "ADIOS2BPWriteADIOS1Read2D4x2Testfstream.bp";
+
+    // Write test data using ADIOS2
+    {
+        adios2::ADIOS adios(true);
+        adios2::IO &io = adios.DeclareIO("TestIO");
+
+        // Declare 1D variables
+        {
+            auto &var_i8 =
+                io.DefineVariable<char>("i8", {}, {}, adios2::Dims{4, 2});
+            auto &var_i16 =
+                io.DefineVariable<short>("i16", {}, {}, adios2::Dims{4, 2});
+            auto &var_i32 =
+                io.DefineVariable<int>("i32", {}, {}, adios2::Dims{4, 2});
+            auto &var_i64 =
+                io.DefineVariable<long>("i64", {}, {}, adios2::Dims{4, 2});
+            auto &var_u8 = io.DefineVariable<unsigned char>("u8", {}, {},
+                                                            adios2::Dims{4, 2});
+            auto &var_u16 = io.DefineVariable<unsigned short>(
+                "u16", {}, {}, adios2::Dims{4, 2});
+            auto &var_u32 = io.DefineVariable<unsigned int>("u32", {}, {},
+                                                            adios2::Dims{4, 2});
+            auto &var_u64 = io.DefineVariable<unsigned long>(
+                "u64", {}, {}, adios2::Dims{4, 2});
+            auto &var_r32 =
+                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{4, 2});
+            auto &var_r64 =
+                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{4, 2});
+        }
+
+        // Create the BP Engine
+        io.SetEngine("BPFileWriter");
+        io.AddTransport("file", {{"Library", "fstream"}});
+
+        auto engine = io.Open(fname, adios2::OpenMode::Write);
+        ASSERT_NE(engine.get(), nullptr);
+
+        for (size_t step = 0; step < 3; ++step)
+        {
+            // Retrieve the variables that previously went out of scope
+            auto &var_i8 = io.GetVariable<char>("i8");
+            auto &var_i16 = io.GetVariable<short>("i16");
+            auto &var_i32 = io.GetVariable<int>("i32");
+            auto &var_i64 = io.GetVariable<long>("i64");
+            auto &var_u8 = io.GetVariable<unsigned char>("u8");
+            auto &var_u16 = io.GetVariable<unsigned short>("u16");
+            auto &var_u32 = io.GetVariable<unsigned int>("u32");
+            auto &var_u64 = io.GetVariable<unsigned long>("u64");
+            auto &var_r32 = io.GetVariable<float>("r32");
+            auto &var_r64 = io.GetVariable<double>("r64");
+
+            // Write each one
+            engine->Write(var_i8, m_TestData.I8.data() + step);
+            engine->Write(var_i16, m_TestData.I16.data() + step);
+            engine->Write(var_i32, m_TestData.I32.data() + step);
+            engine->Write(var_i64, m_TestData.I64.data() + step);
+            engine->Write(var_u8, m_TestData.U8.data() + step);
+            engine->Write(var_u16, m_TestData.U16.data() + step);
+            engine->Write(var_u32, m_TestData.U32.data() + step);
+            engine->Write(var_u64, m_TestData.U64.data() + step);
+            engine->Write(var_r32, m_TestData.R32.data() + step);
+            engine->Write(var_r64, m_TestData.R64.data() + step);
+
+            // Advance to the next time step
+            engine->Advance();
+        }
+
+        // Close the file
+        engine->Close();
+    }
+
+// Read test data using ADIOS1
+#ifdef ADIOS2_HAVE_MPI
+    // Read everything from rank 0
+    int rank;
+    MPI_Comm_rank();
+    if (rank == 0)
+#endif
+    {
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+                               "verbose=3");
+
+        // Open the file for reading
+        ADIOS_FILE *f =
+            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
+                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        ASSERT_NE(f, nullptr);
+
+        // Check the variables exist
+        ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
+        ASSERT_NE(var_i8, nullptr);
+        ASSERT_EQ(var_i8->ndim, 2);
+        ASSERT_EQ(var_i8->dims[0], 4);
+        ASSERT_EQ(var_i8->dims[1], 2);
+        ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
+        ASSERT_NE(var_i16, nullptr);
+        ASSERT_EQ(var_i16->ndim, 2);
+        ASSERT_EQ(var_i16->dims[0], 4);
+        ASSERT_EQ(var_i16->dims[1], 2);
+        ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
+        ASSERT_NE(var_i32, nullptr);
+        ASSERT_EQ(var_i32->ndim, 2);
+        ASSERT_EQ(var_i32->dims[0], 4);
+        ASSERT_EQ(var_i32->dims[1], 2);
+        ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
+        ASSERT_NE(var_i64, nullptr);
+        ASSERT_EQ(var_i64->ndim, 2);
+        ASSERT_EQ(var_i64->dims[0], 4);
+        ASSERT_EQ(var_i64->dims[1], 2);
+        ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
+        ASSERT_NE(var_u8, nullptr);
+        ASSERT_EQ(var_u8->ndim, 2);
+        ASSERT_EQ(var_u8->dims[0], 4);
+        ASSERT_EQ(var_u8->dims[1], 2);
+        ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
+        ASSERT_NE(var_u16, nullptr);
+        ASSERT_EQ(var_u16->ndim, 2);
+        ASSERT_EQ(var_u16->dims[0], 4);
+        ASSERT_EQ(var_u16->dims[1], 2);
+        ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
+        ASSERT_NE(var_u32, nullptr);
+        ASSERT_EQ(var_u32->ndim, 2);
+        ASSERT_EQ(var_u32->dims[0], 4);
+        ASSERT_EQ(var_u32->dims[1], 2);
+        ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
+        ASSERT_NE(var_u64, nullptr);
+        ASSERT_EQ(var_u64->ndim, 2);
+        ASSERT_EQ(var_u64->dims[0], 4);
+        ASSERT_EQ(var_u64->dims[1], 2);
+        ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
+        ASSERT_NE(var_r32, nullptr);
+        ASSERT_EQ(var_r32->ndim, 2);
+        ASSERT_EQ(var_r32->dims[0], 4);
+        ASSERT_EQ(var_r32->dims[1], 2);
+        ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
+        ASSERT_NE(var_r64, nullptr);
+        ASSERT_EQ(var_r64->ndim, 2);
+        ASSERT_EQ(var_r64->dims[0], 4);
+        ASSERT_EQ(var_r64->dims[1], 2);
+
+        std::array<char, 8> I8;
+        std::array<int16_t, 8> I16;
+        std::array<int32_t, 8> I32;
+        std::array<int64_t, 8> I64;
+        std::array<unsigned char, 8> U8;
+        std::array<uint16_t, 8> U16;
+        std::array<uint32_t, 8> U32;
+        std::array<uint64_t, 8> U64;
+        std::array<float, 8> R32;
+        std::array<double, 8> R64;
+
+        uint64_t start[2] = {0, 0};
+        uint64_t count[2] = {4, 2};
+        ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
+
+        // Read stuff
+        for (size_t t = 0; t < 3; ++t)
+        {
+            // Read the current step
+            adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
+            adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
+            adios_schedule_read_byid(f, sel, var_i32->varid, t, 1, I32.data());
+            adios_schedule_read_byid(f, sel, var_i64->varid, t, 1, I64.data());
+            adios_schedule_read_byid(f, sel, var_u8->varid, t, 1, U8.data());
+            adios_schedule_read_byid(f, sel, var_u16->varid, t, 1, U16.data());
+            adios_schedule_read_byid(f, sel, var_u32->varid, t, 1, U32.data());
+            adios_schedule_read_byid(f, sel, var_u64->varid, t, 1, U64.data());
+            adios_schedule_read_byid(f, sel, var_r32->varid, t, 1, R32.data());
+            adios_schedule_read_byid(f, sel, var_r64->varid, t, 1, R64.data());
+            adios_perform_reads(f, 1);
+
+            // Check if it's correct
+            for (size_t i = 0; i < 8; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
+                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
+                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
+                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
+                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
+                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
+                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
+                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
+                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
+                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+            }
+        }
+
+        adios_selection_delete(sel);
+
+        // Cleanup variable structures
+        adios_free_varinfo(var_i8);
+        adios_free_varinfo(var_i16);
+        adios_free_varinfo(var_i32);
+        adios_free_varinfo(var_i64);
+        adios_free_varinfo(var_u8);
+        adios_free_varinfo(var_u16);
+        adios_free_varinfo(var_u32);
+        adios_free_varinfo(var_u64);
+        adios_free_varinfo(var_r32);
+        adios_free_varinfo(var_r64);
+
+        // Cleanup file
+        adios_read_close(f);
+    }
+}
+
+// ADIOS2 write, ADIOS2 read
+TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead2D4x2fstream)
+{
+    std::string fname = "ADIOS2BPWriteADIOS2BPRead2D4x2Testfstream.bp";
+
+    ASSERT_TRUE(false) << "ADIOS2 read API is not yet implemented";
+}
+
+//******************************************************************************
+// main
+//******************************************************************************
+
+int main(int argc, char **argv)
+{
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}

--- a/testing/adios2/engine/bp/TestBPWriteReadstdio.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadstdio.cpp
@@ -1,0 +1,712 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+#include <adios_read.h>
+
+#include <gtest/gtest.h>
+
+#include "../SmallTestData.h"
+
+class BPWriteReadTest : public ::testing::Test
+{
+public:
+    BPWriteReadTest() = default;
+
+    SmallTestData m_TestData;
+};
+
+//******************************************************************************
+// 1D 1x8 test data
+//******************************************************************************
+
+// ADIOS2 write, native ADIOS1 read
+TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8stdio)
+{
+    std::string fname = "ADIOS2BPWriteADIOS1Read1D8stdio.bp";
+
+    // Write test data using ADIOS2
+    {
+        adios2::ADIOS adios(true);
+        adios2::IO &io = adios.DeclareIO("TestIO");
+
+        // Declare 1D variables
+        {
+            auto &var_i8 =
+                io.DefineVariable<char>("i8", {}, {}, adios2::Dims{8});
+            auto &var_i16 =
+                io.DefineVariable<short>("i16", {}, {}, adios2::Dims{8});
+            auto &var_i32 =
+                io.DefineVariable<int>("i32", {}, {}, adios2::Dims{8});
+            auto &var_i64 =
+                io.DefineVariable<long>("i64", {}, {}, adios2::Dims{8});
+            auto &var_u8 =
+                io.DefineVariable<unsigned char>("u8", {}, {}, adios2::Dims{8});
+            auto &var_u16 = io.DefineVariable<unsigned short>("u16", {}, {},
+                                                              adios2::Dims{8});
+            auto &var_u32 =
+                io.DefineVariable<unsigned int>("u32", {}, {}, adios2::Dims{8});
+            auto &var_u64 = io.DefineVariable<unsigned long>("u64", {}, {},
+                                                             adios2::Dims{8});
+            auto &var_r32 =
+                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{8});
+            auto &var_r64 =
+                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{8});
+        }
+
+        // Create the BP Engine
+        io.SetEngine("BPFileWriter");
+        io.AddTransport("File", {{"Library", "stdio"}});
+
+        auto engine = io.Open(fname, adios2::OpenMode::Write);
+        ASSERT_NE(engine.get(), nullptr);
+
+        for (size_t step = 0; step < 3; ++step)
+        {
+            // Retrieve the variables that previously went out of scope
+            auto &var_i8 = io.GetVariable<char>("i8");
+            auto &var_i16 = io.GetVariable<short>("i16");
+            auto &var_i32 = io.GetVariable<int>("i32");
+            auto &var_i64 = io.GetVariable<long>("i64");
+            auto &var_u8 = io.GetVariable<unsigned char>("u8");
+            auto &var_u16 = io.GetVariable<unsigned short>("u16");
+            auto &var_u32 = io.GetVariable<unsigned int>("u32");
+            auto &var_u64 = io.GetVariable<unsigned long>("u64");
+            auto &var_r32 = io.GetVariable<float>("r32");
+            auto &var_r64 = io.GetVariable<double>("r64");
+
+            // Write each one
+            engine->Write(var_i8, m_TestData.I8.data() + step);
+            engine->Write(var_i16, m_TestData.I16.data() + step);
+            engine->Write(var_i32, m_TestData.I32.data() + step);
+            engine->Write(var_i64, m_TestData.I64.data() + step);
+            engine->Write(var_u8, m_TestData.U8.data() + step);
+            engine->Write(var_u16, m_TestData.U16.data() + step);
+            engine->Write(var_u32, m_TestData.U32.data() + step);
+            engine->Write(var_u64, m_TestData.U64.data() + step);
+            engine->Write(var_r32, m_TestData.R32.data() + step);
+            engine->Write(var_r64, m_TestData.R64.data() + step);
+
+            // Advance to the next time step
+            engine->Advance();
+        }
+
+        // Close the file
+        engine->Close();
+    }
+
+// Read test data using ADIOS1
+#ifdef ADIOS2_HAVE_MPI
+    // Read everything from rank 0
+    int rank;
+    MPI_Comm_rank();
+    if (rank == 0)
+#endif
+    {
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+                               "verbose=3");
+
+        // Open the file for reading
+        ADIOS_FILE *f =
+            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
+                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        ASSERT_NE(f, nullptr);
+
+        // Check the variables exist
+        ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
+        ASSERT_NE(var_i8, nullptr);
+        ASSERT_EQ(var_i8->ndim, 1);
+        ASSERT_EQ(var_i8->dims[0], 8);
+        ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
+        ASSERT_NE(var_i16, nullptr);
+        ASSERT_EQ(var_i16->ndim, 1);
+        ASSERT_EQ(var_i16->dims[0], 8);
+        ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
+        ASSERT_NE(var_i32, nullptr);
+        ASSERT_EQ(var_i32->ndim, 1);
+        ASSERT_EQ(var_i32->dims[0], 8);
+        ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
+        ASSERT_NE(var_i64, nullptr);
+        ASSERT_EQ(var_i64->ndim, 1);
+        ASSERT_EQ(var_i64->dims[0], 8);
+        ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
+        ASSERT_NE(var_u8, nullptr);
+        ASSERT_EQ(var_u8->ndim, 1);
+        ASSERT_EQ(var_u8->dims[0], 8);
+        ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
+        ASSERT_NE(var_u16, nullptr);
+        ASSERT_EQ(var_u16->ndim, 1);
+        ASSERT_EQ(var_u16->dims[0], 8);
+        ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
+        ASSERT_NE(var_u32, nullptr);
+        ASSERT_EQ(var_u32->ndim, 1);
+        ASSERT_EQ(var_u32->dims[0], 8);
+        ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
+        ASSERT_NE(var_u64, nullptr);
+        ASSERT_EQ(var_u64->ndim, 1);
+        ASSERT_EQ(var_u64->dims[0], 8);
+        ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
+        ASSERT_NE(var_r32, nullptr);
+        ASSERT_EQ(var_r32->ndim, 1);
+        ASSERT_EQ(var_r32->dims[0], 8);
+        ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
+        ASSERT_NE(var_r64, nullptr);
+        ASSERT_EQ(var_r64->ndim, 1);
+        ASSERT_EQ(var_r64->dims[0], 8);
+
+        std::array<char, 8> I8;
+        std::array<int16_t, 8> I16;
+        std::array<int32_t, 8> I32;
+        std::array<int64_t, 8> I64;
+        std::array<unsigned char, 8> U8;
+        std::array<uint16_t, 8> U16;
+        std::array<uint32_t, 8> U32;
+        std::array<uint64_t, 8> U64;
+        std::array<float, 8> R32;
+        std::array<double, 8> R64;
+
+        uint64_t start[1] = {0};
+        uint64_t count[1] = {8};
+        ADIOS_SELECTION *sel = adios_selection_boundingbox(1, start, count);
+
+        // Read stuff
+        for (size_t t = 0; t < 3; ++t)
+        {
+            // Read the current step
+            adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
+            adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
+            adios_schedule_read_byid(f, sel, var_i32->varid, t, 1, I32.data());
+            adios_schedule_read_byid(f, sel, var_i64->varid, t, 1, I64.data());
+            adios_schedule_read_byid(f, sel, var_u8->varid, t, 1, U8.data());
+            adios_schedule_read_byid(f, sel, var_u16->varid, t, 1, U16.data());
+            adios_schedule_read_byid(f, sel, var_u32->varid, t, 1, U32.data());
+            adios_schedule_read_byid(f, sel, var_u64->varid, t, 1, U64.data());
+            adios_schedule_read_byid(f, sel, var_r32->varid, t, 1, R32.data());
+            adios_schedule_read_byid(f, sel, var_r64->varid, t, 1, R64.data());
+            adios_perform_reads(f, 1);
+
+            // Check if it's correct
+            for (size_t i = 0; i < 8; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
+                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
+                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
+                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
+                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
+                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
+                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
+                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
+                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
+                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+            }
+        }
+
+        adios_selection_delete(sel);
+
+        // Cleanup variable structures
+        adios_free_varinfo(var_i8);
+        adios_free_varinfo(var_i16);
+        adios_free_varinfo(var_i32);
+        adios_free_varinfo(var_i64);
+        adios_free_varinfo(var_u8);
+        adios_free_varinfo(var_u16);
+        adios_free_varinfo(var_u32);
+        adios_free_varinfo(var_u64);
+        adios_free_varinfo(var_r32);
+        adios_free_varinfo(var_r64);
+
+        // Cleanup file
+        adios_read_close(f);
+    }
+}
+
+// ADIOS2 write, ADIOS2 read
+TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead1D8stdio)
+{
+    std::string fname = "ADIOS2BPWriteADIOS2BPRead1D8stdio.bp";
+
+    ASSERT_TRUE(false) << "ADIOS2 read API is not yet implemented";
+}
+
+//******************************************************************************
+// 2D 2x4 test data
+//******************************************************************************
+
+// ADIOS2 write, native ADIOS1 read
+TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4stdio)
+{
+    std::string fname = "ADIOS2BPWriteADIOS1Read2D2x4Teststdio.bp";
+
+    // Write test data using ADIOS2
+    {
+        adios2::ADIOS adios(true);
+        adios2::IO &io = adios.DeclareIO("TestIO");
+
+        // Declare 1D variables
+        {
+            auto &var_i8 =
+                io.DefineVariable<char>("i8", {}, {}, adios2::Dims{2, 4});
+            auto &var_i16 =
+                io.DefineVariable<short>("i16", {}, {}, adios2::Dims{2, 4});
+            auto &var_i32 =
+                io.DefineVariable<int>("i32", {}, {}, adios2::Dims{2, 4});
+            auto &var_i64 =
+                io.DefineVariable<long>("i64", {}, {}, adios2::Dims{2, 4});
+            auto &var_u8 = io.DefineVariable<unsigned char>("u8", {}, {},
+                                                            adios2::Dims{2, 4});
+            auto &var_u16 = io.DefineVariable<unsigned short>(
+                "u16", {}, {}, adios2::Dims{2, 4});
+            auto &var_u32 = io.DefineVariable<unsigned int>("u32", {}, {},
+                                                            adios2::Dims{2, 4});
+            auto &var_u64 = io.DefineVariable<unsigned long>(
+                "u64", {}, {}, adios2::Dims{2, 4});
+            auto &var_r32 =
+                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{2, 4});
+            auto &var_r64 =
+                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{2, 4});
+        }
+
+        // Create the BP Engine
+        io.SetEngine("BPFileWriter");
+        io.AddTransport("file", {{"Library", "stdio"}});
+
+        auto engine = io.Open(fname, adios2::OpenMode::Write);
+        ASSERT_NE(engine.get(), nullptr);
+
+        for (size_t step = 0; step < 3; ++step)
+        {
+            // Retrieve the variables that previously went out of scope
+            auto &var_i8 = io.GetVariable<char>("i8");
+            auto &var_i16 = io.GetVariable<short>("i16");
+            auto &var_i32 = io.GetVariable<int>("i32");
+            auto &var_i64 = io.GetVariable<long>("i64");
+            auto &var_u8 = io.GetVariable<unsigned char>("u8");
+            auto &var_u16 = io.GetVariable<unsigned short>("u16");
+            auto &var_u32 = io.GetVariable<unsigned int>("u32");
+            auto &var_u64 = io.GetVariable<unsigned long>("u64");
+            auto &var_r32 = io.GetVariable<float>("r32");
+            auto &var_r64 = io.GetVariable<double>("r64");
+
+            // Write each one
+            engine->Write(var_i8, m_TestData.I8.data() + step);
+            engine->Write(var_i16, m_TestData.I16.data() + step);
+            engine->Write(var_i32, m_TestData.I32.data() + step);
+            engine->Write(var_i64, m_TestData.I64.data() + step);
+            engine->Write(var_u8, m_TestData.U8.data() + step);
+            engine->Write(var_u16, m_TestData.U16.data() + step);
+            engine->Write(var_u32, m_TestData.U32.data() + step);
+            engine->Write(var_u64, m_TestData.U64.data() + step);
+            engine->Write(var_r32, m_TestData.R32.data() + step);
+            engine->Write(var_r64, m_TestData.R64.data() + step);
+
+            // Advance to the next time step
+            engine->Advance();
+        }
+
+        // Close the file
+        engine->Close();
+    }
+
+// Read test data using ADIOS1
+#ifdef ADIOS2_HAVE_MPI
+    // Read everything from rank 0
+    int rank;
+    MPI_Comm_rank();
+    if (rank == 0)
+#endif
+    {
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+                               "verbose=3");
+
+        // Open the file for reading
+        ADIOS_FILE *f =
+            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
+                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        ASSERT_NE(f, nullptr);
+
+        // Check the variables exist
+        ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
+        ASSERT_NE(var_i8, nullptr);
+        ASSERT_EQ(var_i8->ndim, 2);
+        ASSERT_EQ(var_i8->dims[0], 2);
+        ASSERT_EQ(var_i8->dims[1], 4);
+        ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
+        ASSERT_NE(var_i16, nullptr);
+        ASSERT_EQ(var_i16->ndim, 2);
+        ASSERT_EQ(var_i16->dims[0], 2);
+        ASSERT_EQ(var_i16->dims[1], 4);
+        ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
+        ASSERT_NE(var_i32, nullptr);
+        ASSERT_EQ(var_i32->ndim, 2);
+        ASSERT_EQ(var_i32->dims[0], 2);
+        ASSERT_EQ(var_i32->dims[1], 4);
+        ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
+        ASSERT_NE(var_i64, nullptr);
+        ASSERT_EQ(var_i64->ndim, 2);
+        ASSERT_EQ(var_i64->dims[0], 2);
+        ASSERT_EQ(var_i64->dims[1], 4);
+        ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
+        ASSERT_NE(var_u8, nullptr);
+        ASSERT_EQ(var_u8->ndim, 2);
+        ASSERT_EQ(var_u8->dims[0], 2);
+        ASSERT_EQ(var_u8->dims[1], 4);
+        ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
+        ASSERT_NE(var_u16, nullptr);
+        ASSERT_EQ(var_u16->ndim, 2);
+        ASSERT_EQ(var_u16->dims[0], 2);
+        ASSERT_EQ(var_u16->dims[1], 4);
+        ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
+        ASSERT_NE(var_u32, nullptr);
+        ASSERT_EQ(var_u32->ndim, 2);
+        ASSERT_EQ(var_u32->dims[0], 2);
+        ASSERT_EQ(var_u32->dims[1], 4);
+        ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
+        ASSERT_NE(var_u64, nullptr);
+        ASSERT_EQ(var_u64->ndim, 2);
+        ASSERT_EQ(var_u64->dims[0], 2);
+        ASSERT_EQ(var_u64->dims[1], 4);
+        ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
+        ASSERT_NE(var_r32, nullptr);
+        ASSERT_EQ(var_r32->ndim, 2);
+        ASSERT_EQ(var_r32->dims[0], 2);
+        ASSERT_EQ(var_r32->dims[1], 4);
+        ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
+        ASSERT_NE(var_r64, nullptr);
+        ASSERT_EQ(var_r64->ndim, 2);
+        ASSERT_EQ(var_r64->dims[0], 2);
+        ASSERT_EQ(var_r64->dims[1], 4);
+
+        std::array<char, 8> I8;
+        std::array<int16_t, 8> I16;
+        std::array<int32_t, 8> I32;
+        std::array<int64_t, 8> I64;
+        std::array<unsigned char, 8> U8;
+        std::array<uint16_t, 8> U16;
+        std::array<uint32_t, 8> U32;
+        std::array<uint64_t, 8> U64;
+        std::array<float, 8> R32;
+        std::array<double, 8> R64;
+
+        uint64_t start[2] = {0, 0};
+        uint64_t count[2] = {2, 4};
+        ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
+
+        // Read stuff
+        for (size_t t = 0; t < 3; ++t)
+        {
+            // Read the current step
+            adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
+            adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
+            adios_schedule_read_byid(f, sel, var_i32->varid, t, 1, I32.data());
+            adios_schedule_read_byid(f, sel, var_i64->varid, t, 1, I64.data());
+            adios_schedule_read_byid(f, sel, var_u8->varid, t, 1, U8.data());
+            adios_schedule_read_byid(f, sel, var_u16->varid, t, 1, U16.data());
+            adios_schedule_read_byid(f, sel, var_u32->varid, t, 1, U32.data());
+            adios_schedule_read_byid(f, sel, var_u64->varid, t, 1, U64.data());
+            adios_schedule_read_byid(f, sel, var_r32->varid, t, 1, R32.data());
+            adios_schedule_read_byid(f, sel, var_r64->varid, t, 1, R64.data());
+            adios_perform_reads(f, 1);
+
+            // Check if it's correct
+            for (size_t i = 0; i < 8; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
+                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
+                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
+                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
+                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
+                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
+                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
+                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
+                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
+                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+            }
+        }
+
+        adios_selection_delete(sel);
+
+        // Cleanup variable structures
+        adios_free_varinfo(var_i8);
+        adios_free_varinfo(var_i16);
+        adios_free_varinfo(var_i32);
+        adios_free_varinfo(var_i64);
+        adios_free_varinfo(var_u8);
+        adios_free_varinfo(var_u16);
+        adios_free_varinfo(var_u32);
+        adios_free_varinfo(var_u64);
+        adios_free_varinfo(var_r32);
+        adios_free_varinfo(var_r64);
+
+        // Cleanup file
+        adios_read_close(f);
+    }
+}
+
+// ADIOS2 write, ADIOS2 read
+TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead2D2x4stdio)
+{
+    std::string fname = "ADIOS2BPWriteADIOS2BPRead2D2x4Teststdio.bp";
+
+    ASSERT_TRUE(false) << "ADIOS2 read API is not yet implemented";
+}
+
+//******************************************************************************
+// 2D 4x2 test data
+//******************************************************************************
+
+// ADIOS2 write, native ADIOS1 read
+TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2stdio)
+{
+    std::string fname = "ADIOS2BPWriteADIOS1Read2D4x2Teststdio.bp";
+
+    // Write test data using ADIOS2
+    {
+        adios2::ADIOS adios(true);
+        adios2::IO &io = adios.DeclareIO("TestIO");
+
+        // Declare 1D variables
+        {
+            auto &var_i8 =
+                io.DefineVariable<char>("i8", {}, {}, adios2::Dims{4, 2});
+            auto &var_i16 =
+                io.DefineVariable<short>("i16", {}, {}, adios2::Dims{4, 2});
+            auto &var_i32 =
+                io.DefineVariable<int>("i32", {}, {}, adios2::Dims{4, 2});
+            auto &var_i64 =
+                io.DefineVariable<long>("i64", {}, {}, adios2::Dims{4, 2});
+            auto &var_u8 = io.DefineVariable<unsigned char>("u8", {}, {},
+                                                            adios2::Dims{4, 2});
+            auto &var_u16 = io.DefineVariable<unsigned short>(
+                "u16", {}, {}, adios2::Dims{4, 2});
+            auto &var_u32 = io.DefineVariable<unsigned int>("u32", {}, {},
+                                                            adios2::Dims{4, 2});
+            auto &var_u64 = io.DefineVariable<unsigned long>(
+                "u64", {}, {}, adios2::Dims{4, 2});
+            auto &var_r32 =
+                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{4, 2});
+            auto &var_r64 =
+                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{4, 2});
+        }
+
+        // Create the BP Engine
+        io.SetEngine("BPFileWriter");
+        io.AddTransport("file", {{"Library", "stdio"}});
+
+        auto engine = io.Open(fname, adios2::OpenMode::Write);
+        ASSERT_NE(engine.get(), nullptr);
+
+        for (size_t step = 0; step < 3; ++step)
+        {
+            // Retrieve the variables that previously went out of scope
+            auto &var_i8 = io.GetVariable<char>("i8");
+            auto &var_i16 = io.GetVariable<short>("i16");
+            auto &var_i32 = io.GetVariable<int>("i32");
+            auto &var_i64 = io.GetVariable<long>("i64");
+            auto &var_u8 = io.GetVariable<unsigned char>("u8");
+            auto &var_u16 = io.GetVariable<unsigned short>("u16");
+            auto &var_u32 = io.GetVariable<unsigned int>("u32");
+            auto &var_u64 = io.GetVariable<unsigned long>("u64");
+            auto &var_r32 = io.GetVariable<float>("r32");
+            auto &var_r64 = io.GetVariable<double>("r64");
+
+            // Write each one
+            engine->Write(var_i8, m_TestData.I8.data() + step);
+            engine->Write(var_i16, m_TestData.I16.data() + step);
+            engine->Write(var_i32, m_TestData.I32.data() + step);
+            engine->Write(var_i64, m_TestData.I64.data() + step);
+            engine->Write(var_u8, m_TestData.U8.data() + step);
+            engine->Write(var_u16, m_TestData.U16.data() + step);
+            engine->Write(var_u32, m_TestData.U32.data() + step);
+            engine->Write(var_u64, m_TestData.U64.data() + step);
+            engine->Write(var_r32, m_TestData.R32.data() + step);
+            engine->Write(var_r64, m_TestData.R64.data() + step);
+
+            // Advance to the next time step
+            engine->Advance();
+        }
+
+        // Close the file
+        engine->Close();
+    }
+
+// Read test data using ADIOS1
+#ifdef ADIOS2_HAVE_MPI
+    // Read everything from rank 0
+    int rank;
+    MPI_Comm_rank();
+    if (rank == 0)
+#endif
+    {
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+                               "verbose=3");
+
+        // Open the file for reading
+        ADIOS_FILE *f =
+            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
+                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        ASSERT_NE(f, nullptr);
+
+        // Check the variables exist
+        ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
+        ASSERT_NE(var_i8, nullptr);
+        ASSERT_EQ(var_i8->ndim, 2);
+        ASSERT_EQ(var_i8->dims[0], 4);
+        ASSERT_EQ(var_i8->dims[1], 2);
+        ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
+        ASSERT_NE(var_i16, nullptr);
+        ASSERT_EQ(var_i16->ndim, 2);
+        ASSERT_EQ(var_i16->dims[0], 4);
+        ASSERT_EQ(var_i16->dims[1], 2);
+        ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
+        ASSERT_NE(var_i32, nullptr);
+        ASSERT_EQ(var_i32->ndim, 2);
+        ASSERT_EQ(var_i32->dims[0], 4);
+        ASSERT_EQ(var_i32->dims[1], 2);
+        ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
+        ASSERT_NE(var_i64, nullptr);
+        ASSERT_EQ(var_i64->ndim, 2);
+        ASSERT_EQ(var_i64->dims[0], 4);
+        ASSERT_EQ(var_i64->dims[1], 2);
+        ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
+        ASSERT_NE(var_u8, nullptr);
+        ASSERT_EQ(var_u8->ndim, 2);
+        ASSERT_EQ(var_u8->dims[0], 4);
+        ASSERT_EQ(var_u8->dims[1], 2);
+        ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
+        ASSERT_NE(var_u16, nullptr);
+        ASSERT_EQ(var_u16->ndim, 2);
+        ASSERT_EQ(var_u16->dims[0], 4);
+        ASSERT_EQ(var_u16->dims[1], 2);
+        ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
+        ASSERT_NE(var_u32, nullptr);
+        ASSERT_EQ(var_u32->ndim, 2);
+        ASSERT_EQ(var_u32->dims[0], 4);
+        ASSERT_EQ(var_u32->dims[1], 2);
+        ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
+        ASSERT_NE(var_u64, nullptr);
+        ASSERT_EQ(var_u64->ndim, 2);
+        ASSERT_EQ(var_u64->dims[0], 4);
+        ASSERT_EQ(var_u64->dims[1], 2);
+        ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
+        ASSERT_NE(var_r32, nullptr);
+        ASSERT_EQ(var_r32->ndim, 2);
+        ASSERT_EQ(var_r32->dims[0], 4);
+        ASSERT_EQ(var_r32->dims[1], 2);
+        ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
+        ASSERT_NE(var_r64, nullptr);
+        ASSERT_EQ(var_r64->ndim, 2);
+        ASSERT_EQ(var_r64->dims[0], 4);
+        ASSERT_EQ(var_r64->dims[1], 2);
+
+        std::array<char, 8> I8;
+        std::array<int16_t, 8> I16;
+        std::array<int32_t, 8> I32;
+        std::array<int64_t, 8> I64;
+        std::array<unsigned char, 8> U8;
+        std::array<uint16_t, 8> U16;
+        std::array<uint32_t, 8> U32;
+        std::array<uint64_t, 8> U64;
+        std::array<float, 8> R32;
+        std::array<double, 8> R64;
+
+        uint64_t start[2] = {0, 0};
+        uint64_t count[2] = {4, 2};
+        ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
+
+        // Read stuff
+        for (size_t t = 0; t < 3; ++t)
+        {
+            // Read the current step
+            adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
+            adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
+            adios_schedule_read_byid(f, sel, var_i32->varid, t, 1, I32.data());
+            adios_schedule_read_byid(f, sel, var_i64->varid, t, 1, I64.data());
+            adios_schedule_read_byid(f, sel, var_u8->varid, t, 1, U8.data());
+            adios_schedule_read_byid(f, sel, var_u16->varid, t, 1, U16.data());
+            adios_schedule_read_byid(f, sel, var_u32->varid, t, 1, U32.data());
+            adios_schedule_read_byid(f, sel, var_u64->varid, t, 1, U64.data());
+            adios_schedule_read_byid(f, sel, var_r32->varid, t, 1, R32.data());
+            adios_schedule_read_byid(f, sel, var_r64->varid, t, 1, R64.data());
+            adios_perform_reads(f, 1);
+
+            // Check if it's correct
+            for (size_t i = 0; i < 8; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
+                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
+                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
+                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
+                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
+                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
+                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
+                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
+                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
+                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+            }
+        }
+
+        adios_selection_delete(sel);
+
+        // Cleanup variable structures
+        adios_free_varinfo(var_i8);
+        adios_free_varinfo(var_i16);
+        adios_free_varinfo(var_i32);
+        adios_free_varinfo(var_i64);
+        adios_free_varinfo(var_u8);
+        adios_free_varinfo(var_u16);
+        adios_free_varinfo(var_u32);
+        adios_free_varinfo(var_u64);
+        adios_free_varinfo(var_r32);
+        adios_free_varinfo(var_r64);
+
+        // Cleanup file
+        adios_read_close(f);
+    }
+}
+
+// ADIOS2 write, ADIOS2 read
+TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead2D4x2stdio)
+{
+    std::string fname = "ADIOS2BPWriteADIOS2BPRead2D4x2Teststdio.bp";
+
+    ASSERT_TRUE(false) << "ADIOS2 read API is not yet implemented";
+}
+
+//******************************************************************************
+// main
+//******************************************************************************
+
+int main(int argc, char **argv)
+{
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}


### PR DESCRIPTION
Checking std::ios_base::failure exceptions
IOChrono is off by default, each owner turns it on explicitly
Modified FileDescriptor and FilePointer destructors
Added Tests BPWriteRead for stdio and fstream
Removed IO AddTransport with vector (shoud have been there?) to enable
AddTransport in Tests