### PR TITLE
Issue #405 make Close call MPI_Comm_free in all Engines

### DIFF
--- a/examples/plugins/engine/ExampleEnginePlugin.cpp
+++ b/examples/plugins/engine/ExampleEnginePlugin.cpp
@@ -62,12 +62,6 @@ ExampleEnginePlugin::ExampleEnginePlugin(IO &io, const std::string &name,
 
 ExampleEnginePlugin::~ExampleEnginePlugin() { m_Log.close(); }
 
-void ExampleEnginePlugin::Close(const int transportIndex)
-{
-    m_Log << now() << " Close with transportIndex " << transportIndex
-          << std::endl;
-}
-
 void ExampleEnginePlugin::Init()
 {
     std::string logName = "ExamplePlugin.log";
@@ -96,5 +90,11 @@ void ExampleEnginePlugin::Init()
     }
 ADIOS2_FOREACH_TYPE_1ARG(define)
 #undef define
+
+void ExampleEnginePlugin::DoClose(const int transportIndex)
+{
+    m_Log << now() << " Close with transportIndex " << transportIndex
+          << std::endl;
+}
 
 } // end namespace adios2

--- a/examples/plugins/engine/ExampleEnginePlugin.h
+++ b/examples/plugins/engine/ExampleEnginePlugin.h
@@ -32,8 +32,6 @@ public:
                         MPI_Comm mpiComm);
     virtual ~ExampleEnginePlugin();
 
-    void Close(const int transportIndex = -1) override;
-
 protected:
     void Init() override;
 
@@ -41,6 +39,8 @@ protected:
     void DoPutSync(Variable<T> &variable, const T *values) override;
     ADIOS2_FOREACH_TYPE_1ARG(declare)
 #undef declare
+
+    void DoClose(const int transportIndex = -1) override;
 
 private:
     std::ofstream m_Log;

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -23,7 +23,7 @@ Engine::Engine(const std::string engineType, IO &io, const std::string &name,
 {
 }
 
-Engine::~Engine() { MPI_Comm_free(&m_MPIComm); };
+Engine::~Engine(){};
 
 IO &Engine::GetIO() noexcept { return m_IO; }
 
@@ -134,6 +134,16 @@ void Engine::WriteStep()
     }
     PerformPuts();
     EndStep();
+}
+
+void Engine::Close(const int transportIndex)
+{
+    DoClose(transportIndex);
+
+    if (transportIndex == -1)
+    {
+        MPI_Comm_free(&m_MPIComm);
+    }
 }
 
 // PROTECTED

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -202,11 +202,11 @@ public:
     void WriteStep();
 
     /**
-     * Closes a particular transport, or all if -1. This is a purely virtual
-     * function that all engines must implement.
-     * @param transportIndex order from IO AddTransport
+     * Closes a particular transport, or all if -1.
+     * @param transportIndex index returned from IO AddTransport, default (-1) =
+     * all
      */
-    virtual void Close(const int transportIndex = -1) = 0;
+    void Close(const int transportIndex = -1);
 
 protected:
     /** from derived class */
@@ -256,6 +256,8 @@ protected:
     virtual void DoGetDeferred(Variable<T> &, T &);
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+    virtual void DoClose(const int transportIndex) = 0;
 
 private:
     /** Throw exception by Engine virtual functions not implemented/supported by

--- a/source/adios2/engine/adios1/ADIOS1Reader.cpp
+++ b/source/adios2/engine/adios1/ADIOS1Reader.cpp
@@ -80,8 +80,6 @@ void ADIOS1Reader::EndStep()
     m_ADIOS1.ReleaseStep();
 }
 
-void ADIOS1Reader::Close(const int transportIndex) { m_ADIOS1.Close(); }
-
 // PRIVATE
 void ADIOS1Reader::Init()
 {
@@ -108,5 +106,7 @@ void ADIOS1Reader::InitTransports()
 {
     m_ADIOS1.InitTransports(m_IO.m_TransportsParameters);
 }
+
+void ADIOS1Reader::DoClose(const int transportIndex) { m_ADIOS1.Close(); }
 
 } // end namespace adios2

--- a/source/adios2/engine/adios1/ADIOS1Reader.h
+++ b/source/adios2/engine/adios1/ADIOS1Reader.h
@@ -57,8 +57,6 @@ public:
     void PerformGets() final;
     void EndStep() final;
 
-    void Close(const int transportIndex = -1);
-
 private:
     interop::ADIOS1CommonRead m_ADIOS1;
     // ADIOS_FILE *m_fh = nullptr; ///< ADIOS1 file handler
@@ -77,6 +75,8 @@ private:
 
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+    void DoClose(const int transportIndex = -1) final;
 
     void ReadJoinedArray(const std::string &name, const Dims &offs,
                          const Dims &ldims, const int fromStep,

--- a/source/adios2/engine/adios1/ADIOS1Writer.cpp
+++ b/source/adios2/engine/adios1/ADIOS1Writer.cpp
@@ -41,7 +41,7 @@ void ADIOS1Writer::PerformPuts() {}
 
 void ADIOS1Writer::EndStep() { m_ADIOS1.Advance(); }
 
-void ADIOS1Writer::Close(const int transportIndex) { m_ADIOS1.Close(); }
+void ADIOS1Writer::DoClose(const int transportIndex) { m_ADIOS1.Close(); }
 
 // PRIVATE
 void ADIOS1Writer::Init()

--- a/source/adios2/engine/adios1/ADIOS1Writer.h
+++ b/source/adios2/engine/adios1/ADIOS1Writer.h
@@ -41,16 +41,6 @@ public:
     void PerformPuts() final;
     void EndStep() final;
 
-    /**
-     * Closes a single transport or all transports
-     * @param transportIndex, if -1 (default) closes all transports, otherwise
-     * it
-     * closes a transport in m_Transport[transportIndex]. In debug mode the
-     * latter
-     * is bounds-checked.
-     */
-    void Close(const int transportIndex = -1) final;
-
 private:
     interop::ADIOS1CommonWrite m_ADIOS1;
 
