### PR TITLE
Add non cmake pacakge config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,10 @@ project(ADIOS2 VERSION 2.0.0)
 #------------------------------------------------------------------------------#
 # Some boilerplate to setup nice output directories
 #------------------------------------------------------------------------------#
-include(GNUInstallDirs)
-set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/adios2")
+set(CMAKE_INSTALL_BINDIR bin)
+set(CMAKE_INSTALL_LIBDIR lib)
+set(CMAKE_INSTALL_INCLUDEDIR include)
+set(CMAKE_INSTALL_CMAKEDIR lib/cmake/adios2)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${ADIOS2_SOURCE_DIR}/cmake")
 if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -27,7 +27,8 @@ if(ADIOS2_HAVE_MPI)
   target_link_libraries(adios2py PRIVATE PythonModule::mpi4py)
 endif()
 
-string(REGEX REPLACE "^${PYTHON_PREFIX}/" ""
+string(REGEX REPLACE
+  "^${PYTHON_PREFIX}/[^/]*/python" "${CMAKE_INSTALL_LIBDIR}/python"
   CMAKE_INSTALL_PYTHONDIR "${PYTHON_SITE_PACKAGES}"
 )
 set(CMAKE_INSTALL_PYTHONDIR "${CMAKE_INSTALL_PYTHONDIR}"

--- a/cmake/ADIOS2ConfigCommon.cmake.in
+++ b/cmake/ADIOS2ConfigCommon.cmake.in
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.5)
 
 include(CMakeFindDependencyMacro)
 
+set(ADIOS2_HAVE_MPI @ADIOS2_HAVE_MPI@)
+if(ADIOS2_HAVE_MPI)
+  find_dependency(MPI)
+endif()
+
 if(NOT @BUILD_SHARED_LIBS@)
   set(ADIOS2_HAVE_BZip2 @ADIOS2_HAVE_BZip2@)
   if(ADIOS2_HAVE_BZip2)
@@ -11,11 +16,6 @@ if(NOT @BUILD_SHARED_LIBS@)
   set(ADIOS2_HAVE_ZFP @ADIOS2_HAVE_ZFP@)
   if(ADIOS2_HAVE_ZFP)
     find_dependency(ZFP)
-  endif()
-
-  set(ADIOS2_HAVE_MPI @ADIOS2_HAVE_MPI@)
-  if(ADIOS2_HAVE_MPI)
-    find_dependency(MPI)
   endif()
 
   set(ADIOS2_HAVE_ZeroMQ @ADIOS2_HAVE_ZeroMQ@)

--- a/cmake/ADIOSFunctions.cmake
+++ b/cmake/ADIOSFunctions.cmake
@@ -47,6 +47,37 @@ function(GenerateADIOSHeaderConfig)
   )
 endfunction()
 
+macro(__adios2_list_cleanup_for_bash var)
+  if(${var})
+    list(REMOVE_DUPLICATES ${var})
+  endif()
+  string(REPLACE ";" " " ${var} "${${var}}")
+endmacro()
+
+function(__adios2_list_make_link_args var)
+  set(prefixes)
+  foreach(lib IN LISTS ${var})
+    if(lib MATCHES "^/")
+      get_filename_component(lib_dir "${lib}" DIRECTORY)
+      list(APPEND prefixes "${lib_dir}")
+    endif()
+  endforeach()
+
+  set(var_new)
+  foreach(prefix IN LISTS prefixes)
+    list(APPEND var_new "-L${prefix}")
+  endforeach()
+  foreach(lib IN LISTS ${var})
+    if(lib MATCHES "^/.*/?(${CMAKE_SHARED_LIBRARY_PREFIX}|${CMAKE_STATIC_LIBRARY_PREFIX})(.*)(${CMAKE_SHARED_LIBRARY_SUFFIX}|${CMAKE_STATIC_LIBRARY_SUFFIX})")
+      list(APPEND var_new "-l${CMAKE_MATCH_2}")
+    else()
+      list(APPEND var_new "${lib}")
+    endif()
+  endforeach()
+
+  set(${var} ${var_new} PARENT_SCOPE)
+endfunction()
+
 function(GenerateADIOSPackageConfig)
   include(CMakePackageConfigHelpers)
 
@@ -93,29 +124,72 @@ function(GenerateADIOSPackageConfig)
   )
 
   # Install helper find modules if needed
+  # Also build flags needed for non-cmake config generation
+  set(ADIOS2_CXX_LIBS ${CMAKE_THREAD_LIBS_INIT})
+  set(ADIOS2_CXX_OPTS ${CMAKE_CXX11_EXTENSION_COMPILE_OPTION})
+  set(ADIOS2_CXX_DEFS)
+  set(ADIOS2_CXX_INCS)
+  if(ADIOS2_HAVE_MPI)
+    list(APPEND ADIOS2_CXX_LIBS ${MPI_C_LIBRARIES})
+    list(APPEND ADIOS2_CXX_INCS ${MPI_C_INCLUDE_PATH})
+  endif()
   if(NOT BUILD_SHARED_LIBS)
