### PR TITLE
Fixed bug #478 to correctly reallocate buffer

### DIFF
--- a/source/adios2/engine/bp/BPFileWriter.cpp
+++ b/source/adios2/engine/bp/BPFileWriter.cpp
@@ -47,6 +47,11 @@ size_t BPFileWriter::CurrentStep() const
 
 void BPFileWriter::PerformPuts()
 {
+    if (m_BP3Serializer.m_DeferredVariables.empty())
+    {
+        return;
+    }
+
     m_BP3Serializer.ResizeBuffer(m_BP3Serializer.m_DeferredVariablesDataSize,
                                  "in call to PerformPuts");
 

--- a/source/adios2/toolkit/format/BufferSTL.cpp
+++ b/source/adios2/toolkit/format/BufferSTL.cpp
@@ -17,6 +17,10 @@ void BufferSTL::Resize(const size_t size, const std::string hint)
 {
     try
     {
+        // doing this will effectively replace the STL GNU default power of 2
+        // reallocation.
+        m_Buffer.reserve(size);
+        // must initialize memory (secure)
         m_Buffer.resize(size, '\0');
     }
     catch (...)

--- a/testing/adios2/performance/manyvars/manyVars.c
+++ b/testing/adios2/performance/manyvars/manyVars.c
@@ -287,7 +287,6 @@ int write_file(int step)
             adios2_put_sync(engineW, varW[i], a2);
         }
     }
-    adios2_perform_puts(engineW);
     adios2_end_step(engineW);
 
     te = MPI_Wtime();


### PR DESCRIPTION
Caused when reallocating metadata in data.
Capacity was sufficient, while size was not. 
Enforcing capacity change with reserve (expensive) before a resize
(cheap).
Also, skipping PerformPuts if there is zero deferred variables. this was
resizing the buffer before EndStep.