### PR TITLE
Async I/O implementation of adios Write in heat transfer examples

### DIFF
--- a/examples/heatTransfer/write/CMakeLists.txt
+++ b/examples/heatTransfer/write/CMakeLists.txt
@@ -15,7 +15,7 @@ if(ADIOS2_HAVE_MPI)
   target_include_directories(heatTransfer_write_adios2
     PRIVATE ${MPI_C_INCLUDE_PATH}
   )
-  target_link_libraries(heatTransfer_write_adios2 adios2 ${MPI_C_LIBRARIES})
+  target_link_libraries(heatTransfer_write_adios2 adios2 ${MPI_C_LIBRARIES} pthread)
   target_compile_definitions(heatTransfer_write_adios2 PRIVATE
    -DDEFAULT_CONFIG=${CMAKE_CURRENT_SOURCE_DIR}/config.xml)
 
@@ -33,7 +33,7 @@ if(ADIOS2_HAVE_MPI)
       PRIVATE ${MPI_C_INCLUDE_PATH}
     )
     target_link_libraries(heatTransfer_write_adios1
-      adios1::adios ${MPI_C_LIBRARIES}
+      adios1::adios ${MPI_C_LIBRARIES} pthread
     )
   endif()
 
@@ -51,7 +51,7 @@ if(ADIOS2_HAVE_MPI)
       PRIVATE ${MPI_C_INCLUDE_PATH} ${HDF5_C_INCLUDE_DIRS}
     )
     target_link_libraries(heatTransfer_write_hdf5
-      ${MPI_C_LIBRARIES} ${HDF5_C_LIBRARIES}
+      ${MPI_C_LIBRARIES} ${HDF5_C_LIBRARIES} pthread
     )
   endif()
 
@@ -70,7 +70,7 @@ if(ADIOS2_HAVE_MPI)
       PRIVATE ${MPI_C_INCLUDE_PATH} ${HDF5_C_INCLUDE_DIRS}
     )
     target_link_libraries(heatTransfer_write_ph5
-      ${MPI_C_LIBRARIES} ${HDF5_C_LIBRARIES}
+      ${MPI_C_LIBRARIES} ${HDF5_C_LIBRARIES} pthread
     )
   endif()
 
@@ -91,7 +91,7 @@ if(ADIOS2_HAVE_MPI)
     #target_link_libraries(heatTransfer_write_a2h5
     #  ${MPI_C_LIBRARIES} 
     #)
-    target_link_libraries(heatTransfer_write_a2h5 PUBLIC adios2)
+    target_link_libraries(heatTransfer_write_a2h5 PUBLIC adios2 pthread)
 
   endif()
 

--- a/examples/heatTransfer/write/CMakeLists.txt
+++ b/examples/heatTransfer/write/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 if(ADIOS2_HAVE_MPI)
   find_package(MPI COMPONENTS C REQUIRED)
