### PR TITLE
Make all Bp engine tests able to run in parallel

### DIFF
--- a/testing/adios2/engine/adios1/TestADIOS1WriteRead.cpp
+++ b/testing/adios2/engine/adios1/TestADIOS1WriteRead.cpp
@@ -91,11 +91,7 @@ TEST_F(ADIOS1WriteReadTest, ADIOS2ADIOS1WriteADIOS1Read1D8)
         // Create the ADIOS 1 Engine
         io.SetEngine("ADIOS1Writer");
 
-#ifdef ADIOS2_HAVE_MPI
-        io.AddTransport("file", {{"library", "MPI"}});
-#else
         io.AddTransport("file");
-#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
@@ -387,11 +383,7 @@ TEST_F(ADIOS1WriteReadTest, ADIOS2ADIOS1WriteADIOS1Read2D2x4)
         // Create the ADIOS 1 Engine
         io.SetEngine("ADIOS1Writer");
 
-#ifdef ADIOS2_HAVE_MPI
-        io.AddTransport("file", {{"library", "MPI"}});
-#else
         io.AddTransport("file");
-#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
@@ -696,11 +688,7 @@ TEST_F(ADIOS1WriteReadTest, _ADIOS2ADIOS1WriteADIOS1Read2D4x2)
         // Create the ADIOS 1 Engine
         io.SetEngine("ADIOS1Writer");
 
-#ifdef ADIOS2_HAVE_MPI
-        io.AddTransport("file", {{"library", "MPI"}});
-#else
         io.AddTransport("file");
-#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);

--- a/testing/adios2/engine/adios1/TestADIOS1WriteRead.cpp
+++ b/testing/adios2/engine/adios1/TestADIOS1WriteRead.cpp
@@ -91,7 +91,11 @@ TEST_F(ADIOS1WriteReadTest, ADIOS2ADIOS1WriteADIOS1Read1D8)
         // Create the ADIOS 1 Engine
         io.SetEngine("ADIOS1Writer");
 
+#ifdef ADIOS2_HAVE_MPI
+        io.AddTransport("file", {{"library", "MPI"}});
+#else
         io.AddTransport("file");
+#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
@@ -383,7 +387,11 @@ TEST_F(ADIOS1WriteReadTest, ADIOS2ADIOS1WriteADIOS1Read2D2x4)
         // Create the ADIOS 1 Engine
         io.SetEngine("ADIOS1Writer");
 
+#ifdef ADIOS2_HAVE_MPI
+        io.AddTransport("file", {{"library", "MPI"}});
+#else
         io.AddTransport("file");
+#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
@@ -688,7 +696,11 @@ TEST_F(ADIOS1WriteReadTest, _ADIOS2ADIOS1WriteADIOS1Read2D4x2)
         // Create the ADIOS 1 Engine
         io.SetEngine("ADIOS1Writer");
 
+#ifdef ADIOS2_HAVE_MPI
+        io.AddTransport("file", {{"library", "MPI"}});
+#else
         io.AddTransport("file");
+#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -4,38 +4,19 @@
 #------------------------------------------------------------------------------#
 
 # MPI versions of the test are not properly implemented at the moment
-if(NOT ADIOS2_HAVE_MPI)
-  
-  if(ADIOS2_HAVE_ADIOS1)
-    add_executable(TestBPWriteRead TestBPWriteRead.cpp)
-    target_link_libraries(TestBPWriteRead adios2 gtest adios1::adios)
 
-    add_executable(TestBPWriteReadAttributes TestBPWriteReadAttributes.cpp)
-    target_link_libraries(TestBPWriteReadAttributes adios2 gtest adios1::adios)
-  
-    add_executable(TestBPWriteReadstdio TestBPWriteReadstdio.cpp)
-    target_link_libraries(TestBPWriteReadstdio adios2 gtest adios1::adios)
-
-    add_executable(TestBPWriteReadfstream TestBPWriteReadfstream.cpp)
-    target_link_libraries(TestBPWriteReadfstream adios2 gtest adios1::adios)
-    
-    gtest_add_tests(TARGET TestBPWriteRead)
-    gtest_add_tests(TARGET TestBPWriteReadAttributes)
-    gtest_add_tests(TARGET TestBPWriteReadstdio)
-    gtest_add_tests(TARGET TestBPWriteReadfstream)
-  endif()
-    
-  add_executable(TestBPWriteProfilingJSON TestBPWriteProfilingJSON.cpp)
-  target_link_libraries(TestBPWriteProfilingJSON
-    adios2 gtest gtest_main NLohmannJson
-  )
-  
-  gtest_add_tests(TARGET TestBPWriteProfilingJSON)
-endif()
-
-# Testing CMake code
 add_executable(TestBPWriteRead TestBPWriteRead.cpp)
 target_link_libraries(TestBPWriteRead adios2 gtest adios1::adios)
+
+#add_executable(TestBPWriteReadAttributes TestBPWriteReadAttributes.cpp)
+#target_link_libraries(TestBPWriteReadAttributes adios2 gtest adios1::adios)
+
+#add_executable(TestBPWriteReadstdio TestBPWriteReadstdio.cpp)
+#target_link_libraries(TestBPWriteReadstdio adios2 gtest adios1::adios)
+
+#add_executable(TestBPWriteReadfstream TestBPWriteReadfstream.cpp)
+#target_link_libraries(TestBPWriteReadfstream adios2 gtest adios1::adios)
+
 if(ADIOS2_HAVE_MPI)
   target_include_directories(TestBPWriteRead PRIVATE ${MPI_C_INCLUDE_PATH})
   target_link_libraries(TestBPWriteRead ${MPI_C_LIBRARIES})
@@ -46,3 +27,24 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 gtest_add_tests(TARGET TestBPWriteRead ${extra_test_args})
+#gtest_add_tests(TARGET TestBPWriteReadAttributes)
+#gtest_add_tests(TARGET TestBPWriteReadstdio)
+#gtest_add_tests(TARGET TestBPWriteReadfstream)
+
+add_executable(TestBPWriteProfilingJSON TestBPWriteProfilingJSON.cpp)
+target_link_libraries(TestBPWriteProfilingJSON
+  adios2 gtest gtest_main NLohmannJson
+)
+
+if(ADIOS2_HAVE_MPI)
+  target_include_directories(TestBPWriteProfilingJSON PRIVATE ${MPI_C_INCLUDE_PATH})
+  target_link_libraries(TestBPWriteProfilingJSON ${MPI_C_LIBRARIES})
+  set(extra_test_argsJSON
+    EXEC_WRAPPER
+      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
+  )
+endif()
+
+gtest_add_tests(TARGET TestBPWriteProfilingJSON ${extra_test_argsJSON})
+
+

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -14,8 +14,13 @@ target_link_libraries(TestBPWriteReadAttributes adios2 gtest adios1::adios)
 add_executable(TestBPWriteReadstdio TestBPWriteReadstdio.cpp)
 target_link_libraries(TestBPWriteReadstdio adios2 gtest adios1::adios)
 
-#add_executable(TestBPWriteReadfstream TestBPWriteReadfstream.cpp)
-#target_link_libraries(TestBPWriteReadfstream adios2 gtest adios1::adios)
+add_executable(TestBPWriteReadfstream TestBPWriteReadfstream.cpp)
+target_link_libraries(TestBPWriteReadfstream adios2 gtest adios1::adios)
+
+add_executable(TestBPWriteProfilingJSON TestBPWriteProfilingJSON.cpp)
+target_link_libraries(TestBPWriteProfilingJSON
+  adios2 gtest NLohmannJson
+)
 
 if(ADIOS2_HAVE_MPI)
   target_include_directories(TestBPWriteRead PRIVATE ${MPI_C_INCLUDE_PATH})
@@ -27,34 +32,20 @@ if(ADIOS2_HAVE_MPI)
   target_include_directories(TestBPWriteReadstdio PRIVATE ${MPI_C_INCLUDE_PATH})
   target_link_libraries(TestBPWriteReadstdio ${MPI_C_LIBRARIES})
 
-  #target_include_directories(TestBPWriteReadfstream PRIVATE ${MPI_C_INCLUDE_PATH})
-  #target_link_libraries(TestBPWriteReadfstream ${MPI_C_LIBRARIES})
+  target_include_directories(TestBPWriteReadfstream PRIVATE ${MPI_C_INCLUDE_PATH})
+  target_link_libraries(TestBPWriteReadfstream ${MPI_C_LIBRARIES})
+
+  target_include_directories(TestBPWriteProfilingJSON PRIVATE ${MPI_C_INCLUDE_PATH})
+  target_link_libraries(TestBPWriteProfilingJSON ${MPI_C_LIBRARIES})
 
   set(extra_test_args
     EXEC_WRAPPER
-      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2#${MPIEXEC_MAX_NUMPROCS}
+      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
   )
 endif()
 
 gtest_add_tests(TARGET TestBPWriteRead ${extra_test_args})
 gtest_add_tests(TARGET TestBPWriteReadAttributes ${extra_test_args})
 gtest_add_tests(TARGET TestBPWriteReadstdio ${extra_test_args})
-#gtest_add_tests(TARGET TestBPWriteReadfstream)
-
-add_executable(TestBPWriteProfilingJSON TestBPWriteProfilingJSON.cpp)
-target_link_libraries(TestBPWriteProfilingJSON
-  adios2 gtest gtest_main NLohmannJson
-)
-
-if(ADIOS2_HAVE_MPI)
-  target_include_directories(TestBPWriteProfilingJSON PRIVATE ${MPI_C_INCLUDE_PATH})
-  target_link_libraries(TestBPWriteProfilingJSON ${MPI_C_LIBRARIES})
-  set(extra_test_argsJSON
-    EXEC_WRAPPER
-      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
-  )
-endif()
-
-gtest_add_tests(TARGET TestBPWriteProfilingJSON ${extra_test_argsJSON})
-
-
+gtest_add_tests(TARGET TestBPWriteReadfstream ${extra_test_args})
+gtest_add_tests(TARGET TestBPWriteProfilingJSON ${extra_test_args})

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -32,3 +32,17 @@ if(NOT ADIOS2_HAVE_MPI)
   
   gtest_add_tests(TARGET TestBPWriteProfilingJSON)
 endif()
+
+# Testing CMake code
+add_executable(TestBPWriteRead TestBPWriteRead.cpp)
+target_link_libraries(TestBPWriteRead adios2 gtest adios1::adios)
+if(ADIOS2_HAVE_MPI)
+  target_include_directories(TestBPWriteRead PRIVATE ${MPI_C_INCLUDE_PATH})
+  target_link_libraries(TestBPWriteRead ${MPI_C_LIBRARIES})
+  set(extra_test_args
+    EXEC_WRAPPER
+      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
+  )
+endif()
+
+gtest_add_tests(TARGET TestBPWriteRead ${extra_test_args})

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -8,8 +8,8 @@
 add_executable(TestBPWriteRead TestBPWriteRead.cpp)
 target_link_libraries(TestBPWriteRead adios2 gtest adios1::adios)
 
-#add_executable(TestBPWriteReadAttributes TestBPWriteReadAttributes.cpp)
-#target_link_libraries(TestBPWriteReadAttributes adios2 gtest adios1::adios)
+add_executable(TestBPWriteReadAttributes TestBPWriteReadAttributes.cpp)
+target_link_libraries(TestBPWriteReadAttributes adios2 gtest adios1::adios)
 
 #add_executable(TestBPWriteReadstdio TestBPWriteReadstdio.cpp)
 #target_link_libraries(TestBPWriteReadstdio adios2 gtest adios1::adios)
@@ -20,6 +20,10 @@ target_link_libraries(TestBPWriteRead adios2 gtest adios1::adios)
 if(ADIOS2_HAVE_MPI)
   target_include_directories(TestBPWriteRead PRIVATE ${MPI_C_INCLUDE_PATH})
   target_link_libraries(TestBPWriteRead ${MPI_C_LIBRARIES})
+
+  target_include_directories(TestBPWriteReadAttributes PRIVATE ${MPI_C_INCLUDE_PATH})
+  target_link_libraries(TestBPWriteReadAttributes ${MPI_C_LIBRARIES})
+
   set(extra_test_args
     EXEC_WRAPPER
       ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
@@ -27,7 +31,7 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 gtest_add_tests(TARGET TestBPWriteRead ${extra_test_args})
-#gtest_add_tests(TARGET TestBPWriteReadAttributes)
+gtest_add_tests(TARGET TestBPWriteReadAttributes ${extra_test_args})
 #gtest_add_tests(TARGET TestBPWriteReadstdio)
 #gtest_add_tests(TARGET TestBPWriteReadfstream)
 

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -11,8 +11,8 @@ target_link_libraries(TestBPWriteRead adios2 gtest adios1::adios)
 add_executable(TestBPWriteReadAttributes TestBPWriteReadAttributes.cpp)
 target_link_libraries(TestBPWriteReadAttributes adios2 gtest adios1::adios)
 
-#add_executable(TestBPWriteReadstdio TestBPWriteReadstdio.cpp)
-#target_link_libraries(TestBPWriteReadstdio adios2 gtest adios1::adios)
+add_executable(TestBPWriteReadstdio TestBPWriteReadstdio.cpp)
+target_link_libraries(TestBPWriteReadstdio adios2 gtest adios1::adios)
 
 #add_executable(TestBPWriteReadfstream TestBPWriteReadfstream.cpp)
 #target_link_libraries(TestBPWriteReadfstream adios2 gtest adios1::adios)
@@ -24,15 +24,21 @@ if(ADIOS2_HAVE_MPI)
   target_include_directories(TestBPWriteReadAttributes PRIVATE ${MPI_C_INCLUDE_PATH})
   target_link_libraries(TestBPWriteReadAttributes ${MPI_C_LIBRARIES})
 
+  target_include_directories(TestBPWriteReadstdio PRIVATE ${MPI_C_INCLUDE_PATH})
+  target_link_libraries(TestBPWriteReadstdio ${MPI_C_LIBRARIES})
+
+  #target_include_directories(TestBPWriteReadfstream PRIVATE ${MPI_C_INCLUDE_PATH})
+  #target_link_libraries(TestBPWriteReadfstream ${MPI_C_LIBRARIES})
+
   set(extra_test_args
     EXEC_WRAPPER
-      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
+      ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2#${MPIEXEC_MAX_NUMPROCS}
   )
 endif()
 
 gtest_add_tests(TARGET TestBPWriteRead ${extra_test_args})
 gtest_add_tests(TARGET TestBPWriteReadAttributes ${extra_test_args})
-#gtest_add_tests(TARGET TestBPWriteReadstdio)
+gtest_add_tests(TARGET TestBPWriteReadstdio ${extra_test_args})
 #gtest_add_tests(TARGET TestBPWriteReadfstream)
 
 add_executable(TestBPWriteProfilingJSON TestBPWriteProfilingJSON.cpp)

--- a/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
@@ -38,10 +38,11 @@ public:
 //******************************************************************************
 
 // ADIOS2 write, native ADIOS1 read
-TEST_F(BPWriteProfilingJSONTest, ADIOS2BPWriteProfilingJSON)
+TEST_F(BPWriteProfilingJSONTest, DISABLED_ADIOS2BPWriteProfilingJSON)
 {
     // Use a relative path + file name to test path in file name capability
-    std::string fname = "foo/ADIOS2BPWriteProfilingJSON.bp";
+    std::string fname;
+    fname = "foo/ADIOS2BPWriteProfilingJSON.bp";
 
     int mpiRank = 0, mpiSize = 1;
     // Number of rows
@@ -94,9 +95,8 @@ TEST_F(BPWriteProfilingJSONTest, ADIOS2BPWriteProfilingJSON)
 
         // Create the BP Engine
         io.SetEngine("BPFileWriter");
-        // Using MPI Rank here?
         io.SetParameters({{"Threads", "2"}});
-        io.AddTransport("File", {{"Library", "POSIX"}});
+        io.AddTransport("file", {{"Library", "POSIX"}});
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);

--- a/testing/adios2/engine/bp/TestBPWriteRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteRead.cpp
@@ -83,7 +83,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8)
                 io.DefineVariable<double>("r64", shape, start, count);
         }
 
-        // Create the ADIOS 1 Engine
+        // Create the BP Engine
         io.SetEngine("BPFileWriter");
 
         io.AddTransport("file");
@@ -152,14 +152,19 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8)
     }
 
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
+        // Note: Since collective metadata generation is not implemented yet,
+        // SO for now we read each subfile instead of a single bp file with all
+        // metadata.
+        // Meanwhile if we open file with MPI_COMM_WORLD, then the selection
+        // bounding box should be [0, Nx]
         std::string index = std::to_string(mpiRank);
         ADIOS_FILE *f = adios_read_open_file(
             (fname + ".dir/" + fname + "." + index).c_str(),
-            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
@@ -235,12 +240,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8)
         std::array<float, Nx> R32;
         std::array<double, Nx> R64;
 
