### PR TITLE
Solve Issue #211 and made changes due to Windows warnings and bugs

### DIFF
--- a/examples/hello/bpWriter/helloBPWriter_nompi.cpp
+++ b/examples/hello/bpWriter/helloBPWriter_nompi.cpp
@@ -29,7 +29,6 @@ int main(int argc, char *argv[])
         /*** IO class object: settings and factory of Settings: Variables,
          * Parameters, Transports, and Execution: Engines */
         adios2::IO &bpIO = adios.DeclareIO("BPFile_N2N");
-        bpIO.AddTransport("File", {{"Library", "stdio"}});
 
         /** global array: name, { shape (total dimensions) }, { start (local) },
          * { count (local) }, all are constant dimensions */

--- a/source/adios2/ADIOSTypes.h
+++ b/source/adios2/ADIOSTypes.h
@@ -144,7 +144,7 @@ enum class SelectionType
 
 // adios defaults
 #ifdef _WIN32
-const std::string DefaultFileLibrary("stdio");
+const std::string DefaultFileLibrary("fstream");
 #else
 const std::string DefaultFileLibrary("POSIX");
 #endif
@@ -160,7 +160,7 @@ constexpr size_t DefaultMaxBufferSize(std::numeric_limits<size_t>::max() - 1);
 
 /** default buffer growth factor. Needs to be studied
  * for optimizing applications*/
