### PR TITLE
Sst queue management

### DIFF
--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -152,7 +152,7 @@ void SstReader::Init()
     };
 
 #define get_params(Param, Type, Typedecl, Default)                             \
-    lf_Set##Type##Parameter("##Param##", m_##Param);
+    lf_Set##Type##Parameter(#Param, m_##Param);
     SST_FOREACH_PARAMETER_TYPE_4ARGS(get_params);
 #undef get_params
 #define set_params(Param, Type, Typedecl, Default) Params.Param = m_##Param;

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -51,6 +51,11 @@ public:
 private:
     void Init();
     SstStream m_Input;
+    struct _SstParams Params;
+#define declare_locals(Param, Type, Typedecl, Default)                         \
+    Typedecl m_##Param = Default;
+    SST_FOREACH_PARAMETER_TYPE_4ARGS(declare_locals);
+#undef declare_locals
 
 #define declare_type(T)                                                        \
     void DoGetSync(Variable<T> &, T *) final;                                  \

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -26,9 +26,6 @@ SstWriter::SstWriter(IO &io, const std::string &name, const Mode mode,
     strcpy(cstr, name.c_str());
 
     Init();
-#define set_params(Param, Type, Typedecl, Default) Params.Param = m_##Param;
-    SST_FOREACH_PARAMETER_TYPE_4ARGS(set_params);
-#undef set_params
 
     m_Output = SstWriterOpen(cstr, &Params, mpiComm);
     delete[] cstr;
@@ -93,7 +90,7 @@ void SstWriter::Init()
     };
 
 #define get_params(Param, Type, Typedecl, Default)                             \
-    lf_Set##Type##Parameter("##Param##", m_##Param);
+    lf_Set##Type##Parameter(#Param, m_##Param);
     SST_FOREACH_PARAMETER_TYPE_4ARGS(get_params);
 #undef get_params
 #define set_params(Param, Type, Typedecl, Default) Params.Param = m_##Param;

--- a/source/adios2/engine/sst/SstWriter.h
+++ b/source/adios2/engine/sst/SstWriter.h
@@ -55,7 +55,11 @@ private:
     void PutDeferredCommon(Variable<T> &variable, const T *values);
 
     SstStream m_Output;
-    bool m_FFSmarshal = true;
+    struct _SstParams Params;
+#define declare_locals(Param, Type, Typedecl, Default)                         \
+    Typedecl m_##Param = Default;
+    SST_FOREACH_PARAMETER_TYPE_4ARGS(declare_locals);
+#undef declare_locals
 
     void DoClose(const int transportIndex = -1) final;
 };

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -11,10 +11,28 @@
 
 #include "cp_internal.h"
 
-void CP_parseParams(SstStream Stream, const char *Params)
+void CP_validateParams(SstStream Stream, SstParams Params, int Writer)
 {
-    Stream->WaitForFirstReader = 1;
-    Stream->QueuedTimestepLimit = 0;
+    if (Params->RendezvousReaderCount >= 0)
+    {
+        Stream->RendezvousReaderCount = Params->RendezvousReaderCount;
+    }
+    else
+    {
+        fprintf(stderr, "Invalid RendezvousReaderCount parameter value (%d) "
+                        "for SST Stream %s\n",
+                Params->RendezvousReaderCount, Stream->Filename);
+    }
+    if (Params->QueueLimit >= 0)
+    {
+        Stream->QueueLimit = Params->QueueLimit;
+    }
+    else
+    {
+        fprintf(stderr,
+                "Invalid QueueLimit parameter value (%d) for SST Stream %s\n",
+                Params->QueueLimit, Stream->Filename);
+    }
 }
 
 static FMField CP_ReaderInitList[] = {

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -33,6 +33,7 @@ void CP_validateParams(SstStream Stream, SstParams Params, int Writer)
                 "Invalid QueueLimit parameter value (%d) for SST Stream %s\n",
                 Params->QueueLimit, Stream->Filename);
     }
