### PR TITLE
Fix for issue #295

### DIFF
--- a/bindings/fortran/f2c/adios2_f2c_adios.cpp
+++ b/bindings/fortran/f2c/adios2_f2c_adios.cpp
@@ -43,7 +43,8 @@ void FC_GLOBAL(adios2_init_f2c, ADIOS2_INIT_F2C)(adios2_ADIOS **adios,
                                                  const int *debug_mode,
                                                  int *ierr)
 {
-    adios2_init_config_f2c_(adios, "", debug_mode, ierr);
+    FC_GLOBAL(adios2_init_config_f2c, ADIOS2_INIT_CONFIG_F2C)
+    (adios, "", debug_mode, ierr);
 }
 
 void FC_GLOBAL(adios2_init_config_f2c,


### PR DESCRIPTION
Missing cmake FCInterface macro FC_GLOBAL for non-MPI function