@@ -63,6 +53,14 @@ private:
     void DoPutDeferred(Variable<T> &variable, const T *values) final;
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+    /**
+     * Closes a single transport or all transports
+     * @param transportIndex, if -1 (default) closes all transports,
+     * otherwise it closes a transport in m_Transport[transportIndex].
+     * In debug mode the latter is bounds-checked.
+     */
+    void DoClose(const int transportIndex) final;
 };
 
 } // end namespace adios2

--- a/source/adios2/engine/bp/BPFileReader.cpp
+++ b/source/adios2/engine/bp/BPFileReader.cpp
@@ -102,17 +102,6 @@ void BPFileReader::PerformGets()
     m_BP3Deserializer.m_PerformedGets = true;
 }
 
-void BPFileReader::Close(const int transportIndex)
-{
-    if (!m_BP3Deserializer.m_PerformedGets)
-    {
-        PerformGets();
-    }
-
-    m_SubFileManager.CloseFiles();
-    m_FileManager.CloseFiles();
-}
-
 // PRIVATE
 void BPFileReader::Init()
 {
@@ -231,6 +220,17 @@ void BPFileReader::ReadVariables(
             }     // end step
         }         // end subfile
     }             // end variable
+}
+
+void BPFileReader::DoClose(const int transportIndex)
+{
+    if (!m_BP3Deserializer.m_PerformedGets)
+    {
+        PerformGets();
+    }
+
+    m_SubFileManager.CloseFiles();
+    m_FileManager.CloseFiles();
 }
 
 } // end namespace adios2

--- a/source/adios2/engine/bp/BPFileReader.h
+++ b/source/adios2/engine/bp/BPFileReader.h
@@ -49,8 +49,6 @@ public:
 
     void PerformGets() final;
 
-    void Close(const int transportIndex = -1);
-
 private:
     format::BP3Deserializer m_BP3Deserializer;
     transportman::TransportMan m_FileManager;
@@ -70,6 +68,8 @@ private:
     void DoGetDeferred(Variable<T> &, T &) final;
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+    void DoClose(const int transportIndex = -1) final;
 
     template <class T>
     void GetSyncCommon(Variable<T> &variable, T *data);

--- a/source/adios2/engine/bp/BPFileWriter.cpp
+++ b/source/adios2/engine/bp/BPFileWriter.cpp
@@ -77,35 +77,6 @@ void BPFileWriter::EndStep()
     }
 }
 
-void BPFileWriter::Close(const int transportIndex)
-{
-    if (m_BP3Serializer.m_DeferredVariables.size() > 0)
-    {
-        PerformPuts();
-    }
-
-    // close bp buffer by serializing data and metadata
-    m_BP3Serializer.CloseData(m_IO);
-    // send data to corresponding transports
-    m_FileDataManager.WriteFiles(m_BP3Serializer.m_Data.m_Buffer.data(),
-                                 m_BP3Serializer.m_Data.m_Position,
-                                 transportIndex);
-
-    m_FileDataManager.CloseFiles(transportIndex);
-
-    if (m_BP3Serializer.m_Profiler.IsActive &&
-        m_FileDataManager.AllTransportsClosed())
-    {
-        WriteProfilingJSONFile();
-    }
-
-    if (m_BP3Serializer.m_CollectiveMetadata &&
-        m_FileDataManager.AllTransportsClosed())
-    {
-        WriteCollectiveMetadataFile();
-    }
-}
-
 // PRIVATE FUNCTIONS
 // PRIVATE
 void BPFileWriter::Init()
