### PR TITLE
Various fixes and tweaks for SST

### DIFF
--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -60,11 +60,15 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
         std::string Type(type);
         typename SstReader::SstReader *Reader =
             reinterpret_cast<typename SstReader::SstReader *>(reader);
+        /*
+         * setup shape of array variable as global (I.E. Count == Shape,
+         * Start == 0)
+         */
         for (int i = 0; i < DimCount; i++)
         {
             VecShape.push_back(Shape[i]);
-            VecStart.push_back(Start[i]);
-            VecCount.push_back(Count[i]);
+            VecStart.push_back(0);
+            VecCount.push_back(Shape[i]);
         }
         if (Type == "compound")
         {
@@ -91,17 +95,30 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
 
 StepStatus SstReader::BeginStep(StepMode mode, const float timeout_sec)
 {
-    return (StepStatus)SstAdvanceStep(m_Input, (int)mode, timeout_sec);
+    SstStatusValue result;
+    m_IO.RemoveAllVariables();
+    m_IO.RemoveAllAttributes();
+    result = SstAdvanceStep(m_Input, (int)mode, timeout_sec);
+    if (result == SstSuccess)
+    {
+        m_CurrentStep++;
+        return StepStatus::OK;
+    }
+    else if (result == SstEndOfStream)
+    {
+        return StepStatus::EndOfStream;
+    }
+    else
+    {
+        return StepStatus::OtherError;
+    }
 }
 
-size_t SstReader::CurrentStep() const
-{
-    return 0; /* should return something like m_Input.GetReaderTimestep() ??? */
-}
+size_t SstReader::CurrentStep() const { return m_CurrentStep; }
 
 void SstReader::EndStep()
 {
-    m_IO.RemoveAllVariables();
+    SstPerformGets(m_Input);
     SstReleaseStep(m_Input);
 }
 

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -51,6 +51,7 @@ public:
 private:
     void Init();
     SstStream m_Input;
+    size_t m_CurrentStep = 0;
 
 #define declare_type(T)                                                        \
     void DoGetSync(Variable<T> &, T *) final;                                  \

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -51,7 +51,7 @@ public:
 private:
     void Init();
     SstStream m_Input;
-    size_t m_CurrentStep = 0;
+    size_t m_CurrentStep = -1;
 
 #define declare_type(T)                                                        \
     void DoGetSync(Variable<T> &, T *) final;                                  \

--- a/testing/adios2/engine/sst/run_staging_test.in
+++ b/testing/adios2/engine/sst/run_staging_test.in
@@ -38,13 +38,6 @@ EO
 }
 
 PROGNAME=${0##*/} 
-SHORTOPTS="p:r:w:n:t:o:qhv" 
-LONGOPTS="p:,nw:,nr:,help,timeout:" 
-
-ARGS=$(getopt -a -s bash --options $SHORTOPTS  \
-  --longoptions $LONGOPTS --name $PROGNAME -- "$@" ) 
-
-eval set -- "$ARGS" 
 
 reader_prog="UNSET"
 writer_prog="UNSET"
@@ -62,11 +55,11 @@ do
     (-w) writer_prog="$2"; shift;;
     (-n) nw="$2"; nr="$2"; shift;;
     (-p) prefix="$2"; shift;;
-    (--nw) nw="$2"; shift;;
-    (--nr) nr="$2"; shift;;
-    (--timeout) timeout="$2"; shift;;
+    (-nw) nw="$2"; shift;;
+    (-nr) nr="$2"; shift;;
+    (-timeout) timeout="$2"; shift;;
     (--) shift; break;;
-    (-*) echo "$0: error - unrecognized option $1" 1>&2; exit 1;;
+    (-*) echo "$0: error - unrecognized option $1" ; usage; 1>&2; exit 1;;
     (*)  break;;
     esac
     shift


### PR DESCRIPTION
Support CurrentStep(), modify array shape to match global, remove getopt in run_staging_test, patch possible race condition in Control Plane, remove contact information for writer immediately to avoid a race in testing (must change for multiple readers).