-constexpr float DefaultBufferGrowthFactor(1.05);
+constexpr float DefaultBufferGrowthFactor(1.05f);
 
 /** default size for writing/reading files using POSIX/fstream/stdio write
  *  2Gb - 100Kb (tolerance)*/

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(adios2
   
 #helper
   helper/adiosMath.cpp
+  helper/adiosMPIFunctions.cpp
   helper/adiosString.cpp
   helper/adiosSystem.cpp
   helper/adiosType.cpp

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -33,7 +33,9 @@ class ADIOS
 public:
     /** Passed from parallel constructor, MPI_Comm is a pointer itself. */
     MPI_Comm m_MPIComm;
-    std::string m_HostLanguage = "C++"; ///< changed by language bindings
+
+    /** Changed by language bindings */
+    std::string m_HostLanguage = "C++";
 
     /**
      * @brief Constructor for MPI applications WITH a XML config file
@@ -66,6 +68,13 @@ public:
      */
     ADIOS(const bool debugMode = false);
 
+    /**
+     * Delete copy constructor explicitly. Objects shouldn't be allowed to be
+     * redefined. Use smart pointers if this is absolutely necessary.
+     * @param adios reference to another adios object
+     */
+    ADIOS(const ADIOS &adios) = delete;
+
     ~ADIOS() = default;
 
     /**
@@ -81,16 +90,18 @@ public:
     IO &DeclareIO(const std::string ioName);
 
     /**
-     * Retrieve an already defined IO object
+     * Retrieve an already defined IO object. Make sure IO was previously
+     * created with DeclareIO. Otherwise, throws an exception in debug mode.
+     * @return reference to existing IO object inside ADIOS
      */
     IO &GetIO(const std::string name);
 
-protected: // no const member to allow default empty and copy constructors
+private:
     /** XML File to be read containing configuration information */
-    std::string m_ConfigFile;
+    const std::string m_ConfigFile;
 
     /** if true will do more checks, exceptions, warnings, expect slower code */
-    bool m_DebugMode = false;
+    const bool m_DebugMode = false;
 
     /** transforms associated with ADIOS run */
     std::vector<std::shared_ptr<Transform>> m_Transforms;

--- a/source/adios2/helper/adiosFunctions.h
+++ b/source/adios2/helper/adiosFunctions.h
@@ -12,9 +12,10 @@
 #ifndef ADIOS2_HELPER_ADIOSFUNCTIONS_H_
 #define ADIOS2_HELPER_ADIOSFUNCTIONS_H_
 
-#include "adios2/helper/adiosMath.h"   //math functions (cmath, algorithm)
-#include "adios2/helper/adiosMemory.h" //memcpy, std::copy, insert, resize
-#include "adios2/helper/adiosString.h" //std::string manipulation
+#include "adios2/helper/adiosMPIFunctions.h" //MPI functions (Bcast, send/recv)
+#include "adios2/helper/adiosMath.h"         //math functions (cmath, algorithm)
+#include "adios2/helper/adiosMemory.h"       //memcpy, std::copy, insert, resize
+#include "adios2/helper/adiosString.h"       //std::string manipulation
 #include "adios2/helper/adiosSystem.h" //OS functionality, POSIX, filesystem
 #include "adios2/helper/adiosType.h"   //Type casting, conversion, checks, etc.
 #include "adios2/helper/adiosXML.h"    //XML parsing

--- a/source/adios2/helper/adiosMPIFunctions.cpp
+++ b/source/adios2/helper/adiosMPIFunctions.cpp
@@ -1,0 +1,46 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosMPIFunctions.cpp
+ *
+ *  Created on: Jul 20, 2017
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+#include "adiosMPIFunctions.h"
+
+#include "adios2/ADIOSMPI.h"
+#include "adios2/ADIOSTypes.h"
+
+namespace adios2
+{
+
+std::string BroadcastString(const std::string &input, MPI_Comm mpiComm,
+                            const int rankSource)
+{
+    int rank;
+    MPI_Comm_rank(mpiComm, &rank);
+    size_t length = 0;
+    std::string output;
+
+    if (rank == rankSource)
+    {
+        length = input.size();
+        MPI_Bcast(&length, 1, ADIOS2_MPI_SIZE_T, rankSource, mpiComm);
+
+        MPI_Bcast(const_cast<char *>(input.data()), length, MPI_CHAR,
+                  rankSource, mpiComm);
+
+        return input;
+    }
+    else
+    {
+        MPI_Bcast(&length, 1, ADIOS2_MPI_SIZE_T, rankSource, mpiComm);
+        output.resize(length);
+        MPI_Bcast(const_cast<char *>(output.data()), length, MPI_CHAR,
+                  rankSource, mpiComm);
+    }
+    return output;
+}
+
+} // end namespace adios2

--- a/source/adios2/helper/adiosMPIFunctions.h
+++ b/source/adios2/helper/adiosMPIFunctions.h
@@ -1,0 +1,36 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosMPIFunctions.h : collection of MPI functions used across adios2
+ *
+ *  Created on: Jul 20, 2017
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#ifndef ADIOS2_HELPER_ADIOMPIFUNCTIONS_H_
+#define ADIOS2_HELPER_ADIOMPIFUNCTIONS_H_
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <string>
+/// \endcond
+
+#include "adios2/ADIOSMPICommOnly.h"
+
+namespace adios2
+{
+
+/**
+ * rankSource: owns a string and broadcast to all other ranks
+ * Others: receive std::vector<char> and copy to a string
+ * @param mpiComm MPI communicator defining all ranks and size domain
+ * @param input string input from rankSource
+ * @param rankSource rank that broadcast the string, (default = 0)
+ * @return input contents for each rank
+ */
+std::string BroadcastString(const std::string &input, MPI_Comm mpiComm,
+                            const int rankSource = 0);
+
+} // end namespace adios2
+
+#endif /* ADIOS2_HELPER_ADIOMPIFUNCTIONS_H_ */

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -83,6 +83,14 @@ void MemcpyToBufferThreads(std::vector<char> &buffer, size_t &position,
                            const T *source, size_t size,
                            const unsigned int threads = 1);
 
+/**
+ * Cast an element to uint64 and insert to a buffer
+ * @param buffer data destination
+ * @param element to be added to buffer
+ */
+template <class T>
+void InsertU64(std::vector<char> &buffer, const T element) noexcept;
+
 } // end namespace adios
 
 #include "adiosMemory.inl"

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -25,7 +25,7 @@ namespace adios2
 
 template <class T>
 void InsertToBuffer(std::vector<char> &buffer, const T *source,
-                    const std::size_t elements) noexcept
+                    const size_t elements) noexcept
 {
     const char *src = reinterpret_cast<const char *>(source);
     buffer.insert(buffer.end(), src, src + elements * sizeof(T));
@@ -157,6 +157,13 @@ void MemcpyToBufferThreads(std::vector<char> &buffer, size_t &position,
     {
         thread.join();
     }
+}
+
+template <class T>
+void InsertU64(std::vector<char> &buffer, const T element) noexcept
+{
+    const uint64_t element64 = static_cast<const uint64_t>(element);
+    InsertToBuffer(buffer, &element64);
 }
 
 } // end namespace

--- a/source/adios2/helper/adiosSystem.cpp
+++ b/source/adios2/helper/adiosSystem.cpp
@@ -20,11 +20,8 @@
 #include "adios2/helper/adiosString.h"
 
 // remove ctime warning on Windows
