### PR TITLE
Fix warnings from python and GNU headers.

### DIFF
--- a/bindings/python/ADIOSPy.cpp
+++ b/bindings/python/ADIOSPy.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "ADIOSPy.h"
+
 #include "adios2/ADIOSMPI.h"
 
 namespace adios2

--- a/bindings/python/ADIOSPy.h
+++ b/bindings/python/ADIOSPy.h
@@ -11,12 +11,13 @@
 #ifndef ADIOS2_BINDINGS_PYTHON_SOURCE_ADIOSPY_H_
 #define ADIOS2_BINDINGS_PYTHON_SOURCE_ADIOSPY_H_
 
+#include "IOPy.h"
+
 /// \cond EXCLUDE_FROM_DOXYGEN
 #include <memory> //std::shared_ptr
 #include <string>
 /// \endcond
 
-#include "IOPy.h"
 #include "adios2/ADIOSMPICommOnly.h"
 #include "adios2/core/ADIOS.h"
 

--- a/bindings/python/EnginePy.h
+++ b/bindings/python/EnginePy.h
@@ -11,13 +11,14 @@
 #ifndef ADIOS2_BINDINGS_PYTHON_SOURCE_ENGINEPY_H_
 #define ADIOS2_BINDINGS_PYTHON_SOURCE_ENGINEPY_H_
 
+#include <pybind11/numpy.h>
+
 /// \cond EXCLUDE_FROM_DOXYGEN
 #include <memory> //std::shared_ptr
 #include <string>
 /// \endcond
 
 #include <adios2.h>
-#include <pybind11/numpy.h>
 
 namespace adios2
 {

--- a/bindings/python/IOPy.h
+++ b/bindings/python/IOPy.h
@@ -11,13 +11,13 @@
 #ifndef ADIOS2_BINDINGS_PYTHON_SOURCE_IOPY_H_
 #define ADIOS2_BINDINGS_PYTHON_SOURCE_IOPY_H_
 
-/// \cond EXCLUDE_FROM_DOXYGEN
-#include <string>
-/// \endcond
-
 #include <pybind11/numpy.h>
 
 #include "EnginePy.h"
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <string>
+/// \endcond
 
 namespace adios2
 {

--- a/bindings/python/gluePyBind11.cpp
+++ b/bindings/python/gluePyBind11.cpp
@@ -8,19 +8,20 @@
  *      Author: William F Godoy godoywf@ornl.gov
  */
 
-#include <stdexcept>
-
-#include <adios2.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-
-#ifdef ADIOS2_HAVE_MPI
-#include <mpi4py/mpi4py.h>
-#endif
 
 #include "ADIOSPy.h"
 #include "EnginePy.h"
 #include "IOPy.h"
+
+#include <stdexcept>
+
+#include <adios2.h>
+
+#ifdef ADIOS2_HAVE_MPI
+#include <mpi4py/mpi4py.h>
+#endif
 
 #ifdef ADIOS2_HAVE_MPI
 adios2::ADIOSPy ADIOSPyInitConfig(const std::string configFile,


### PR DESCRIPTION
Due to some squireliness of how python headers work, we need to include
any python binding headers first, before any C library headers.  This is
contrary to the projects coding and style guidelines but necessary
since python.h will otherwise re-define core system feature macros.