-        // QUESTION: For ADIOS1Writer, the start index would be mpiRank * Nx.
-        // However it seems that BPWriter would skip empty values to find the
-        // right start index. Here 0 would make the test pass.
-        // Note: Since collective metadata generation is not implemented yet,
-        // which makes sence.
-        uint64_t start[1] = {0};
+        uint64_t start[1] = {mpiRank * Nx};
         uint64_t count[1] = {Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(1, start, count);
 
@@ -441,14 +441,19 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4)
     }
 
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
+        // Note: Since collective metadata generation is not implemented yet,
+        // SO for now we read each subfile instead of a single bp file with all
+        // metadata.
+        // Meanwhile if we open file with MPI_COMM_WORLD, then the selection
+        // bounding box should be [0, Nx]
         std::string index = std::to_string(mpiRank);
         ADIOS_FILE *f = adios_read_open_file(
             (fname + ".dir/" + fname + "." + index).c_str(),
-            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
@@ -537,8 +542,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4)
         std::array<float, Nx * Ny> R32;
         std::array<double, Nx * Ny> R64;
 
-        // FIXME: When bp metadata generation has landed, use mpiRank * Nx
-        uint64_t start[2] = {0, 0};
+        uint64_t start[2] = {0, mpiRank * Nx};
         uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 
@@ -675,7 +679,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2)
                 io.DefineVariable<double>("r64", shape, start, count);
         }
 
-        // Create the ADIOS 1 Engine
+        // Create the BP Engine
         io.SetEngine("BPFileWriter");
 
         io.AddTransport("file");
@@ -739,14 +743,19 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2)
     }
 
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
+        // Note: Since collective metadata generation is not implemented yet,
+        // SO for now we read each subfile instead of a single bp file with all
+        // metadata.
+        // Meanwhile if we open file with MPI_COMM_WORLD, then the selection
+        // bounding box should be [0, Nx]
         std::string index = std::to_string(mpiRank);
         ADIOS_FILE *f = adios_read_open_file(
             (fname + ".dir/" + fname + "." + index).c_str(),
-            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
@@ -835,8 +844,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2)
         std::array<float, Nx * Ny> R32;
         std::array<double, Nx * Ny> R64;
 
-        // FIXME: When bp metadata generation has landed, use mpiRank * Nx
-        uint64_t start[2] = {0, 0};
+        uint64_t start[2] = {0, mpiRank * Nx};
         uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 

--- a/testing/adios2/engine/bp/TestBPWriteRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteRead.cpp
@@ -27,49 +27,85 @@ public:
 // 1D 1x8 test data
 //******************************************************************************
 
