### PR TITLE
Fix for #401 missing data in BP File

### DIFF
--- a/source/adios2/engine/bp/BPFileWriter.cpp
+++ b/source/adios2/engine/bp/BPFileWriter.cpp
@@ -62,18 +62,26 @@ void BPFileWriter::EndStep()
         PerformPuts();
     }
 
-    m_BP3Serializer.SerializeData(m_IO, true); // true: advances step
-
     const size_t currentStep = m_BP3Serializer.m_MetadataSet.TimeStep - 1;
     const size_t flushStepsCount = m_BP3Serializer.m_FlushStepsCount;
 
-    if (currentStep % flushStepsCount)
+    m_BP3Serializer.SerializeData(m_IO, true); // true: advances step
+
+    // must be explicit
+    if (currentStep % flushStepsCount == 0)
     {
-        m_BP3Serializer.SerializeData(m_IO);
+        const size_t dataSize = m_BP3Serializer.m_Data.m_Position;
+        m_BP3Serializer.CloseStream(m_IO);
         m_FileDataManager.WriteFiles(m_BP3Serializer.m_Data.m_Buffer.data(),
-                                     m_BP3Serializer.m_Data.m_Position);
+                                     dataSize);
         m_BP3Serializer.ResetBuffer(m_BP3Serializer.m_Data);
         WriteCollectiveMetadataFile();
+
+        //        if (currentStep == 5)
+        //        {
+        //            throw std::runtime_error("STOPPING AT 5 to test METADATA
+        //            FILE");
+        //        }
     }
 }
 

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -143,7 +143,7 @@ void BP3Serializer::CloseData(IO &io)
 
         SerializeMetadataInData();
 
-        m_Profiler.Bytes.at("buffering") += m_Data.m_AbsolutePosition;
+        m_Profiler.Bytes.at("buffering") = m_Data.m_AbsolutePosition;
 
         m_IsClosed = true;
     }
@@ -158,7 +158,7 @@ void BP3Serializer::CloseStream(IO &io)
     {
         SerializeDataBuffer(io);
     }
-    SerializeMetadataInData();
+    SerializeMetadataInData(false);
     m_Profiler.Bytes.at("buffering") += m_Data.m_Position;
     ProfilerStop("buffering");
 }
@@ -448,7 +448,8 @@ void BP3Serializer::SerializeDataBuffer(IO &io) noexcept
     m_MetadataSet.DataPGIsOpen = false;
 }
 
-void BP3Serializer::SerializeMetadataInData() noexcept
+void BP3Serializer::SerializeMetadataInData(
+    const bool updateAbsolutePosition) noexcept
 {
     auto lf_SetIndexCountLength =
         [](std::unordered_map<std::string, SerialElementIndex> &indices,
@@ -536,7 +537,11 @@ void BP3Serializer::SerializeMetadataInData() noexcept
     PutMinifooter(pgIndexStart, variablesIndexStart, attributesIndexStart,
                   buffer, position);
 
-    absolutePosition += footerSize;
+    if (updateAbsolutePosition)
+    {
+        absolutePosition += footerSize;
+    }
+
     if (m_Profiler.IsActive)
     {
         m_Profiler.Bytes.emplace("buffering", absolutePosition);

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.h
@@ -74,9 +74,13 @@ public:
 
     /**
      * Serializes the metadata indices appending it into the data buffer inside
-     * m_HeapBuffer
+     * m_Data
+     * @param updateAbsolutePosition true: adds footer size to absolute position
+     * used for Close,
+     * false: doesn't update absolute, used for partial buffer
      */
-    void SerializeMetadataInData() noexcept;
+    void
+    SerializeMetadataInData(const bool updateAbsolutePosition = true) noexcept;
 
     /**
      * Finishes bp buffer by serializing data and adding trailing metadata
@@ -85,7 +89,7 @@ public:
     void CloseData(IO &io);
 
     /**
-     * Closes bp buffer for streaming mdoe...must reset metadata for the next
+     * Closes bp buffer for streaming mode...must reset metadata for the next
      * step
      * @param io
      */


### PR DESCRIPTION
Buffer wasn't being reset so size kept increasing
Using CloseStream to avoid increasing absolute data, this was causing a
false offset.
Verified that data wasn't missing in the heat transfer example.