@@ -169,6 +140,35 @@ void BPFileWriter::InitBPBuffer()
     {
         m_BP3Serializer.PutProcessGroupIndex(
             m_IO.m_HostLanguage, m_FileDataManager.GetTransportsTypes());
+    }
+}
+
+void BPFileWriter::DoClose(const int transportIndex)
+{
+    if (m_BP3Serializer.m_DeferredVariables.size() > 0)
+    {
+        PerformPuts();
+    }
+
+    // close bp buffer by serializing data and metadata
+    m_BP3Serializer.CloseData(m_IO);
+    // send data to corresponding transports
+    m_FileDataManager.WriteFiles(m_BP3Serializer.m_Data.m_Buffer.data(),
+                                 m_BP3Serializer.m_Data.m_Position,
+                                 transportIndex);
+
+    m_FileDataManager.CloseFiles(transportIndex);
+
+    if (m_BP3Serializer.m_Profiler.IsActive &&
+        m_FileDataManager.AllTransportsClosed())
+    {
+        WriteProfilingJSONFile();
+    }
+
+    if (m_BP3Serializer.m_CollectiveMetadata &&
+        m_FileDataManager.AllTransportsClosed())
+    {
+        WriteCollectiveMetadataFile();
     }
 }
 

--- a/source/adios2/engine/bp/BPFileWriter.h
+++ b/source/adios2/engine/bp/BPFileWriter.h
@@ -38,8 +38,6 @@ public:
     void PerformPuts() final;
     void EndStep() final;
 
-    void Close(const int transportIndex = -1) final;
-
 private:
     /** Single object controlling BP buffering */
     format::BP3Serializer m_BP3Serializer;
@@ -76,6 +74,8 @@ private:
 
     template <class T>
     void PutDeferredCommon(Variable<T> &variable, const T *values);
+
+    void DoClose(const int transportIndex = -1) final;
 
     /** Write a profiling.json file from m_BP1Writer and m_TransportsManager
      * profilers*/

--- a/source/adios2/engine/dataman/DataManReader.cpp
+++ b/source/adios2/engine/dataman/DataManReader.cpp
@@ -60,8 +60,6 @@ void DataManReader::PerformGets() {}
 
 void DataManReader::EndStep() {}
 
-void DataManReader::Close(const int transportIndex) {}
-
 // PRIVATE
 bool DataManReader::GetBoolParameter(Params &params, std::string key,
                                      bool &value)
@@ -167,5 +165,7 @@ void DataManReader::Init()
     }
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+void DataManReader::DoClose(const int transportIndex) {}
 
 } // end namespace adios2

--- a/source/adios2/engine/dataman/DataManReader.h
+++ b/source/adios2/engine/dataman/DataManReader.h
@@ -47,8 +47,6 @@ public:
 
     void EndStep() final;
 
-    void Close(const int transportIndex = -1);
-
 private:
     format::BP3Deserializer m_BP3Deserializer;
     transportman::DataMan m_Man;
