### PR TITLE
Set debugMode to true by default.

### DIFF
--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -45,7 +45,7 @@ public:
      * @param debugMode true: extra exception checks (recommended)
      */
     ADIOS(const std::string configFile, MPI_Comm mpiComm,
-          const bool debugMode = false);
+          const bool debugMode = true);
 
     /**
      * @brief Constructor for non-MPI applications WITH a XML config file
@@ -53,20 +53,20 @@ public:
      * future?)
      * @param debugMode true: extra exception checks (recommended)
      */
-    ADIOS(const std::string configFile, const bool debugMode = false);
+    ADIOS(const std::string configFile, const bool debugMode = true);
 
     /**
      * @brief Constructor for MPI apps WITHOUT a XML config file
      * @param mpiComm MPI communicator from application
      * @param debugMode true: extra exception checks (recommended)
      */
-    ADIOS(MPI_Comm mpiComm, const bool debugMode = false);
+    ADIOS(MPI_Comm mpiComm, const bool debugMode = true);
 
     /**
      *  @brief ADIOS no-MPI default empty constructor
      *  @param debugMode true: extra exception checks (recommended)
      */
-    ADIOS(const bool debugMode = false);
+    ADIOS(const bool debugMode = true);
 
     /**
      * Delete copy constructor explicitly. Objects shouldn't be allowed to be
@@ -103,7 +103,7 @@ private:
     const std::string m_ConfigFile;
 
     /** if true will do more checks, exceptions, warnings, expect slower code */
-    const bool m_DebugMode = false;
+    const bool m_DebugMode = true;
 
     /** transforms associated with ADIOS run */
     std::map<std::string, std::shared_ptr<Transform>> m_Transforms;


### PR DESCRIPTION
Let sophisticated users turn off the debugMode flag off. This change causes that examples/basics/value and examples/basics/globalArray to throw an exception. The examples are correct. The library needs to be fixed to handle the dimension definition API correctly to make the examples work again. 