+  find_package(Threads REQUIRED)
 
   add_executable(heatTransfer_write_adios2
     main.cpp
@@ -15,13 +16,15 @@ if(ADIOS2_HAVE_MPI)
   target_include_directories(heatTransfer_write_adios2
     PRIVATE ${MPI_C_INCLUDE_PATH}
   )
-  target_link_libraries(heatTransfer_write_adios2 adios2 ${MPI_C_LIBRARIES} pthread)
+  target_link_libraries(heatTransfer_write_adios2 adios2 ${MPI_C_LIBRARIES} 
+                        ${CMAKE_THREAD_LIBS_INIT})
   target_compile_definitions(heatTransfer_write_adios2 PRIVATE
    -DDEFAULT_CONFIG=${CMAKE_CURRENT_SOURCE_DIR}/config.xml)
 
   if(ADIOS2_HAVE_ADIOS1)
     find_package(ADIOS1 REQUIRED)
     find_package(MPI COMPONENTS C REQUIRED)
+    find_package(Threads REQUIRED)
 
     add_executable(heatTransfer_write_adios1
       main.cpp
@@ -33,13 +36,14 @@ if(ADIOS2_HAVE_MPI)
       PRIVATE ${MPI_C_INCLUDE_PATH}
     )
     target_link_libraries(heatTransfer_write_adios1
-      adios1::adios ${MPI_C_LIBRARIES} pthread
+      adios1::adios ${MPI_C_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
     )
   endif()
 
   if(ADIOS2_HAVE_HDF5)
     find_package(HDF5 REQUIRED)
     find_package(MPI COMPONENTS C REQUIRED)
+    find_package(Threads REQUIRED)
 
     add_executable(heatTransfer_write_hdf5
       main.cpp
@@ -51,7 +55,7 @@ if(ADIOS2_HAVE_MPI)
       PRIVATE ${MPI_C_INCLUDE_PATH} ${HDF5_C_INCLUDE_DIRS}
     )
     target_link_libraries(heatTransfer_write_hdf5
-      ${MPI_C_LIBRARIES} ${HDF5_C_LIBRARIES} pthread
+      ${MPI_C_LIBRARIES} ${HDF5_C_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
     )
   endif()
 
@@ -59,6 +63,7 @@ if(ADIOS2_HAVE_MPI)
   if(ADIOS2_HAVE_HDF5)
     find_package(HDF5 REQUIRED)
     find_package(MPI COMPONENTS C REQUIRED)
+    find_package(Threads REQUIRED)
 
     add_executable(heatTransfer_write_ph5
       main.cpp
@@ -70,13 +75,14 @@ if(ADIOS2_HAVE_MPI)
       PRIVATE ${MPI_C_INCLUDE_PATH} ${HDF5_C_INCLUDE_DIRS}
     )
     target_link_libraries(heatTransfer_write_ph5
-      ${MPI_C_LIBRARIES} ${HDF5_C_LIBRARIES} pthread
+      ${MPI_C_LIBRARIES} ${HDF5_C_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
     )
   endif()
 
 
   if(ADIOS2_HAVE_HDF5)
      find_package(MPI COMPONENTS C REQUIRED)
+     find_package(Threads REQUIRED)
 
      add_executable(heatTransfer_write_a2h5
       main.cpp
@@ -91,7 +97,8 @@ if(ADIOS2_HAVE_MPI)
     #target_link_libraries(heatTransfer_write_a2h5
     #  ${MPI_C_LIBRARIES} 
     #)
-    target_link_libraries(heatTransfer_write_a2h5 PUBLIC adios2 pthread)
+    target_link_libraries(heatTransfer_write_a2h5 PUBLIC adios2 
+                          ${CMAKE_THREAD_LIBS_INIT})
 
   endif()
 

--- a/examples/heatTransfer/write/CMakeLists.txt
+++ b/examples/heatTransfer/write/CMakeLists.txt
@@ -24,7 +24,6 @@ if(ADIOS2_HAVE_MPI)
   if(ADIOS2_HAVE_ADIOS1)
     find_package(ADIOS1 REQUIRED)
     find_package(MPI COMPONENTS C REQUIRED)
-    find_package(Threads REQUIRED)
 
     add_executable(heatTransfer_write_adios1
       main.cpp
@@ -43,7 +42,6 @@ if(ADIOS2_HAVE_MPI)
   if(ADIOS2_HAVE_HDF5)
     find_package(HDF5 REQUIRED)
     find_package(MPI COMPONENTS C REQUIRED)
-    find_package(Threads REQUIRED)
 
     add_executable(heatTransfer_write_hdf5
       main.cpp
@@ -63,7 +61,6 @@ if(ADIOS2_HAVE_MPI)
   if(ADIOS2_HAVE_HDF5)
     find_package(HDF5 REQUIRED)
     find_package(MPI COMPONENTS C REQUIRED)
-    find_package(Threads REQUIRED)
 
     add_executable(heatTransfer_write_ph5
       main.cpp
@@ -82,7 +79,6 @@ if(ADIOS2_HAVE_MPI)
 
   if(ADIOS2_HAVE_HDF5)
      find_package(MPI COMPONENTS C REQUIRED)
-     find_package(Threads REQUIRED)
 
      add_executable(heatTransfer_write_a2h5
       main.cpp

--- a/examples/heatTransfer/write/Settings.cpp
+++ b/examples/heatTransfer/write/Settings.cpp
@@ -49,6 +49,24 @@ Settings::Settings(int argc, char *argv[], int rank, int nproc) : rank{rank}
     steps = convertToUint("steps", argv[6]);
     iterations = convertToUint("iterations", argv[7]);
 
+    if (argc == 9)
+    {
+        const std::string asyncArg(argv[8]);
+        if (asyncArg == "ON" || asyncArg == "on")
+        {
+            async = true;
+        }
+        else if (asyncArg == "OFF" || asyncArg == "off")
+        {
+            // nothing off is default
+        }
+        else
+        {
+            throw std::invalid_argument("ERROR: wrong async argument " +
+                                        asyncArg + " must be on or off\n");
+        }
+    }
+
     if (npx * npy != this->nproc)
     {
         throw std::invalid_argument("N*M must equal the number of processes");

--- a/examples/heatTransfer/write/Settings.h
+++ b/examples/heatTransfer/write/Settings.h
@@ -47,6 +47,9 @@ public:
     int rank_up;
     int rank_down;
 
+    /** true: std::async Write, false (default): sync */
+    bool async = false;
+
     Settings(int argc, char *argv[], int rank, int nproc);
 };
 


### PR DESCRIPTION
Added an extra argument to the heat transfer example to make I/O truly asynchronous using C++11 std::future and std::async. 

I can see some overlap:
sync: ./heatTransfer_write_adios2 ht2 1 1 2500 2500 500 10  --> 136 s

async : ./heatTransfer_write_adios2 ht2 1 1 2500 2500 500 10 on ---> 96 s