### PR TITLE
Do not duplicate MPI_COMM_WORLD in InSituMPI engine because MPI_Comm_…

### DIFF
--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -27,7 +27,6 @@ InSituMPIReader::InSituMPIReader(IO &io, const std::string &name,
   m_BP3Deserializer(mpiComm, m_DebugMode)
 {
     m_EndMessage = " in call to IO Open InSituMPIReader " + m_Name + "\n";
-    MPI_Comm_dup(MPI_COMM_WORLD, &m_CommWorld);
     Init();
 
     m_RankAllPeers = insitumpi::FindPeers(mpiComm, m_Name, false, m_CommWorld);
@@ -94,7 +93,6 @@ InSituMPIReader::~InSituMPIReader()
         std::cout << "InSituMPI Reader " << m_ReaderRank << " Deconstructor on "
                   << m_Name << "\n";
     }
-    MPI_Comm_free(&m_CommWorld);
 }
 
 void InSituMPIReader::ClearMetadataBuffer()

--- a/source/adios2/engine/insitumpi/InSituMPIReader.h
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.h
@@ -49,7 +49,7 @@ public:
     void Close(const int transportIndex = -1);
 
 private:
-    MPI_Comm m_CommWorld;
+    MPI_Comm m_CommWorld = MPI_COMM_WORLD;
     int m_Verbosity = 0;
     bool m_FixedSchedule = false; // true: metadata in steps does NOT change
 

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
@@ -29,7 +29,6 @@ InSituMPIWriter::InSituMPIWriter(IO &io, const std::string &name,
   m_BP3Serializer(mpiComm, m_DebugMode)
 {
     m_EndMessage = " in call to InSituMPIWriter " + m_Name + " Open\n";
-    MPI_Comm_dup(MPI_COMM_WORLD, &m_CommWorld);
     Init();
     m_BP3Serializer.InitParameters(m_IO.m_Parameters);
 
@@ -54,7 +53,7 @@ InSituMPIWriter::InSituMPIWriter(IO &io, const std::string &name,
                                   m_GlobalRank, m_RankDirectPeers);
 }
 
-InSituMPIWriter::~InSituMPIWriter() { MPI_Comm_free(&m_CommWorld); }
+InSituMPIWriter::~InSituMPIWriter() {}
 
 StepStatus InSituMPIWriter::BeginStep(StepMode mode, const float timeoutSeconds)
 {
@@ -186,7 +185,8 @@ void InSituMPIWriter::PerformPuts()
         }
 
         // build (and remember for fixed schedule) the read request table
-        // std::map<std::string, std::map<size_t, std::vector<SubFileInfo>>> map
+        // std::map<std::string, std::map<size_t, std::vector<SubFileInfo>>>
+        // map
         m_WriteScheduleMap.clear();
         m_WriteScheduleMap =
             insitumpi::DeserializeReadSchedule(serializedSchedules);

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.h
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.h
@@ -54,7 +54,7 @@ public:
     void Close(const int transportIndex = -1) final;
 
 private:
-    MPI_Comm m_CommWorld;
+    MPI_Comm m_CommWorld = MPI_COMM_WORLD;
     int m_Verbosity = 0;
     bool m_FixedSchedule = false; // true: metadata in steps does NOT change
 


### PR DESCRIPTION
…dup() is collective operation. Not every process gets to this call.