### PR TITLE
Issue #363 BPFileReader BeginStep return

### DIFF
--- a/source/adios2/engine/bp/BPFileReader.cpp
+++ b/source/adios2/engine/bp/BPFileReader.cpp
@@ -46,8 +46,6 @@ StepStatus BPFileReader::BeginStep(StepMode mode, const float timeoutSeconds)
         }
     }
 
-    StepStatus status = StepStatus::OK;
-
     if (m_FirstStep)
     {
         m_FirstStep = false;
@@ -57,9 +55,9 @@ StepStatus BPFileReader::BeginStep(StepMode mode, const float timeoutSeconds)
         ++m_CurrentStep;
     }
 
-    if (m_CurrentStep >= m_BP3Deserializer.m_MetadataSet.StepsCount - 1)
+    if (m_CurrentStep >= m_BP3Deserializer.m_MetadataSet.StepsCount)
     {
-        status = StepStatus::EndOfStream;
+        return StepStatus::EndOfStream;
     }
 
     const auto &variablesData = m_IO.GetVariablesDataMap();
@@ -85,7 +83,7 @@ StepStatus BPFileReader::BeginStep(StepMode mode, const float timeoutSeconds)
 #undef declare_type
     }
 
-    return status;
+    return StepStatus::OK;
 }
 
 void BPFileReader::EndStep()

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
@@ -218,11 +218,9 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead1D8)
         var_r64->SetSelection(sel);
 
         unsigned int t = 0;
-        adios2::StepStatus status = adios2::StepStatus::OK;
-        while (status == adios2::StepStatus::OK)
-        {
-            status = bpReader.BeginStep();
 
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
             bpReader.GetDeferred(*var_i8, I8.data());
             bpReader.GetDeferred(*var_i16, I16.data());
             bpReader.GetDeferred(*var_i32, I32.data());
@@ -470,11 +468,9 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D2x4)
         var_r64->SetSelection(sel);
 
         unsigned int t = 0;
-        adios2::StepStatus status = adios2::StepStatus::OK;
-        while (status == adios2::StepStatus::OK)
-        {
-            status = bpReader.BeginStep();
 
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
             bpReader.GetDeferred(*var_i8, I8.data());
             bpReader.GetDeferred(*var_i16, I16.data());
             bpReader.GetDeferred(*var_i32, I32.data());
@@ -727,11 +723,9 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D4x2)
         var_r64->SetSelection(sel);
 
         unsigned int t = 0;
-        adios2::StepStatus status = adios2::StepStatus::OK;
-        while (status == adios2::StepStatus::OK)
-        {
-            status = bpReader.BeginStep();
 
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
             bpReader.GetDeferred(*var_i8, I8.data());
             bpReader.GetDeferred(*var_i16, I16.data());
             bpReader.GetDeferred(*var_i32, I32.data());
@@ -968,10 +962,9 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead1D8MissingPerformGets)
         var_r64->SetSelection(sel);
 
         unsigned int t = 0;
-        adios2::StepStatus status = adios2::StepStatus::OK;
-        while (status == adios2::StepStatus::OK)
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
         {
-            status = bpReader.BeginStep();
             bpReader.GetDeferred(*var_i8, I8.data());
             bpReader.GetDeferred(*var_i16, I16.data());
             bpReader.GetDeferred(*var_i32, I32.data());
@@ -1218,11 +1211,9 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D2x4MissingPerformGets)
         var_r64->SetSelection(sel);
 
         unsigned int t = 0;
-        adios2::StepStatus status = adios2::StepStatus::OK;
-        while (status == adios2::StepStatus::OK)
-        {
-            status = bpReader.BeginStep();
 
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
             bpReader.GetDeferred(*var_i8, I8.data());
             bpReader.GetDeferred(*var_i16, I16.data());
             bpReader.GetDeferred(*var_i32, I32.data());
@@ -1475,11 +1466,8 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D4x2MissingPerformGets)
         var_r64->SetSelection(sel);
 
         unsigned int t = 0;
-        adios2::StepStatus status = adios2::StepStatus::OK;
-        while (status == adios2::StepStatus::OK)
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
         {
-            status = bpReader.BeginStep();
-
             bpReader.GetDeferred(*var_i8, I8.data());
             bpReader.GetDeferred(*var_i16, I16.data());
             bpReader.GetDeferred(*var_i32, I32.data());


### PR DESCRIPTION
BeginStep shouldn't return EndOfStream status after reading last step.

Heat transfer example working as expected.
Tests modified.