-#ifdef _MSC_VER
-#define _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_DEPRECATE
-#define _SCL_SECURE_NO_WARNINGS
-#define _SCL_SECURE_NO_DEPRECATE
+#ifdef _WIN32
+#pragma warning(disable : 4996)
 #endif
 
 namespace adios2

--- a/source/adios2/helper/adiosSystem.cpp
+++ b/source/adios2/helper/adiosSystem.cpp
@@ -9,7 +9,7 @@
  */
 #include "adiosSystem.h"
 
-#include <ctime> //std::ctime
+#include <ctime>
 
 #include <chrono> //system_clock, now
 
@@ -19,8 +19,12 @@
 #include "adios2/ADIOSTypes.h"
 #include "adios2/helper/adiosString.h"
 
-#ifdef _WIN32
-#define _CRT_SECURE_NO_DEPRECATE // remove warning for ctime
+// remove ctime warning on Windows
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_DEPRECATE
+#define _SCL_SECURE_NO_WARNINGS
+#define _SCL_SECURE_NO_DEPRECATE
 #endif
 
 namespace adios2

--- a/source/adios2/helper/adiosSystem.h
+++ b/source/adios2/helper/adiosSystem.h
@@ -17,8 +17,6 @@
 #include <vector>
 /// \endcond
 
-#include "adios2/ADIOSMPICommOnly.h"
-
 namespace adios2
 {
 
@@ -42,15 +40,6 @@ bool IsLittleEndian() noexcept;
  * @return string from char* std::ctime
  */
 std::string LocalTimeDate() noexcept;
-
-/**
- * Rank 0: opens file, dumps contents string and broadcast.
- * Others: receive std::vector<char> and copy to a string
- * @param fileName
- * @param mpiComm
- * @return fileContents as a single string
- */
-std::string BroadcastString(const std::string &input, MPI_Comm mpiComm);
 
 } // end namespace adios
 

--- a/source/adios2/mpidummy.cpp
+++ b/source/adios2/mpidummy.cpp
@@ -26,7 +26,6 @@
 #define open64 open
 #endif
 */
-
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>

--- a/source/adios2/mpidummy.cpp
+++ b/source/adios2/mpidummy.cpp
@@ -33,11 +33,10 @@
 #include <chrono>
 #include <string>
 
-#ifdef _MSC_VER
-#define _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_DEPRECATE
-#define _SCL_SECURE_NO_WARNINGS
-#define _SCL_SECURE_NO_DEPRECATE
+// remove warnings on Windows
+#ifdef _WIN32
+#pragma warning(disable : 4996) // fopen
+#pragma warning(disable : 4477) // strcpy, sprintf
 #endif
 
 namespace adios2
@@ -302,7 +301,7 @@ int MPI_File_open(MPI_Comm /*comm*/, const char *filename, int amode,
     }
     mode += "b";
 