@@ -73,6 +71,8 @@ private:
     void DoGetDeferred(Variable<T> &, T &) final;
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+    void DoClose(const int transportIndex = -1) final;
 
     /**
      * All DoGetSync virtual functions call this function

--- a/source/adios2/engine/dataman/DataManWriter.cpp
+++ b/source/adios2/engine/dataman/DataManWriter.cpp
@@ -41,20 +41,6 @@ void DataManWriter::EndStep()
     }
 }
 
-void DataManWriter::Close(const int transportIndex)
-{
-    if (m_UseFormat == "bp" || m_UseFormat == "BP")
-    {
-        m_BP3Serializer.CloseData(m_IO);
-        auto &buffer = m_BP3Serializer.m_Data.m_Buffer;
-        auto &position = m_BP3Serializer.m_Data.m_Position;
-        if (position > 0)
-        {
-            m_Man.WriteWAN(buffer.data(), position);
-        }
-    }
-}
-
 // PRIVATE functions below
 
 bool DataManWriter::GetBoolParameter(Params &params, std::string key,
@@ -152,5 +138,19 @@ void DataManWriter::Init()
     void DataManWriter::DoPutDeferred(Variable<T> &, const T &value) {}
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+void DataManWriter::DoClose(const int transportIndex)
+{
+    if (m_UseFormat == "bp" || m_UseFormat == "BP")
+    {
+        m_BP3Serializer.CloseData(m_IO);
+        auto &buffer = m_BP3Serializer.m_Data.m_Buffer;
+        auto &position = m_BP3Serializer.m_Data.m_Position;
+        if (position > 0)
+        {
+            m_Man.WriteWAN(buffer.data(), position);
+        }
+    }
+}
 
 } // end namespace adios2

--- a/source/adios2/engine/dataman/DataManWriter.h
+++ b/source/adios2/engine/dataman/DataManWriter.h
@@ -31,8 +31,6 @@ public:
     StepStatus BeginStep(StepMode mode, const float timeoutSeconds = 0.f) final;
     void EndStep() final;
 
-    void Close(const int transportIndex = -1) final;
-
 private:
     format::BP3Serializer m_BP3Serializer;
     transportman::DataMan m_Man;
@@ -66,6 +64,8 @@ private:
 
     template <class T>
     void PutSyncCommonBP(Variable<T> &variable, const T *values);
+
+    void DoClose(const int transportIndex = -1) final;
 };
 
 } // end namespace adios2

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -24,7 +24,7 @@ HDF5ReaderP::HDF5ReaderP(IO &io, const std::string &name, const Mode openMode,
     Init();
 }
 
-HDF5ReaderP::~HDF5ReaderP() { Close(); }
+HDF5ReaderP::~HDF5ReaderP() { DoClose(); }
 
 bool HDF5ReaderP::IsValid()
 {
@@ -279,8 +279,6 @@ void HDF5ReaderP::PerformGets()
     m_DeferredStack.clear();
 }
 
-void HDF5ReaderP::Close(const int transportIndex) { m_H5File.Close(); }
-
 #define declare_type(T)                                                        \
     void HDF5ReaderP::DoGetSync(Variable<T> &variable, T *data)                \
     {                                                                          \
@@ -297,4 +295,6 @@ void HDF5ReaderP::Close(const int transportIndex) { m_H5File.Close(); }
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
 
-} // end namespace adios
+void HDF5ReaderP::DoClose(const int transportIndex) { m_H5File.Close(); }
+
+} // end namespace adios2

--- a/source/adios2/engine/hdf5/HDF5ReaderP.h
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.h
@@ -41,8 +41,6 @@ public:
 
     void PerformGets() final;
 
-    void Close(const int transportIndex = -1) final;
-
 private:
     interop::HDF5Common m_H5File;
     void Init() final;
@@ -55,6 +53,8 @@ private:
     void DoGetDeferred(Variable<T> &, T &) final;
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+    void DoClose(const int transportIndex = -1) final;
 
     template <class T>
     void GetSyncCommon(Variable<T> &variable, T *data);

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -24,7 +24,7 @@ HDF5WriterP::HDF5WriterP(IO &io, const std::string &name, const Mode mode,
     Init();
 }
 
-HDF5WriterP::~HDF5WriterP() { Close(); }
+HDF5WriterP::~HDF5WriterP() { DoClose(); }
 
 StepStatus HDF5WriterP::BeginStep(StepMode mode, const float timeoutSeconds)
 {
@@ -32,8 +32,6 @@ StepStatus HDF5WriterP::BeginStep(StepMode mode, const float timeoutSeconds)
 }
 
 void HDF5WriterP::EndStep() { m_H5File.Advance(); }
-
-void HDF5WriterP::Close(const int transportIndex) { m_H5File.Close(); }
 
 // PRIVATE
 void HDF5WriterP::Init()
@@ -88,5 +86,7 @@ void HDF5WriterP::DoPutSyncCommon(Variable<T> &variable, const T *values)
     variable.SetData(values);
     m_H5File.Write(variable, values);
 }
+
+void HDF5WriterP::DoClose(const int transportIndex) { m_H5File.Close(); }
 
 } // end namespace adios2

--- a/source/adios2/engine/hdf5/HDF5WriterP.h
+++ b/source/adios2/engine/hdf5/HDF5WriterP.h
@@ -41,8 +41,6 @@ public:
     StepStatus BeginStep(StepMode mode, const float timeoutSeconds = 0.f) final;
     void EndStep() final;
 
-    void Close(const int transportIndex = -1) final;
-
 private:
     interop::HDF5Common m_H5File;
 
@@ -56,6 +54,8 @@ private:
 
     template <class T>
     void DoPutSyncCommon(Variable<T> &variable, const T *values);
+
+    void DoClose(const int transportIndex = -1) final;
 };
 
 } // end namespace adios2

--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -250,29 +250,6 @@ void InSituMPIReader::EndStep()
     ClearMetadataBuffer();
 }
 
-void InSituMPIReader::Close(const int transportIndex)
-{
-    if (m_Verbosity == 5)
-    {
-        std::cout << "InSituMPI Reader " << m_ReaderRank << " Close(" << m_Name
-                  << ")\n";
-    }
-    if (m_Verbosity > 2)
-    {
-        uint64_t inPlaceBytes, inTempBytes;
-        MPI_Reduce(&m_BytesReceivedInPlace, &inPlaceBytes, 1, MPI_LONG_LONG_INT,
-                   MPI_SUM, 0, m_MPIComm);
-        MPI_Reduce(&m_BytesReceivedInTemporary, &inTempBytes, 1,
-                   MPI_LONG_LONG_INT, MPI_SUM, 0, m_MPIComm);
-        if (m_ReaderRank == 0)
-        {
-            std::cout << "ADIOS InSituMPI Reader for " << m_Name << " received "
-                      << Statistics(inPlaceBytes, inTempBytes)
-                      << "% of data in place (zero-copy)" << std::endl;
-        }
-    }
-}
-
 // PRIVATE
 
 void InSituMPIReader::SendReadSchedule(
@@ -442,6 +419,29 @@ void InSituMPIReader::InitParameters()
 void InSituMPIReader::InitTransports()
 {
     // Nothing to process from m_IO.m_TransportsParameters
+}
+
+void InSituMPIReader::DoClose(const int transportIndex)
+{
+    if (m_Verbosity == 5)
+    {
+        std::cout << "InSituMPI Reader " << m_ReaderRank << " Close(" << m_Name
+                  << ")\n";
+    }
+    if (m_Verbosity > 2)
+    {
+        uint64_t inPlaceBytes, inTempBytes;
+        MPI_Reduce(&m_BytesReceivedInPlace, &inPlaceBytes, 1, MPI_LONG_LONG_INT,
+                   MPI_SUM, 0, m_MPIComm);
+        MPI_Reduce(&m_BytesReceivedInTemporary, &inTempBytes, 1,
+                   MPI_LONG_LONG_INT, MPI_SUM, 0, m_MPIComm);
+        if (m_ReaderRank == 0)
+        {
+            std::cout << "ADIOS InSituMPI Reader for " << m_Name << " received "
+                      << Statistics(inPlaceBytes, inTempBytes)
+                      << "% of data in place (zero-copy)" << std::endl;
+        }
+    }
 }
 
 } // end namespace adios2

--- a/source/adios2/engine/insitumpi/InSituMPIReader.h
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.h
@@ -46,8 +46,6 @@ public:
     void PerformGets() final;
     void EndStep() final;
 
-    void Close(const int transportIndex = -1);
-
 private:
     MPI_Comm m_CommWorld = MPI_COMM_WORLD;
     int m_Verbosity = 0;
@@ -92,6 +90,8 @@ private:
 
     template <class T>
     void GetDeferredCommon(Variable<T> &variable, T *data);
+
+    void DoClose(const int transportIndex = -1) final;
 
     void ClearMetadataBuffer();
 

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
@@ -286,23 +286,6 @@ void InSituMPIWriter::EndStep()
     m_MPIRequests.clear();
 }
 
-void InSituMPIWriter::Close(const int transportIndex)
-{
-    if (m_Verbosity == 5)
-    {
-        std::cout << "InSituMPI Writer " << m_WriterRank << " Close(" << m_Name
-                  << ")\n";
-    }
-    m_CurrentStep = -1; // -1 will indicate end of stream
-    // Send -1 to all reader peers, asynchronously
-    MPI_Request request;
-    for (auto peerRank : m_RankDirectPeers)
-    {
-        MPI_Isend(&m_CurrentStep, 1, MPI_INT, peerRank,
-                  insitumpi::MpiTags::Step, m_CommWorld, &request);
-    }
-}
-
 // PRIVATE
 
 #define declare_type(T)                                                        \
@@ -356,6 +339,23 @@ void InSituMPIWriter::InitParameters()
 void InSituMPIWriter::InitTransports()
 {
     // Nothing to process from m_IO.m_TransportsParameters
+}
+
+void InSituMPIWriter::DoClose(const int transportIndex)
+{
+    if (m_Verbosity == 5)
+    {
+        std::cout << "InSituMPI Writer " << m_WriterRank << " Close(" << m_Name
+                  << ")\n";
+    }
+    m_CurrentStep = -1; // -1 will indicate end of stream
+    // Send -1 to all reader peers, asynchronously
+    MPI_Request request;
+    for (auto peerRank : m_RankDirectPeers)
+    {
+        MPI_Isend(&m_CurrentStep, 1, MPI_INT, peerRank,
+                  insitumpi::MpiTags::Step, m_CommWorld, &request);
+    }
 }
 
 } // end namespace adios2

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.h
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.h
@@ -43,16 +43,6 @@ public:
     void PerformPuts() final;
     void EndStep() final;
 
-    /**
-     * Closes a single transport or all transports
-     * @param transportIndex, if -1 (default) closes all transports, otherwise
-     * it
-     * closes a transport in m_Transport[transportIndex]. In debug mode the
-     * latter
-     * is bounds-checked.
-     */
-    void Close(const int transportIndex = -1) final;
-
 private:
     MPI_Comm m_CommWorld = MPI_COMM_WORLD;
     int m_Verbosity = 0;
