### PR TITLE
Modify SST components to make it easy to implement BP marshalling 

### DIFF
--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -36,8 +36,13 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
                                     "\".  Non-current SST contact file?" +
                                     m_EndMessage);
     }
-    auto varCallback = [](void *reader, const char *variableName,
-                          const char *type, void *data) {
+
+    // Maybe need other writer-side params in the future, but for now only
+    // marshal methods.
+    SstReaderGetParams(m_Input, &m_WriterFFSmarshal, &m_WriterBPmarshal);
+
+    auto varFFSCallback = [](void *reader, const char *variableName,
+                             const char *type, void *data) {
         std::string Type(type);
         typename SstReader::SstReader *Reader =
             reinterpret_cast<typename SstReader::SstReader *>(reader);
@@ -61,9 +66,9 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
         return (void *)NULL;
     };
 
-    auto arrayCallback = [](void *reader, const char *variableName,
-                            const char *type, int DimCount, size_t *Shape,
-                            size_t *Start, size_t *Count) {
+    auto arrayFFSCallback = [](void *reader, const char *variableName,
+                               const char *type, int DimCount, size_t *Shape,
+                               size_t *Start, size_t *Count) {
         std::vector<size_t> VecShape;
         std::vector<size_t> VecStart;
         std::vector<size_t> VecCount;
@@ -97,7 +102,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
         return (void *)NULL;
     };
 
-    SstReaderInitCallback(m_Input, this, varCallback, arrayCallback);
+    SstReaderInitFFSCallback(m_Input, this, varFFSCallback, arrayFFSCallback);
 
     delete[] cstr;
 }
@@ -120,13 +125,78 @@ StepStatus SstReader::BeginStep(StepMode mode, const float timeout_sec)
     {
         return StepStatus::OtherError;
     }
+    if (m_WriterBPmarshal)
+    {
+        m_CurrentStepMetaData = SstGetCurMetadata(m_Input);
+        // At begin step, you get metadata from the writers.  You need to
+        // use this for two things: First, you need to create the
+        // appropriate variables on the reader side to represent what has
+        // been written.  Second, you must keep the metadata around (or a
+        // summary structure that represents its contents), so that you can
+        // look at it in DoGets* and issue the appropriate
+        // ReadRemoteMemory() requests to the writers.  This is because the
+        // full data isn't here yet.  We don't know what we'll need on this
+        // reader, and we don't want to send *all* data from *all* writers
+        // here because that's not scalable.  So, we'll fetch what we need.
+        // This is one of the core ideas of SST.
+
+        //   Further clarification:
+        //   m_CurrentStepMetaData is a struct like this:
+
+        //     struct _SstFullMetadata
+        //     {
+        //       int WriterCohortSize;
+        //       struct _SstData **WriterMetadata;
+        //       void **DP_TimestepInfo;
+        //     };
+
+        //   WriterMetadata has an element for each Writer rank
+        //   (WriterCohortSize).  WriterMetadata[i] is a pointer to (a copy
+        //   of) the SstData block of Metadata that was passed to
+        //   SstProvideTimestep by Writer rank i.  SST has simply gathered
+        //   them and provided them to each reader.  The DP_TimestepInfo is
+        //   for the DataPlane, and DP_TimestepInfo[i] should be passed as
+        //   the DP_TimestepInfo parameter when a SstReadRemoteMemory call
+        //   is made requesting rank i.  (This may contain MR keys, or
+        //   anything else that the Data Plane needs for efficient RDMA on
+        //   whatever transport it is using.  But it is opaque to the Engine
+        //   (and to the control plane).)
+    }
+    if (m_WriterFFSmarshal)
+    {
+        // For FFS-based marshaling, SstAdvanceStep takes care of installing
+        // the metadata, creating variables using the varFFScallback and
+        // arrayFFScallback, so there's nothing to be done now.  This
+        // comment is just for clarification.
+    }
 }
 
 size_t SstReader::CurrentStep() const { return SstCurrentStep(m_Input); }
 
 void SstReader::EndStep()
 {
-    SstPerformGets(m_Input);
+    if (m_FFSmarshal)
+    {
+        // this does all the deferred gets and fills in the variable array data
+        SstFFSPerformGets(m_Input);
+    }
+    if (m_BPmarshal)
+    {
+        //  I'm assuming that the DoGet calls below have been constructing
+        //  some kind of data structure that indicates what data this reader
+        //  needs from different writers, what read requests it needs to
+        //  make, where to put the data when it arrives, etc.  Therefore the
+        //  pseudocode here looks like:
+        //         IssueReadRequests()   I.E. do calls to SstReadRemoteMemory()
+        //         as necessary to get the data coming these are asynchronous
+        //	   so that they can happen in parallel.
+        //         WaitForReadRequests()   Wait for each of these read requests
+        //         to complete.  See the SstWaitForCompletion function.
+        //         FillReadRequests()    Given the data that was just read,
+        //         place it appropriately into the waiting vars.
+        //	   ClearReadRequests()  Clean up as necessary
+        //
+    }
     SstReleaseStep(m_Input);
 }
 
