### PR TITLE
Support for Fortran local variables

### DIFF
--- a/bindings/fortran/modules/adios2_parameters_mod.f90
+++ b/bindings/fortran/modules/adios2_parameters_mod.f90
@@ -61,4 +61,6 @@ module adios2_parameters
     !! must be less or equal than C equivalent in adios2_c_types.h
     integer, parameter :: adios2_string_array_element_max_size = 256
 
+    integer(kind=8),parameter,dimension(1) :: adios2_null_dims = (/-1/)
+
 end module

--- a/testing/adios2/bindings/fortran/TestBPWriteTypesLocal.f90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypesLocal.f90
@@ -5,7 +5,6 @@
      implicit none
 
      integer(kind=8), dimension(1) :: count_dims
-     integer(kind=8), dimension(0) :: empty_dims
      integer :: inx, irank, isize, ierr, i
 
      integer(kind=8) :: adios, ioWrite, bpWriter, ioRead, bpReader
@@ -35,27 +34,27 @@
 
      ! Defines a variable to be written in bp format
      call adios2_define_variable(variables(1), ioWrite, "var_I8", 1, &
-                                 empty_dims, empty_dims, count_dims, &
+                                 adios2_null_dims, adios2_null_dims, count_dims, &
                                  adios2_constant_dims, data_I8, ierr)
 
      call adios2_define_variable(variables(2), ioWrite, "var_I16", 1, &
-                                 empty_dims, empty_dims, count_dims, &
+                                 adios2_null_dims, adios2_null_dims, count_dims, &
                                  adios2_constant_dims, data_I16, ierr)
 
      call adios2_define_variable(variables(3), ioWrite, "var_I32", 1, &
-                                 empty_dims, empty_dims, count_dims, &
+                                 adios2_null_dims, adios2_null_dims, count_dims, &
                                  adios2_constant_dims, data_I32, ierr)
 
      call adios2_define_variable(variables(4), ioWrite, "var_I64", 1, &
-                                 empty_dims, empty_dims, count_dims, &
+                                 adios2_null_dims, adios2_null_dims, count_dims, &
                                  adios2_constant_dims, data_I64, ierr)
 
      call adios2_define_variable(variables(5), ioWrite, "var_R32", 1, &
-                                 empty_dims, empty_dims, count_dims, &
+                                 adios2_null_dims, adios2_null_dims, count_dims, &
                                  adios2_constant_dims, data_R32, ierr)
 
      call adios2_define_variable(variables(6), ioWrite, "var_R64", 1, &
-                                 empty_dims, empty_dims, count_dims, &
+                                 adios2_null_dims, adios2_null_dims, count_dims, &
                                  adios2_constant_dims, data_R64, ierr)
 
      ! Global variables


### PR DESCRIPTION
Added adios2_null_dims parameter for shape and start of local variables in adios2_define_variable