-    *fh = fopen(filename, mode.c_str());
+    *fh = std::fopen(filename, mode.c_str());
     if (!*fh)
     {
         std::snprintf(mpierrmsg, MPI_MAX_ERROR_STRING, "File not found: %s",
@@ -316,10 +315,10 @@ int MPI_File_close(MPI_File *fh) { return fclose(*fh); }
 
 int MPI_File_get_size(MPI_File fh, MPI_Offset *size)
 {
-    long curpos = ftell(fh);
+    long curpos = std::ftell(fh);
     fseek(fh, 0, SEEK_END); // go to end, returned is the size in bytes
-    long endpos = ftell(fh);
-    fseek(fh, curpos, SEEK_SET); // go back where we were
+    long endpos = std::ftell(fh);
+    std::fseek(fh, curpos, SEEK_SET); // go back where we were
     *size = static_cast<MPI_Offset>(endpos);
     // printf("MPI_File_get_size: fh=%d, size=%lld\n", fh, *size);
     return MPI_SUCCESS;
@@ -331,7 +330,7 @@ int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype,
     // FIXME: int count can read only 2GB (*datatype size) array at max
     size_t bytes_to_read = static_cast<size_t>(count) * datatype;
     size_t bytes_read;
-    bytes_read = fread(buf, 1, bytes_to_read, fh);
+    bytes_read = std::fread(buf, 1, bytes_to_read, fh);
     if (bytes_read != bytes_to_read)
     {
         std::snprintf(mpierrmsg, MPI_MAX_ERROR_STRING,
@@ -348,7 +347,7 @@ int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype,
 
 int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
 {
-    return fseek(fh, offset, whence) == MPI_SUCCESS;
+    return std::fseek(fh, offset, whence) == MPI_SUCCESS;
 }
 
 int MPI_Get_count(const MPI_Status *status, MPI_Datatype, int *count)

--- a/source/adios2/mpidummy.cpp
+++ b/source/adios2/mpidummy.cpp
@@ -33,6 +33,13 @@
 #include <chrono>
 #include <string>
 
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_DEPRECATE
+#define _SCL_SECURE_NO_WARNINGS
+#define _SCL_SECURE_NO_DEPRECATE
+#endif
+
 namespace adios2
 {
 

--- a/source/adios2/mpidummy.h
+++ b/source/adios2/mpidummy.h
@@ -14,9 +14,6 @@
 #include <cstdint>
 #include <cstdio>
 
-/// \cond EXCLUDE_FROM_DOXYGEN
-/// \endcond
-
 namespace adios2
 {
 

--- a/source/adios2/toolkit/capsule/Capsule.h
+++ b/source/adios2/toolkit/capsule/Capsule.h
@@ -61,8 +61,8 @@ public:
 
     size_t GetAvailableDataSize() const;
 
-    virtual void ResizeData(size_t size);     ///< resize data buffer
-    virtual void ResizeMetadata(size_t size); ///< resize metadata buffer
+    virtual void ResizeData(const size_t size);     ///< resize data buffer
+    virtual void ResizeMetadata(const size_t size); ///< resize metadata buffer
 
 protected:
     const bool m_DebugMode = false; ///< true: extra exception checks

--- a/source/adios2/toolkit/capsule/heap/STLVector.cpp
+++ b/source/adios2/toolkit/capsule/heap/STLVector.cpp
@@ -43,10 +43,10 @@ void STLVector::ResizeData(const size_t size)
         }
         catch (std::bad_alloc &e)
         {
-            throw std::runtime_error("ERROR: bad_alloc detected when resizing "
-                                     "data buffer with size " +
-                                     std::to_string(size) + "\ndescription: " +
-                                     std::string(e.what()) + "\n");
+            std::throw_with_nested(
+                std::runtime_error("ERROR: bad_alloc detected when resizing "
+                                   "data buffer with size " +
+                                   std::to_string(size) + "\n"));
         }
     }
     else
@@ -65,11 +65,10 @@ void STLVector::ResizeMetadata(const size_t size)
         }
         catch (std::bad_alloc &e)
         {
-            throw std::runtime_error("ERROR: bad_alloc detected when resizing "
-                                     "metadata buffer with size " +
-                                     std::to_string(size) +
-                                     "\nadditional description: " +
-                                     std::string(e.what()) + "\n");
+            std::throw_with_nested(
+                std::runtime_error("ERROR: bad_alloc detected when resizing "
+                                   "metadata buffer with size " +
+                                   std::to_string(size) + "\n"));
         }
     }
     else

--- a/source/adios2/toolkit/capsule/heap/STLVector.cpp
+++ b/source/adios2/toolkit/capsule/heap/STLVector.cpp
@@ -41,10 +41,10 @@ void STLVector::ResizeData(const size_t size)
         {
             m_Data.resize(size);
         }
-        catch (std::bad_alloc &e)
+        catch (...)
         {
             std::throw_with_nested(
-                std::runtime_error("ERROR: bad_alloc detected when resizing "
+                std::runtime_error("ERROR: possible overflow when resizing "
                                    "data buffer with size " +
                                    std::to_string(size) + "\n"));
         }
@@ -63,10 +63,10 @@ void STLVector::ResizeMetadata(const size_t size)
         {
             m_Metadata.resize(size);
         }
-        catch (std::bad_alloc &e)
+        catch (...)
         {
             std::throw_with_nested(
-                std::runtime_error("ERROR: bad_alloc detected when resizing "
+                std::runtime_error("ERROR: possible overflow when resizing "
                                    "metadata buffer with size " +
                                    std::to_string(size) + "\n"));
         }

--- a/source/adios2/toolkit/capsule/heap/STLVector.cpp
+++ b/source/adios2/toolkit/capsule/heap/STLVector.cpp
@@ -45,7 +45,8 @@ void STLVector::ResizeData(const size_t size)
         {
             throw std::runtime_error("ERROR: bad_alloc detected when resizing "
                                      "data buffer with size " +
-                                     std::to_string(size) + "\n");
+                                     std::to_string(size) + "\ndescription: " +
+                                     std::string(e.what()) + "\n");
         }
     }
     else
@@ -66,7 +67,9 @@ void STLVector::ResizeMetadata(const size_t size)
         {
             throw std::runtime_error("ERROR: bad_alloc detected when resizing "
                                      "metadata buffer with size " +
-                                     std::to_string(size) + "\n");
+                                     std::to_string(size) +
+                                     "\nadditional description: " +
+                                     std::string(e.what()) + "\n");
         }
     }
     else

--- a/source/adios2/toolkit/capsule/shmem/ShmSystemV.cpp
+++ b/source/adios2/toolkit/capsule/shmem/ShmSystemV.cpp
@@ -2,10 +2,10 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * ShmSystemV.cpp
+ * ShmSystemV.cpp : implementation of ShmSystemV class
  *
  *  Created on: Dec 22, 2016
- *      Author: wfg
+ *      Author: William F Godoy godoywf@ornl.gov
  */
 
 #include "ShmSystemV.h"

--- a/source/adios2/toolkit/capsule/shmem/ShmSystemV.h
+++ b/source/adios2/toolkit/capsule/shmem/ShmSystemV.h
@@ -1,6 +1,12 @@
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
+ *
+ * ShmSystemV.h : ShmSystem class as a thin wrapper to a shared memory capsule
+ *                using POSIX SystemV
+ *
+ * Created on: Dec 22, 2016
+ *      Author: William F Godoy godoywf@ornl.gov
  */
 
 #ifndef ADIOS2_TOOLKIT_CAPSULE_SHMEM_SHMSYSTEMV_H_

--- a/source/adios2/toolkit/format/bp1/BP1Base.cpp
+++ b/source/adios2/toolkit/format/bp1/BP1Base.cpp
@@ -170,6 +170,8 @@ void BP1Base::InitParameterBufferGrowth(const std::string value)
     if (m_DebugMode)
     {
         bool success = true;
+        std::string description;
+
         try
         {
             m_GrowthFactor = std::stof(value);
@@ -177,6 +179,7 @@ void BP1Base::InitParameterBufferGrowth(const std::string value)
         catch (std::exception &e)
         {
             success = false;
+            description = std::string(e.what());
         }
 
         if (!success || m_GrowthFactor <= 1.f)
@@ -184,7 +187,8 @@ void BP1Base::InitParameterBufferGrowth(const std::string value)
             throw std::invalid_argument(
                 "ERROR: BufferGrowthFactor value "
                 "can't be less or equal than 1 (default = 1.5), or couldn't "
-                "convert number, in call to Open\n");
+                "convert number,\n additional description:" +
+                description + "\n, in call to Open\n");
         }
     }
     else