@@ -170,7 +240,8 @@ void SstReader::Init()
         return false;
     };
 
-    auto lf_SetRegMethodParameter = [&](const std::string key, int &parameter) {
+    auto lf_SetRegMethodParameter = [&](const std::string key,
+                                        size_t &parameter) {
 
         auto itKey = m_IO.m_Parameters.find(key);
         if (itKey != m_IO.m_Parameters.end())
@@ -213,30 +284,62 @@ void SstReader::Init()
 #undef set_params
 }
 
-#define declare_type(T)                                                        \
+#define declare_gets(T)                                                        \
     void SstReader::DoGetSync(Variable<T> &variable, T *data)                  \
     {                                                                          \
-        SstGetDeferred(m_Input, (void *)&variable, variable.m_Name.c_str(),    \
-                       variable.m_Start.size(), variable.m_Start.data(),       \
-                       variable.m_Count.data(), data);                         \
-        SstPerformGets(m_Input);                                               \
+        if (m_WriterFFSmarshal)                                                \
+        {                                                                      \
+            SstFFSGetDeferred(                                                 \
+                m_Input, (void *)&variable, variable.m_Name.c_str(),           \
+                variable.m_Start.size(), variable.m_Start.data(),              \
+                variable.m_Count.data(), data);                                \
+            SstFFSPerformGets(m_Input);                                        \
+        }                                                                      \
+        if (m_WriterBPmarshal)                                                 \
+        {                                                                      \
+            /*  DoGetSync() is going to have terrible performance 'cause */    \
+            /*  it's a	bad idea in an SST-like environment.  But do */         \
+            /*  whatever you do forDoGetDeferred() and then PerformGets() */   \
+        }                                                                      \
     }                                                                          \
     void SstReader::DoGetDeferred(Variable<T> &variable, T *data)              \
     {                                                                          \
-        SstGetDeferred(m_Input, (void *)&variable, variable.m_Name.c_str(),    \
-                       variable.m_Start.size(), variable.m_Start.data(),       \
-                       variable.m_Count.data(), data);                         \
+        if (m_WriterFFSmarshal)                                                \
+        {                                                                      \
+            SstFFSGetDeferred(                                                 \
+                m_Input, (void *)&variable, variable.m_Name.c_str(),           \
+                variable.m_Start.size(), variable.m_Start.data(),              \
+                variable.m_Count.data(), data);                                \
+        }                                                                      \
+        if (m_WriterBPmarshal)                                                 \
+        {                                                                      \
+            /*  Look at the data requested and examine the metadata to see  */ \
+            /*  what writer has what you need.  Build up a set of read	*/      \
+            /*  requests (maybe just get all the data from every writer */     \
+            /*  that has *something* you need).  You'll use this in EndStep,*/ \
+            /*  when you have to get all the array data and put it where  */   \
+            /*  it's supposed to go.	*/                                        \
+        }                                                                      \
     }                                                                          \
     void SstReader::DoGetDeferred(Variable<T> &variable, T &data)              \
     {                                                                          \
-        SstGetDeferred(m_Input, (void *)&variable, variable.m_Name.c_str(),    \
-                       variable.m_Start.size(), variable.m_Start.data(),       \
-                       variable.m_Count.data(), &data);                        \
+        if (m_WriterFFSmarshal)                                                \
+        {                                                                      \
+            SstFFSGetDeferred(                                                 \
+                m_Input, (void *)&variable, variable.m_Name.c_str(),           \
+                variable.m_Start.size(), variable.m_Start.data(),              \
+                variable.m_Count.data(), &data);                               \
+        }                                                                      \
+        if (m_WriterBPmarshal)                                                 \
+        {                                                                      \
+            /* See the routine above.*/                                        \
+        }                                                                      \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
-#undef declare_type
 
-void SstReader::PerformGets() { SstPerformGets(m_Input); }
+ADIOS2_FOREACH_TYPE_1ARG(declare_gets)
+#undef declare_gets
+
+void SstReader::PerformGets() { SstFFSPerformGets(m_Input); }
 
 void SstReader::DoClose(const int transportIndex) { SstReaderClose(m_Input); }
 

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -51,6 +51,11 @@ public:
 private:
     void Init();
     SstStream m_Input;
+    int m_WriterFFSmarshal;
+    int m_WriterBPmarshal;
+    SstFullMetadata m_CurrentStepMetaData =
+        NULL; // Used only with BP marshaling
+
     struct _SstParams Params;
 #define declare_locals(Param, Type, Typedecl, Default)                         \
     Typedecl m_##Param = Default;

--- a/source/adios2/engine/sst/SstWriter.h
+++ b/source/adios2/engine/sst/SstWriter.h
@@ -55,6 +55,7 @@ private:
     void PutDeferredCommon(Variable<T> &variable, const T *values);
 
     SstStream m_Output;
+    size_t m_WriterStep = -1;
     struct _SstParams Params;
 #define declare_locals(Param, Type, Typedecl, Default)                         \
     Typedecl m_##Param = Default;

--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -37,14 +37,15 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
 
     if (m_FFSmarshal)
     {
-        SstMarshal(m_Output, (void *)&variable, variable.m_Name.c_str(),
-                   variable.m_Type.c_str(), variable.m_ElementSize,
-                   variable.m_Shape.size(), variable.m_Shape.data(),
-                   variable.m_Count.data(), variable.m_Start.data(), values);
+        SstFFSMarshal(m_Output, (void *)&variable, variable.m_Name.c_str(),
+                      variable.m_Type.c_str(), variable.m_ElementSize,
+                      variable.m_Shape.size(), variable.m_Shape.data(),
+                      variable.m_Count.data(), variable.m_Start.data(), values);
     }
     else
     {
         // Do BP marshaling
+        // The result of BP marshalling (in EndStep) should be a single buffer
     }
 }
 

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -190,38 +190,6 @@ static FMStructDescRec CP_WriterResponseStructs[] = {
     {"SstParams", NULL, sizeof(struct _SstParams), NULL},
     {NULL, NULL, 0, NULL}};
 
-/* static FMField SstMetadataList[] = {{"DataSize", "integer", sizeof(size_t),
- */
-/*                                      FMOffset(struct _SstMetadata *,
- * DataSize)}, */
-/*                                     {"VarCount", "integer", sizeof(int), */
-/*                                      FMOffset(struct _SstMetadata *,
- * VarCount)}, */
-/*                                     {"Vars", "VarMetadata[VarCount]", */
-/*                                      sizeof(struct _SstVarMeta), */
-/*                                      FMOffset(struct _SstMetadata *, Vars)},
- */
-/*                                     {NULL, NULL, 0, 0}}; */
-
-static FMField SstVarMetaList[] = {
-    {"VarName", "string", sizeof(char *),
-     FMOffset(struct _SstVarMeta *, VarName)},
-    {"DimensionCount", "integer", sizeof(int),
-     FMOffset(struct _SstVarMeta *, DimensionCount)},
-    {"Dimensions", "VarDimension[DimensionCount]", sizeof(struct _SstDimenMeta),
-     FMOffset(struct _SstVarMeta *, Dimensions)},
-    {"DataOffsetInBlock", "integer", sizeof(int),
-     FMOffset(struct _SstVarMeta *, DataOffsetInBlock)},
-    {NULL, NULL, 0, 0}};
-
-static FMField SstDimenMetaList[] = {
-    {"Offset", "integer", sizeof(int),
-     FMOffset(struct _SstDimenMeta *, Offset)},
-    {"Size", "integer", sizeof(int), FMOffset(struct _SstDimenMeta *, Size)},
-    {"GlobalSize", "integer", sizeof(int),
-     FMOffset(struct _SstDimenMeta *, GlobalSize)},
-    {NULL, NULL, 0, 0}};
-
 static FMField MetaDataPlusDPInfoList[] = {
     {"RequestGlobalOp", "integer", sizeof(int),
      FMOffset(struct _MetadataPlusDPInfo *, RequestGlobalOp)},
@@ -257,10 +225,6 @@ static FMStructDescRec MetaDataPlusDPInfoStructs[] = {
      sizeof(struct _MetadataPlusDPInfo), NULL},
     {"FFSFormatBlock", FFSFormatBlockList, sizeof(struct FFSFormatBlock), NULL},
     {"SstBlock", SstBlockList, sizeof(struct _SstBlock), NULL},
-    //    {"SstMetadata", SstMetadataList, sizeof(struct _SstMetadata), NULL},
-    //    {"VarMetadata", SstVarMetaList, sizeof(struct _SstVarMeta), NULL},
-    //    {"VarDimension", SstDimenMetaList, sizeof(struct _SstDimenMeta),
-    //    NULL},
     {NULL, NULL, 0, NULL}};
 
 static FMField TimestepMetadataList[] = {
@@ -721,7 +685,8 @@ extern CP_GlobalInfo CP_getCPInfo(CP_DP_Interface DPInfo)
         CP_SstParamsList = copy_field_list(CP_SstParamsList_RAW);
         while (CP_SstParamsList[i].field_name)
         {
-            if (strcmp(CP_SstParamsList[i].field_type, "int") == 0)
+            if ((strcmp(CP_SstParamsList[i].field_type, "int") == 0) ||
+                (strcmp(CP_SstParamsList[i].field_type, "size_t") == 0))
             {
                 free((void *)CP_SstParamsList[i].field_type);
                 CP_SstParamsList[i].field_type = strdup("integer");
@@ -768,7 +733,7 @@ SstStream CP_newStream()
     memset(Stream, 0, sizeof(*Stream));
     pthread_mutex_init(&Stream->DataLock, NULL);
     pthread_cond_init(&Stream->DataCondition, NULL);
-    Stream->WriterTimestep = -1; // first beginstep will get us timestep 0
+    Stream->WriterTimestep = -1; // Filled in by ProvideTimestep
     Stream->ReaderTimestep = -1; // first beginstep will get us timestep 0
     if (getenv("SstVerbose"))
     {

--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -78,7 +78,7 @@ typedef struct _CPTimestepEntry
     struct _TimestepMetadataMsg *Msg;
     int ReferenceCount;
     void **DP_TimestepInfo;
-    SstBlock *MetadataArray;
+    SstData *MetadataArray;
     void (*DataFreeFunc)(void *);
     void *FreeClientData;
     struct _CPTimestepEntry *Next;
@@ -150,6 +150,7 @@ struct _SstStream
     enum StreamStatus Status;
     int FinalTimestep;
     int CurrentWorkingTimestep;
+    struct _SstParams *WriterConfigParams;
 
     /* reader side marshal info */
     FFSContext ReaderFFSContext;
@@ -204,7 +205,7 @@ struct FFSFormatBlock
 struct _MetadataPlusDPInfo
 {
     int RequestGlobalOp;
-    SstBlock Metadata;
+    SstData Metadata;
     FFSFormatList Formats;
     void *DP_TimestepInfo;
 };
@@ -278,7 +279,7 @@ typedef struct _TimestepMetadataMsg
     int Timestep;
     int CohortSize;
     FFSFormatList Formats;
-    SstBlock *Metadata;
+    SstData *Metadata;
     void **DP_TimestepInfo;
 } * TSMetadataMsg;
 

--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -23,7 +23,6 @@ typedef struct _SstStream *SstStream;
 /*
  *  metadata and typedefs are tentative and may come from ADIOS2 constructors.
 */
-typedef struct _SstMetadata *SstMetadata;
 typedef struct _SstFullMetadata *SstFullMetadata;
 typedef struct _SstData *SstData;
 
@@ -47,8 +46,11 @@ typedef struct _SstParams *SstParams;
  */
 extern SstStream SstWriterOpen(const char *filename, SstParams Params,
                                MPI_Comm comm);
-extern void SstProvideTimestep(SstStream s, SstMetadata local_metadata,
-                               SstData data, long timestep);
+
+typedef void (*DataFreeFunc)(void *Data);
+extern void SstProvideTimestep(SstStream s, SstData LocalMetadata,
+                               SstData LocalData, long Timestep,
+                               DataFreeFunc FreeData, void *FreeClientData);
 extern void SstWriterClose(SstStream stream);
 
 /*
@@ -56,7 +58,9 @@ extern void SstWriterClose(SstStream stream);
  */
 extern SstStream SstReaderOpen(const char *filename, SstParams Params,
                                MPI_Comm comm);
-extern SstFullMetadata SstGetMetadata(SstStream stream, long timestep);
+extern void SstReaderGetParams(SstStream stream, int *WriterFFSmarshal,
+                               int *WriterBPmarshal);
+extern SstFullMetadata SstGetCurMetadata(SstStream stream);
 extern void *SstReadRemoteMemory(SstStream s, int rank, long timestep,
                                  size_t offset, size_t length, void *buffer,
                                  void *DP_TimestepInfo);
@@ -67,29 +71,35 @@ extern SstStatusValue SstAdvanceStep(SstStream stream, int mode,
 extern void SstReaderClose(SstStream stream);
 extern long SstCurrentStep(SstStream s);
 
+/*
+ *  Calls that support FFS-based marshaling, source code in cp/ffs_marshal.c
+ */
 typedef void *(*VarSetupUpcallFunc)(void *Reader, const char *Name,
                                     const char *Type, void *Data);
 typedef void *(*ArraySetupUpcallFunc)(void *Reader, const char *Name,
                                       const char *Type, int DimsCount,
                                       size_t *Shape, size_t *Start,
                                       size_t *Count);
-extern void SstReaderInitCallback(SstStream stream, void *Reader,
-                                  VarSetupUpcallFunc VarCallback,
-                                  ArraySetupUpcallFunc ArrayCallback);
+extern void SstReaderInitFFSCallback(SstStream stream, void *Reader,
+                                     VarSetupUpcallFunc VarCallback,
+                                     ArraySetupUpcallFunc ArrayCallback);
 
-extern void SstMarshal(SstStream Stream, void *Variable, const char *Name,
-                       const char *Type, size_t ElemSize, size_t DimCount,
-                       const unsigned long *Shape, const unsigned long *Count,
-                       const unsigned long *Offsets, const void *data);
-extern void SstGetDeferred(SstStream Stream, void *Variable, const char *Name,
-                           size_t DimCount, const unsigned long *Start,
-                           const unsigned long *Count, void *Data);
+extern void SstFFSMarshal(SstStream Stream, void *Variable, const char *Name,
+                          const char *Type, size_t ElemSize, size_t DimCount,
+                          const unsigned long *Shape,
+                          const unsigned long *Count,
+                          const unsigned long *Offsets, const void *data);
+extern void SstFFSGetDeferred(SstStream Stream, void *Variable,
+                              const char *Name, size_t DimCount,
+                              const unsigned long *Start,
+                              const unsigned long *Count, void *Data);
 
-extern void SstPerformGets(SstStream Stream);
+extern void SstFFSPerformGets(SstStream Stream);
 
-extern int SstWriterBeginStep(SstStream Stream, int mode,
-                              const float timeout_sec);
-extern void SstWriterEndStep(SstStream Stream);
+extern int SstFFSWriterBeginStep(SstStream Stream, int mode,
+                                 const float timeout_sec);
+extern void SstFFSWriterEndStep(SstStream Stream, size_t Step);
+
 /*
  *  General Operations
  */
@@ -101,7 +111,7 @@ extern void SstSetStatsSave(SstStream Stream, SstStats Save);
 
 #define SST_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                \
     MACRO(FFSmarshal, Bool, int, true)                                         \
-    MACRO(RegistrationMethod, RegMethod, int, NULL)                            \
+    MACRO(RegistrationMethod, RegMethod, size_t, NULL)                         \
     MACRO(DataTransport, String, char *, NULL)                                 \
     MACRO(BPmarshal, Bool, int, false)                                         \
     MACRO(RendezvousReaderCount, Int, int, 1)                                  \

--- a/source/adios2/toolkit/sst/sst_data.h
+++ b/source/adios2/toolkit/sst/sst_data.h
@@ -10,19 +10,8 @@ typedef enum { SST_UINT = 1, SST_INT = 2, SST_FLOAT = 3 } SST_BASE_TYPE;
 struct _SstFullMetadata
 {
     int WriterCohortSize;
-    struct _SstBlock **WriterMetadata;
+    struct _SstData **WriterMetadata;
     void **DP_TimestepInfo;
-};
-
-struct _SstMetadata
-{
-    size_t DataSize;
-    int IntVarCount;
-    struct _SstIntMeta *IntVars;
-    int FloatVarCount;
-    struct _SstFloatMeta *FloatVars;
-    int VarCount;
-    struct _SstVarMeta *Vars;
 };
 
 struct _SstData
@@ -31,43 +20,10 @@ struct _SstData
     char *block;
 };
 
-typedef struct _SstBlock
+struct _SstBlock
 {
     size_t BlockSize;
     char *BlockData;
-} * SstBlock;
-
-struct _SstVarMeta
-{
-    char *VarName;
-    int DimensionCount;
-    struct _SstDimenMeta *Dimensions;
-    int DataOffsetInBlock;
-};
-
-struct _SstIntMeta
-{
-    char *VarName;
-    int64_t Value;
-};
-
-struct _SstUintMeta
-{
-    char *VarName;
-    u_int64_t Value;
-};
-
-struct _SstFloatMeta
-{
-    char *VarName;
-    double Value;
-};
-
-struct _SstDimenMeta
-{
-    int Offset;
-    int Size;
-    int GlobalSize;
 };
 
 #endif /* !_SST_DATA_H_ */


### PR DESCRIPTION
by dropping code into indicated places.    This PR does not include any new functionality _per se_, but it cleans up some detritus, pushes marshaling configuration information up to the SstReader object and includes indications where code should be added to implement BP-based marshaling in SST.