### PR TITLE
fixed a compiler warning in PluginEngine

### DIFF
--- a/source/adios2/engine/plugin/PluginEngine.h
+++ b/source/adios2/engine/plugin/PluginEngine.h
@@ -86,7 +86,7 @@ protected:
     ADIOS2_FOREACH_TYPE_1ARG(declare)
 #undef declare
 
-    void DoClose(const int transportIndex = -1);
+    void DoClose(const int transportIndex = -1) override;
 
 private:
     struct Impl;


### PR DESCRIPTION
I have seen this warning for long on Mac and I am now trying to fix it.


In file included from /Users/w4g/dropbox/adios2/source/adios2/core/IO.cpp:20:
/Users/w4g/dropbox/adios2/source/adios2/engine/plugin/PluginEngine.h:89:10: warning: 'DoClose' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void DoClose(const int transportIndex = -1);
         ^
/Users/w4g/dropbox/adios2/source/adios2/core/Engine.h:266:18: note: overridden virtual function is here
    virtual void DoClose(const int transportIndex) = 0;
                 ^
1 warning generated.