@@ -195,15 +199,14 @@ void BP1Base::InitParameterBufferGrowth(const std::string value)
 
 void BP1Base::InitParameterInitBufferSize(const std::string value)
 {
-    const std::string errorMessage(
-        "ERROR: wrong value for InitialBufferSize, it must be larger than "
-        "16Kb (minimum default), in call to Open\n");
-
     if (m_DebugMode)
     {
         if (value.size() < 2)
         {
-            throw std::invalid_argument(errorMessage);
+            throw std::invalid_argument(
+                "ERROR: wrong value for InitialBufferSize, it must be larger "
+                "than "
+                "16Kb (minimum default), in call to Open\n");
         }
     }
 
@@ -215,6 +218,8 @@ void BP1Base::InitParameterInitBufferSize(const std::string value)
     if (m_DebugMode)
     {
         bool success = true;
+        std::string description;
+
         try
         {
             bufferSize = static_cast<size_t>(std::stoul(number) * factor);
@@ -222,11 +227,16 @@ void BP1Base::InitParameterInitBufferSize(const std::string value)
         catch (std::exception &e)
         {
             success = false;
+            description = std::string(e.what());
         }
 
         if (!success || bufferSize < DefaultInitialBufferSize) // 16384b
         {
-            throw std::invalid_argument(errorMessage);
+            throw std::invalid_argument(
+                "ERROR: wrong value for InitialBufferSize, it must be larger "
+                "than "
+                "16Kb (minimum default), additional description: " +
+                description + " in call to Open\n");
         }
     }
     else
@@ -239,17 +249,15 @@ void BP1Base::InitParameterInitBufferSize(const std::string value)
 
 void BP1Base::InitParameterMaxBufferSize(const std::string value)
 {
-    const std::string errorMessage(
-        "ERROR: couldn't convert value of max_buffer_size IO "
-        "SetParameter, valid syntax: MaxBufferSize=10Gb, "
-        "MaxBufferSize=1000Mb, MaxBufferSize=16Kb (minimum default), "
-        " in call to Open");
-
     if (m_DebugMode)
     {
         if (value.size() < 2)
         {
-            throw std::invalid_argument(errorMessage);
+            throw std::invalid_argument(
+                "ERROR: couldn't convert value of max_buffer_size IO "
+                "SetParameter, valid syntax: MaxBufferSize=10Gb, "
+                "MaxBufferSize=1000Mb, MaxBufferSize=16Kb (minimum default), "
+                " in call to Open");
         }
     }
 
@@ -260,6 +268,8 @@ void BP1Base::InitParameterMaxBufferSize(const std::string value)
     if (m_DebugMode)
     {
         bool success = true;
+        std::string description;
+
         try
         {
             m_MaxBufferSize = static_cast<size_t>(std::stoul(number) * factor);
@@ -267,11 +277,17 @@ void BP1Base::InitParameterMaxBufferSize(const std::string value)
         catch (std::exception &e)
         {
             success = false;
+            description = std::string(e.what());
         }
 
         if (!success || m_MaxBufferSize < 16 * 1024) // 16384b
         {
-            throw std::invalid_argument(errorMessage);
+            throw std::invalid_argument(
+                "ERROR: couldn't convert value of max_buffer_size IO "
+                "SetParameter, valid syntax: MaxBufferSize=10Gb, "
+                "MaxBufferSize=1000Mb, MaxBufferSize=16Kb (minimum default), "
+                "\nadditional description: " +
+                description + " in call to Open");
         }
     }
     else
@@ -287,6 +303,7 @@ void BP1Base::InitParameterThreads(const std::string value)
     if (m_DebugMode)
     {
         bool success = true;
+        std::string description;
 
         try
         {
@@ -295,13 +312,15 @@ void BP1Base::InitParameterThreads(const std::string value)
         catch (std::exception &e)
         {
             success = false;
+            description = std::string(e.what());
         }
 
         if (!success || threads < 1)
         {
             throw std::invalid_argument(
                 "ERROR: value in Threads=value in IO SetParameters must be "
-                "an integer >= 1 (default), in call to Open\n");
+                "an integer >= 1 (default) \nadditional description: " +
+                description + "\n, in call to Open\n");
         }
     }
     else
@@ -319,6 +338,7 @@ void BP1Base::InitParameterVerbose(const std::string value)
     if (m_DebugMode)
     {
         bool success = true;
+        std::string description;
 
         try
         {
@@ -327,13 +347,15 @@ void BP1Base::InitParameterVerbose(const std::string value)
         catch (std::exception &e)
         {
             success = false;
+            description = std::string(e.what());
         }
 
         if (!success || verbosity < 0 || verbosity > 5)
         {
             throw std::invalid_argument(
                 "ERROR: value in Verbose=value in IO SetParameters must be "
-                "an integer in the range [0,5], in call to Open\n");
+                "an integer in the range [0,5], \nadditional description: " +
+                description + "\n, in call to Open\n");
         }
     }
     else

--- a/source/adios2/toolkit/format/bp1/BP1Writer.h
+++ b/source/adios2/toolkit/format/bp1/BP1Writer.h
@@ -72,7 +72,7 @@ public:
     void Advance();
 
     /** Flattens data buffer and close current process group, doesn't
-     * advance time index */
+     *  advance time index */
     void Flush();
 
     /**

--- a/source/adios2/toolkit/transport/file/FilePointer.cpp
+++ b/source/adios2/toolkit/transport/file/FilePointer.cpp
@@ -14,6 +14,14 @@
 #include <ios> //std::ios_base::failure
 /// \endcond
 
+// removes fopen warning on Windows
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_DEPRECATE
+#define _SCL_SECURE_NO_WARNINGS
+#define _SCL_SECURE_NO_DEPRECATE
+#endif
+
 namespace adios2
 {
 namespace transport
@@ -60,7 +68,7 @@ void FilePointer::Open(const std::string &name, const OpenMode openMode)
         m_File = fopen(name.c_str(), "rb");
     }
 
-    if (std::ferror(m_File))
+    if (ferror(m_File))
     {
         throw std::ios_base::failure("ERROR: couldn't open file " + name +
                                      ", "
@@ -72,7 +80,7 @@ void FilePointer::Open(const std::string &name, const OpenMode openMode)
 
 void FilePointer::SetBuffer(char *buffer, size_t size)
 {
-    const int status = std::setvbuf(m_File, buffer, _IOFBF, size);
+    const int status = setvbuf(m_File, buffer, _IOFBF, size);
 
     if (!status)
     {
@@ -90,7 +98,7 @@ void FilePointer::Write(const char *buffer, size_t size)
         {
             m_Profiler.Timers.at("write").Resume();
         }
-        auto writtenSize = std::fwrite(buffer, sizeof(char), size, m_File);
+        auto writtenSize = fwrite(buffer, sizeof(char), size, m_File);
 
         if (m_Profiler.IsActive)
         {
@@ -133,7 +141,7 @@ void FilePointer::Write(const char *buffer, size_t size)
 
 void FilePointer::Flush()
 {
-    const int status = std::fflush(m_File);
+    const int status = fflush(m_File);
 
     if (status == EOF)
     {
@@ -149,7 +157,7 @@ void FilePointer::Close()
         m_Profiler.Timers.at("close").Resume();
     }
 
-    const int status = std::fclose(m_File);
+    const int status = fclose(m_File);
 
     if (m_Profiler.IsActive)
     {

--- a/source/adios2/toolkit/transport/file/FilePointer.cpp
+++ b/source/adios2/toolkit/transport/file/FilePointer.cpp
@@ -48,16 +48,16 @@ void FilePointer::Open(const std::string &name, const OpenMode openMode)
 
     if (m_OpenMode == OpenMode::Write)
     {
-        m_File = std::fopen(name.c_str(), "w");
+        m_File = fopen(name.c_str(), "wb");
     }
     else if (m_OpenMode == OpenMode::Append)
     {
         // need to change when implemented
-        m_File = std::fopen(name.c_str(), "a");
+        m_File = fopen(name.c_str(), "ab");
     }
     else if (m_OpenMode == OpenMode::Read)
     {
-        m_File = std::fopen(name.c_str(), "r");
+        m_File = fopen(name.c_str(), "rb");
     }
 
     if (std::ferror(m_File))

--- a/source/adios2/toolkit/transport/file/FilePointer.cpp
+++ b/source/adios2/toolkit/transport/file/FilePointer.cpp
@@ -15,11 +15,8 @@
 /// \endcond
 
 // removes fopen warning on Windows
-#ifdef _MSC_VER
-#define _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_DEPRECATE
-#define _SCL_SECURE_NO_WARNINGS
-#define _SCL_SECURE_NO_DEPRECATE
+#ifdef _WIN32
+#pragma warning(disable : 4996) // fopen
 #endif
 
 namespace adios2
@@ -36,7 +33,7 @@ FilePointer::~FilePointer()
 {
     if (m_IsOpen)
     {
-        fclose(m_File);
+        std::fclose(m_File);
     }
 }
 
@@ -56,16 +53,16 @@ void FilePointer::Open(const std::string &name, const OpenMode openMode)
 
     if (m_OpenMode == OpenMode::Write)
     {
-        m_File = fopen(name.c_str(), "wb");
+        m_File = std::fopen(name.c_str(), "wb");
     }
     else if (m_OpenMode == OpenMode::Append)
     {
         // need to change when implemented
-        m_File = fopen(name.c_str(), "ab");
+        m_File = std::fopen(name.c_str(), "ab");
     }
     else if (m_OpenMode == OpenMode::Read)
     {
-        m_File = fopen(name.c_str(), "rb");
+        m_File = std::fopen(name.c_str(), "rb");
     }
 
     if (ferror(m_File))
@@ -80,7 +77,7 @@ void FilePointer::Open(const std::string &name, const OpenMode openMode)
 
 void FilePointer::SetBuffer(char *buffer, size_t size)
 {
-    const int status = setvbuf(m_File, buffer, _IOFBF, size);
+    const int status = std::setvbuf(m_File, buffer, _IOFBF, size);
 
     if (!status)
     {
@@ -98,7 +95,7 @@ void FilePointer::Write(const char *buffer, size_t size)
         {
             m_Profiler.Timers.at("write").Resume();
         }
-        auto writtenSize = fwrite(buffer, sizeof(char), size, m_File);
+        auto writtenSize = std::fwrite(buffer, sizeof(char), size, m_File);
 
         if (m_Profiler.IsActive)
         {
@@ -141,7 +138,7 @@ void FilePointer::Write(const char *buffer, size_t size)
 
 void FilePointer::Flush()
 {
-    const int status = fflush(m_File);
+    const int status = std::fflush(m_File);
 
     if (status == EOF)
     {
@@ -157,7 +154,7 @@ void FilePointer::Close()
         m_Profiler.Timers.at("close").Resume();
     }
 
-    const int status = fclose(m_File);
+    const int status = std::fclose(m_File);
 
     if (m_Profiler.IsActive)
     {

--- a/source/adios2/toolkit/transport/file/FilePointer.h
+++ b/source/adios2/toolkit/transport/file/FilePointer.h
@@ -45,7 +45,7 @@ public:
 
 private:
     /** C File pointer */
-    std::FILE *m_File = nullptr; // NULL or nullptr?
+    FILE *m_File = nullptr; // NULL or nullptr?
 };
 
 } // end namespace transport

--- a/source/adios2/toolkit/transport/file/FileStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileStream.cpp
@@ -40,16 +40,17 @@ void FileStream::Open(const std::string &name, const OpenMode openMode)
 
     if (m_OpenMode == OpenMode::Write)
     {
-        m_FileStream.open(name, std::fstream::out);
+        m_FileStream.open(name, std::fstream::out | std::fstream::binary);
     }
     else if (m_OpenMode == OpenMode::Append)
     {
         // to be changed to rw?
-        m_FileStream.open(name, std::fstream::out | std::fstream::app);
+        m_FileStream.open(name, std::fstream::out | std::fstream::app |
+                                    std::fstream::binary);
     }
     else if (m_OpenMode == OpenMode::Read)
     {
-        m_FileStream.open(name, std::fstream::in);
+        m_FileStream.open(name, std::fstream::in | std::fstream::binary);
     }
 
     if (!m_FileStream)

--- a/testing/adios2/xml/TestXMLConfig.cpp
+++ b/testing/adios2/xml/TestXMLConfig.cpp
@@ -51,6 +51,21 @@ TEST_F(XMLConfigTest, TwoIOs)
     });
 }
 
