### PR TITLE
Add a RegistrationMethod parameter to Sst engines.  

### DIFF
--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -170,6 +170,40 @@ void SstReader::Init()
         return false;
     };
 
+    auto lf_SetRegMethodParameter = [&](const std::string key, int &parameter) {
+
+        auto itKey = m_IO.m_Parameters.find(key);
+        if (itKey != m_IO.m_Parameters.end())
+        {
+            std::string method = itKey->second;
+            std::transform(method.begin(), method.end(), method.begin(),
+                           ::tolower);
+            if (method == "file")
+            {
+                parameter = SstRegisterFile;
+            }
+            else if (method == "screen")
+            {
+                parameter = SstRegisterScreen;
+            }
+            else if (method == "cloud")
+            {
+                parameter = SstRegisterCloud;
+                throw std::invalid_argument("ERROR: Sst RegistrationMethod "
+                                            "\"cloud\" not yet implemented" +
+                                            m_EndMessage);
+            }
+            else
+            {
+                throw std::invalid_argument(
+                    "ERROR: Unknown Sst RegistrationMethod parameter \"" +
+                    method + "\"" + m_EndMessage);
+            }
+            return true;
+        }
+        return false;
+    };
+
 #define get_params(Param, Type, Typedecl, Default)                             \
     lf_Set##Type##Parameter(#Param, m_##Param);
     SST_FOREACH_PARAMETER_TYPE_4ARGS(get_params);

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -100,6 +100,40 @@ void SstWriter::Init()
         return false;
     };
 
+    auto lf_SetRegMethodParameter = [&](const std::string key, int &parameter) {
+
+        auto itKey = m_IO.m_Parameters.find(key);
+        if (itKey != m_IO.m_Parameters.end())
+        {
+            std::string method = itKey->second;
+            std::transform(method.begin(), method.end(), method.begin(),
+                           ::tolower);
+            if (method == "file")
+            {
+                parameter = SstRegisterFile;
+            }
+            else if (method == "screen")
+            {
+                parameter = SstRegisterScreen;
+            }
+            else if (method == "cloud")
+            {
+                parameter = SstRegisterCloud;
+                throw std::invalid_argument("ERROR: Sst RegistrationMethod "
+                                            "\"cloud\" not yet implemented" +
+                                            m_EndMessage);
+            }
+            else
+            {
+                throw std::invalid_argument(
+                    "ERROR: Unknown Sst RegistrationMethod parameter \"" +
+                    method + "\"" + m_EndMessage);
+            }
+            return true;
+        }
+        return false;
+    };
+
 #define get_params(Param, Type, Typedecl, Default)                             \
     lf_Set##Type##Parameter(#Param, m_##Param);
     SST_FOREACH_PARAMETER_TYPE_4ARGS(get_params);

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -36,6 +36,7 @@ void CP_validateParams(SstStream Stream, SstParams Params, int Writer)
                 Params->QueueLimit, Stream->Filename);
     }
     Stream->DiscardOnQueueFull = Params->DiscardOnQueueFull;
