### PR TITLE
Suppress warnings from third party dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,11 @@ set(ADIOS2_CONFIG_OPTS
   BZip2 ZFP MPI DataMan SST ZeroMQ HDF5 ADIOS1 Python Fortran SysVShMem
 )
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})
+configure_file(
+  ${ADIOS2_SOURCE_DIR}/CTestCustom.cmake.in
+  ${ADIOS2_BINARY_DIR}/CTestCustom.cmake
+  @ONLY
+)
 
 install(FILES ${ADIOS2_BINARY_DIR}/source/adios2/ADIOSConfig.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/adios2

--- a/CTestCustom.cmake.in
+++ b/CTestCustom.cmake.in
@@ -1,0 +1,8 @@
+#------------------------------------------------------------------------------#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#------------------------------------------------------------------------------#
+
+list(APPEND CTEST_CUSTOM_WARNING_EXCEPTION
+  "H5PL\\.c.*dlopen.*glibc"
+)

--- a/CTestCustom.cmake.in
+++ b/CTestCustom.cmake.in
@@ -5,4 +5,5 @@
 
 list(APPEND CTEST_CUSTOM_WARNING_EXCEPTION
   "H5PL\\.c.*dlopen.*glibc"
+  "gtest\\.cc.*getaddrinfo.*glibc"
 )


### PR DESCRIPTION
HDF5 and GoogleTest generate warning spam when built with static glibc (i.e. Cray)