+TEST_F(XMLConfigTest, TwoEnginesException)
+{
+    std::string configFile = configDir + "/config2.xml";
+    adios2::ADIOS adios;
+
+#ifdef ADIOS2_HAVE_MPI
+    EXPECT_THROW(adios =
+                     adios2::ADIOS(configFile, MPI_COMM_WORLD, adios2::DebugON),
+                 std::invalid_argument);
+#else
+    EXPECT_THROW(adios = adios2::ADIOS(configFile, adios2::DebugON),
+                 std::invalid_argument);
+#endif
+}
+
 int main(int argc, char **argv)
 {
 #ifdef ADIOS2_HAVE_MPI

--- a/testing/adios2/xml/TestXMLConfig.cpp
+++ b/testing/adios2/xml/TestXMLConfig.cpp
@@ -54,14 +54,13 @@ TEST_F(XMLConfigTest, TwoIOs)
 TEST_F(XMLConfigTest, TwoEnginesException)
 {
     std::string configFile = configDir + "/config2.xml";
-    adios2::ADIOS adios;
 
 #ifdef ADIOS2_HAVE_MPI
-    EXPECT_THROW(adios =
-                     adios2::ADIOS(configFile, MPI_COMM_WORLD, adios2::DebugON),
-                 std::invalid_argument);
+    EXPECT_THROW(
+        adios2::ADIOS adios(configFile, MPI_COMM_WORLD, adios2::DebugON),
+        std::invalid_argument);
 #else
-    EXPECT_THROW(adios = adios2::ADIOS(configFile, adios2::DebugON),
+    EXPECT_THROW(adios2::ADIOS adios(configFile, adios2::DebugON),
                  std::invalid_argument);
 #endif
 }

--- a/testing/adios2/xml/config2.xml
+++ b/testing/adios2/xml/config2.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<adios-config>
+    <io name="Test IO 2">
+        <engine type="BPFileWriter" />
+        <engine type="Other" /> <!-- std::invalid_argument exception -->
+    </io>
+</adios-config>


### PR DESCRIPTION
Bugs: 1) Missing binary mode in FilePointer fopen and FStream ofstream
transports was adding characters to bp files becoming corrupted.
      2) Replacing reinterpret_cast of size_t to uint_64, not the same size
on Windows 64-bit

Removed some warnings generated by Visual Studio

Added static_cast for type conversions

Refactor XML reader to restore original check on single engine
conditions and eliminate warnings. Test added.

Allow ctime and fopen "not secure" warnings: now using binary fstream as
default file IO library on Windows