@@ -92,6 +82,14 @@ private:
     void DoPutDeferred(Variable<T> &, const T &) final;
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+    /**
+     * Closes a single transport or all transports
+     * @param transportIndex, if -1 (default) closes all transports,
+     * otherwise it closes a transport in m_Transport[transportIndex].
+     * In debug mode the latter is bounds-checked.
+     */
+    void DoClose(const int transportIndex = -1) final;
 
     /**
      * Common function for primitive PutSync, puts variables in buffer

--- a/source/adios2/engine/mixer/HDFMixer.cpp
+++ b/source/adios2/engine/mixer/HDFMixer.cpp
@@ -60,41 +60,6 @@ void HDFMixer::EndStep()
     m_HDFVDSWriter.Advance();
 }
 
-void HDFMixer::Close(const int transportIndex)
-{
-    /*if (m_DebugMode)
-      {
-          if (!m_TransportsManager.CheckTransportIndex(transportIndex))
-          {
-              auto transportsSize = m_TransportsManager.m_Transports.size();
-              throw std::invalid_argument(
-                  "ERROR: transport index " + std::to_string(transportIndex) +
-                  " outside range, -1 (default) to " +
-                  std::to_string(transportsSize - 1) + ", in call to Close\n");
-          }
-      }
-    */
-    // close bp buffer by flattening data and metadata
-    m_HDFSerialWriter.Close();
-    m_HDFVDSWriter.Close();
-    // send data to corresponding transports
-    /*
-    m_TransportsManager.WriteFiles(m_HDFSerialWriter.m_HeapBuffer.GetData(),
-                                   m_HDFSerialWriter.m_HeapBuffer.m_DataPosition,
-                                   transportIndex);
-
-    m_TransportsManager.CloseFiles(transportIndex);
-    */
-    /*
-      // do profiling later
-    if (m_HDFSerialWriter.m_Profiler.IsActive &&
-        m_TransportsManager.AllTransportsClosed())
-    {
-        WriteProfilingJSONFile();
-    }
-    */
-}
-
 // PRIVATE FUNCTIONS
 void HDFMixer::InitParameters()
 {
@@ -185,4 +150,39 @@ void HDFMixer::WriteProfilingJSONFile() { /*
      }
   */}
 
-} // end namespace adios
+void HDFMixer::DoClose(const int transportIndex)
+{
+    /*if (m_DebugMode)
+      {
+          if (!m_TransportsManager.CheckTransportIndex(transportIndex))
+          {
+              auto transportsSize = m_TransportsManager.m_Transports.size();
+              throw std::invalid_argument(
+                  "ERROR: transport index " + std::to_string(transportIndex) +
+                  " outside range, -1 (default) to " +
+                  std::to_string(transportsSize - 1) + ", in call to Close\n");
+          }
+      }
+    */
+    // close bp buffer by flattening data and metadata
+    m_HDFSerialWriter.Close();
+    m_HDFVDSWriter.Close();
+    // send data to corresponding transports
+    /*
+    m_TransportsManager.WriteFiles(m_HDFSerialWriter.m_HeapBuffer.GetData(),
+                                   m_HDFSerialWriter.m_HeapBuffer.m_DataPosition,
+                                   transportIndex);
+
+    m_TransportsManager.CloseFiles(transportIndex);
+    */
+    /*
+      // do profiling later
+    if (m_HDFSerialWriter.m_Profiler.IsActive &&
+        m_TransportsManager.AllTransportsClosed())
+    {
+        WriteProfilingJSONFile();
+    }
+    */
+}
+
+} // end namespace adios2