+    if(ADIOS2_HAVE_DataMan)
+    list(APPEND ADIOS2_CXX_LIBS -ldataman)
+    endif()
     if(ADIOS2_HAVE_BZip2)
-    install(FILES cmake/FindBZip2.cmake
-      DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/Modules
-    )
-    install(FILES cmake/upstream/FindBZip2.cmake
-      DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/Modules/upstream
-    )
+      install(FILES cmake/FindBZip2.cmake
+        DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/Modules
+      )
+      install(FILES cmake/upstream/FindBZip2.cmake
+        DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/Modules/upstream
+      )
+      list(APPEND ADIOS2_CXX_LIBS ${BZIP2_LIBRARIES})
+      list(APPEND ADIOS2_CXX_INCS ${BZIP2_INCLUDE_DIR})
     endif()
     if(ADIOS2_HAVE_ZFP)
       install(FILES cmake/FindZFP.cmake
         DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/Modules
       )
+      list(APPEND ADIOS2_CXX_LIBS ${ZFP_LIBRARIES})
+      list(APPEND ADIOS2_CXX_INCS ${ZFP_INCLUDE_DIRS})
     endif()
     if(ADIOS2_HAVE_ZeroMQ)
       install(FILES cmake/FindZeroMQ.cmake
         DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/Modules
       )
+      list(APPEND ADIOS2_CXX_LIBS ${ZeroMQ_LIBRARIES})
+      list(APPEND ADIOS2_CXX_INCS ${ZeroMQ_INCLUDE_DIRS})
     endif()
     if(ADIOS2_HAVE_ADIOS1)
       install(FILES cmake/FindADIOS1.cmake
         DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/Modules
       )
+      list(APPEND ADIOS2_CXX_LIBS ${ADIOS1_LIBRARIES})
+      list(APPEND ADIOS2_CXX_INCS ${ADIOS1_INCLUDE_DIRS})
+    endif()
+    if(ADIOS2_HAVE_HDF5)
+      list(APPEND ADIOS2_CXX_LIBS ${HDF5_C_LIBRARIES})
+      if(HDF5_C_INCLUDE_DIRS)
+        list(APPEND ADIOS2_CXX_INCS ${HDF5_C_INCLUDE_DIRS})
+      else()
+        list(APPEND ADIOS2_CXX_INCS ${HDF5_INCLUDE_DIRS})
+      endif()
     endif()
   endif()
+
+  # Build the non-cmake config script
+  __adios2_list_make_link_args(ADIOS2_CXX_LIBS)
+  __adios2_list_cleanup_for_bash(ADIOS2_CXX_LIBS)
+  __adios2_list_cleanup_for_bash(ADIOS2_CXX_OPTS)
+  __adios2_list_cleanup_for_bash(ADIOS2_CXX_DEFS)
+  __adios2_list_cleanup_for_bash(ADIOS2_CXX_INCS)
+  configure_file(
+    ${ADIOS2_SOURCE_DIR}/cmake/adios2-config.in
+    ${ADIOS2_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/adios2-config
+    @ONLY
+  )
+  install(PROGRAMS ${ADIOS2_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/adios2-config
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )
 endfunction()

--- a/cmake/adios2-config.in
+++ b/cmake/adios2-config.in
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+function usage() {
+  echo "Usage: $1 [OPTION]"
+  echo
+  echo "Known values for OPTION are:"
+  echo
+  echo "  --prefix      print installation prefix"
+  echo "  --libs        print library linling information"
+  echo "  --cxxflags    print preprocessor and compiler flags"
+  echo "  --help        display this help and exit"
+  echo "  --version     output version information"
+}
+
+if [ $# -ne 1 ]
+then
+  usage $0
+  exit 1
+fi
+
+prefix=$(readlink -f $(dirname ${BASH_SOURCE})/..)
+ADIOS2_CXX_LIBS=$(echo "@ADIOS2_CXX_LIBS@")
+ADIOS2_CXX_OPTS=$(echo "@ADIOS2_CXX_OPTS@")
+ADIOS2_CXX_DEFS=$(echo "@ADIOS2_CXX_DEFS@")
+ADIOS2_CXX_INCS=$(echo "@ADIOS2_CXX_INCS@")
+
+case $1 in
+  --prefix) echo ${prefix} ;;
+  --libs)
+    echo -n "-L${prefix}/@CMAKE_INSTALL_LIBDIR@ -ladios2 "
+    for LIB in ${ADIOS2_CXX_LIBS}
+    do
+      echo -n "${LIB} "
+    done
+    echo
+    ;;
+  --cxxflags)
+    for OPT in ${ADIOS2_CXX_OPTS}
+    do
+      echo -n "${OPT} "
+    done
+    for DEF in ${ADIOS2_CXX_DEFS}
+    do
+      echo -n "-D${DEF} "
+    done
+    for INC in ${ADIOS2_CXX_INCS}
+    do
+      echo -n "-I${prefix}/@CMAKE_INSTALL_INCLUDEDIR@ "
+    done
+    echo
+    ;;
+  --version) echo @ADIOS2_VERSION@ ;;
+  --help)
+    usage
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This adds an adios2-config shell script that will generate the necessary build flags for a non-cmake project to use ADIOS2.

Also Fixes #154