### PR TITLE
At read time, define the variable start/count with {0,...,0}/shape so…

### DIFF
--- a/source/adios2/toolkit/format/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Deserializer.tcc
@@ -160,9 +160,9 @@ BP3Deserializer::DefineVariableInIO(const ElementIndexHeader &header, IO &io,
     else
     {
         std::lock_guard<std::mutex> lock(m_Mutex);
-        variable =
-            &io.DefineVariable<T>(variableName, characteristics.Shape,
-                                  characteristics.Start, characteristics.Count);
+        Dims zeros(characteristics.Shape.size(), 0);
+        variable = &io.DefineVariable<T>(variableName, characteristics.Shape,
+                                         zeros, characteristics.Shape);
 
         variable->m_Min = characteristics.Statistics.Min;
         variable->m_Max = characteristics.Statistics.Max;

--- a/source/adios2/toolkit/interop/adios1/ADIOS1CommonRead.tcc
+++ b/source/adios2/toolkit/interop/adios1/ADIOS1CommonRead.tcc
@@ -28,7 +28,9 @@ void ADIOS1CommonRead::DefineADIOS2Variable(IO &io, const char *name,
 {
     if (vi != nullptr)
     {
-        adios2::Variable<T> &var = io.DefineVariable<T>(name, gdims);
+        Dims zeros(gdims.size(), 0);
+        adios2::Variable<T> &var =
+            io.DefineVariable<T>(name, gdims, zeros, gdims);
         if (vi->ndim == 0 && isGlobal)
         {
             /* Global value: store the value now */

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -220,7 +220,9 @@ void HDF5Common::AddVar(IO &io, std::string const &name, hid_t datasetId)
                 shape[i] = dims[i];
         }
 
-        auto &foo = io.DefineVariable<T>(name, shape);
+        Dims zeros(shape.size(), 0);
+
+        auto &foo = io.DefineVariable<T>(name, shape, zeros, shape);
         // default was set to 0 while m_AvailabelStepsStart is 1.
         // correcting
         if (0 == foo.m_AvailableStepsCount)


### PR DESCRIPTION
… that the selection is the whole variable. This way Variable.TotalSize() is correct after InquireVariable, and also one can immediately just read the whole variable without making a selection.

I wanted to use TotalSize() after InquireVariable() to allocate the array for a single-process reader, but the TotalSize is calculated from offset/count, which was set with the first block's offset/count, not the entire variable. 

As far as I know this piece was not used anywhere before and the new setup makes more sense when using it.