### PR TITLE
Fixing Issue #216 Python bindings

### DIFF
--- a/bindings/python/ADIOSPy.cpp
+++ b/bindings/python/ADIOSPy.cpp
@@ -19,7 +19,8 @@ namespace adios2
 
 ADIOSPy::ADIOSPy(const std::string configFile, MPI_Comm mpiComm,
                  const bool debugMode)
-: m_DebugMode(debugMode), m_ADIOS(configFile, mpiComm, debugMode)
+: m_DebugMode(debugMode),
+  m_ADIOS(std::make_shared<adios2::ADIOS>(configFile, mpiComm, debugMode))
 {
 }
 
@@ -29,7 +30,7 @@ ADIOSPy::ADIOSPy(MPI_Comm mpiComm, const bool debugMode)
 }
 
 ADIOSPy::ADIOSPy(const std::string configFile, const bool debugMode)
-: ADIOSPy("", MPI_COMM_SELF, debugMode)
+: ADIOSPy(configFile, MPI_COMM_SELF, debugMode)
 {
 }
 
@@ -39,7 +40,7 @@ ADIOSPy::ADIOSPy(const bool debugMode) : ADIOSPy("", MPI_COMM_SELF, debugMode)
 
 IOPy ADIOSPy::DeclareIO(const std::string name)
 {
-    return IOPy(m_ADIOS.DeclareIO(name), m_DebugMode);
+    return IOPy(m_ADIOS->DeclareIO(name), m_DebugMode);
 }
 
 } // end namespace adios

--- a/bindings/python/ADIOSPy.h
+++ b/bindings/python/ADIOSPy.h
@@ -12,6 +12,7 @@
 #define ADIOS2_BINDINGS_PYTHON_SOURCE_ADIOSPY_H_
 
 /// \cond EXCLUDE_FROM_DOXYGEN
+#include <memory> //std::shared_ptr
 #include <string>
 /// \endcond
 
@@ -32,13 +33,14 @@ public:
     ADIOSPy(MPI_Comm mpiComm, const bool debugMode);
     ADIOSPy(const std::string configFile, const bool debugMode);
     ADIOSPy(const bool debugMode);
+
     ~ADIOSPy() = default;
 
     IOPy DeclareIO(const std::string name);
 
 private:
     const bool m_DebugMode;
-    adios2::ADIOS m_ADIOS;
+    std::shared_ptr<adios2::ADIOS> m_ADIOS;
 };
 
 } // end namespace adios

--- a/bindings/python/gluePyBind11.cpp
+++ b/bindings/python/gluePyBind11.cpp
@@ -68,7 +68,7 @@ adios2::ADIOSPy ADIOSPyInit(adios2::pyObject &object, const bool debugMode)
 adios2::ADIOSPy ADIOSPyInitConfig(const std::string configFile,
                                   const bool debugMode)
 {
-    return adios2::ADIOSPy(debugMode);
+    return adios2::ADIOSPy(configFile, debugMode);
 }
 
 adios2::ADIOSPy ADIOSPyInit(const bool debugMode)

--- a/testing/adios2/bindings/python/CMakeLists.txt
+++ b/testing/adios2/bindings/python/CMakeLists.txt
@@ -3,4 +3,10 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-python_add_test(PythonBPWrite TestBPWriteTypes.py)
+if(NOT ADIOS2_HAVE_MPI)
+    python_add_test(PythonBPWrite TestBPWriteTypes_nompi.py)
+endif()
+
+if(ADIOS2_HAVE_MPI)
+    python_add_test(PythonBPWrite TestBPWriteTypes.py)
+endif()

--- a/testing/adios2/bindings/python/TestBPWriteTypes_nompi.py
+++ b/testing/adios2/bindings/python/TestBPWriteTypes_nompi.py
@@ -10,15 +10,13 @@
 
 
 from adios2NPTypes import SmallTestData
-from mpi4py import MPI
 import adios2
 
 
 # Test data
 data = SmallTestData()
 
-comm = MPI.COMM_WORLD
-adios = adios2.ADIOS(comm, adios2.DebugON)
+adios = adios2.ADIOS(adios2.DebugON)
 
 bpIO = adios.DeclareIO("NPTypes")
 


### PR DESCRIPTION
Copy constructor was implicitly removed for ADIOSPy due to m_ADIOS.

PyBind11 needed the copy constructor.

m_ADIOS is now a shared pointer to avoid copy constructor removal

Separated MPI nonMPI test as ctest failed for MPI