+    Stream->DiscardOnQueueFull = Params->DiscardOnQueueFull;
 }
 
 static FMField CP_ReaderInitList[] = {

--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -92,7 +92,7 @@ struct _SstStream
     enum StreamRole Role;
 
     /* params */
-    int WaitForFirstReader;
+    int RendezvousReaderCount;
 
     /* state */
     int Verbose;
@@ -115,7 +115,7 @@ struct _SstStream
     int ReaderTimestep;
     CPTimestepList QueuedTimesteps;
     int QueuedTimestepCount;
-    int QueuedTimestepLimit;
+    int QueueLimit;
     int LastProvidedTimestep;
     int NewReaderPresent;
 
@@ -315,7 +315,7 @@ typedef struct _MetadataPlusDPInfo *MetadataPlusDPInfo;
 
 extern atom_t CM_TRANSPORT_ATOM;
 
-void CP_parseParams(SstStream stream, const char *params);
+void CP_validateParams(SstStream stream, SstParams Params, int Writer);
 extern CP_GlobalInfo CP_getCPInfo(CP_DP_Interface DPInfo);
 extern SstStream CP_newStream();
 extern void SstInternalProvideTimestep(SstStream s, SstData LocalMetadata,

--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -50,6 +50,7 @@ typedef struct _WS_ReaderInfo
     SstStream ParentStream;
     enum StreamStatus ReaderStatus;
     long StartingTimestep;
+    long LastSentTimestep;
     void *DP_WSR_Stream;
     void *RS_StreamID;
     int ReaderCohortSize;
@@ -116,6 +117,7 @@ struct _SstStream
     CPTimestepList QueuedTimesteps;
     int QueuedTimestepCount;
     int QueueLimit;
+    int DiscardOnQueueFull;
     int LastProvidedTimestep;
     int NewReaderPresent;
 
@@ -321,7 +323,7 @@ extern SstStream CP_newStream();
 extern void SstInternalProvideTimestep(SstStream s, SstData LocalMetadata,
                                        SstData Data, long Timestep,
                                        FFSFormatList Formats,
-                                       void *DataFreeFunc,
+                                       void DataFreeFunc(void *),
                                        void *FreeClientData);
 
 void **CP_consolidateDataToRankZero(SstStream stream, void *local_info,

--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -40,10 +40,12 @@ typedef struct _SstStats
     size_t BytesTransferred;
 } * SstStats;
 
+typedef struct _SstParams *SstParams;
+
 /*
  *  Writer-side operations
  */
-extern SstStream SstWriterOpen(const char *filename, const char *params,
+extern SstStream SstWriterOpen(const char *filename, SstParams Params,
                                MPI_Comm comm);
 extern void SstProvideTimestep(SstStream s, SstMetadata local_metadata,
                                SstData data, long timestep);
@@ -52,7 +54,7 @@ extern void SstWriterClose(SstStream stream);
 /*
  *  Reader-side operations
  */
-extern SstStream SstReaderOpen(const char *filename, const char *params,
+extern SstStream SstReaderOpen(const char *filename, SstParams Params,
                                MPI_Comm comm);
 extern SstFullMetadata SstGetMetadata(SstStream stream, long timestep);
 extern void *SstReadRemoteMemory(SstStream s, int rank, long timestep,
@@ -94,6 +96,20 @@ extern void SstWriterEndStep(SstStream Stream);
 extern void SstSetStatsSave(SstStream Stream, SstStats Save);
 
 #include "sst_data.h"
+
+#define SST_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                \
+    MACRO(FFSmarshal, Bool, int, true)                                         \
+    MACRO(BPmarshal, Bool, int, false)                                         \
+    MACRO(RendezvousReaderCount, Int, int, 1)                                  \
+    MACRO(QueueLimit, Int, int, 0)                                             \
+    MACRO(DiscardOnQueueFull, Bool, int, 1)
+
+struct _SstParams
+{
+#define declare_struct(Param, Type, Typedecl, Default) Typedecl Param;
+    SST_FOREACH_PARAMETER_TYPE_4ARGS(declare_struct);
+#undef declare_struct
+};
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Implement step queue drop functionality similar to what is outlined in [Confluence](https://confluence.exascaleproject.org/display/STDM11/Notes+on+some+SST+Operations).  Add a mechanism to communicate engine parameters to the SST layer.  Currently implemented parameters are:
- RendezvousReaderCount : How many readers the writer should wait for at startup. (default 1)
- QueueLimit : Max number of steps allowed in the step queue. (default 0 (no limit))
- DiscardOnQueueFull : If true and there is a queue limit, discard steps as appropriate (default true)

This PR does not yet implement the situation where there is a queue limit DiscardOnQueueFull is false, so we should block the writing application until the queue empties.
