### PR TITLE
fixed a linker warning complaining about a library path not found in …

### DIFF
--- a/thirdparty/GTest/googletest/googletest/CMakeLists.txt
+++ b/thirdparty/GTest/googletest/googletest/CMakeLists.txt
@@ -71,9 +71,6 @@ include_directories(
   ${gtest_SOURCE_DIR}/include
   ${gtest_SOURCE_DIR})
 
-# Where Google Test's libraries can be found.
-link_directories(${gtest_BINARY_DIR}/src)
-
 # Summary of tuple support for Microsoft Visual Studio:
 # Compiler    version(MS)  version(cmake)  Support
 # ----------  -----------  --------------  -----------------------------


### PR DESCRIPTION
fixed a linker warning complaining about a library path not found in gtest build dir.