### PR TITLE
Fix Fortran module race condition in build of tests

### DIFF
--- a/testing/adios2/bindings/fortran/CMakeLists.txt
+++ b/testing/adios2/bindings/fortran/CMakeLists.txt
@@ -3,13 +3,17 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-add_executable(TestBPWriteReadTypes_f SmallTestData_mod.f90)
+add_library(SmallTestData_f OBJECT SmallTestData_mod.f90)
+
+add_executable(TestBPWriteReadTypes_f $<TARGET_OBJECTS:SmallTestData_f>)
 target_link_libraries(TestBPWriteReadTypes_f adios2_f)
 
-add_executable(TestBPWriteReadTypesHighLevelAPI_f SmallTestData_mod.f90)
+add_executable(TestBPWriteReadTypesHighLevelAPI_f
+  $<TARGET_OBJECTS:SmallTestData_f>
+)
 target_link_libraries(TestBPWriteReadTypesHighLevelAPI_f adios2_f)
 
-add_executable(TestRemove_f SmallTestData_mod.f90)
+add_executable(TestRemove_f $<TARGET_OBJECTS:SmallTestData_f>)
 target_link_libraries(TestRemove_f adios2_f)
 
 if(ADIOS2_HAVE_MPI)
@@ -23,22 +27,22 @@ if(ADIOS2_HAVE_MPI)
   target_sources(TestRemove_f PRIVATE TestRemove.f90)
   target_link_libraries(TestRemove_f MPI::MPI_Fortran)
   
-  add_executable(TestBPWriteAttributes_f SmallTestData_mod.f90)
+  add_executable(TestBPWriteAttributes_f $<TARGET_OBJECTS:SmallTestData_f>)
   target_link_libraries(TestBPWriteAttributes_f adios2_f)
   target_sources(TestBPWriteAttributes_f PRIVATE TestBPWriteAttributes.f90)
   target_link_libraries(TestBPWriteAttributes_f MPI::MPI_Fortran)
   
-  add_executable(TestBPWriteTypesByName_f SmallTestData_mod.f90)
+  add_executable(TestBPWriteTypesByName_f $<TARGET_OBJECTS:SmallTestData_f>)
   target_link_libraries(TestBPWriteTypesByName_f adios2_f)
   target_sources(TestBPWriteTypesByName_f PRIVATE TestBPWriteTypesByName.f90)
   target_link_libraries(TestBPWriteTypesByName_f MPI::MPI_Fortran)
   
-  add_executable(TestBPWriteStep_f SmallTestData_mod.f90)
+  add_executable(TestBPWriteStep_f $<TARGET_OBJECTS:SmallTestData_f>)
   target_link_libraries(TestBPWriteStep_f adios2_f)
   target_sources(TestBPWriteStep_f PRIVATE TestBPWriteStep.f90)
   target_link_libraries(TestBPWriteStep_f MPI::MPI_Fortran)
   
-  add_executable(TestBPWriteLocal_f SmallTestData_mod.f90)
+  add_executable(TestBPWriteLocal_f $<TARGET_OBJECTS:SmallTestData_f>)
   target_link_libraries(TestBPWriteLocal_f adios2_f)
   target_sources(TestBPWriteLocal_f PRIVATE TestBPWriteTypesLocal.f90)
   target_link_libraries(TestBPWriteLocal_f MPI::MPI_Fortran)


### PR DESCRIPTION
Place SmallTestData_mod.f90 into an object library to avoid multiple copies of
small_test_data.mod from overwriting one another in parallel builds.  CMake
should be able to handle this on it's own a bit more inteligently but at the
moment it does not so the object library approach used here is really just a
workaround but should be sufficient for what we need.