-// ADIOS2 write, native ADIOS1 read
+// ADIOS2 BP write, native ADIOS1 read
 TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8)
 {
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
     std::string fname = "ADIOS2BPWriteADIOS1Read1D8.bp";
 
-    // Write test data using ADIOS2
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 8;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+    // Write test data using BP
     {
+#ifdef ADIOS2_HAVE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
         adios2::ADIOS adios(true);
+#endif
         adios2::IO &io = adios.DeclareIO("TestIO");
 
-        // Declare 1D variables
+        // Declare 1D variables (NumOfProcesses * Nx)
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
         {
-            auto &var_i8 =
-                io.DefineVariable<int8_t>("i8", {}, {}, adios2::Dims{8});
+            adios2::Dims shape{static_cast<unsigned int>(Nx * mpiSize)};
+            adios2::Dims start{static_cast<unsigned int>(Nx * mpiRank)};
+            adios2::Dims count{static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
             auto &var_i16 =
-                io.DefineVariable<int16_t>("i16", {}, {}, adios2::Dims{8});
+                io.DefineVariable<int16_t>("i16", shape, start, count);
             auto &var_i32 =
-                io.DefineVariable<int32_t>("i32", {}, {}, adios2::Dims{8});
+                io.DefineVariable<int32_t>("i32", shape, start, count);
             auto &var_i64 =
-                io.DefineVariable<int64_t>("i64", {}, {}, adios2::Dims{8});
+                io.DefineVariable<int64_t>("i64", shape, start, count);
             auto &var_u8 =
-                io.DefineVariable<uint8_t>("u8", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
             auto &var_u16 =
-                io.DefineVariable<uint16_t>("u16", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
             auto &var_u32 =
-                io.DefineVariable<uint32_t>("u32", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
             auto &var_u64 =
-                io.DefineVariable<uint64_t>("u64", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
             auto &var_r32 =
-                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{8});
+                io.DefineVariable<float>("r32", shape, start, count);
             auto &var_r64 =
-                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{8});
+                io.DefineVariable<double>("r64", shape, start, count);
         }
 
-        // Create the BP Engine
+        // Create the ADIOS 1 Engine
         io.SetEngine("BPFileWriter");
-        io.AddTransport("File");
 
+#ifdef ADIOS2_HAVE_MPI
+        io.AddTransport("file", {{"library", "MPI"}});
+#else
+        io.AddTransport("file");
+#endif
+        // QUESTION: It seems that BPFilterWriter cannot overwrite existing
+        // files
+        // Ex. if you tune Nx and NSteps, the test would fail. But if you clear
+        // the cache in
+        // ${adios2Build}/testing/adios2/engine/bp/ADIOS2BPWriteADIOS1Read1D8.bp.dir,
+        // then it works
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
 
-        for (size_t step = 0; step < 3; ++step)
+        for (size_t step = 0; step < NSteps; ++step)
         {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, step, mpiRank, mpiSize);
+
             // Retrieve the variables that previously went out of scope
             auto &var_i8 = io.GetVariable<int8_t>("i8");
             auto &var_i16 = io.GetVariable<int16_t>("i16");
@@ -82,17 +118,33 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8)
             auto &var_r32 = io.GetVariable<float>("r32");
             auto &var_r64 = io.GetVariable<double>("r64");
 
+            // Make a 1D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::SelectionBoundingBox sel({mpiRank * Nx}, {Nx});
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
             // Write each one
-            engine->Write(var_i8, m_TestData.I8.data() + step);
-            engine->Write(var_i16, m_TestData.I16.data() + step);
-            engine->Write(var_i32, m_TestData.I32.data() + step);
-            engine->Write(var_i64, m_TestData.I64.data() + step);
-            engine->Write(var_u8, m_TestData.U8.data() + step);
-            engine->Write(var_u16, m_TestData.U16.data() + step);
-            engine->Write(var_u32, m_TestData.U32.data() + step);
-            engine->Write(var_u64, m_TestData.U64.data() + step);
-            engine->Write(var_r32, m_TestData.R32.data() + step);
-            engine->Write(var_r64, m_TestData.R64.data() + step);
+            // fill in the variable with values from starting index to
+            // starting index + count
+            engine->Write(var_i8, currentTestData.I8.data());
+            engine->Write(var_i16, currentTestData.I16.data());
+            engine->Write(var_i32, currentTestData.I32.data());
+            engine->Write(var_i64, currentTestData.I64.data());
+            engine->Write(var_u8, currentTestData.U8.data());
+            engine->Write(var_u16, currentTestData.U16.data());
+            engine->Write(var_u32, currentTestData.U32.data());
+            engine->Write(var_u64, currentTestData.U64.data());
+            engine->Write(var_r32, currentTestData.R32.data());
+            engine->Write(var_r64, currentTestData.R64.data());
 
             // Advance to the next time step
             engine->Advance();
@@ -102,83 +154,105 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8)
         engine->Close();
     }
 
-// Read test data using ADIOS1
-#ifdef ADIOS2_HAVE_MPI
-    // Read everything from rank 0
-    int rank;
-    MPI_Comm_rank();
-    if (rank == 0)
-#endif
     {
         adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
                                "verbose=3");
 
         // Open the file for reading
-        ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
-                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        std::string index = std::to_string(mpiRank);
+        ADIOS_FILE *f = adios_read_open_file(
+            (fname + ".dir/" + fname + "." + index).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
         ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
         ASSERT_NE(var_i8, nullptr);
         ASSERT_EQ(var_i8->ndim, 1);
-        ASSERT_EQ(var_i8->dims[0], 8);
+        ASSERT_EQ(var_i8->global, 1);
+        ASSERT_EQ(var_i8->nsteps, NSteps);
+        ASSERT_EQ(var_i8->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
         ASSERT_NE(var_i16, nullptr);
         ASSERT_EQ(var_i16->ndim, 1);
-        ASSERT_EQ(var_i16->dims[0], 8);
+        ASSERT_EQ(var_i16->global, 1);
+        ASSERT_EQ(var_i16->nsteps, NSteps);
+        ASSERT_EQ(var_i16->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
         ASSERT_NE(var_i32, nullptr);
         ASSERT_EQ(var_i32->ndim, 1);
-        ASSERT_EQ(var_i32->dims[0], 8);
+        ASSERT_EQ(var_i32->global, 1);
+        ASSERT_EQ(var_i32->nsteps, NSteps);
+        ASSERT_EQ(var_i32->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
         ASSERT_NE(var_i64, nullptr);
         ASSERT_EQ(var_i64->ndim, 1);
-        ASSERT_EQ(var_i64->dims[0], 8);
+        ASSERT_EQ(var_i64->global, 1);
+        ASSERT_EQ(var_i64->nsteps, NSteps);
+        ASSERT_EQ(var_i64->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
         ASSERT_NE(var_u8, nullptr);
         ASSERT_EQ(var_u8->ndim, 1);
-        ASSERT_EQ(var_u8->dims[0], 8);
+        ASSERT_EQ(var_u8->global, 1);
+        ASSERT_EQ(var_u8->nsteps, NSteps);
+        ASSERT_EQ(var_u8->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
         ASSERT_NE(var_u16, nullptr);
         ASSERT_EQ(var_u16->ndim, 1);
-        ASSERT_EQ(var_u16->dims[0], 8);
+        ASSERT_EQ(var_u16->global, 1);
+        ASSERT_EQ(var_u16->nsteps, NSteps);
+        ASSERT_EQ(var_u16->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
         ASSERT_NE(var_u32, nullptr);
         ASSERT_EQ(var_u32->ndim, 1);
-        ASSERT_EQ(var_u32->dims[0], 8);
+        ASSERT_EQ(var_u32->global, 1);
+        ASSERT_EQ(var_u32->nsteps, NSteps);
+        ASSERT_EQ(var_u32->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
         ASSERT_NE(var_u64, nullptr);
         ASSERT_EQ(var_u64->ndim, 1);
-        ASSERT_EQ(var_u64->dims[0], 8);
+        ASSERT_EQ(var_u64->global, 1);
+        ASSERT_EQ(var_u64->nsteps, NSteps);
+        ASSERT_EQ(var_u64->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
         ASSERT_NE(var_r32, nullptr);
         ASSERT_EQ(var_r32->ndim, 1);
-        ASSERT_EQ(var_r32->dims[0], 8);
+        ASSERT_EQ(var_r32->global, 1);
+        ASSERT_EQ(var_r32->nsteps, NSteps);
+        ASSERT_EQ(var_r32->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
         ASSERT_NE(var_r64, nullptr);
         ASSERT_EQ(var_r64->ndim, 1);
-        ASSERT_EQ(var_r64->dims[0], 8);
+        ASSERT_EQ(var_r64->global, 1);
+        ASSERT_EQ(var_r64->nsteps, NSteps);
+        ASSERT_EQ(var_r64->dims[0], mpiSize * Nx);
 
-        std::array<int8_t, 8> I8;
-        std::array<int16_t, 8> I16;
-        std::array<int32_t, 8> I32;
-        std::array<int64_t, 8> I64;
-        std::array<uint8_t, 8> U8;
-        std::array<uint16_t, 8> U16;
-        std::array<uint32_t, 8> U32;
-        std::array<uint64_t, 8> U64;
-        std::array<float, 8> R32;
-        std::array<double, 8> R64;
+        std::array<int8_t, Nx> I8;
+        std::array<int16_t, Nx> I16;
+        std::array<int32_t, Nx> I32;
+        std::array<int64_t, Nx> I64;
+        std::array<uint8_t, Nx> U8;
+        std::array<uint16_t, Nx> U16;
+        std::array<uint32_t, Nx> U32;
+        std::array<uint64_t, Nx> U64;
+        std::array<float, Nx> R32;
+        std::array<double, Nx> R64;
 
+        // QUESTION: For ADIOS1Writer, the start index would be mpiRank * Nx.
+        // However it seems that BPWriter would skip empty values to find the
+        // right start index. Here 0 would make the test pass.
+        // Note: Since collective metadata generation is not implemented yet,
+        // which makes sence.
         uint64_t start[1] = {0};
-        uint64_t count[1] = {8};
+        uint64_t count[1] = {Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(1, start, count);
 
         // Read stuff
-        for (size_t t = 0; t < 3; ++t)
+        for (size_t t = 0; t < NSteps; ++t)
         {
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, t, mpiRank, mpiSize);
             // Read the current step
             adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
             adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
@@ -193,22 +267,22 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8)
             adios_perform_reads(f, 1);
 
             // Check if it's correct
-            for (size_t i = 0; i < 8; ++i)
+            for (size_t i = 0; i < Nx; ++i)
             {
                 std::stringstream ss;
-                ss << "t=" << t << " i=" << i;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
-                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
-                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
-                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
-                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
-                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
-                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
-                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
-                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
-                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
-                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
             }
         }
 
@@ -228,6 +302,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8)
 
         // Cleanup file
         adios_read_close(f);
+
+        adios_read_finalize_method(ADIOS_READ_METHOD_BP);
     }
 }
 
@@ -243,49 +319,85 @@ TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead1D8)
 // 2D 2x4 test data
 //******************************************************************************
 
-// ADIOS2 write, native ADIOS1 read
+// ADIOS2 BP write, native ADIOS1 read
 TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4)
 {
+    // Each process would write a 2x4 array and all processes would
+    // form a 2D 2 * (numberOfProcess*Nx) matrix where Nx is 4 here
     std::string fname = "ADIOS2BPWriteADIOS1Read2D2x4Test.bp";
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 4;
+
+    // Number of rows
+    const std::size_t Ny = 2;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
 
     // Write test data using ADIOS2
     {
+#ifdef ADIOS2_HAVE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
         adios2::ADIOS adios(true);
+#endif
         adios2::IO &io = adios.DeclareIO("TestIO");
 
-        // Declare 1D variables
+        // Declare 2D variables (Ny * (NumOfProcesses * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
         {
-            auto &var_i8 =
-                io.DefineVariable<int8_t>("i8", {}, {}, adios2::Dims{2, 4});
+            adios2::Dims shape{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx * mpiSize)};
+            adios2::Dims start{static_cast<unsigned int>(0),
+                               static_cast<unsigned int>(mpiRank * Nx)};
+            adios2::Dims count{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
             auto &var_i16 =
-                io.DefineVariable<int16_t>("i16", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<int16_t>("i16", shape, start, count);
             auto &var_i32 =
-                io.DefineVariable<int32_t>("i32", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<int32_t>("i32", shape, start, count);
             auto &var_i64 =
-                io.DefineVariable<int64_t>("i64", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<int64_t>("i64", shape, start, count);
             auto &var_u8 =
-                io.DefineVariable<uint8_t>("u8", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
             auto &var_u16 =
-                io.DefineVariable<uint16_t>("u16", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
             auto &var_u32 =
-                io.DefineVariable<uint32_t>("u32", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
             auto &var_u64 =
-                io.DefineVariable<uint64_t>("u64", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
             auto &var_r32 =
-                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<float>("r32", shape, start, count);
             auto &var_r64 =
-                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<double>("r64", shape, start, count);
         }
 
         // Create the BP Engine
         io.SetEngine("BPFileWriter");
+#ifdef ADIOS2_HAVE_MPI
+        io.AddTransport("file", {{"library", "MPI"}});
+#else
         io.AddTransport("file");
+#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
 
-        for (size_t step = 0; step < 3; ++step)
+        for (size_t step = 0; step < NSteps; ++step)
         {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, step, mpiRank, mpiSize);
+
             // Retrieve the variables that previously went out of scope
             auto &var_i8 = io.GetVariable<int8_t>("i8");
             auto &var_i16 = io.GetVariable<int16_t>("i16");
@@ -298,17 +410,34 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4)
             auto &var_r32 = io.GetVariable<float>("r32");
             auto &var_r64 = io.GetVariable<double>("r64");
 
+            // Make a 2D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::SelectionBoundingBox sel(
+                {0, static_cast<unsigned int>(mpiRank * Nx)}, {Ny, Nx});
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
             // Write each one
-            engine->Write(var_i8, m_TestData.I8.data() + step);
-            engine->Write(var_i16, m_TestData.I16.data() + step);
-            engine->Write(var_i32, m_TestData.I32.data() + step);
-            engine->Write(var_i64, m_TestData.I64.data() + step);
-            engine->Write(var_u8, m_TestData.U8.data() + step);
-            engine->Write(var_u16, m_TestData.U16.data() + step);
-            engine->Write(var_u32, m_TestData.U32.data() + step);
-            engine->Write(var_u64, m_TestData.U64.data() + step);
-            engine->Write(var_r32, m_TestData.R32.data() + step);
-            engine->Write(var_r64, m_TestData.R64.data() + step);
+            // fill in the variable with values from starting index to
+            // starting index + count
+            engine->Write(var_i8, currentTestData.I8.data());
+            engine->Write(var_i16, currentTestData.I16.data());
+            engine->Write(var_i32, currentTestData.I32.data());
+            engine->Write(var_i64, currentTestData.I64.data());
+            engine->Write(var_u8, currentTestData.U8.data());
+            engine->Write(var_u16, currentTestData.U16.data());
+            engine->Write(var_u32, currentTestData.U32.data());
+            engine->Write(var_u64, currentTestData.U64.data());
+            engine->Write(var_r32, currentTestData.R32.data());
+            engine->Write(var_r64, currentTestData.R64.data());
 
             // Advance to the next time step
             engine->Advance();
@@ -318,93 +447,114 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4)
         engine->Close();
     }
 
-// Read test data using ADIOS1
-#ifdef ADIOS2_HAVE_MPI
-    // Read everything from rank 0
-    int rank;
-    MPI_Comm_rank();
-    if (rank == 0)
-#endif
     {
         adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
                                "verbose=3");
 
         // Open the file for reading
-        ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
-                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        std::string index = std::to_string(mpiRank);
+        ADIOS_FILE *f = adios_read_open_file(
+            (fname + ".dir/" + fname + "." + index).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
         ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
         ASSERT_NE(var_i8, nullptr);
         ASSERT_EQ(var_i8->ndim, 2);
-        ASSERT_EQ(var_i8->dims[0], 2);
-        ASSERT_EQ(var_i8->dims[1], 4);
+        ASSERT_EQ(var_i8->global, 1);
+        ASSERT_EQ(var_i8->nsteps, NSteps);
+        ASSERT_EQ(var_i8->dims[0], Ny);
+        ASSERT_EQ(var_i8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
         ASSERT_NE(var_i16, nullptr);
         ASSERT_EQ(var_i16->ndim, 2);
-        ASSERT_EQ(var_i16->dims[0], 2);
-        ASSERT_EQ(var_i16->dims[1], 4);
+        ASSERT_EQ(var_i16->global, 1);
+        ASSERT_EQ(var_i16->nsteps, NSteps);
+        ASSERT_EQ(var_i16->dims[0], Ny);
+        ASSERT_EQ(var_i16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
         ASSERT_NE(var_i32, nullptr);
         ASSERT_EQ(var_i32->ndim, 2);
-        ASSERT_EQ(var_i32->dims[0], 2);
-        ASSERT_EQ(var_i32->dims[1], 4);
+        ASSERT_EQ(var_i32->global, 1);
+        ASSERT_EQ(var_i32->nsteps, NSteps);
+        ASSERT_EQ(var_i32->dims[0], Ny);
+        ASSERT_EQ(var_i32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
         ASSERT_NE(var_i64, nullptr);
         ASSERT_EQ(var_i64->ndim, 2);
-        ASSERT_EQ(var_i64->dims[0], 2);
-        ASSERT_EQ(var_i64->dims[1], 4);
+        ASSERT_EQ(var_i64->global, 1);
+        ASSERT_EQ(var_i64->nsteps, NSteps);
+        ASSERT_EQ(var_i64->dims[0], Ny);
+        ASSERT_EQ(var_i64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
         ASSERT_NE(var_u8, nullptr);
         ASSERT_EQ(var_u8->ndim, 2);
-        ASSERT_EQ(var_u8->dims[0], 2);
-        ASSERT_EQ(var_u8->dims[1], 4);
+        ASSERT_EQ(var_u8->global, 1);
+        ASSERT_EQ(var_u8->nsteps, NSteps);
+        ASSERT_EQ(var_u8->dims[0], Ny);
+        ASSERT_EQ(var_u8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
         ASSERT_NE(var_u16, nullptr);
         ASSERT_EQ(var_u16->ndim, 2);
-        ASSERT_EQ(var_u16->dims[0], 2);
-        ASSERT_EQ(var_u16->dims[1], 4);
+        ASSERT_EQ(var_u16->global, 1);
+        ASSERT_EQ(var_u16->nsteps, NSteps);
+        ASSERT_EQ(var_u16->dims[0], Ny);
+        ASSERT_EQ(var_u16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
         ASSERT_NE(var_u32, nullptr);
         ASSERT_EQ(var_u32->ndim, 2);
-        ASSERT_EQ(var_u32->dims[0], 2);
-        ASSERT_EQ(var_u32->dims[1], 4);
+        ASSERT_EQ(var_u32->global, 1);
+        ASSERT_EQ(var_u32->nsteps, NSteps);
+        ASSERT_EQ(var_u32->dims[0], Ny);
+        ASSERT_EQ(var_u32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
         ASSERT_NE(var_u64, nullptr);
         ASSERT_EQ(var_u64->ndim, 2);
-        ASSERT_EQ(var_u64->dims[0], 2);
-        ASSERT_EQ(var_u64->dims[1], 4);
+        ASSERT_EQ(var_u64->global, 1);
+        ASSERT_EQ(var_u64->nsteps, NSteps);
+        ASSERT_EQ(var_u64->dims[0], Ny);
+        ASSERT_EQ(var_u64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
         ASSERT_NE(var_r32, nullptr);
         ASSERT_EQ(var_r32->ndim, 2);
-        ASSERT_EQ(var_r32->dims[0], 2);
-        ASSERT_EQ(var_r32->dims[1], 4);
+        ASSERT_EQ(var_r32->global, 1);
+        ASSERT_EQ(var_r32->nsteps, NSteps);
+        ASSERT_EQ(var_r32->dims[0], Ny);
+        ASSERT_EQ(var_r32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
         ASSERT_NE(var_r64, nullptr);
         ASSERT_EQ(var_r64->ndim, 2);
-        ASSERT_EQ(var_r64->dims[0], 2);
-        ASSERT_EQ(var_r64->dims[1], 4);
+        ASSERT_EQ(var_r64->global, 1);
+        ASSERT_EQ(var_r64->nsteps, NSteps);
+        ASSERT_EQ(var_r64->dims[0], Ny);
+        ASSERT_EQ(var_r64->dims[1], mpiSize * Nx);
 
-        std::array<int8_t, 8> I8;
-        std::array<int16_t, 8> I16;
-        std::array<int32_t, 8> I32;
-        std::array<int64_t, 8> I64;
-        std::array<uint8_t, 8> U8;
-        std::array<uint16_t, 8> U16;
-        std::array<uint32_t, 8> U32;
-        std::array<uint64_t, 8> U64;
-        std::array<float, 8> R32;
-        std::array<double, 8> R64;
+        // If the size of the array is smaller than the data
+        // the result is weird... double and uint64_t would get completely
+        // garbage data
+        std::array<int8_t, Nx * Ny> I8;
+        std::array<int16_t, Nx * Ny> I16;
+        std::array<int32_t, Nx * Ny> I32;
+        std::array<int64_t, Nx * Ny> I64;
+        std::array<uint8_t, Nx * Ny> U8;
+        std::array<uint16_t, Nx * Ny> U16;
+        std::array<uint32_t, Nx * Ny> U32;
+        std::array<uint64_t, Nx * Ny> U64;
+        std::array<float, Nx * Ny> R32;
+        std::array<double, Nx * Ny> R64;
 
+        // FIXME: When bp metadata generation has landed, use mpiRank * Nx
         uint64_t start[2] = {0, 0};
-        uint64_t count[2] = {2, 4};
+        uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 
         // Read stuff
-        for (size_t t = 0; t < 3; ++t)
+        for (size_t t = 0; t < NSteps; ++t)
         {
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, t, mpiRank, mpiSize);
             // Read the current step
             adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
             adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
@@ -419,22 +569,22 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4)
             adios_perform_reads(f, 1);
 
             // Check if it's correct
-            for (size_t i = 0; i < 8; ++i)
+            for (size_t i = 0; i < Nx; ++i)
             {
                 std::stringstream ss;
-                ss << "t=" << t << " i=" << i;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
-                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
-                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
-                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
-                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
-                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
-                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
-                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
-                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
-                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
-                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
             }
         }
 
@@ -454,6 +604,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4)
 
         // Cleanup file
         adios_read_close(f);
+
+        adios_read_finalize_method(ADIOS_READ_METHOD_BP);
     }
 }
 
@@ -472,46 +624,82 @@ TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead2D2x4)
 // ADIOS2 write, native ADIOS1 read
 TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2)
 {
+    // Each process would write a 4x2 array and all processes would
+    // form a 2D 4 * (NumberOfProcess * Nx) matrix where Nx is 2 here
     std::string fname = "ADIOS2BPWriteADIOS1Read2D4x2Test.bp";
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 2;
+    // Number of cols
+    const std::size_t Ny = 4;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
 
     // Write test data using ADIOS2
     {
+#ifdef ADIOS2_HAVE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
         adios2::ADIOS adios(true);
+#endif
         adios2::IO &io = adios.DeclareIO("TestIO");
 
-        // Declare 1D variables
+        // Declare 2D variables (4 * (NumberOfProcess * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
         {
-            auto &var_i8 =
-                io.DefineVariable<int8_t>("i8", {}, {}, adios2::Dims{4, 2});
+            adios2::Dims shape{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(mpiSize * Nx)};
+            adios2::Dims start{static_cast<unsigned int>(0),
+                               static_cast<unsigned int>(mpiRank * Nx)};
+            adios2::Dims count{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
             auto &var_i16 =
-                io.DefineVariable<int16_t>("i16", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<int16_t>("i16", shape, start, count);
             auto &var_i32 =
-                io.DefineVariable<int32_t>("i32", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<int32_t>("i32", shape, start, count);
             auto &var_i64 =
-                io.DefineVariable<int64_t>("i64", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<int64_t>("i64", shape, start, count);
             auto &var_u8 =
-                io.DefineVariable<uint8_t>("u8", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
             auto &var_u16 =
-                io.DefineVariable<uint16_t>("u16", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
             auto &var_u32 =
-                io.DefineVariable<uint32_t>("u32", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
             auto &var_u64 =
-                io.DefineVariable<uint64_t>("u64", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
             auto &var_r32 =
-                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<float>("r32", shape, start, count);
             auto &var_r64 =
-                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<double>("r64", shape, start, count);
         }
 
-        // Create the BP Engine
+        // Create the ADIOS 1 Engine
         io.SetEngine("BPFileWriter");
+
+#ifdef ADIOS2_HAVE_MPI
+        io.AddTransport("file", {{"library", "MPI"}});
+#else
         io.AddTransport("file");
+#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
 
-        for (size_t step = 0; step < 3; ++step)
+        for (size_t step = 0; step < NSteps; ++step)
         {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, step, mpiRank, mpiSize);
+
             // Retrieve the variables that previously went out of scope
             auto &var_i8 = io.GetVariable<int8_t>("i8");
             auto &var_i16 = io.GetVariable<int16_t>("i16");
@@ -524,17 +712,34 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2)
             auto &var_r32 = io.GetVariable<float>("r32");
             auto &var_r64 = io.GetVariable<double>("r64");
 
+            // Make a 2D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::SelectionBoundingBox sel(
+                {0, static_cast<unsigned int>(mpiRank * Nx)}, {Ny, Nx});
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
             // Write each one
-            engine->Write(var_i8, m_TestData.I8.data() + step);
-            engine->Write(var_i16, m_TestData.I16.data() + step);
-            engine->Write(var_i32, m_TestData.I32.data() + step);
-            engine->Write(var_i64, m_TestData.I64.data() + step);
-            engine->Write(var_u8, m_TestData.U8.data() + step);
-            engine->Write(var_u16, m_TestData.U16.data() + step);
-            engine->Write(var_u32, m_TestData.U32.data() + step);
-            engine->Write(var_u64, m_TestData.U64.data() + step);
-            engine->Write(var_r32, m_TestData.R32.data() + step);
-            engine->Write(var_r64, m_TestData.R64.data() + step);
+            // fill in the variable with values from starting index to
+            // starting index + count
+            engine->Write(var_i8, currentTestData.I8.data());
+            engine->Write(var_i16, currentTestData.I16.data());
+            engine->Write(var_i32, currentTestData.I32.data());
+            engine->Write(var_i64, currentTestData.I64.data());
+            engine->Write(var_u8, currentTestData.U8.data());
+            engine->Write(var_u16, currentTestData.U16.data());
+            engine->Write(var_u32, currentTestData.U32.data());
+            engine->Write(var_u64, currentTestData.U64.data());
+            engine->Write(var_r32, currentTestData.R32.data());
+            engine->Write(var_r64, currentTestData.R64.data());
 
             // Advance to the next time step
             engine->Advance();
@@ -544,93 +749,114 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2)
         engine->Close();
     }
 
-// Read test data using ADIOS1
-#ifdef ADIOS2_HAVE_MPI
-    // Read everything from rank 0
-    int rank;
-    MPI_Comm_rank();
-    if (rank == 0)
-#endif
     {
         adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
                                "verbose=3");
 
         // Open the file for reading
-        ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
-                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        std::string index = std::to_string(mpiRank);
+        ADIOS_FILE *f = adios_read_open_file(
+            (fname + ".dir/" + fname + "." + index).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
         ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
         ASSERT_NE(var_i8, nullptr);
         ASSERT_EQ(var_i8->ndim, 2);
-        ASSERT_EQ(var_i8->dims[0], 4);
-        ASSERT_EQ(var_i8->dims[1], 2);
+        ASSERT_EQ(var_i8->global, 1);
+        ASSERT_EQ(var_i8->nsteps, NSteps);
+        ASSERT_EQ(var_i8->dims[0], Ny);
+        ASSERT_EQ(var_i8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
         ASSERT_NE(var_i16, nullptr);
         ASSERT_EQ(var_i16->ndim, 2);
-        ASSERT_EQ(var_i16->dims[0], 4);
-        ASSERT_EQ(var_i16->dims[1], 2);
+        ASSERT_EQ(var_i16->global, 1);
+        ASSERT_EQ(var_i16->nsteps, NSteps);
+        ASSERT_EQ(var_i16->dims[0], Ny);
+        ASSERT_EQ(var_i16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
         ASSERT_NE(var_i32, nullptr);
         ASSERT_EQ(var_i32->ndim, 2);
-        ASSERT_EQ(var_i32->dims[0], 4);
-        ASSERT_EQ(var_i32->dims[1], 2);
+        ASSERT_EQ(var_i32->global, 1);
+        ASSERT_EQ(var_i32->nsteps, NSteps);
+        ASSERT_EQ(var_i32->dims[0], Ny);
+        ASSERT_EQ(var_i32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
         ASSERT_NE(var_i64, nullptr);
         ASSERT_EQ(var_i64->ndim, 2);
-        ASSERT_EQ(var_i64->dims[0], 4);
-        ASSERT_EQ(var_i64->dims[1], 2);
+        ASSERT_EQ(var_i64->global, 1);
+        ASSERT_EQ(var_i64->nsteps, NSteps);
+        ASSERT_EQ(var_i64->dims[0], Ny);
+        ASSERT_EQ(var_i64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
         ASSERT_NE(var_u8, nullptr);
         ASSERT_EQ(var_u8->ndim, 2);
-        ASSERT_EQ(var_u8->dims[0], 4);
-        ASSERT_EQ(var_u8->dims[1], 2);
+        ASSERT_EQ(var_u8->global, 1);
+        ASSERT_EQ(var_u8->nsteps, NSteps);
+        ASSERT_EQ(var_u8->dims[0], Ny);
+        ASSERT_EQ(var_u8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
         ASSERT_NE(var_u16, nullptr);
         ASSERT_EQ(var_u16->ndim, 2);
-        ASSERT_EQ(var_u16->dims[0], 4);
-        ASSERT_EQ(var_u16->dims[1], 2);
+        ASSERT_EQ(var_u16->global, 1);
+        ASSERT_EQ(var_u16->nsteps, NSteps);
+        ASSERT_EQ(var_u16->dims[0], Ny);
+        ASSERT_EQ(var_u16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
         ASSERT_NE(var_u32, nullptr);
         ASSERT_EQ(var_u32->ndim, 2);
-        ASSERT_EQ(var_u32->dims[0], 4);
-        ASSERT_EQ(var_u32->dims[1], 2);
+        ASSERT_EQ(var_u32->global, 1);
+        ASSERT_EQ(var_u32->nsteps, NSteps);
+        ASSERT_EQ(var_u32->dims[0], Ny);
+        ASSERT_EQ(var_u32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
         ASSERT_NE(var_u64, nullptr);
         ASSERT_EQ(var_u64->ndim, 2);
-        ASSERT_EQ(var_u64->dims[0], 4);
-        ASSERT_EQ(var_u64->dims[1], 2);
+        ASSERT_EQ(var_u64->global, 1);
+        ASSERT_EQ(var_u64->nsteps, NSteps);
+        ASSERT_EQ(var_u64->dims[0], Ny);
+        ASSERT_EQ(var_u64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
         ASSERT_NE(var_r32, nullptr);
         ASSERT_EQ(var_r32->ndim, 2);
-        ASSERT_EQ(var_r32->dims[0], 4);
-        ASSERT_EQ(var_r32->dims[1], 2);
+        ASSERT_EQ(var_r32->global, 1);
+        ASSERT_EQ(var_r32->nsteps, NSteps);
+        ASSERT_EQ(var_r32->dims[0], Ny);
+        ASSERT_EQ(var_r32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
         ASSERT_NE(var_r64, nullptr);
         ASSERT_EQ(var_r64->ndim, 2);
-        ASSERT_EQ(var_r64->dims[0], 4);
-        ASSERT_EQ(var_r64->dims[1], 2);
+        ASSERT_EQ(var_r64->global, 1);
+        ASSERT_EQ(var_r64->nsteps, NSteps);
+        ASSERT_EQ(var_r64->dims[0], Ny);
+        ASSERT_EQ(var_r64->dims[1], mpiSize * Nx);
 
-        std::array<int8_t, 8> I8;
-        std::array<int16_t, 8> I16;
-        std::array<int32_t, 8> I32;
-        std::array<int64_t, 8> I64;
-        std::array<uint8_t, 8> U8;
-        std::array<uint16_t, 8> U16;
-        std::array<uint32_t, 8> U32;
-        std::array<uint64_t, 8> U64;
-        std::array<float, 8> R32;
-        std::array<double, 8> R64;
+        // If the size of the array is smaller than the data
+        // the result is weird... double and uint64_t would get completely
+        // garbage data
+        std::array<int8_t, Nx * Ny> I8;
+        std::array<int16_t, Nx * Ny> I16;
+        std::array<int32_t, Nx * Ny> I32;
+        std::array<int64_t, Nx * Ny> I64;
+        std::array<uint8_t, Nx * Ny> U8;
+        std::array<uint16_t, Nx * Ny> U16;
+        std::array<uint32_t, Nx * Ny> U32;
+        std::array<uint64_t, Nx * Ny> U64;
+        std::array<float, Nx * Ny> R32;
+        std::array<double, Nx * Ny> R64;
 
+        // FIXME: When bp metadata generation has landed, use mpiRank * Nx
         uint64_t start[2] = {0, 0};
-        uint64_t count[2] = {4, 2};
+        uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 
         // Read stuff
-        for (size_t t = 0; t < 3; ++t)
+        for (size_t t = 0; t < NSteps; ++t)
         {
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, t, mpiRank, mpiSize);
             // Read the current step
             adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
             adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
@@ -645,22 +871,22 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2)
             adios_perform_reads(f, 1);
 
             // Check if it's correct
-            for (size_t i = 0; i < 8; ++i)
+            for (size_t i = 0; i < Nx; ++i)
             {
                 std::stringstream ss;
-                ss << "t=" << t << " i=" << i;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
-                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
-                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
-                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
-                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
-                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
-                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
-                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
-                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
-                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
-                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
             }
         }
 
@@ -680,6 +906,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2)
 
         // Cleanup file
         adios_read_close(f);
+
+        adios_read_finalize_method(ADIOS_READ_METHOD_BP);
     }
 }
 

--- a/testing/adios2/engine/bp/TestBPWriteRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteRead.cpp
@@ -86,11 +86,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8)
         // Create the ADIOS 1 Engine
         io.SetEngine("BPFileWriter");
 
-#ifdef ADIOS2_HAVE_MPI
-        io.AddTransport("file", {{"library", "MPI"}});
-#else
         io.AddTransport("file");
-#endif
+
         // QUESTION: It seems that BPFilterWriter cannot overwrite existing
         // files
         // Ex. if you tune Nx and NSteps, the test would fail. But if you clear
@@ -383,11 +380,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4)
 
         // Create the BP Engine
         io.SetEngine("BPFileWriter");
-#ifdef ADIOS2_HAVE_MPI
-        io.AddTransport("file", {{"library", "MPI"}});
-#else
         io.AddTransport("file");
-#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
@@ -685,11 +678,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2)
         // Create the ADIOS 1 Engine
         io.SetEngine("BPFileWriter");
 
-#ifdef ADIOS2_HAVE_MPI
-        io.AddTransport("file", {{"library", "MPI"}});
-#else
         io.AddTransport("file");
-#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
@@ -97,11 +97,7 @@ TEST_F(BPWriteReadAttributeTest, ADIOS2BPWriteADIOS1ReadSingleTypes)
         // Create the BP Engine
         io.SetEngine("BPFileWriter");
 
-#ifdef ADIOS2_HAVE_MPI
-        io.AddTransport("file", {{"library", "MPI"}});
-#else
         io.AddTransport("file");
-#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
@@ -247,6 +243,7 @@ TEST_F(BPWriteReadAttributeTest, ADIOS2BPWriteADIOS1ReadArrayTypes)
 
         // Create the BP Engine
         io.SetEngine("BPFileWriter");
+
         io.AddTransport("File");
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
@@ -30,7 +30,8 @@ public:
 // ADIOS2 write, native ADIOS1 read for single value attributes
 TEST_F(BPWriteReadAttributeTest, ADIOS2BPWriteADIOS1ReadSingleTypes)
 {
-    std::string fname = "ADIOS2BPWriteAttributeADIOS1ReadSingleTypes.bp";
+    std::string fname = "foo/ADIOS2BPWriteAttributeADIOS1ReadSingleTypes.bp";
+    std::string fRootName = "ADIOS2BPWriteAttributeADIOS1ReadSingleTypes.bp";
 
     int mpiRank = 0, mpiSize = 1;
 #ifdef ADIOS2_HAVE_MPI
@@ -40,7 +41,8 @@ TEST_F(BPWriteReadAttributeTest, ADIOS2BPWriteADIOS1ReadSingleTypes)
 
     // FIXME: Since collective meta generation has not landed yet, so there is
     // no way for us to gather different attribute data per process. Ideally we
-    // should use unique attribute data per process. Ex: std::to_string(mpiRank);
+    // should use unique attribute data per process. Ex:
+    // std::to_string(mpiRank);
     std::string mpiRankString = std::to_string(0);
     std::string s1_Single = std::string("s1_Single_") + mpiRankString;
     std::string i8_Single = std::string("i8_Single_") + mpiRankString;
@@ -107,13 +109,13 @@ TEST_F(BPWriteReadAttributeTest, ADIOS2BPWriteADIOS1ReadSingleTypes)
     }
 
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
         ADIOS_FILE *f = adios_read_open_file(
-            (fname + ".dir/" + fname + "." + mpiRankString).c_str(),
-            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+            (fname + ".dir/" + fRootName + "." + mpiRankString).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         int size, status;
@@ -206,7 +208,8 @@ TEST_F(BPWriteReadAttributeTest, ADIOS2BPWriteADIOS1ReadSingleTypes)
 // ADIOS2 write, native ADIOS1 read for array attributes
 TEST_F(BPWriteReadAttributeTest, ADIOS2BPWriteADIOS1ReadArrayTypes)
 {
-    std::string fname = "ADIOS2BPWriteAttributeADIOS1ReadArrayTypes.bp";
+    std::string fname = "foo/bar/ADIOS2BPWriteAttributeADIOS1ReadArrayTypes.bp";
+    std::string fRootName = "ADIOS2BPWriteAttributeADIOS1ReadArrayTypes.bp";
 
     // Write test data using ADIOS2
     {
@@ -244,7 +247,7 @@ TEST_F(BPWriteReadAttributeTest, ADIOS2BPWriteADIOS1ReadArrayTypes)
         // Create the BP Engine
         io.SetEngine("BPFileWriter");
 
-        io.AddTransport("File");
+        io.AddTransport("file");
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
@@ -259,7 +262,7 @@ TEST_F(BPWriteReadAttributeTest, ADIOS2BPWriteADIOS1ReadArrayTypes)
 
         // Open the file for reading
         ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
+            adios_read_open_file((fname + ".dir/" + fRootName + ".0").c_str(),
                                  ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
         ASSERT_NE(f, nullptr);
 

--- a/testing/adios2/engine/bp/TestBPWriteReadfstream.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadfstream.cpp
@@ -27,49 +27,81 @@ public:
 // 1D 1x8 test data
 //******************************************************************************
 
-// ADIOS2 write, native ADIOS1 read
+// ADIOS2 BP write, native ADIOS1 read
 TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8fstream)
 {
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
     std::string fname = "ADIOS2BPWriteADIOS1Read1D8fstream.bp";
 
-    // Write test data using ADIOS2
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 8;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+    // Write test data using BP
     {
+#ifdef ADIOS2_HAVE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
         adios2::ADIOS adios(true);
+#endif
         adios2::IO &io = adios.DeclareIO("TestIO");
 
-        // Declare 1D variables
+        // Declare 1D variables (NumOfProcesses * Nx)
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
         {
-            auto &var_i8 =
-                io.DefineVariable<int8_t>("i8", {}, {}, adios2::Dims{8});
+            adios2::Dims shape{static_cast<unsigned int>(Nx * mpiSize)};
+            adios2::Dims start{static_cast<unsigned int>(Nx * mpiRank)};
+            adios2::Dims count{static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
             auto &var_i16 =
-                io.DefineVariable<int16_t>("i16", {}, {}, adios2::Dims{8});
+                io.DefineVariable<int16_t>("i16", shape, start, count);
             auto &var_i32 =
-                io.DefineVariable<int32_t>("i32", {}, {}, adios2::Dims{8});
+                io.DefineVariable<int32_t>("i32", shape, start, count);
             auto &var_i64 =
-                io.DefineVariable<int64_t>("i64", {}, {}, adios2::Dims{8});
+                io.DefineVariable<int64_t>("i64", shape, start, count);
             auto &var_u8 =
-                io.DefineVariable<uint8_t>("u8", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
             auto &var_u16 =
-                io.DefineVariable<uint16_t>("u16", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
             auto &var_u32 =
-                io.DefineVariable<uint32_t>("u32", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
             auto &var_u64 =
-                io.DefineVariable<uint64_t>("u64", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
             auto &var_r32 =
-                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{8});
+                io.DefineVariable<float>("r32", shape, start, count);
             auto &var_r64 =
-                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{8});
+                io.DefineVariable<double>("r64", shape, start, count);
         }
 
         // Create the BP Engine
         io.SetEngine("BPFileWriter");
-        io.AddTransport("File", {{"Library", "fstream"}});
+        io.AddTransport("file", {{"Library", "fstream"}});
 
+        // QUESTION: It seems that BPFilterWriter cannot overwrite existing
+        // files
+        // Ex. if you tune Nx and NSteps, the test would fail. But if you clear
+        // the cache in
+        // ${adios2Build}/testing/adios2/engine/bp/ADIOS2BPWriteADIOS1Read1D8.bp.dir,
+        // then it works
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
 
-        for (size_t step = 0; step < 3; ++step)
+        for (size_t step = 0; step < NSteps; ++step)
         {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, step, mpiRank, mpiSize);
+
             // Retrieve the variables that previously went out of scope
             auto &var_i8 = io.GetVariable<int8_t>("i8");
             auto &var_i16 = io.GetVariable<int16_t>("i16");
@@ -82,17 +114,33 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8fstream)
             auto &var_r32 = io.GetVariable<float>("r32");
             auto &var_r64 = io.GetVariable<double>("r64");
 
+            // Make a 1D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::SelectionBoundingBox sel({mpiRank * Nx}, {Nx});
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
             // Write each one
-            engine->Write(var_i8, m_TestData.I8.data() + step);
-            engine->Write(var_i16, m_TestData.I16.data() + step);
-            engine->Write(var_i32, m_TestData.I32.data() + step);
-            engine->Write(var_i64, m_TestData.I64.data() + step);
-            engine->Write(var_u8, m_TestData.U8.data() + step);
-            engine->Write(var_u16, m_TestData.U16.data() + step);
-            engine->Write(var_u32, m_TestData.U32.data() + step);
-            engine->Write(var_u64, m_TestData.U64.data() + step);
-            engine->Write(var_r32, m_TestData.R32.data() + step);
-            engine->Write(var_r64, m_TestData.R64.data() + step);
+            // fill in the variable with values from starting index to
+            // starting index + count
+            engine->Write(var_i8, currentTestData.I8.data());
+            engine->Write(var_i16, currentTestData.I16.data());
+            engine->Write(var_i32, currentTestData.I32.data());
+            engine->Write(var_i64, currentTestData.I64.data());
+            engine->Write(var_u8, currentTestData.U8.data());
+            engine->Write(var_u16, currentTestData.U16.data());
+            engine->Write(var_u32, currentTestData.U32.data());
+            engine->Write(var_u64, currentTestData.U64.data());
+            engine->Write(var_r32, currentTestData.R32.data());
+            engine->Write(var_r64, currentTestData.R64.data());
 
             // Advance to the next time step
             engine->Advance();
@@ -102,83 +150,105 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8fstream)
         engine->Close();
     }
 
-// Read test data using ADIOS1
-#ifdef ADIOS2_HAVE_MPI
-    // Read everything from rank 0
-    int rank;
-    MPI_Comm_rank();
-    if (rank == 0)
-#endif
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
-        ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
-                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        // Note: Since collective metadata generation is not implemented yet,
+        // SO for now we read each subfile instead of a single bp file with all
+        // metadata.
+        // Meanwhile if we open file with MPI_COMM_WORLD, then the selection
+        // bounding box should be [0, Nx]
+        std::string index = std::to_string(mpiRank);
+        ADIOS_FILE *f = adios_read_open_file(
+            (fname + ".dir/" + fname + "." + index).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
         ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
         ASSERT_NE(var_i8, nullptr);
         ASSERT_EQ(var_i8->ndim, 1);
-        ASSERT_EQ(var_i8->dims[0], 8);
+        ASSERT_EQ(var_i8->global, 1);
+        ASSERT_EQ(var_i8->nsteps, NSteps);
+        ASSERT_EQ(var_i8->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
         ASSERT_NE(var_i16, nullptr);
         ASSERT_EQ(var_i16->ndim, 1);
-        ASSERT_EQ(var_i16->dims[0], 8);
+        ASSERT_EQ(var_i16->global, 1);
+        ASSERT_EQ(var_i16->nsteps, NSteps);
+        ASSERT_EQ(var_i16->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
         ASSERT_NE(var_i32, nullptr);
         ASSERT_EQ(var_i32->ndim, 1);
-        ASSERT_EQ(var_i32->dims[0], 8);
+        ASSERT_EQ(var_i32->global, 1);
+        ASSERT_EQ(var_i32->nsteps, NSteps);
+        ASSERT_EQ(var_i32->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
         ASSERT_NE(var_i64, nullptr);
         ASSERT_EQ(var_i64->ndim, 1);
-        ASSERT_EQ(var_i64->dims[0], 8);
+        ASSERT_EQ(var_i64->global, 1);
+        ASSERT_EQ(var_i64->nsteps, NSteps);
+        ASSERT_EQ(var_i64->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
         ASSERT_NE(var_u8, nullptr);
         ASSERT_EQ(var_u8->ndim, 1);
-        ASSERT_EQ(var_u8->dims[0], 8);
+        ASSERT_EQ(var_u8->global, 1);
+        ASSERT_EQ(var_u8->nsteps, NSteps);
+        ASSERT_EQ(var_u8->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
         ASSERT_NE(var_u16, nullptr);
         ASSERT_EQ(var_u16->ndim, 1);
-        ASSERT_EQ(var_u16->dims[0], 8);
+        ASSERT_EQ(var_u16->global, 1);
+        ASSERT_EQ(var_u16->nsteps, NSteps);
+        ASSERT_EQ(var_u16->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
         ASSERT_NE(var_u32, nullptr);
         ASSERT_EQ(var_u32->ndim, 1);
-        ASSERT_EQ(var_u32->dims[0], 8);
+        ASSERT_EQ(var_u32->global, 1);
+        ASSERT_EQ(var_u32->nsteps, NSteps);
+        ASSERT_EQ(var_u32->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
         ASSERT_NE(var_u64, nullptr);
         ASSERT_EQ(var_u64->ndim, 1);
-        ASSERT_EQ(var_u64->dims[0], 8);
+        ASSERT_EQ(var_u64->global, 1);
+        ASSERT_EQ(var_u64->nsteps, NSteps);
+        ASSERT_EQ(var_u64->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
         ASSERT_NE(var_r32, nullptr);
         ASSERT_EQ(var_r32->ndim, 1);
-        ASSERT_EQ(var_r32->dims[0], 8);
+        ASSERT_EQ(var_r32->global, 1);
+        ASSERT_EQ(var_r32->nsteps, NSteps);
+        ASSERT_EQ(var_r32->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
         ASSERT_NE(var_r64, nullptr);
         ASSERT_EQ(var_r64->ndim, 1);
-        ASSERT_EQ(var_r64->dims[0], 8);
+        ASSERT_EQ(var_r64->global, 1);
+        ASSERT_EQ(var_r64->nsteps, NSteps);
+        ASSERT_EQ(var_r64->dims[0], mpiSize * Nx);
 
-        std::array<int8_t, 8> I8;
-        std::array<int16_t, 8> I16;
-        std::array<int32_t, 8> I32;
-        std::array<int64_t, 8> I64;
-        std::array<uint8_t, 8> U8;
-        std::array<uint16_t, 8> U16;
-        std::array<uint32_t, 8> U32;
-        std::array<uint64_t, 8> U64;
-        std::array<float, 8> R32;
-        std::array<double, 8> R64;
+        std::array<int8_t, Nx> I8;
+        std::array<int16_t, Nx> I16;
+        std::array<int32_t, Nx> I32;
+        std::array<int64_t, Nx> I64;
+        std::array<uint8_t, Nx> U8;
+        std::array<uint16_t, Nx> U16;
+        std::array<uint32_t, Nx> U32;
+        std::array<uint64_t, Nx> U64;
+        std::array<float, Nx> R32;
+        std::array<double, Nx> R64;
 
-        uint64_t start[1] = {0};
-        uint64_t count[1] = {8};
+        uint64_t start[1] = {mpiRank * Nx};
+        uint64_t count[1] = {Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(1, start, count);
 
         // Read stuff
-        for (size_t t = 0; t < 3; ++t)
+        for (size_t t = 0; t < NSteps; ++t)
         {
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, t, mpiRank, mpiSize);
             // Read the current step
             adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
             adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
@@ -193,22 +263,22 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8fstream)
             adios_perform_reads(f, 1);
 
             // Check if it's correct
-            for (size_t i = 0; i < 8; ++i)
+            for (size_t i = 0; i < Nx; ++i)
             {
                 std::stringstream ss;
-                ss << "t=" << t << " i=" << i;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
-                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
-                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
-                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
-                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
-                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
-                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
-                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
-                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
-                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
-                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
             }
         }
 
@@ -228,6 +298,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8fstream)
 
         // Cleanup file
         adios_read_close(f);
+
+        adios_read_finalize_method(ADIOS_READ_METHOD_BP);
     }
 }
 
@@ -243,38 +315,66 @@ TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead1D8fstream)
 // 2D 2x4 test data
 //******************************************************************************
 
-// ADIOS2 write, native ADIOS1 read
+// ADIOS2 BP write, native ADIOS1 read
 TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4fstream)
 {
+    // Each process would write a 2x4 array and all processes would
+    // form a 2D 2 * (numberOfProcess*Nx) matrix where Nx is 4 here
     std::string fname = "ADIOS2BPWriteADIOS1Read2D2x4Testfstream.bp";
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 4;
+
+    // Number of rows
+    const std::size_t Ny = 2;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
 
     // Write test data using ADIOS2
     {
+#ifdef ADIOS2_HAVE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
         adios2::ADIOS adios(true);
+#endif
         adios2::IO &io = adios.DeclareIO("TestIO");
 
-        // Declare 1D variables
+        // Declare 2D variables (Ny * (NumOfProcesses * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
         {
-            auto &var_i8 =
-                io.DefineVariable<int8_t>("i8", {}, {}, adios2::Dims{2, 4});
+            adios2::Dims shape{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx * mpiSize)};
+            adios2::Dims start{static_cast<unsigned int>(0),
+                               static_cast<unsigned int>(mpiRank * Nx)};
+            adios2::Dims count{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
             auto &var_i16 =
-                io.DefineVariable<int16_t>("i16", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<int16_t>("i16", shape, start, count);
             auto &var_i32 =
-                io.DefineVariable<int32_t>("i32", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<int32_t>("i32", shape, start, count);
             auto &var_i64 =
-                io.DefineVariable<int64_t>("i64", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<int64_t>("i64", shape, start, count);
             auto &var_u8 =
-                io.DefineVariable<uint8_t>("u8", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
             auto &var_u16 =
-                io.DefineVariable<uint16_t>("u16", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
             auto &var_u32 =
-                io.DefineVariable<uint32_t>("u32", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
             auto &var_u64 =
-                io.DefineVariable<uint64_t>("u64", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
             auto &var_r32 =
-                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<float>("r32", shape, start, count);
             auto &var_r64 =
-                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<double>("r64", shape, start, count);
         }
 
         // Create the BP Engine
@@ -284,8 +384,12 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4fstream)
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
 
-        for (size_t step = 0; step < 3; ++step)
+        for (size_t step = 0; step < NSteps; ++step)
         {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, step, mpiRank, mpiSize);
+
             // Retrieve the variables that previously went out of scope
             auto &var_i8 = io.GetVariable<int8_t>("i8");
             auto &var_i16 = io.GetVariable<int16_t>("i16");
@@ -298,17 +402,34 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4fstream)
             auto &var_r32 = io.GetVariable<float>("r32");
             auto &var_r64 = io.GetVariable<double>("r64");
 
+            // Make a 2D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::SelectionBoundingBox sel(
+                {0, static_cast<unsigned int>(mpiRank * Nx)}, {Ny, Nx});
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
             // Write each one
-            engine->Write(var_i8, m_TestData.I8.data() + step);
-            engine->Write(var_i16, m_TestData.I16.data() + step);
-            engine->Write(var_i32, m_TestData.I32.data() + step);
-            engine->Write(var_i64, m_TestData.I64.data() + step);
-            engine->Write(var_u8, m_TestData.U8.data() + step);
-            engine->Write(var_u16, m_TestData.U16.data() + step);
-            engine->Write(var_u32, m_TestData.U32.data() + step);
-            engine->Write(var_u64, m_TestData.U64.data() + step);
-            engine->Write(var_r32, m_TestData.R32.data() + step);
-            engine->Write(var_r64, m_TestData.R64.data() + step);
+            // fill in the variable with values from starting index to
+            // starting index + count
+            engine->Write(var_i8, currentTestData.I8.data());
+            engine->Write(var_i16, currentTestData.I16.data());
+            engine->Write(var_i32, currentTestData.I32.data());
+            engine->Write(var_i64, currentTestData.I64.data());
+            engine->Write(var_u8, currentTestData.U8.data());
+            engine->Write(var_u16, currentTestData.U16.data());
+            engine->Write(var_u32, currentTestData.U32.data());
+            engine->Write(var_u64, currentTestData.U64.data());
+            engine->Write(var_r32, currentTestData.R32.data());
+            engine->Write(var_r64, currentTestData.R64.data());
 
             // Advance to the next time step
             engine->Advance();
@@ -318,93 +439,118 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4fstream)
         engine->Close();
     }
 
-// Read test data using ADIOS1
-#ifdef ADIOS2_HAVE_MPI
-    // Read everything from rank 0
-    int rank;
-    MPI_Comm_rank();
-    if (rank == 0)
-#endif
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
-        ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
-                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        // Note: Since collective metadata generation is not implemented yet,
+        // SO for now we read each subfile instead of a single bp file with all
+        // metadata.
+        // Meanwhile if we open file with MPI_COMM_WORLD, then the selection
+        // bounding box should be [0, Nx]
+        std::string index = std::to_string(mpiRank);
+        ADIOS_FILE *f = adios_read_open_file(
+            (fname + ".dir/" + fname + "." + index).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
         ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
         ASSERT_NE(var_i8, nullptr);
         ASSERT_EQ(var_i8->ndim, 2);
-        ASSERT_EQ(var_i8->dims[0], 2);
-        ASSERT_EQ(var_i8->dims[1], 4);
+        ASSERT_EQ(var_i8->global, 1);
+        ASSERT_EQ(var_i8->nsteps, NSteps);
+        ASSERT_EQ(var_i8->dims[0], Ny);
+        ASSERT_EQ(var_i8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
         ASSERT_NE(var_i16, nullptr);
         ASSERT_EQ(var_i16->ndim, 2);
-        ASSERT_EQ(var_i16->dims[0], 2);
-        ASSERT_EQ(var_i16->dims[1], 4);
+        ASSERT_EQ(var_i16->global, 1);
+        ASSERT_EQ(var_i16->nsteps, NSteps);
+        ASSERT_EQ(var_i16->dims[0], Ny);
+        ASSERT_EQ(var_i16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
         ASSERT_NE(var_i32, nullptr);
         ASSERT_EQ(var_i32->ndim, 2);
-        ASSERT_EQ(var_i32->dims[0], 2);
-        ASSERT_EQ(var_i32->dims[1], 4);
+        ASSERT_EQ(var_i32->global, 1);
+        ASSERT_EQ(var_i32->nsteps, NSteps);
+        ASSERT_EQ(var_i32->dims[0], Ny);
+        ASSERT_EQ(var_i32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
         ASSERT_NE(var_i64, nullptr);
         ASSERT_EQ(var_i64->ndim, 2);
-        ASSERT_EQ(var_i64->dims[0], 2);
-        ASSERT_EQ(var_i64->dims[1], 4);
+        ASSERT_EQ(var_i64->global, 1);
+        ASSERT_EQ(var_i64->nsteps, NSteps);
+        ASSERT_EQ(var_i64->dims[0], Ny);
+        ASSERT_EQ(var_i64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
         ASSERT_NE(var_u8, nullptr);
         ASSERT_EQ(var_u8->ndim, 2);
-        ASSERT_EQ(var_u8->dims[0], 2);
-        ASSERT_EQ(var_u8->dims[1], 4);
+        ASSERT_EQ(var_u8->global, 1);
+        ASSERT_EQ(var_u8->nsteps, NSteps);
+        ASSERT_EQ(var_u8->dims[0], Ny);
+        ASSERT_EQ(var_u8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
         ASSERT_NE(var_u16, nullptr);
         ASSERT_EQ(var_u16->ndim, 2);
-        ASSERT_EQ(var_u16->dims[0], 2);
-        ASSERT_EQ(var_u16->dims[1], 4);
+        ASSERT_EQ(var_u16->global, 1);
+        ASSERT_EQ(var_u16->nsteps, NSteps);
+        ASSERT_EQ(var_u16->dims[0], Ny);
+        ASSERT_EQ(var_u16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
         ASSERT_NE(var_u32, nullptr);
         ASSERT_EQ(var_u32->ndim, 2);
-        ASSERT_EQ(var_u32->dims[0], 2);
-        ASSERT_EQ(var_u32->dims[1], 4);
+        ASSERT_EQ(var_u32->global, 1);
+        ASSERT_EQ(var_u32->nsteps, NSteps);
+        ASSERT_EQ(var_u32->dims[0], Ny);
+        ASSERT_EQ(var_u32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
         ASSERT_NE(var_u64, nullptr);
         ASSERT_EQ(var_u64->ndim, 2);
-        ASSERT_EQ(var_u64->dims[0], 2);
-        ASSERT_EQ(var_u64->dims[1], 4);
+        ASSERT_EQ(var_u64->global, 1);
+        ASSERT_EQ(var_u64->nsteps, NSteps);
+        ASSERT_EQ(var_u64->dims[0], Ny);
+        ASSERT_EQ(var_u64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
         ASSERT_NE(var_r32, nullptr);
         ASSERT_EQ(var_r32->ndim, 2);
-        ASSERT_EQ(var_r32->dims[0], 2);
-        ASSERT_EQ(var_r32->dims[1], 4);
+        ASSERT_EQ(var_r32->global, 1);
+        ASSERT_EQ(var_r32->nsteps, NSteps);
+        ASSERT_EQ(var_r32->dims[0], Ny);
+        ASSERT_EQ(var_r32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
         ASSERT_NE(var_r64, nullptr);
         ASSERT_EQ(var_r64->ndim, 2);
-        ASSERT_EQ(var_r64->dims[0], 2);
-        ASSERT_EQ(var_r64->dims[1], 4);
+        ASSERT_EQ(var_r64->global, 1);
+        ASSERT_EQ(var_r64->nsteps, NSteps);
+        ASSERT_EQ(var_r64->dims[0], Ny);
+        ASSERT_EQ(var_r64->dims[1], mpiSize * Nx);
 
-        std::array<int8_t, 8> I8;
-        std::array<int16_t, 8> I16;
-        std::array<int32_t, 8> I32;
-        std::array<int64_t, 8> I64;
-        std::array<uint8_t, 8> U8;
-        std::array<uint16_t, 8> U16;
-        std::array<uint32_t, 8> U32;
-        std::array<uint64_t, 8> U64;
-        std::array<float, 8> R32;
-        std::array<double, 8> R64;
+        // If the size of the array is smaller than the data
+        // the result is weird... double and uint64_t would get completely
+        // garbage data
+        std::array<int8_t, Nx * Ny> I8;
+        std::array<int16_t, Nx * Ny> I16;
+        std::array<int32_t, Nx * Ny> I32;
+        std::array<int64_t, Nx * Ny> I64;
+        std::array<uint8_t, Nx * Ny> U8;
+        std::array<uint16_t, Nx * Ny> U16;
+        std::array<uint32_t, Nx * Ny> U32;
+        std::array<uint64_t, Nx * Ny> U64;
+        std::array<float, Nx * Ny> R32;
+        std::array<double, Nx * Ny> R64;
 
-        uint64_t start[2] = {0, 0};
-        uint64_t count[2] = {2, 4};
+        uint64_t start[2] = {0, mpiRank * Nx};
+        uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 
         // Read stuff
-        for (size_t t = 0; t < 3; ++t)
+        for (size_t t = 0; t < NSteps; ++t)
         {
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, t, mpiRank, mpiSize);
             // Read the current step
             adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
             adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
@@ -419,22 +565,22 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4fstream)
             adios_perform_reads(f, 1);
 
             // Check if it's correct
-            for (size_t i = 0; i < 8; ++i)
+            for (size_t i = 0; i < Nx; ++i)
             {
                 std::stringstream ss;
-                ss << "t=" << t << " i=" << i;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
-                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
-                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
-                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
-                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
-                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
-                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
-                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
-                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
-                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
-                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
             }
         }
 
@@ -454,6 +600,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4fstream)
 
         // Cleanup file
         adios_read_close(f);
+
+        adios_read_finalize_method(ADIOS_READ_METHOD_BP);
     }
 }
 
@@ -472,35 +620,62 @@ TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead2D2x4fstream)
 // ADIOS2 write, native ADIOS1 read
 TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2fstream)
 {
+    // Each process would write a 4x2 array and all processes would
+    // form a 2D 4 * (NumberOfProcess * Nx) matrix where Nx is 2 here
     std::string fname = "ADIOS2BPWriteADIOS1Read2D4x2Testfstream.bp";
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 2;
+    // Number of cols
+    const std::size_t Ny = 4;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
 
     // Write test data using ADIOS2
     {
+#ifdef ADIOS2_HAVE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
         adios2::ADIOS adios(true);
+#endif
         adios2::IO &io = adios.DeclareIO("TestIO");
 
-        // Declare 1D variables
+        // Declare 2D variables (4 * (NumberOfProcess * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
         {
-            auto &var_i8 =
-                io.DefineVariable<int8_t>("i8", {}, {}, adios2::Dims{4, 2});
+            adios2::Dims shape{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(mpiSize * Nx)};
+            adios2::Dims start{static_cast<unsigned int>(0),
+                               static_cast<unsigned int>(mpiRank * Nx)};
+            adios2::Dims count{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
             auto &var_i16 =
-                io.DefineVariable<int16_t>("i16", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<int16_t>("i16", shape, start, count);
             auto &var_i32 =
-                io.DefineVariable<int32_t>("i32", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<int32_t>("i32", shape, start, count);
             auto &var_i64 =
-                io.DefineVariable<int64_t>("i64", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<int64_t>("i64", shape, start, count);
             auto &var_u8 =
-                io.DefineVariable<uint8_t>("u8", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
             auto &var_u16 =
-                io.DefineVariable<uint16_t>("u16", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
             auto &var_u32 =
-                io.DefineVariable<uint32_t>("u32", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
             auto &var_u64 =
-                io.DefineVariable<uint64_t>("u64", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
             auto &var_r32 =
-                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<float>("r32", shape, start, count);
             auto &var_r64 =
-                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<double>("r64", shape, start, count);
         }
 
         // Create the BP Engine
@@ -510,8 +685,12 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2fstream)
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
 
-        for (size_t step = 0; step < 3; ++step)
+        for (size_t step = 0; step < NSteps; ++step)
         {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, step, mpiRank, mpiSize);
+
             // Retrieve the variables that previously went out of scope
             auto &var_i8 = io.GetVariable<int8_t>("i8");
             auto &var_i16 = io.GetVariable<int16_t>("i16");
@@ -524,17 +703,34 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2fstream)
             auto &var_r32 = io.GetVariable<float>("r32");
             auto &var_r64 = io.GetVariable<double>("r64");
 
+            // Make a 2D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::SelectionBoundingBox sel(
+                {0, static_cast<unsigned int>(mpiRank * Nx)}, {Ny, Nx});
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
             // Write each one
-            engine->Write(var_i8, m_TestData.I8.data() + step);
-            engine->Write(var_i16, m_TestData.I16.data() + step);
-            engine->Write(var_i32, m_TestData.I32.data() + step);
-            engine->Write(var_i64, m_TestData.I64.data() + step);
-            engine->Write(var_u8, m_TestData.U8.data() + step);
-            engine->Write(var_u16, m_TestData.U16.data() + step);
-            engine->Write(var_u32, m_TestData.U32.data() + step);
-            engine->Write(var_u64, m_TestData.U64.data() + step);
-            engine->Write(var_r32, m_TestData.R32.data() + step);
-            engine->Write(var_r64, m_TestData.R64.data() + step);
+            // fill in the variable with values from starting index to
+            // starting index + count
+            engine->Write(var_i8, currentTestData.I8.data());
+            engine->Write(var_i16, currentTestData.I16.data());
+            engine->Write(var_i32, currentTestData.I32.data());
+            engine->Write(var_i64, currentTestData.I64.data());
+            engine->Write(var_u8, currentTestData.U8.data());
+            engine->Write(var_u16, currentTestData.U16.data());
+            engine->Write(var_u32, currentTestData.U32.data());
+            engine->Write(var_u64, currentTestData.U64.data());
+            engine->Write(var_r32, currentTestData.R32.data());
+            engine->Write(var_r64, currentTestData.R64.data());
 
             // Advance to the next time step
             engine->Advance();
@@ -544,93 +740,118 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2fstream)
         engine->Close();
     }
 
-// Read test data using ADIOS1
-#ifdef ADIOS2_HAVE_MPI
-    // Read everything from rank 0
-    int rank;
-    MPI_Comm_rank();
-    if (rank == 0)
-#endif
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
-        ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
-                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        // Note: Since collective metadata generation is not implemented yet,
+        // SO for now we read each subfile instead of a single bp file with all
+        // metadata.
+        // Meanwhile if we open file with MPI_COMM_WORLD, then the selection
+        // bounding box should be [0, Nx]
+        std::string index = std::to_string(mpiRank);
+        ADIOS_FILE *f = adios_read_open_file(
+            (fname + ".dir/" + fname + "." + index).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
         ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
         ASSERT_NE(var_i8, nullptr);
         ASSERT_EQ(var_i8->ndim, 2);
-        ASSERT_EQ(var_i8->dims[0], 4);
-        ASSERT_EQ(var_i8->dims[1], 2);
+        ASSERT_EQ(var_i8->global, 1);
+        ASSERT_EQ(var_i8->nsteps, NSteps);
+        ASSERT_EQ(var_i8->dims[0], Ny);
+        ASSERT_EQ(var_i8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
         ASSERT_NE(var_i16, nullptr);
         ASSERT_EQ(var_i16->ndim, 2);
-        ASSERT_EQ(var_i16->dims[0], 4);
-        ASSERT_EQ(var_i16->dims[1], 2);
+        ASSERT_EQ(var_i16->global, 1);
+        ASSERT_EQ(var_i16->nsteps, NSteps);
+        ASSERT_EQ(var_i16->dims[0], Ny);
+        ASSERT_EQ(var_i16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
         ASSERT_NE(var_i32, nullptr);
         ASSERT_EQ(var_i32->ndim, 2);
-        ASSERT_EQ(var_i32->dims[0], 4);
-        ASSERT_EQ(var_i32->dims[1], 2);
+        ASSERT_EQ(var_i32->global, 1);
+        ASSERT_EQ(var_i32->nsteps, NSteps);
+        ASSERT_EQ(var_i32->dims[0], Ny);
+        ASSERT_EQ(var_i32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
         ASSERT_NE(var_i64, nullptr);
         ASSERT_EQ(var_i64->ndim, 2);
-        ASSERT_EQ(var_i64->dims[0], 4);
-        ASSERT_EQ(var_i64->dims[1], 2);
+        ASSERT_EQ(var_i64->global, 1);
+        ASSERT_EQ(var_i64->nsteps, NSteps);
+        ASSERT_EQ(var_i64->dims[0], Ny);
+        ASSERT_EQ(var_i64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
         ASSERT_NE(var_u8, nullptr);
         ASSERT_EQ(var_u8->ndim, 2);
-        ASSERT_EQ(var_u8->dims[0], 4);
-        ASSERT_EQ(var_u8->dims[1], 2);
+        ASSERT_EQ(var_u8->global, 1);
+        ASSERT_EQ(var_u8->nsteps, NSteps);
+        ASSERT_EQ(var_u8->dims[0], Ny);
+        ASSERT_EQ(var_u8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
         ASSERT_NE(var_u16, nullptr);
         ASSERT_EQ(var_u16->ndim, 2);
-        ASSERT_EQ(var_u16->dims[0], 4);
-        ASSERT_EQ(var_u16->dims[1], 2);
+        ASSERT_EQ(var_u16->global, 1);
+        ASSERT_EQ(var_u16->nsteps, NSteps);
+        ASSERT_EQ(var_u16->dims[0], Ny);
+        ASSERT_EQ(var_u16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
         ASSERT_NE(var_u32, nullptr);
         ASSERT_EQ(var_u32->ndim, 2);
-        ASSERT_EQ(var_u32->dims[0], 4);
-        ASSERT_EQ(var_u32->dims[1], 2);
+        ASSERT_EQ(var_u32->global, 1);
+        ASSERT_EQ(var_u32->nsteps, NSteps);
+        ASSERT_EQ(var_u32->dims[0], Ny);
+        ASSERT_EQ(var_u32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
         ASSERT_NE(var_u64, nullptr);
         ASSERT_EQ(var_u64->ndim, 2);
-        ASSERT_EQ(var_u64->dims[0], 4);
-        ASSERT_EQ(var_u64->dims[1], 2);
+        ASSERT_EQ(var_u64->global, 1);
+        ASSERT_EQ(var_u64->nsteps, NSteps);
+        ASSERT_EQ(var_u64->dims[0], Ny);
+        ASSERT_EQ(var_u64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
         ASSERT_NE(var_r32, nullptr);
         ASSERT_EQ(var_r32->ndim, 2);
-        ASSERT_EQ(var_r32->dims[0], 4);
-        ASSERT_EQ(var_r32->dims[1], 2);
+        ASSERT_EQ(var_r32->global, 1);
+        ASSERT_EQ(var_r32->nsteps, NSteps);
+        ASSERT_EQ(var_r32->dims[0], Ny);
+        ASSERT_EQ(var_r32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
         ASSERT_NE(var_r64, nullptr);
         ASSERT_EQ(var_r64->ndim, 2);
-        ASSERT_EQ(var_r64->dims[0], 4);
-        ASSERT_EQ(var_r64->dims[1], 2);
+        ASSERT_EQ(var_r64->global, 1);
+        ASSERT_EQ(var_r64->nsteps, NSteps);
+        ASSERT_EQ(var_r64->dims[0], Ny);
+        ASSERT_EQ(var_r64->dims[1], mpiSize * Nx);
 
-        std::array<int8_t, 8> I8;
-        std::array<int16_t, 8> I16;
-        std::array<int32_t, 8> I32;
-        std::array<int64_t, 8> I64;
-        std::array<uint8_t, 8> U8;
-        std::array<uint16_t, 8> U16;
-        std::array<uint32_t, 8> U32;
-        std::array<uint64_t, 8> U64;
-        std::array<float, 8> R32;
-        std::array<double, 8> R64;
+        // If the size of the array is smaller than the data
+        // the result is weird... double and uint64_t would get completely
+        // garbage data
+        std::array<int8_t, Nx * Ny> I8;
+        std::array<int16_t, Nx * Ny> I16;
+        std::array<int32_t, Nx * Ny> I32;
+        std::array<int64_t, Nx * Ny> I64;
+        std::array<uint8_t, Nx * Ny> U8;
+        std::array<uint16_t, Nx * Ny> U16;
+        std::array<uint32_t, Nx * Ny> U32;
+        std::array<uint64_t, Nx * Ny> U64;
+        std::array<float, Nx * Ny> R32;
+        std::array<double, Nx * Ny> R64;
 
-        uint64_t start[2] = {0, 0};
-        uint64_t count[2] = {4, 2};
+        uint64_t start[2] = {0, mpiRank * Nx};
+        uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 
         // Read stuff
-        for (size_t t = 0; t < 3; ++t)
+        for (size_t t = 0; t < NSteps; ++t)
         {
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, t, mpiRank, mpiSize);
             // Read the current step
             adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
             adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
@@ -645,22 +866,22 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2fstream)
             adios_perform_reads(f, 1);
 
             // Check if it's correct
-            for (size_t i = 0; i < 8; ++i)
+            for (size_t i = 0; i < Nx; ++i)
             {
                 std::stringstream ss;
-                ss << "t=" << t << " i=" << i;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
-                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
-                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
-                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
-                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
-                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
-                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
-                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
-                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
-                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
-                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
             }
         }
 
@@ -680,6 +901,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2fstream)
 
         // Cleanup file
         adios_read_close(f);
+
+        adios_read_finalize_method(ADIOS_READ_METHOD_BP);
     }
 }
 

--- a/testing/adios2/engine/bp/TestBPWriteReadstdio.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadstdio.cpp
@@ -83,7 +83,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8stdio)
                 io.DefineVariable<double>("r64", shape, start, count);
         }
 
-        // Create the ADIOS 1 Engine
+        // Create the BP Engine
         io.SetEngine("BPFileWriter");
 
 #ifdef ADIOS2_HAVE_MPI
@@ -155,14 +155,19 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8stdio)
     }
 
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
+        // Note: Since collective metadata generation is not implemented yet,
+        // SO for now we read each subfile instead of a single bp file with all
+        // metadata.
+        // Meanwhile if we open file with MPI_COMM_WORLD, then the selection
+        // bounding box should be [0, Nx]
         std::string index = std::to_string(mpiRank);
         ADIOS_FILE *f = adios_read_open_file(
             (fname + ".dir/" + fname + "." + index).c_str(),
-            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
@@ -238,12 +243,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8stdio)
         std::array<float, Nx> R32;
         std::array<double, Nx> R64;
 
-        // QUESTION: For ADIOS1Writer, the start index would be mpiRank * Nx.
-        // However it seems that BPWriter would skip empty values to find the
-        // right start index. Here 0 would make the test pass.
-        // Note: Since collective metadata generation is not implemented yet,
-        // which makes sence.
-        uint64_t start[1] = {0};
+        uint64_t start[1] = {mpiRank * Nx};
         uint64_t count[1] = {Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(1, start, count);
 
@@ -448,14 +448,19 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4stdio)
     }
 
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
+        // Note: Since collective metadata generation is not implemented yet,
+        // SO for now we read each subfile instead of a single bp file with all
+        // metadata.
+        // Meanwhile if we open file with MPI_COMM_WORLD, then the selection
+        // bounding box should be [0, Nx]
         std::string index = std::to_string(mpiRank);
         ADIOS_FILE *f = adios_read_open_file(
             (fname + ".dir/" + fname + "." + index).c_str(),
-            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
@@ -544,8 +549,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4stdio)
         std::array<float, Nx * Ny> R32;
         std::array<double, Nx * Ny> R64;
 
-        // FIXME: When bp metadata generation has landed, use mpiRank * Nx
-        uint64_t start[2] = {0, 0};
+        uint64_t start[2] = {0, mpiRank * Nx};
         uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 
@@ -682,7 +686,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2stdio)
                 io.DefineVariable<double>("r64", shape, start, count);
         }
 
-        // Create the ADIOS 1 Engine
+        // Create the BP Engine
         io.SetEngine("BPFileWriter");
 
 #ifdef ADIOS2_HAVE_MPI
@@ -750,14 +754,19 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2stdio)
     }
 
     {
-        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
+        adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_SELF,
                                "verbose=3");
 
         // Open the file for reading
+        // Note: Since collective metadata generation is not implemented yet,
+        // SO for now we read each subfile instead of a single bp file with all
+        // metadata.
+        // Meanwhile if we open file with MPI_COMM_WORLD, then the selection
+        // bounding box should be [0, Nx]
         std::string index = std::to_string(mpiRank);
         ADIOS_FILE *f = adios_read_open_file(
             (fname + ".dir/" + fname + "." + index).c_str(),
-            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+            ADIOS_READ_METHOD_BP, MPI_COMM_SELF);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
@@ -846,8 +855,7 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2stdio)
         std::array<float, Nx * Ny> R32;
         std::array<double, Nx * Ny> R64;
 
-        // FIXME: When bp metadata generation has landed, use mpiRank * Nx
-        uint64_t start[2] = {0, 0};
+        uint64_t start[2] = {0, mpiRank * Nx};
         uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 

--- a/testing/adios2/engine/bp/TestBPWriteReadstdio.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadstdio.cpp
@@ -27,49 +27,85 @@ public:
 // 1D 1x8 test data
 //******************************************************************************
 
-// ADIOS2 write, native ADIOS1 read
+// ADIOS2 BP write, native ADIOS1 read
 TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8stdio)
 {
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
     std::string fname = "ADIOS2BPWriteADIOS1Read1D8stdio.bp";
 
-    // Write test data using ADIOS2
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 8;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+    // Write test data using BP
     {
+#ifdef ADIOS2_HAVE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
         adios2::ADIOS adios(true);
+#endif
         adios2::IO &io = adios.DeclareIO("TestIO");
 
-        // Declare 1D variables
+        // Declare 1D variables (NumOfProcesses * Nx)
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
         {
-            auto &var_i8 =
-                io.DefineVariable<int8_t>("i8", {}, {}, adios2::Dims{8});
+            adios2::Dims shape{static_cast<unsigned int>(Nx * mpiSize)};
+            adios2::Dims start{static_cast<unsigned int>(Nx * mpiRank)};
+            adios2::Dims count{static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
             auto &var_i16 =
-                io.DefineVariable<int16_t>("i16", {}, {}, adios2::Dims{8});
+                io.DefineVariable<int16_t>("i16", shape, start, count);
             auto &var_i32 =
-                io.DefineVariable<int32_t>("i32", {}, {}, adios2::Dims{8});
+                io.DefineVariable<int32_t>("i32", shape, start, count);
             auto &var_i64 =
-                io.DefineVariable<int64_t>("i64", {}, {}, adios2::Dims{8});
+                io.DefineVariable<int64_t>("i64", shape, start, count);
             auto &var_u8 =
-                io.DefineVariable<uint8_t>("u8", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
             auto &var_u16 =
-                io.DefineVariable<uint16_t>("u16", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
             auto &var_u32 =
-                io.DefineVariable<uint32_t>("u32", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
             auto &var_u64 =
-                io.DefineVariable<uint64_t>("u64", {}, {}, adios2::Dims{8});
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
             auto &var_r32 =
-                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{8});
+                io.DefineVariable<float>("r32", shape, start, count);
             auto &var_r64 =
-                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{8});
+                io.DefineVariable<double>("r64", shape, start, count);
         }
 
-        // Create the BP Engine
+        // Create the ADIOS 1 Engine
         io.SetEngine("BPFileWriter");
-        io.AddTransport("File", {{"Library", "stdio"}});
 
+#ifdef ADIOS2_HAVE_MPI
+        io.AddTransport("file", {{"Library", "stdio"}});
+#else
+        io.AddTransport("file");
+#endif
+        // QUESTION: It seems that BPFilterWriter cannot overwrite existing
+        // files
+        // Ex. if you tune Nx and NSteps, the test would fail. But if you clear
+        // the cache in
+        // ${adios2Build}/testing/adios2/engine/bp/ADIOS2BPWriteADIOS1Read1D8.bp.dir,
+        // then it works
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
 
-        for (size_t step = 0; step < 3; ++step)
+        for (size_t step = 0; step < NSteps; ++step)
         {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, step, mpiRank, mpiSize);
+
             // Retrieve the variables that previously went out of scope
             auto &var_i8 = io.GetVariable<int8_t>("i8");
             auto &var_i16 = io.GetVariable<int16_t>("i16");
@@ -82,17 +118,33 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8stdio)
             auto &var_r32 = io.GetVariable<float>("r32");
             auto &var_r64 = io.GetVariable<double>("r64");
 
+            // Make a 1D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::SelectionBoundingBox sel({mpiRank * Nx}, {Nx});
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
             // Write each one
-            engine->Write(var_i8, m_TestData.I8.data() + step);
-            engine->Write(var_i16, m_TestData.I16.data() + step);
-            engine->Write(var_i32, m_TestData.I32.data() + step);
-            engine->Write(var_i64, m_TestData.I64.data() + step);
-            engine->Write(var_u8, m_TestData.U8.data() + step);
-            engine->Write(var_u16, m_TestData.U16.data() + step);
-            engine->Write(var_u32, m_TestData.U32.data() + step);
-            engine->Write(var_u64, m_TestData.U64.data() + step);
-            engine->Write(var_r32, m_TestData.R32.data() + step);
-            engine->Write(var_r64, m_TestData.R64.data() + step);
+            // fill in the variable with values from starting index to
+            // starting index + count
+            engine->Write(var_i8, currentTestData.I8.data());
+            engine->Write(var_i16, currentTestData.I16.data());
+            engine->Write(var_i32, currentTestData.I32.data());
+            engine->Write(var_i64, currentTestData.I64.data());
+            engine->Write(var_u8, currentTestData.U8.data());
+            engine->Write(var_u16, currentTestData.U16.data());
+            engine->Write(var_u32, currentTestData.U32.data());
+            engine->Write(var_u64, currentTestData.U64.data());
+            engine->Write(var_r32, currentTestData.R32.data());
+            engine->Write(var_r64, currentTestData.R64.data());
 
             // Advance to the next time step
             engine->Advance();
@@ -102,83 +154,105 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8stdio)
         engine->Close();
     }
 
-// Read test data using ADIOS1
-#ifdef ADIOS2_HAVE_MPI
-    // Read everything from rank 0
-    int rank;
-    MPI_Comm_rank();
-    if (rank == 0)
-#endif
     {
         adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
                                "verbose=3");
 
         // Open the file for reading
-        ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
-                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        std::string index = std::to_string(mpiRank);
+        ADIOS_FILE *f = adios_read_open_file(
+            (fname + ".dir/" + fname + "." + index).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
         ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
         ASSERT_NE(var_i8, nullptr);
         ASSERT_EQ(var_i8->ndim, 1);
-        ASSERT_EQ(var_i8->dims[0], 8);
+        ASSERT_EQ(var_i8->global, 1);
+        ASSERT_EQ(var_i8->nsteps, NSteps);
+        ASSERT_EQ(var_i8->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
         ASSERT_NE(var_i16, nullptr);
         ASSERT_EQ(var_i16->ndim, 1);
-        ASSERT_EQ(var_i16->dims[0], 8);
+        ASSERT_EQ(var_i16->global, 1);
+        ASSERT_EQ(var_i16->nsteps, NSteps);
+        ASSERT_EQ(var_i16->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
         ASSERT_NE(var_i32, nullptr);
         ASSERT_EQ(var_i32->ndim, 1);
-        ASSERT_EQ(var_i32->dims[0], 8);
+        ASSERT_EQ(var_i32->global, 1);
+        ASSERT_EQ(var_i32->nsteps, NSteps);
+        ASSERT_EQ(var_i32->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
         ASSERT_NE(var_i64, nullptr);
         ASSERT_EQ(var_i64->ndim, 1);
-        ASSERT_EQ(var_i64->dims[0], 8);
+        ASSERT_EQ(var_i64->global, 1);
+        ASSERT_EQ(var_i64->nsteps, NSteps);
+        ASSERT_EQ(var_i64->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
         ASSERT_NE(var_u8, nullptr);
         ASSERT_EQ(var_u8->ndim, 1);
-        ASSERT_EQ(var_u8->dims[0], 8);
+        ASSERT_EQ(var_u8->global, 1);
+        ASSERT_EQ(var_u8->nsteps, NSteps);
+        ASSERT_EQ(var_u8->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
         ASSERT_NE(var_u16, nullptr);
         ASSERT_EQ(var_u16->ndim, 1);
-        ASSERT_EQ(var_u16->dims[0], 8);
+        ASSERT_EQ(var_u16->global, 1);
+        ASSERT_EQ(var_u16->nsteps, NSteps);
+        ASSERT_EQ(var_u16->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
         ASSERT_NE(var_u32, nullptr);
         ASSERT_EQ(var_u32->ndim, 1);
-        ASSERT_EQ(var_u32->dims[0], 8);
+        ASSERT_EQ(var_u32->global, 1);
+        ASSERT_EQ(var_u32->nsteps, NSteps);
+        ASSERT_EQ(var_u32->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
         ASSERT_NE(var_u64, nullptr);
         ASSERT_EQ(var_u64->ndim, 1);
-        ASSERT_EQ(var_u64->dims[0], 8);
+        ASSERT_EQ(var_u64->global, 1);
+        ASSERT_EQ(var_u64->nsteps, NSteps);
+        ASSERT_EQ(var_u64->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
         ASSERT_NE(var_r32, nullptr);
         ASSERT_EQ(var_r32->ndim, 1);
-        ASSERT_EQ(var_r32->dims[0], 8);
+        ASSERT_EQ(var_r32->global, 1);
+        ASSERT_EQ(var_r32->nsteps, NSteps);
+        ASSERT_EQ(var_r32->dims[0], mpiSize * Nx);
         ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
         ASSERT_NE(var_r64, nullptr);
         ASSERT_EQ(var_r64->ndim, 1);
-        ASSERT_EQ(var_r64->dims[0], 8);
+        ASSERT_EQ(var_r64->global, 1);
+        ASSERT_EQ(var_r64->nsteps, NSteps);
+        ASSERT_EQ(var_r64->dims[0], mpiSize * Nx);
 
-        std::array<int8_t, 8> I8;
-        std::array<int16_t, 8> I16;
-        std::array<int32_t, 8> I32;
-        std::array<int64_t, 8> I64;
-        std::array<uint8_t, 8> U8;
-        std::array<uint16_t, 8> U16;
-        std::array<uint32_t, 8> U32;
-        std::array<uint64_t, 8> U64;
-        std::array<float, 8> R32;
-        std::array<double, 8> R64;
+        std::array<int8_t, Nx> I8;
+        std::array<int16_t, Nx> I16;
+        std::array<int32_t, Nx> I32;
+        std::array<int64_t, Nx> I64;
+        std::array<uint8_t, Nx> U8;
+        std::array<uint16_t, Nx> U16;
+        std::array<uint32_t, Nx> U32;
+        std::array<uint64_t, Nx> U64;
+        std::array<float, Nx> R32;
+        std::array<double, Nx> R64;
 
+        // QUESTION: For ADIOS1Writer, the start index would be mpiRank * Nx.
+        // However it seems that BPWriter would skip empty values to find the
+        // right start index. Here 0 would make the test pass.
+        // Note: Since collective metadata generation is not implemented yet,
+        // which makes sence.
         uint64_t start[1] = {0};
-        uint64_t count[1] = {8};
+        uint64_t count[1] = {Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(1, start, count);
 
         // Read stuff
-        for (size_t t = 0; t < 3; ++t)
+        for (size_t t = 0; t < NSteps; ++t)
         {
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, t, mpiRank, mpiSize);
             // Read the current step
             adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
             adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
@@ -193,22 +267,22 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8stdio)
             adios_perform_reads(f, 1);
 
             // Check if it's correct
-            for (size_t i = 0; i < 8; ++i)
+            for (size_t i = 0; i < Nx; ++i)
             {
                 std::stringstream ss;
-                ss << "t=" << t << " i=" << i;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
-                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
-                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
-                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
-                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
-                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
-                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
-                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
-                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
-                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
-                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
             }
         }
 
@@ -228,6 +302,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read1D8stdio)
 
         // Cleanup file
         adios_read_close(f);
+
+        adios_read_finalize_method(ADIOS_READ_METHOD_BP);
     }
 }
 
@@ -243,49 +319,85 @@ TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead1D8stdio)
 // 2D 2x4 test data
 //******************************************************************************
 
-// ADIOS2 write, native ADIOS1 read
+// ADIOS2 BP write, native ADIOS1 read
 TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4stdio)
 {
+    // Each process would write a 2x4 array and all processes would
+    // form a 2D 2 * (numberOfProcess*Nx) matrix where Nx is 4 here
     std::string fname = "ADIOS2BPWriteADIOS1Read2D2x4Teststdio.bp";
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 4;
+
+    // Number of rows
+    const std::size_t Ny = 2;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
 
     // Write test data using ADIOS2
     {
+#ifdef ADIOS2_HAVE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
         adios2::ADIOS adios(true);
+#endif
         adios2::IO &io = adios.DeclareIO("TestIO");
 
-        // Declare 1D variables
+        // Declare 2D variables (Ny * (NumOfProcesses * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
         {
-            auto &var_i8 =
-                io.DefineVariable<int8_t>("i8", {}, {}, adios2::Dims{2, 4});
+            adios2::Dims shape{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx * mpiSize)};
+            adios2::Dims start{static_cast<unsigned int>(0),
+                               static_cast<unsigned int>(mpiRank * Nx)};
+            adios2::Dims count{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
             auto &var_i16 =
-                io.DefineVariable<int16_t>("i16", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<int16_t>("i16", shape, start, count);
             auto &var_i32 =
-                io.DefineVariable<int32_t>("i32", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<int32_t>("i32", shape, start, count);
             auto &var_i64 =
-                io.DefineVariable<int64_t>("i64", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<int64_t>("i64", shape, start, count);
             auto &var_u8 =
-                io.DefineVariable<uint8_t>("u8", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
             auto &var_u16 =
-                io.DefineVariable<uint16_t>("u16", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
             auto &var_u32 =
-                io.DefineVariable<uint32_t>("u32", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
             auto &var_u64 =
-                io.DefineVariable<uint64_t>("u64", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
             auto &var_r32 =
-                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<float>("r32", shape, start, count);
             auto &var_r64 =
-                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{2, 4});
+                io.DefineVariable<double>("r64", shape, start, count);
         }
 
         // Create the BP Engine
         io.SetEngine("BPFileWriter");
+#ifdef ADIOS2_HAVE_MPI
         io.AddTransport("file", {{"Library", "stdio"}});
+#else
+        io.AddTransport("file");
+#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
 
-        for (size_t step = 0; step < 3; ++step)
+        for (size_t step = 0; step < NSteps; ++step)
         {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, step, mpiRank, mpiSize);
+
             // Retrieve the variables that previously went out of scope
             auto &var_i8 = io.GetVariable<int8_t>("i8");
             auto &var_i16 = io.GetVariable<int16_t>("i16");
@@ -298,17 +410,34 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4stdio)
             auto &var_r32 = io.GetVariable<float>("r32");
             auto &var_r64 = io.GetVariable<double>("r64");
 
+            // Make a 2D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::SelectionBoundingBox sel(
+                {0, static_cast<unsigned int>(mpiRank * Nx)}, {Ny, Nx});
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
             // Write each one
-            engine->Write(var_i8, m_TestData.I8.data() + step);
-            engine->Write(var_i16, m_TestData.I16.data() + step);
-            engine->Write(var_i32, m_TestData.I32.data() + step);
-            engine->Write(var_i64, m_TestData.I64.data() + step);
-            engine->Write(var_u8, m_TestData.U8.data() + step);
-            engine->Write(var_u16, m_TestData.U16.data() + step);
-            engine->Write(var_u32, m_TestData.U32.data() + step);
-            engine->Write(var_u64, m_TestData.U64.data() + step);
-            engine->Write(var_r32, m_TestData.R32.data() + step);
-            engine->Write(var_r64, m_TestData.R64.data() + step);
+            // fill in the variable with values from starting index to
+            // starting index + count
+            engine->Write(var_i8, currentTestData.I8.data());
+            engine->Write(var_i16, currentTestData.I16.data());
+            engine->Write(var_i32, currentTestData.I32.data());
+            engine->Write(var_i64, currentTestData.I64.data());
+            engine->Write(var_u8, currentTestData.U8.data());
+            engine->Write(var_u16, currentTestData.U16.data());
+            engine->Write(var_u32, currentTestData.U32.data());
+            engine->Write(var_u64, currentTestData.U64.data());
+            engine->Write(var_r32, currentTestData.R32.data());
+            engine->Write(var_r64, currentTestData.R64.data());
 
             // Advance to the next time step
             engine->Advance();
@@ -318,93 +447,114 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4stdio)
         engine->Close();
     }
 
-// Read test data using ADIOS1
-#ifdef ADIOS2_HAVE_MPI
-    // Read everything from rank 0
-    int rank;
-    MPI_Comm_rank();
-    if (rank == 0)
-#endif
     {
         adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
                                "verbose=3");
 
         // Open the file for reading
-        ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
-                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        std::string index = std::to_string(mpiRank);
+        ADIOS_FILE *f = adios_read_open_file(
+            (fname + ".dir/" + fname + "." + index).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
         ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
         ASSERT_NE(var_i8, nullptr);
         ASSERT_EQ(var_i8->ndim, 2);
-        ASSERT_EQ(var_i8->dims[0], 2);
-        ASSERT_EQ(var_i8->dims[1], 4);
+        ASSERT_EQ(var_i8->global, 1);
+        ASSERT_EQ(var_i8->nsteps, NSteps);
+        ASSERT_EQ(var_i8->dims[0], Ny);
+        ASSERT_EQ(var_i8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
         ASSERT_NE(var_i16, nullptr);
         ASSERT_EQ(var_i16->ndim, 2);
-        ASSERT_EQ(var_i16->dims[0], 2);
-        ASSERT_EQ(var_i16->dims[1], 4);
+        ASSERT_EQ(var_i16->global, 1);
+        ASSERT_EQ(var_i16->nsteps, NSteps);
+        ASSERT_EQ(var_i16->dims[0], Ny);
+        ASSERT_EQ(var_i16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
         ASSERT_NE(var_i32, nullptr);
         ASSERT_EQ(var_i32->ndim, 2);
-        ASSERT_EQ(var_i32->dims[0], 2);
-        ASSERT_EQ(var_i32->dims[1], 4);
+        ASSERT_EQ(var_i32->global, 1);
+        ASSERT_EQ(var_i32->nsteps, NSteps);
+        ASSERT_EQ(var_i32->dims[0], Ny);
+        ASSERT_EQ(var_i32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
         ASSERT_NE(var_i64, nullptr);
         ASSERT_EQ(var_i64->ndim, 2);
-        ASSERT_EQ(var_i64->dims[0], 2);
-        ASSERT_EQ(var_i64->dims[1], 4);
+        ASSERT_EQ(var_i64->global, 1);
+        ASSERT_EQ(var_i64->nsteps, NSteps);
+        ASSERT_EQ(var_i64->dims[0], Ny);
+        ASSERT_EQ(var_i64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
         ASSERT_NE(var_u8, nullptr);
         ASSERT_EQ(var_u8->ndim, 2);
-        ASSERT_EQ(var_u8->dims[0], 2);
-        ASSERT_EQ(var_u8->dims[1], 4);
+        ASSERT_EQ(var_u8->global, 1);
+        ASSERT_EQ(var_u8->nsteps, NSteps);
+        ASSERT_EQ(var_u8->dims[0], Ny);
+        ASSERT_EQ(var_u8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
         ASSERT_NE(var_u16, nullptr);
         ASSERT_EQ(var_u16->ndim, 2);
-        ASSERT_EQ(var_u16->dims[0], 2);
-        ASSERT_EQ(var_u16->dims[1], 4);
+        ASSERT_EQ(var_u16->global, 1);
+        ASSERT_EQ(var_u16->nsteps, NSteps);
+        ASSERT_EQ(var_u16->dims[0], Ny);
+        ASSERT_EQ(var_u16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
         ASSERT_NE(var_u32, nullptr);
         ASSERT_EQ(var_u32->ndim, 2);
-        ASSERT_EQ(var_u32->dims[0], 2);
-        ASSERT_EQ(var_u32->dims[1], 4);
+        ASSERT_EQ(var_u32->global, 1);
+        ASSERT_EQ(var_u32->nsteps, NSteps);
+        ASSERT_EQ(var_u32->dims[0], Ny);
+        ASSERT_EQ(var_u32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
         ASSERT_NE(var_u64, nullptr);
         ASSERT_EQ(var_u64->ndim, 2);
-        ASSERT_EQ(var_u64->dims[0], 2);
-        ASSERT_EQ(var_u64->dims[1], 4);
+        ASSERT_EQ(var_u64->global, 1);
+        ASSERT_EQ(var_u64->nsteps, NSteps);
+        ASSERT_EQ(var_u64->dims[0], Ny);
+        ASSERT_EQ(var_u64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
         ASSERT_NE(var_r32, nullptr);
         ASSERT_EQ(var_r32->ndim, 2);
-        ASSERT_EQ(var_r32->dims[0], 2);
-        ASSERT_EQ(var_r32->dims[1], 4);
+        ASSERT_EQ(var_r32->global, 1);
+        ASSERT_EQ(var_r32->nsteps, NSteps);
+        ASSERT_EQ(var_r32->dims[0], Ny);
+        ASSERT_EQ(var_r32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
         ASSERT_NE(var_r64, nullptr);
         ASSERT_EQ(var_r64->ndim, 2);
-        ASSERT_EQ(var_r64->dims[0], 2);
-        ASSERT_EQ(var_r64->dims[1], 4);
+        ASSERT_EQ(var_r64->global, 1);
+        ASSERT_EQ(var_r64->nsteps, NSteps);
+        ASSERT_EQ(var_r64->dims[0], Ny);
+        ASSERT_EQ(var_r64->dims[1], mpiSize * Nx);
 
-        std::array<int8_t, 8> I8;
-        std::array<int16_t, 8> I16;
-        std::array<int32_t, 8> I32;
-        std::array<int64_t, 8> I64;
-        std::array<uint8_t, 8> U8;
-        std::array<uint16_t, 8> U16;
-        std::array<uint32_t, 8> U32;
-        std::array<uint64_t, 8> U64;
-        std::array<float, 8> R32;
-        std::array<double, 8> R64;
+        // If the size of the array is smaller than the data
+        // the result is weird... double and uint64_t would get completely
+        // garbage data
+        std::array<int8_t, Nx * Ny> I8;
+        std::array<int16_t, Nx * Ny> I16;
+        std::array<int32_t, Nx * Ny> I32;
+        std::array<int64_t, Nx * Ny> I64;
+        std::array<uint8_t, Nx * Ny> U8;
+        std::array<uint16_t, Nx * Ny> U16;
+        std::array<uint32_t, Nx * Ny> U32;
+        std::array<uint64_t, Nx * Ny> U64;
+        std::array<float, Nx * Ny> R32;
+        std::array<double, Nx * Ny> R64;
 
+        // FIXME: When bp metadata generation has landed, use mpiRank * Nx
         uint64_t start[2] = {0, 0};
-        uint64_t count[2] = {2, 4};
+        uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 
         // Read stuff
-        for (size_t t = 0; t < 3; ++t)
+        for (size_t t = 0; t < NSteps; ++t)
         {
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, t, mpiRank, mpiSize);
             // Read the current step
             adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
             adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
@@ -419,22 +569,22 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4stdio)
             adios_perform_reads(f, 1);
 
             // Check if it's correct
-            for (size_t i = 0; i < 8; ++i)
+            for (size_t i = 0; i < Nx; ++i)
             {
                 std::stringstream ss;
-                ss << "t=" << t << " i=" << i;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
-                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
-                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
-                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
-                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
-                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
-                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
-                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
-                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
-                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
-                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
             }
         }
 
@@ -454,6 +604,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D2x4stdio)
 
         // Cleanup file
         adios_read_close(f);
+
+        adios_read_finalize_method(ADIOS_READ_METHOD_BP);
     }
 }
 
@@ -472,46 +624,82 @@ TEST_F(BPWriteReadTest, DISABLED_ADIOS2BPWriteADIOS2BPRead2D2x4stdio)
 // ADIOS2 write, native ADIOS1 read
 TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2stdio)
 {
+    // Each process would write a 4x2 array and all processes would
+    // form a 2D 4 * (NumberOfProcess * Nx) matrix where Nx is 2 here
     std::string fname = "ADIOS2BPWriteADIOS1Read2D4x2Teststdio.bp";
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 2;
+    // Number of cols
+    const std::size_t Ny = 4;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
 
     // Write test data using ADIOS2
     {
+#ifdef ADIOS2_HAVE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
         adios2::ADIOS adios(true);
+#endif
         adios2::IO &io = adios.DeclareIO("TestIO");
 
-        // Declare 1D variables
+        // Declare 2D variables (4 * (NumberOfProcess * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
         {
-            auto &var_i8 =
-                io.DefineVariable<int8_t>("i8", {}, {}, adios2::Dims{4, 2});
+            adios2::Dims shape{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(mpiSize * Nx)};
+            adios2::Dims start{static_cast<unsigned int>(0),
+                               static_cast<unsigned int>(mpiRank * Nx)};
+            adios2::Dims count{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
             auto &var_i16 =
-                io.DefineVariable<int16_t>("i16", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<int16_t>("i16", shape, start, count);
             auto &var_i32 =
-                io.DefineVariable<int32_t>("i32", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<int32_t>("i32", shape, start, count);
             auto &var_i64 =
-                io.DefineVariable<int64_t>("i64", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<int64_t>("i64", shape, start, count);
             auto &var_u8 =
-                io.DefineVariable<uint8_t>("u8", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
             auto &var_u16 =
-                io.DefineVariable<uint16_t>("u16", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
             auto &var_u32 =
-                io.DefineVariable<uint32_t>("u32", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
             auto &var_u64 =
-                io.DefineVariable<uint64_t>("u64", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
             auto &var_r32 =
-                io.DefineVariable<float>("r32", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<float>("r32", shape, start, count);
             auto &var_r64 =
-                io.DefineVariable<double>("r64", {}, {}, adios2::Dims{4, 2});
+                io.DefineVariable<double>("r64", shape, start, count);
         }
 
-        // Create the BP Engine
+        // Create the ADIOS 1 Engine
         io.SetEngine("BPFileWriter");
+
+#ifdef ADIOS2_HAVE_MPI
         io.AddTransport("file", {{"Library", "stdio"}});
+#else
+        io.AddTransport("file");
+#endif
 
         auto engine = io.Open(fname, adios2::OpenMode::Write);
         ASSERT_NE(engine.get(), nullptr);
 
-        for (size_t step = 0; step < 3; ++step)
+        for (size_t step = 0; step < NSteps; ++step)
         {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, step, mpiRank, mpiSize);
+
             // Retrieve the variables that previously went out of scope
             auto &var_i8 = io.GetVariable<int8_t>("i8");
             auto &var_i16 = io.GetVariable<int16_t>("i16");
@@ -524,17 +712,34 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2stdio)
             auto &var_r32 = io.GetVariable<float>("r32");
             auto &var_r64 = io.GetVariable<double>("r64");
 
+            // Make a 2D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::SelectionBoundingBox sel(
+                {0, static_cast<unsigned int>(mpiRank * Nx)}, {Ny, Nx});
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
             // Write each one
-            engine->Write(var_i8, m_TestData.I8.data() + step);
-            engine->Write(var_i16, m_TestData.I16.data() + step);
-            engine->Write(var_i32, m_TestData.I32.data() + step);
-            engine->Write(var_i64, m_TestData.I64.data() + step);
-            engine->Write(var_u8, m_TestData.U8.data() + step);
-            engine->Write(var_u16, m_TestData.U16.data() + step);
-            engine->Write(var_u32, m_TestData.U32.data() + step);
-            engine->Write(var_u64, m_TestData.U64.data() + step);
-            engine->Write(var_r32, m_TestData.R32.data() + step);
-            engine->Write(var_r64, m_TestData.R64.data() + step);
+            // fill in the variable with values from starting index to
+            // starting index + count
+            engine->Write(var_i8, currentTestData.I8.data());
+            engine->Write(var_i16, currentTestData.I16.data());
+            engine->Write(var_i32, currentTestData.I32.data());
+            engine->Write(var_i64, currentTestData.I64.data());
+            engine->Write(var_u8, currentTestData.U8.data());
+            engine->Write(var_u16, currentTestData.U16.data());
+            engine->Write(var_u32, currentTestData.U32.data());
+            engine->Write(var_u64, currentTestData.U64.data());
+            engine->Write(var_r32, currentTestData.R32.data());
+            engine->Write(var_r64, currentTestData.R64.data());
 
             // Advance to the next time step
             engine->Advance();
@@ -544,93 +749,114 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2stdio)
         engine->Close();
     }
 
-// Read test data using ADIOS1
-#ifdef ADIOS2_HAVE_MPI
-    // Read everything from rank 0
-    int rank;
-    MPI_Comm_rank();
-    if (rank == 0)
-#endif
     {
         adios_read_init_method(ADIOS_READ_METHOD_BP, MPI_COMM_WORLD,
                                "verbose=3");
 
         // Open the file for reading
-        ADIOS_FILE *f =
-            adios_read_open_file((fname + ".dir/" + fname + ".0").c_str(),
-                                 ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
+        std::string index = std::to_string(mpiRank);
+        ADIOS_FILE *f = adios_read_open_file(
+            (fname + ".dir/" + fname + "." + index).c_str(),
+            ADIOS_READ_METHOD_BP, MPI_COMM_WORLD);
         ASSERT_NE(f, nullptr);
 
         // Check the variables exist
         ADIOS_VARINFO *var_i8 = adios_inq_var(f, "i8");
         ASSERT_NE(var_i8, nullptr);
         ASSERT_EQ(var_i8->ndim, 2);
-        ASSERT_EQ(var_i8->dims[0], 4);
-        ASSERT_EQ(var_i8->dims[1], 2);
+        ASSERT_EQ(var_i8->global, 1);
+        ASSERT_EQ(var_i8->nsteps, NSteps);
+        ASSERT_EQ(var_i8->dims[0], Ny);
+        ASSERT_EQ(var_i8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i16 = adios_inq_var(f, "i16");
         ASSERT_NE(var_i16, nullptr);
         ASSERT_EQ(var_i16->ndim, 2);
-        ASSERT_EQ(var_i16->dims[0], 4);
-        ASSERT_EQ(var_i16->dims[1], 2);
+        ASSERT_EQ(var_i16->global, 1);
+        ASSERT_EQ(var_i16->nsteps, NSteps);
+        ASSERT_EQ(var_i16->dims[0], Ny);
+        ASSERT_EQ(var_i16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i32 = adios_inq_var(f, "i32");
         ASSERT_NE(var_i32, nullptr);
         ASSERT_EQ(var_i32->ndim, 2);
-        ASSERT_EQ(var_i32->dims[0], 4);
-        ASSERT_EQ(var_i32->dims[1], 2);
+        ASSERT_EQ(var_i32->global, 1);
+        ASSERT_EQ(var_i32->nsteps, NSteps);
+        ASSERT_EQ(var_i32->dims[0], Ny);
+        ASSERT_EQ(var_i32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_i64 = adios_inq_var(f, "i64");
         ASSERT_NE(var_i64, nullptr);
         ASSERT_EQ(var_i64->ndim, 2);
-        ASSERT_EQ(var_i64->dims[0], 4);
-        ASSERT_EQ(var_i64->dims[1], 2);
+        ASSERT_EQ(var_i64->global, 1);
+        ASSERT_EQ(var_i64->nsteps, NSteps);
+        ASSERT_EQ(var_i64->dims[0], Ny);
+        ASSERT_EQ(var_i64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u8 = adios_inq_var(f, "u8");
         ASSERT_NE(var_u8, nullptr);
         ASSERT_EQ(var_u8->ndim, 2);
-        ASSERT_EQ(var_u8->dims[0], 4);
-        ASSERT_EQ(var_u8->dims[1], 2);
+        ASSERT_EQ(var_u8->global, 1);
+        ASSERT_EQ(var_u8->nsteps, NSteps);
+        ASSERT_EQ(var_u8->dims[0], Ny);
+        ASSERT_EQ(var_u8->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u16 = adios_inq_var(f, "u16");
         ASSERT_NE(var_u16, nullptr);
         ASSERT_EQ(var_u16->ndim, 2);
-        ASSERT_EQ(var_u16->dims[0], 4);
-        ASSERT_EQ(var_u16->dims[1], 2);
+        ASSERT_EQ(var_u16->global, 1);
+        ASSERT_EQ(var_u16->nsteps, NSteps);
+        ASSERT_EQ(var_u16->dims[0], Ny);
+        ASSERT_EQ(var_u16->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u32 = adios_inq_var(f, "u32");
         ASSERT_NE(var_u32, nullptr);
         ASSERT_EQ(var_u32->ndim, 2);
-        ASSERT_EQ(var_u32->dims[0], 4);
-        ASSERT_EQ(var_u32->dims[1], 2);
+        ASSERT_EQ(var_u32->global, 1);
+        ASSERT_EQ(var_u32->nsteps, NSteps);
+        ASSERT_EQ(var_u32->dims[0], Ny);
+        ASSERT_EQ(var_u32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_u64 = adios_inq_var(f, "u64");
         ASSERT_NE(var_u64, nullptr);
         ASSERT_EQ(var_u64->ndim, 2);
-        ASSERT_EQ(var_u64->dims[0], 4);
-        ASSERT_EQ(var_u64->dims[1], 2);
+        ASSERT_EQ(var_u64->global, 1);
+        ASSERT_EQ(var_u64->nsteps, NSteps);
+        ASSERT_EQ(var_u64->dims[0], Ny);
+        ASSERT_EQ(var_u64->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r32 = adios_inq_var(f, "r32");
         ASSERT_NE(var_r32, nullptr);
         ASSERT_EQ(var_r32->ndim, 2);
-        ASSERT_EQ(var_r32->dims[0], 4);
-        ASSERT_EQ(var_r32->dims[1], 2);
+        ASSERT_EQ(var_r32->global, 1);
+        ASSERT_EQ(var_r32->nsteps, NSteps);
+        ASSERT_EQ(var_r32->dims[0], Ny);
+        ASSERT_EQ(var_r32->dims[1], mpiSize * Nx);
         ADIOS_VARINFO *var_r64 = adios_inq_var(f, "r64");
         ASSERT_NE(var_r64, nullptr);
         ASSERT_EQ(var_r64->ndim, 2);
-        ASSERT_EQ(var_r64->dims[0], 4);
-        ASSERT_EQ(var_r64->dims[1], 2);
+        ASSERT_EQ(var_r64->global, 1);
+        ASSERT_EQ(var_r64->nsteps, NSteps);
+        ASSERT_EQ(var_r64->dims[0], Ny);
+        ASSERT_EQ(var_r64->dims[1], mpiSize * Nx);
 
-        std::array<int8_t, 8> I8;
-        std::array<int16_t, 8> I16;
-        std::array<int32_t, 8> I32;
-        std::array<int64_t, 8> I64;
-        std::array<uint8_t, 8> U8;
-        std::array<uint16_t, 8> U16;
-        std::array<uint32_t, 8> U32;
-        std::array<uint64_t, 8> U64;
-        std::array<float, 8> R32;
-        std::array<double, 8> R64;
+        // If the size of the array is smaller than the data
+        // the result is weird... double and uint64_t would get completely
+        // garbage data
+        std::array<int8_t, Nx * Ny> I8;
+        std::array<int16_t, Nx * Ny> I16;
+        std::array<int32_t, Nx * Ny> I32;
+        std::array<int64_t, Nx * Ny> I64;
+        std::array<uint8_t, Nx * Ny> U8;
+        std::array<uint16_t, Nx * Ny> U16;
+        std::array<uint32_t, Nx * Ny> U32;
+        std::array<uint64_t, Nx * Ny> U64;
+        std::array<float, Nx * Ny> R32;
+        std::array<double, Nx * Ny> R64;
 
+        // FIXME: When bp metadata generation has landed, use mpiRank * Nx
         uint64_t start[2] = {0, 0};
-        uint64_t count[2] = {4, 2};
+        uint64_t count[2] = {Ny, Nx};
         ADIOS_SELECTION *sel = adios_selection_boundingbox(2, start, count);
 
         // Read stuff
-        for (size_t t = 0; t < 3; ++t)
+        for (size_t t = 0; t < NSteps; ++t)
         {
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, t, mpiRank, mpiSize);
             // Read the current step
             adios_schedule_read_byid(f, sel, var_i8->varid, t, 1, I8.data());
             adios_schedule_read_byid(f, sel, var_i16->varid, t, 1, I16.data());
@@ -645,22 +871,22 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2stdio)
             adios_perform_reads(f, 1);
 
             // Check if it's correct
-            for (size_t i = 0; i < 8; ++i)
+            for (size_t i = 0; i < Nx; ++i)
             {
                 std::stringstream ss;
-                ss << "t=" << t << " i=" << i;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
                 std::string msg = ss.str();
 
-                EXPECT_EQ(I8[i], m_TestData.I8[i + t]) << msg;
-                EXPECT_EQ(I16[i], m_TestData.I16[i + t]) << msg;
-                EXPECT_EQ(I32[i], m_TestData.I32[i + t]) << msg;
-                EXPECT_EQ(I64[i], m_TestData.I64[i + t]) << msg;
-                EXPECT_EQ(U8[i], m_TestData.U8[i + t]) << msg;
-                EXPECT_EQ(U16[i], m_TestData.U16[i + t]) << msg;
-                EXPECT_EQ(U32[i], m_TestData.U32[i + t]) << msg;
-                EXPECT_EQ(U64[i], m_TestData.U64[i + t]) << msg;
-                EXPECT_EQ(R32[i], m_TestData.R32[i + t]) << msg;
-                EXPECT_EQ(R64[i], m_TestData.R64[i + t]) << msg;
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
             }
         }
 
@@ -680,6 +906,8 @@ TEST_F(BPWriteReadTest, ADIOS2BPWriteADIOS1Read2D4x2stdio)
 
         // Cleanup file
         adios_read_close(f);
+
+        adios_read_finalize_method(ADIOS_READ_METHOD_BP);
     }
 }
 


### PR DESCRIPTION
Now BPWriteProfilingJSON would use a BP filename with path. Close #230 

BPWriteReadAttribute: Since collective meta generation has not landed yet, I have to use
same attribute for all processes. Ideally attribute per process
should be unique to each other for testing purpose.