+    Stream->RegistrationMethod = Params->RegistrationMethod;
     char *SelectedTransport = NULL;
     if (Params->DataTransport != NULL)
     {

--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -96,6 +96,7 @@ struct _SstStream
     /* params */
     int RendezvousReaderCount;
     char *DataTransport;
+    SstRegistrationMethod RegistrationMethod;
 
     /* state */
     int Verbose;

--- a/source/adios2/toolkit/sst/cp/cp_reader.c
+++ b/source/adios2/toolkit/sst/cp/cp_reader.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <ctype.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,7 +17,7 @@
 
 #include "cp_internal.h"
 
-static char *readContactInfo(const char *Name, SstStream Stream)
+static char *readContactInfoFile(const char *Name, SstStream Stream)
 {
     char *FileName = malloc(strlen(Name) + strlen(SST_POSTFIX) + 1);
     FILE *WriterInfo;
@@ -43,6 +44,37 @@ redo:
     (void)fread(Buffer, Size, 1, WriterInfo);
     fclose(WriterInfo);
     return Buffer;
+}
+
+static char *readContactInfoScreen(const char *Name, SstStream Stream)
+{
+    char *FileName = malloc(strlen(Name) + strlen(SST_POSTFIX) + 1);
+    char Input[10240];
+    char *Skip = Input;
+    fprintf(stdout, "Please enter the contact information associated with SST "
+                    "input stream \"%s\":\n",
+            Name);
+    fgets(Input, sizeof(Input), stdin);
+    while (isspace(*Skip))
+        Skip++;
+    return strdup(Skip);
+}
+
+static char *readContactInfo(const char *Name, SstStream Stream)
+{
+    switch (Stream->RegistrationMethod)
+    {
+    case SstRegisterFile:
+        return readContactInfoFile(Name, Stream);
+        break;
+    case SstRegisterScreen:
+        return readContactInfoScreen(Name, Stream);
+        break;
+    case SstRegisterCloud:
+        /* not yet */
+        return NULL;
+        break;
+    }
 }
 
 static void ReaderConnCloseHandler(CManager cm, CMConnection closed_conn,

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -21,9 +21,18 @@ extern void CP_verbose(SstStream Stream, char *Format, ...);
 
 static void sendOneToEachWriterRank(SstStream s, CMFormat f, void *Msg,
                                     void **WS_StreamPtr);
-static void writeContactInfo(const char *Name, SstStream Stream)
+
+static char *buildContactInfo(SstStream Stream)
 {
     char *Contact = attr_list_to_string(CMget_contact_list(Stream->CPInfo->cm));
+    char *FullInfo = malloc(strlen(Contact) + 20);
+    sprintf(FullInfo, "%p:%s", (void *)Stream, Contact);
+    return FullInfo;
+}
+
+static void writeContactInfoFile(const char *Name, SstStream Stream)
+{
+    char *Contact = buildContactInfo(Stream);
     char *TmpName = malloc(strlen(Name) + strlen(".tmp") + 1);
     char *FileName = malloc(strlen(Name) + strlen(SST_POSTFIX) + 1);
     FILE *WriterInfo;
@@ -35,20 +44,67 @@ static void writeContactInfo(const char *Name, SstStream Stream)
     sprintf(TmpName, "%s.tmp", Name);
     sprintf(FileName, "%s" SST_POSTFIX, Name);
     WriterInfo = fopen(TmpName, "w");
-    fprintf(WriterInfo, "%p:%s", (void *)Stream, Contact);
+    fprintf(WriterInfo, "%s", Contact);
     fclose(WriterInfo);
     rename(TmpName, FileName);
     free(TmpName);
     free(FileName);
 }
 
-static void removeContactInfo(SstStream Stream)
+static void writeContactInfoScreen(const char *Name, SstStream Stream)
+{
+    char *Contact = buildContactInfo(Stream);
+
+    /*
+     * write the contact information file to the screen
+     */
+    fprintf(stdout, "The next line of output is the contact information "
+                    "associated with SST output stream \"%s\".  Please make it "
+                    "available to the reader.\n",
+            Name);
+    fprintf(stdout, "\t%s\n", Contact);
+    free(Contact);
+}
+
+static void registerContactInfo(const char *Name, SstStream Stream)
+{
+    switch (Stream->RegistrationMethod)
+    {
+    case SstRegisterFile:
+        writeContactInfoFile(Name, Stream);
+        break;
+    case SstRegisterScreen:
+        writeContactInfoScreen(Name, Stream);
+        break;
+    case SstRegisterCloud:
+        /* not yet */
+        break;
+    }
+}
+
+static void removeContactInfoFile(SstStream Stream)
 {
     const char *Name = Stream->Filename;
     char *FileName = malloc(strlen(Name) + strlen(SST_POSTFIX) + 1);
     FILE *WriterInfo;
     sprintf(FileName, "%s" SST_POSTFIX, Name);
     unlink(FileName);
+}
+
+static void removeContactInfo(SstStream Stream)
+{
+    switch (Stream->RegistrationMethod)
+    {
+    case SstRegisterFile:
+        removeContactInfoFile(Stream);
+        break;
+    case SstRegisterScreen:
+        /* nothing necessary here */
+        break;
+    case SstRegisterCloud:
+        /* not yet */
+        break;
+    }
 }
 
 static void WriterConnCloseHandler(CManager cm, CMConnection closed_conn,
@@ -480,7 +536,7 @@ SstStream SstWriterOpen(const char *Name, SstParams Params, MPI_Comm comm)
 
     if (Stream->Rank == 0)
     {
-        writeContactInfo(Filename, Stream);
+        registerContactInfo(Filename, Stream);
     }
 
     CP_verbose(Stream, "Opening Stream \"%s\"\n", Filename);

--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -101,11 +101,18 @@ extern void SstSetStatsSave(SstStream Stream, SstStats Save);
 
 #define SST_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                \
     MACRO(FFSmarshal, Bool, int, true)                                         \
+    MACRO(RegistrationMethod, RegMethod, int, NULL)                            \
     MACRO(DataTransport, String, char *, NULL)                                 \
     MACRO(BPmarshal, Bool, int, false)                                         \
     MACRO(RendezvousReaderCount, Int, int, 1)                                  \
     MACRO(QueueLimit, Int, int, 0)                                             \
     MACRO(DiscardOnQueueFull, Bool, int, 1)
+
+typedef enum {
+    SstRegisterFile,
+    SstRegisterScreen,
+    SstRegisterCloud
+} SstRegistrationMethod;
 
 struct _SstParams
 {


### PR DESCRIPTION
This parameter controls how the contact information is communicated between writers and readers.  Current options are File (which is how things have worked before with the Name parameter being interpreted as a filename into which to write contact information) and Screen (where contact information is written to and read from stdout and stdin respectively).