--- a/source/adios2/engine/mixer/HDFMixer.h
+++ b/source/adios2/engine/mixer/HDFMixer.h
@@ -54,15 +54,6 @@ public:
     StepStatus BeginStep(StepMode mode, const float timeout_sec);
     // void EndStep(const float /*timeout_sec*/);
     void EndStep() final;
-    /**
-     * Closes a single transport or all transports
-     * @param transportIndex, if -1 (default) closes all transports, otherwise
-     * it
-     * closes a transport in m_Transport[transportIndex]. In debug mode the
-     * latter
-     * is bounds-checked.
-     */
-    void Close(const int transportIndex = -1) final;
 
     void CreateName(std::string &pathName, std::string &rootName,
                     std::string &fullH5Name, int rank);
@@ -94,6 +85,15 @@ private:
 #undef declare_type
 
     /**
+     * Closes a single transport or all transports
+     * @param transportIndex, if -1 (default) closes all transports,
+     * otherwise it
+     * closes a transport in m_Transport[transportIndex]. In debug mode the
+     * latter is bounds-checked.
+     */
+    void DoClose(const int transportIndex = -1) final;
+
+    /**
      * Common function for primitive (including std::complex) writes
      * @param variable
      * @param values
@@ -106,6 +106,6 @@ private:
     void WriteProfilingJSONFile();
 };
 
-} // end namespace adios
+} // end namespace adios2
 
 #endif /* ADIOS2_ENGINE_H5_HDFMIXER_H_ */

--- a/source/adios2/engine/plugin/PluginEngine.cpp
+++ b/source/adios2/engine/plugin/PluginEngine.cpp
@@ -72,11 +72,6 @@ void PluginEngine::PerformGets() { m_Impl->m_Plugin->PerformGets(); }
 
 void PluginEngine::EndStep() { m_Impl->m_Plugin->EndStep(); }
 
-void PluginEngine::Close(const int transportIndex)
-{
-    m_Impl->m_Plugin->Close(transportIndex);
-}
-
 void PluginEngine::Init()
 {
     auto paramPluginNameIt = m_IO.m_Parameters.find("PluginName");
@@ -161,5 +156,10 @@ void PluginEngine::Init()
 
 ADIOS2_FOREACH_TYPE_1ARG(declare)
 #undef declare
+
+void PluginEngine::DoClose(const int transportIndex)
+{
+    m_Impl->m_Plugin->Close(transportIndex);
+}
 
 } // end namespace adios2

--- a/source/adios2/engine/plugin/PluginEngine.h
+++ b/source/adios2/engine/plugin/PluginEngine.h
@@ -72,8 +72,6 @@ public:
     void PerformGets() override;
     void EndStep() override;
 
-    void Close(const int transportIndex = -1) override;
-
 protected:
     void Init() override;
 
@@ -87,6 +85,8 @@ protected:
 
     ADIOS2_FOREACH_TYPE_1ARG(declare)
 #undef declare
+
+    void DoClose(const int transportIndex = -1);
 
 private:
     struct Impl;

--- a/source/adios2/engine/skeleton/SkeletonReader.cpp
+++ b/source/adios2/engine/skeleton/SkeletonReader.cpp
@@ -99,15 +99,6 @@ void SkeletonReader::EndStep()
     }
 }
 
-void SkeletonReader::Close(const int transportIndex)
-{
-    if (m_Verbosity == 5)
-    {
-        std::cout << "Skeleton Reader " << m_ReaderRank << " Close(" << m_Name
-                  << ")\n";
-    }
-}
-
 // PRIVATE
 
 #define declare_type(T)                                                        \
@@ -153,6 +144,15 @@ void SkeletonReader::InitParameters()
 void SkeletonReader::InitTransports()
 {
     // Nothing to process from m_IO.m_TransportsParameters
+}
+
+void SkeletonReader::DoClose(const int transportIndex)
+{
+    if (m_Verbosity == 5)
+    {
+        std::cout << "Skeleton Reader " << m_ReaderRank << " Close(" << m_Name
+                  << ")\n";
+    }
 }
 
 } // end namespace adios2

--- a/source/adios2/engine/skeleton/SkeletonReader.h
+++ b/source/adios2/engine/skeleton/SkeletonReader.h
@@ -43,8 +43,6 @@ public:
     void PerformGets() final;
     void EndStep() final;
 
-    void Close(const int transportIndex = -1);
-
 private:
     int m_Verbosity = 0;
     int m_ReaderRank; // my rank in the readers' comm
@@ -66,6 +64,8 @@ private:
     void DoGetDeferred(Variable<T> &, T &) final;
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+    void DoClose(const int transportIndex = -1);
 
     template <class T>
     void GetSyncCommon(Variable<T> &variable, T *data);

--- a/source/adios2/engine/skeleton/SkeletonWriter.cpp
+++ b/source/adios2/engine/skeleton/SkeletonWriter.cpp
@@ -67,15 +67,6 @@ void SkeletonWriter::EndStep()
     }
 }
 
-void SkeletonWriter::Close(const int transportIndex)
-{
-    if (m_Verbosity == 5)
-    {
-        std::cout << "Skeleton Writer " << m_WriterRank << " Close(" << m_Name
-                  << ")\n";
-    }
-}
-
 // PRIVATE
 
 #define declare_type(T)                                                        \
@@ -118,6 +109,15 @@ void SkeletonWriter::InitParameters()
 void SkeletonWriter::InitTransports()
 {
     // Nothing to process from m_IO.m_TransportsParameters
+}
+
+void SkeletonWriter::DoClose(const int transportIndex)
+{
+    if (m_Verbosity == 5)
+    {
+        std::cout << "Skeleton Writer " << m_WriterRank << " Close(" << m_Name
+                  << ")\n";
+    }
 }
 
 } // end namespace adios2

--- a/source/adios2/engine/skeleton/SkeletonWriter.h
+++ b/source/adios2/engine/skeleton/SkeletonWriter.h
@@ -39,16 +39,6 @@ public:
     void PerformPuts() final;
     void EndStep() final;
 
-    /**
-     * Closes a single transport or all transports
-     * @param transportIndex, if -1 (default) closes all transports, otherwise
-     * it
-     * closes a transport in m_Transport[transportIndex]. In debug mode the
-     * latter
-     * is bounds-checked.
-     */
-    void Close(const int transportIndex = -1) final;
-
 private:
     int m_Verbosity = 0;
     int m_WriterRank;       // my rank in the writers' comm
@@ -67,6 +57,14 @@ private:
     void DoPutDeferred(Variable<T> &, const T &) final;
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
+
+    /**
+     * Closes a single transport or all transports
+     * @param transportIndex, if -1 (default) closes all transports,
+     * otherwise it closes a transport in m_Transport[transportIndex].
+     * In debug mode the latter is bounds-checked.
+     */
+    void DoClose(const int transportIndex = -1) final;
 
     /**
      * Common function for primitive PutSync, puts variables in buffer

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -100,8 +100,6 @@ void SstReader::EndStep()
     SstReleaseStep(m_Input);
 }
 
-void SstReader::Close(const int transportIndex) { SstReaderClose(m_Input); }
-
 // PRIVATE
 void SstReader::Init()
 {
@@ -133,4 +131,6 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 
 void SstReader::PerformGets() { SstPerformGets(m_Input); }
 
-} // end namespace adios
+void SstReader::DoClose(const int transportIndex) { SstReaderClose(m_Input); }
+
+} // end namespace adios2

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -46,7 +46,6 @@ public:
     StepStatus BeginStep(StepMode mode, const float timeoutSeconds = 0.f);
 
     void EndStep();
-    void Close(const int transportIndex = -1);
     void PerformGets();
 
 private:
@@ -60,6 +59,8 @@ private:
     ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
 
+    void DoClose(const int transportIndex = -1) final;
+
     template <class T>
     void GetSyncCommon(Variable<T> &variable, T *data);
 
@@ -67,6 +68,6 @@ private:
     void GetDeferredCommon(Variable<T> &variable, T *data);
 };
 
-} // end namespace adios
+} // end namespace adios2
 
 #endif /* ADIOS2_ENGINE_SST_SSTREADER_H_ */

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -57,7 +57,6 @@ void SstWriter::EndStep()
     }
 }
 
-void SstWriter::Close(const int transportIndex) { SstWriterClose(m_Output); }
 void SstWriter::PerformPuts() {}
 
 // PRIVATE functions below
@@ -94,4 +93,6 @@ void SstWriter::Init()
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
 
-} // end namespace adios
+void SstWriter::DoClose(const int transportIndex) { SstWriterClose(m_Output); }
+
+} // end namespace adios2

--- a/source/adios2/engine/sst/SstWriter.h
+++ b/source/adios2/engine/sst/SstWriter.h
@@ -37,8 +37,6 @@ public:
     void PerformPuts() final;
     void EndStep() final;
 
-    void Close(const int transportIndex = -1) final;
-
 private:
     void Init(); ///< calls InitCapsules and InitTransports based on Method,
                  /// called from constructor
@@ -58,8 +56,10 @@ private:
 
     SstStream m_Output;
     bool m_FFSmarshal = true;
+
+    void DoClose(const int transportIndex = -1) final;
 };
 
-} // end namespace adios
+} // end namespace adios2
 
 #endif /* ADIOS2_ENGINE_SST_SST_WRITER_H_ */

--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -86,6 +86,6 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
     }
 }
 
-} // end namespace adios
+} // end namespace adios2
 
 #endif /* ADIOS2_ENGINE_SST_SST_WRITER_H_ */


### PR DESCRIPTION
Close now calls a derived class DoClose (private) function and free the Communicator if all transports are closed.
Remove MPI_Comm_free from Engine destructor.
Modified all derived engines to pass tests