### PR TITLE
Enhancement #471 ADIOS and IO FlushAll, Engine Flush

### DIFF
--- a/bindings/C/adios2/adios2_c_adios.cpp
+++ b/bindings/C/adios2/adios2_c_adios.cpp
@@ -45,6 +45,11 @@ adios2_io *adios2_declare_io(adios2_adios *adios, const char *ioName)
     return io;
 }
 
+void adios2_flush_all(adios2_adios *adios)
+{
+    reinterpret_cast<adios2::ADIOS *>(adios)->FlushAll();
+}
+
 void adios2_finalize(adios2_adios *adios)
 {
     delete reinterpret_cast<adios2::ADIOS *>(adios);

--- a/bindings/C/adios2/adios2_c_adios.h
+++ b/bindings/C/adios2/adios2_c_adios.h
@@ -65,6 +65,14 @@ adios2_adios *adios2_init_nompi(const adios2_debug_mode debug_mode);
 adios2_io *adios2_declare_io(adios2_adios *adios, const char *io_name);
 
 /**
+ * Flushes all adios2_engine in all adios2_io handlers created with the current
+ * adios2_adios handler using adios2_declare_io and adios2_open
+ * If no adios2_io or adios2_engine is created it does nothing.
+ * @param adios input handler
+ */
+void adios2_flush_all(adios2_adios *adios);
+
+/**
  * Final point for adios2_ADIOS handler.
  * Deallocate adios pointer. Required to avoid memory leaks.
  * @param adios input to be deallocated

--- a/bindings/C/adios2/adios2_c_engine.cpp
+++ b/bindings/C/adios2/adios2_c_engine.cpp
@@ -352,6 +352,12 @@ void adios2_write_step(adios2_engine *engine)
     engineCpp.WriteStep();
 }
 
+void adios2_flush(adios2_engine *engine)
+{
+    auto &engineCpp = *reinterpret_cast<adios2::Engine *>(engine);
+    engineCpp.Flush();
+}
+
 void adios2_close(adios2_engine *engine)
 {
     auto &engineCpp = *reinterpret_cast<adios2::Engine *>(engine);

--- a/bindings/C/adios2/adios2_c_engine.h
+++ b/bindings/C/adios2/adios2_c_engine.h
@@ -91,6 +91,12 @@ void adios2_end_step(adios2_engine *engine);
 void adios2_write_step(adios2_engine *engine);
 
 /**
+ * Explicit engine buffer flush to transports
+ * @param engine input
+ */
+void adios2_flush(adios2_engine *engine);
+
+/**
  * Close all transports in adios2_Engine
  * @param engine handler containing all transports to
  * be closed. engine Becomes NULL after this function is called.

--- a/bindings/C/adios2/adios2_c_io.cpp
+++ b/bindings/C/adios2/adios2_c_io.cpp
@@ -509,3 +509,8 @@ adios2_engine *adios2_open_new_comm(adios2_io *io, const char *name,
 
     return reinterpret_cast<adios2_engine *>(engine);
 }
+
+void adios2_flush_all_engines(adios2_io *io)
+{
+    reinterpret_cast<adios2::IO *>(io)->FlushAll();
+}

--- a/bindings/C/adios2/adios2_c_io.h
+++ b/bindings/C/adios2/adios2_c_io.h
@@ -154,6 +154,8 @@ adios2_engine *adios2_open_new_comm(adios2_io *io, const char *name,
                                     const adios2_mode open_mode,
                                     MPI_Comm mpi_comm);
 
+void adios2_flush_all_engines(adios2_io *io);
+
 #ifdef __cplusplus
 } // end extern C
 #endif

--- a/bindings/fortran/f2c/adios2_f2c_adios.cpp
+++ b/bindings/fortran/f2c/adios2_f2c_adios.cpp
@@ -86,6 +86,21 @@ void FC_GLOBAL(adios2_declare_io_f2c,
     }
 }
 
+void FC_GLOBAL(adios2_flush_all_f2c, ADIOS2_FLUSH_ALL_F2C)(adios2_adios **adios,
+                                                           int *ierr)
+{
+    *ierr = 0;
+    try
+    {
+        adios2_flush_all(*adios);
+    }
+    catch (std::exception &e)
+    {
+        std::cerr << "ADIOS2 flush_all: " << e.what() << "\n";
+        *ierr = -1;
+    }
+}
+
 void FC_GLOBAL(adios2_finalize_f2c, ADIOS2_FINALIZE_F2C)(adios2_adios **adios,
                                                          int *ierr)
 {

--- a/bindings/fortran/f2c/adios2_f2c_adios.h
+++ b/bindings/fortran/f2c/adios2_f2c_adios.h
@@ -47,6 +47,9 @@ void FC_GLOBAL(adios2_declare_io_f2c,
                ADIOS2_DECLARE_IO_F2C)(adios2_io **io, adios2_adios **adios,
                                       const char *io_name, int *ierr);
 
+void FC_GLOBAL(adios2_flush_all_f2c, ADIOS2_FLUSH_ALL_F2C)(adios2_adios **adios,
+                                                           int *ierr);
+
 void FC_GLOBAL(adios2_finalize_f2c, ADIOS2_FINALIZE_F2C)(adios2_adios **adios,
                                                          int *ierr);
 

--- a/bindings/fortran/f2c/adios2_f2c_engine.cpp
+++ b/bindings/fortran/f2c/adios2_f2c_engine.cpp
@@ -230,6 +230,21 @@ void FC_GLOBAL(adios2_write_step_f2c,
     }
 }
 
+void FC_GLOBAL(adios2_flush_f2c, ADIOS2_FLUSH_F2C)(adios2_engine **engine,
+                                                   int *ierr)
+{
+    *ierr = 0;
+    try
+    {
+        adios2_flush(*engine);
+    }
+    catch (std::exception &e)
+    {
+        std::cerr << "ADIOS2 flush: " << e.what() << "\n";
+        *ierr = -1;
+    }
+}
+
 void FC_GLOBAL(adios2_close_f2c, ADIOS2_CLOSE_F2C)(adios2_engine **engine,
                                                    int *ierr)
 {

--- a/bindings/fortran/f2c/adios2_f2c_engine.h
+++ b/bindings/fortran/f2c/adios2_f2c_engine.h
@@ -78,6 +78,9 @@ void FC_GLOBAL(adios2_end_step_f2c, ADIOS2_END_STEP_F2C)(adios2_engine **engine,
 void FC_GLOBAL(adios2_write_step_f2c,
                ADIOS2_WRITE_STEP_F2C)(adios2_engine **engine, int *ierr);
 
+void FC_GLOBAL(adios2_flush_f2c, ADIOS2_FLUSH_F2C)(adios2_engine **engine,
+                                                   int *ierr);
+
 void FC_GLOBAL(adios2_close_f2c, ADIOS2_CLOSE_F2C)(adios2_engine **engine,
                                                    int *ierr);
 

--- a/bindings/fortran/f2c/adios2_f2c_io.cpp
+++ b/bindings/fortran/f2c/adios2_f2c_io.cpp
@@ -311,3 +311,18 @@ void FC_GLOBAL(adios2_open_f2c,
         *ierr = -1;
     }
 }
+
+void FC_GLOBAL(adios2_flush_all_engines_f2c,
+               ADIOS2_FLUSH_ALL_ENGINES_F2C)(adios2_io **io, int *ierr)
+{
+    *ierr = 0;
+    try
+    {
+        adios2_flush_all_engines(*io);
+    }
+    catch (std::exception &e)
+    {
+        std::cerr << "ADIOS2 flush_all_engines: " << e.what() << "\n";
+        *ierr = -1;
+    }
+}

--- a/bindings/fortran/f2c/adios2_f2c_io.h
+++ b/bindings/fortran/f2c/adios2_f2c_io.h
@@ -89,6 +89,9 @@ void FC_GLOBAL(adios2_open_f2c,
                                 const char *name, const int *open_mode,
                                 int *ierr);
 
+void FC_GLOBAL(adios2_flush_all_engines_f2c,
+               ADIOS2_FLUSH_ALL_ENGINES_F2C)(adios2_io **io, int *ierr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bindings/fortran/modules/adios2_adios_mod.f90
+++ b/bindings/fortran/modules/adios2_adios_mod.f90
@@ -25,6 +25,15 @@ contains
 
     end subroutine
 
+
+    subroutine adios2_flush_all(adios, ierr)
+        integer(kind=8), intent(in) :: adios
+        integer, intent(out) :: ierr
+
+        call adios2_flush_all_f2c(adios, ierr)
+
+    end subroutine
+
     subroutine adios2_finalize(adios, ierr)
         integer(kind=8), intent(in) :: adios
         integer, intent(out) :: ierr

--- a/bindings/fortran/modules/adios2_engine_mod.f90
+++ b/bindings/fortran/modules/adios2_engine_mod.f90
@@ -59,6 +59,14 @@ contains
 
     end subroutine
 
+    subroutine adios2_flush(engine, ierr)
+        integer(kind=8), intent(in) :: engine
+        integer, intent(out) :: ierr
+
+        call adios2_flush_f2c(engine, ierr)
+
+    end subroutine
+
     subroutine adios2_close(engine, ierr)
         integer(kind=8), intent(in) :: engine
         integer, intent(out) :: ierr

--- a/bindings/fortran/modules/adios2_io_mod.f90
+++ b/bindings/fortran/modules/adios2_io_mod.f90
@@ -102,4 +102,12 @@ contains
     end subroutine
 
 
+    subroutine adios2_flush_all_engines(io, ierr)
+        integer(kind=8), intent(in) :: io
+        integer, intent(out) :: ierr
+
+        call adios2_flush_all_engines_f2c(io, ierr)
+
+    end subroutine
+
 end module

--- a/bindings/python/ADIOSPy.cpp
+++ b/bindings/python/ADIOSPy.cpp
@@ -46,4 +46,6 @@ IOPy ADIOSPy::AtIO(const std::string name)
     return IOPy(m_ADIOS->AtIO(name), m_DebugMode);
 }
 
+void ADIOSPy::FlushAll() { m_ADIOS->FlushAll(); }
+
 } // end namespace adios2

--- a/bindings/python/ADIOSPy.h
+++ b/bindings/python/ADIOSPy.h
@@ -39,6 +39,8 @@ public:
     IOPy DeclareIO(const std::string name);
     IOPy AtIO(const std::string name);
 
+    void FlushAll();
+
 private:
     const bool m_DebugMode = true;
     std::shared_ptr<adios2::ADIOS> m_ADIOS;

--- a/bindings/python/EnginePy.cpp
+++ b/bindings/python/EnginePy.cpp
@@ -193,6 +193,11 @@ void EnginePy::EndStep() { m_Engine.EndStep(); }
 
 void EnginePy::WriteStep() { m_Engine.WriteStep(); }
 
+void EnginePy::Flush(const int transportIndex)
+{
+    m_Engine.Flush(transportIndex);
+}
+
 void EnginePy::Close(const int transportIndex)
 {
     m_Engine.Close(transportIndex);

--- a/bindings/python/EnginePy.h
+++ b/bindings/python/EnginePy.h
@@ -54,6 +54,8 @@ public:
 
     void WriteStep();
 
+    void Flush(const int transportIndex = -1);
+
     void Close(const int transportIndex = -1);
 
 private:

--- a/bindings/python/IOPy.cpp
+++ b/bindings/python/IOPy.cpp
@@ -148,4 +148,6 @@ EnginePy IOPy::Open(const std::string &name, const int openMode)
                     m_IO.m_MPIComm);
 }
 
+void IOPy::FlushAll() { m_IO.FlushAll(); }
+
 } // end namespace adios2

--- a/bindings/python/IOPy.h
+++ b/bindings/python/IOPy.h
@@ -57,6 +57,8 @@ public:
 
     EnginePy Open(const std::string &name, const int openMode);
 
+    void FlushAll();
+
 private:
     const bool m_DebugMode;
 };

--- a/bindings/python/gluePyBind11.cpp
+++ b/bindings/python/gluePyBind11.cpp
@@ -181,7 +181,8 @@ PYBIND11_MODULE(adios2, m)
 
     pybind11::class_<adios2::ADIOSPy>(m, "ADIOSPy")
         .def("DeclareIO", &adios2::ADIOSPy::DeclareIO)
-        .def("AtIO", &adios2::ADIOSPy::AtIO);
+        .def("AtIO", &adios2::ADIOSPy::AtIO)
+        .def("FlushAll", &adios2::ADIOSPy::FlushAll);
 
     pybind11::class_<adios2::VariableBase>(m, "Variable")
         .def("SetShape", &adios2::VariableBase::SetShape)
@@ -236,7 +237,8 @@ PYBIND11_MODULE(adios2, m)
              pybind11::return_value_policy::reference_internal)
         .def("Open", (adios2::EnginePy (adios2::IOPy::*)(const std::string &,
                                                          const int)) &
-                         adios2::IOPy::Open);
+                         adios2::IOPy::Open)
+        .def("FlushAll", &adios2::IOPy::FlushAll);
 
     pybind11::class_<adios2::EnginePy>(m, "EnginePy")
         .def("BeginStep", &adios2::EnginePy::BeginStep,
@@ -271,6 +273,7 @@ PYBIND11_MODULE(adios2, m)
         .def("PerformGets", &adios2::EnginePy::PerformGets)
         .def("EndStep", &adios2::EnginePy::EndStep)
         .def("WriteStep", &adios2::EnginePy::WriteStep)
+        .def("Flush", &adios2::EnginePy::Flush)
         .def("Close", &adios2::EnginePy::Close,
              pybind11::arg("transportIndex") = -1);
 

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -131,6 +131,14 @@ IO &ADIOS::AtIO(const std::string name)
     return itIO->second;
 }
 
+void ADIOS::FlushAll()
+{
+    for (auto &ioPair : m_IOs)
+    {
+        ioPair.second.FlushAll();
+    }
+}
+
 Operator &ADIOS::DefineOperator(const std::string name, const std::string type,
                                 const Params &parameters)
 {

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -108,6 +108,14 @@ public:
     IO &AtIO(const std::string name);
 
     /**
+     * Flushes all engines in all IOs created with the current ADIOS object
+     * using DeclareIO and IO.Open.
+     * If no IO or engine is created it does nothing.
+     * @exception std::runtime_error if any engine Flush fails
+     */
+    void FlushAll();
+
+    /**
      * Declares a derived class of the Operator abstract class. If object is
      * defined in the user
      * config file, by name, it will be already created during the processing of

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -27,6 +27,8 @@ Engine::~Engine(){};
 
 IO &Engine::GetIO() noexcept { return m_IO; }
 
+Mode Engine::OpenMode() const noexcept { return m_OpenMode; }
+
 StepStatus Engine::BeginStep()
 {
     if (m_OpenMode == Mode::Read)

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -63,6 +63,8 @@ public:
      */
     IO &GetIO() noexcept;
 
+    Mode OpenMode() const noexcept;
+
     StepStatus BeginStep();
 
     /**

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -470,6 +470,18 @@ Engine &IO::Open(const std::string &name, const Mode mode)
     return Open(name, mode, m_MPIComm);
 }
 
+void IO::FlushAll()
+{
+    for (auto &enginePair : m_Engines)
+    {
+        auto &engine = enginePair.second;
+        if (engine->OpenMode() != Mode::Read)
+        {
+            enginePair.second->Flush();
+        }
+    }
+}
+
 // PRIVATE
 int IO::GetMapIndex(const std::string &name, const DataMap &dataMap) const
     noexcept

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -327,6 +327,13 @@ public:
      */
     Engine &Open(const std::string &name, const Mode mode);
 
+    /**
+     * Flushes all engines created with the current IO object using Open.
+     * If no engine is created it does nothing.
+     * @exception std::runtime_error if any engine Flush fails
+     */
+    void FlushAll();
+
     // READ FUNCTIONS, not yet implemented:
     /**
      * not yet implented

--- a/source/adios2/engine/bp/BPFileWriter.cpp
+++ b/source/adios2/engine/bp/BPFileWriter.cpp
@@ -281,6 +281,8 @@ void BPFileWriter::WriteData(const bool isFinal, const int transportIndex)
 
     m_FileDataManager.WriteFiles(m_BP3Serializer.m_Data.m_Buffer.data(),
                                  dataSize, transportIndex);
+
+    m_FileDataManager.FlushFiles(transportIndex);
 }
 
 void BPFileWriter::AggregateWriteData(const bool isFinal,
@@ -304,6 +306,8 @@ void BPFileWriter::AggregateWriteData(const bool isFinal,
 
             m_FileDataManager.WriteFiles(bufferSTL.m_Buffer.data(),
                                          bufferSTL.m_Position, transportIndex);
+
+            m_FileDataManager.FlushFiles(transportIndex);
         }
 
         m_BP3Serializer.AggregatorsIReceive(r);

--- a/source/adios2/engine/bp/BPFileWriter.tcc
+++ b/source/adios2/engine/bp/BPFileWriter.tcc
@@ -37,11 +37,9 @@ void BPFileWriter::PutSyncCommon(Variable<T> &variable, const T *values)
 
     if (resizeResult == format::BP3Base::ResizeResult::Flush)
     {
-        // TODO: refactor
-        m_BP3Serializer.SerializeData(m_IO);
-        m_FileDataManager.WriteFiles(m_BP3Serializer.m_Data.m_Buffer.data(),
-                                     m_BP3Serializer.m_Data.m_Position);
+        DoFlush(false);
         m_BP3Serializer.ResetBuffer(m_BP3Serializer.m_Data);
+
         // new group index for incoming variable
         m_BP3Serializer.PutProcessGroupIndex(
             m_IO.m_Name, m_IO.m_HostLanguage,

--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -158,7 +158,9 @@ size_t FileFStream::GetSize()
 
 void FileFStream::Flush()
 {
+    ProfilerStart("write");
     m_FileStream.flush();
+    ProfilerStart("write");
     CheckFile("couldn't flush to file " + m_Name +
               ", in call to fstream flush");
 }

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -137,7 +137,7 @@ void FileStdio::Read(char *buffer, size_t size, size_t start)
         if (readSize != size)
         {
             throw std::ios_base::failure(
-                "ERROR: read size + " + std::to_string(readSize) +
+                "ERROR: read size of " + std::to_string(readSize) +
                 " is not equal to intended size " + std::to_string(size) +
                 " in file " + m_Name + ", in call to stdio fread\n");
         }
@@ -188,7 +188,9 @@ size_t FileStdio::GetSize()
 
 void FileStdio::Flush()
 {
+    ProfilerStart("write");
     const int status = std::fflush(m_File);
+    ProfilerStop("write");
 
     if (status == EOF)
     {

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -174,6 +174,29 @@ void TransportMan::ReadFile(char *buffer, const size_t size, const size_t start,
     itTransport->second->Read(buffer, size, start);
 }
 
+void TransportMan::FlushFiles(const int transportIndex)
+{
+    if (transportIndex == -1)
+    {
+        for (auto &transportPair : m_Transports)
+        {
+            auto &transport = transportPair.second;
+
+            if (transport->m_Type == "File")
+            {
+                transport->Flush();
+            }
+        }
+    }
+    else
+    {
+        auto itTransport = m_Transports.find(transportIndex);
+        CheckFile(itTransport, ", in call to FlushFiles with index " +
+                                   std::to_string(transportIndex));
+        itTransport->second->Flush();
+    }
+}
+
 void TransportMan::CloseFiles(const int transportIndex)
 {
     if (transportIndex == -1)

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -121,6 +121,13 @@ public:
                   const size_t transportIndex = 0);
 
     /**
+     * Flush file or files depending on transport index. Throws an exception
+     * if transport is not a file when transportIndex > -1.
+     * @param transportIndex -1: all transports, otherwise index in m_Transports
+     */
+    void FlushFiles(const int transportIndex = -1);
+
+    /**
      * Close file or files depending on transport index. Throws an exception
      * if transport is not a file when transportIndex > -1.
      * @param transportIndex -1: all transports, otherwise index in m_Transports

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(TestBPWriteReadAttributesADIOS2 adios2 gtest gtest_main)
 add_executable(TestStreamWriteReadHighLevelAPI TestStreamWriteReadHighLevelAPI.cpp)
 target_link_libraries(TestStreamWriteReadHighLevelAPI adios2 gtest gtest_main)
 
+add_executable(TestBPWriteFlushRead TestBPWriteFlushRead.cpp)
+target_link_libraries(TestBPWriteFlushRead adios2 gtest gtest_main)
 
 if(ADIOS2_HAVE_MPI)
 
@@ -26,6 +28,7 @@ if(ADIOS2_HAVE_MPI)
   target_link_libraries(TestBPWriteReadAsStreamADIOS2_Threads MPI::MPI_C)
   target_link_libraries(TestBPWriteReadAttributesADIOS2 MPI::MPI_C)
   target_link_libraries(TestStreamWriteReadHighLevelAPI MPI::MPI_C)
+  target_link_libraries(TestBPWriteFlushRead MPI::MPI_C)
   
   add_executable(TestBPWriteAggregateRead TestBPWriteAggregateRead.cpp)
   target_link_libraries(TestBPWriteAggregateRead adios2 gtest gtest_main MPI::MPI_C)
@@ -40,6 +43,7 @@ gtest_add_tests(TARGET TestBPWriteReadAsStreamADIOS2 ${extra_test_args})
 gtest_add_tests(TARGET TestBPWriteReadAsStreamADIOS2_Threads ${extra_test_args})
 gtest_add_tests(TARGET TestBPWriteReadAttributesADIOS2 ${extra_test_args})
 gtest_add_tests(TARGET TestStreamWriteReadHighLevelAPI ${extra_test_args})
+gtest_add_tests(TARGET TestBPWriteFlushRead ${extra_test_args})
   
 if (ADIOS2_HAVE_ADIOS1)
   add_executable(TestBPWriteRead TestBPWriteRead.cpp)
@@ -55,9 +59,7 @@ if (ADIOS2_HAVE_ADIOS1)
   target_link_libraries(TestBPWriteReadfstream adios2 gtest adios1::adios)
 
   add_executable(TestBPWriteProfilingJSON TestBPWriteProfilingJSON.cpp)
-  target_link_libraries(TestBPWriteProfilingJSON
-    adios2 gtest NLohmannJson
-  )
+  target_link_libraries(TestBPWriteProfilingJSON adios2 gtest NLohmannJson)
 
   if(ADIOS2_HAVE_MPI)
     target_link_libraries(TestBPWriteRead MPI::MPI_C)

--- a/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
@@ -589,8 +589,10 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dstdio)
                                         m_TestData.R64.data());
         }
 
-        adios2::Engine &bpWriter1D = io1D.Open("Flush1D", adios2::Mode::Write);
-        adios2::Engine &bpWriter2D = io2D.Open("Flush2D", adios2::Mode::Write);
+        adios2::Engine &bpWriter1D =
+            io1D.Open("Flush1Dstdio", adios2::Mode::Write);
+        adios2::Engine &bpWriter2D =
+            io2D.Open("Flush2Dstdio", adios2::Mode::Write);
 
         for (size_t step = 0; step < NSteps / 2; ++step)
         {
@@ -609,7 +611,8 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dstdio)
         {
             adios2::IO &io = adios.DeclareIO("ReadIO1");
 
-            adios2::Engine &bpReader = io.Open("Flush1D", adios2::Mode::Read);
+            adios2::Engine &bpReader =
+                io.Open("Flush1Dstdio", adios2::Mode::Read);
 
             auto var_i8 = io.InquireVariable<int8_t>("i8");
             ASSERT_NE(var_i8, nullptr);
@@ -757,7 +760,8 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dstdio)
         {
             adios2::IO &io = adios.DeclareIO("ReadIO2");
 
-            adios2::Engine &bpReader = io.Open("Flush2D", adios2::Mode::Read);
+            adios2::Engine &bpReader =
+                io.Open("Flush2Dstdio", adios2::Mode::Read);
 
             auto var_i8 = io.InquireVariable<int8_t>("i8");
             ASSERT_NE(var_i8, nullptr);
@@ -1033,8 +1037,10 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dfstream)
                                         m_TestData.R64.data());
         }
 
-        adios2::Engine &bpWriter1D = io1D.Open("Flush1D", adios2::Mode::Write);
-        adios2::Engine &bpWriter2D = io2D.Open("Flush2D", adios2::Mode::Write);
+        adios2::Engine &bpWriter1D =
+            io1D.Open("Flush1Dfstream", adios2::Mode::Write);
+        adios2::Engine &bpWriter2D =
+            io2D.Open("Flush2Dfstream", adios2::Mode::Write);
 
         for (size_t step = 0; step < NSteps / 2; ++step)
         {
@@ -1053,7 +1059,8 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dfstream)
         {
             adios2::IO &io = adios.DeclareIO("ReadIO1");
 
-            adios2::Engine &bpReader = io.Open("Flush1D", adios2::Mode::Read);
+            adios2::Engine &bpReader =
+                io.Open("Flush1Dfstream", adios2::Mode::Read);
 
             auto var_i8 = io.InquireVariable<int8_t>("i8");
             ASSERT_NE(var_i8, nullptr);
@@ -1201,7 +1208,8 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dfstream)
         {
             adios2::IO &io = adios.DeclareIO("ReadIO2");
 
-            adios2::Engine &bpReader = io.Open("Flush2D", adios2::Mode::Read);
+            adios2::Engine &bpReader =
+                io.Open("Flush2Dfstream", adios2::Mode::Read);
 
             auto var_i8 = io.InquireVariable<int8_t>("i8");
             ASSERT_NE(var_i8, nullptr);

--- a/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
@@ -1,0 +1,491 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#include "../SmallTestData.h"
+
+class BPWriteFlushRead : public ::testing::Test
+{
+public:
+    BPWriteFlushRead() = default;
+
+    SmallTestData m_TestData;
+    SmallTestData m_OriginalData1D;
+    SmallTestData m_OriginalData2D;
+};
+
+//******************************************************************************
+// 1D 1x8 test data
+//******************************************************************************
+
+// ADIOS2 BP write, native ADIOS1 read
+TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2D)
+{
+    int mpiRank = 0, mpiSize = 1;
+
+    const size_t Nx1D = 10;
+
+    // Number of rows
+    const std::size_t Nx2D = 4;
+
+    // Number of rows
+    const std::size_t Ny2D = 2;
+
+    // Number of steps
+    const size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using BP
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO &io1D = adios.DeclareIO("Flush1D");
+        adios2::IO &io2D = adios.DeclareIO("Flush2D");
+
+        io1D.SetParameter("FlushStepsCount", std::to_string(NSteps + 1));
+        io2D.SetParameter("FlushStepsCount", std::to_string(NSteps + 1));
+
+        // io1D Variables
+        {
+            const adios2::Dims shape{static_cast<size_t>(Nx1D * mpiSize)};
+            const adios2::Dims start{static_cast<size_t>(Nx1D * mpiRank)};
+            const adios2::Dims count{Nx1D};
+
+            io1D.DefineVariable<int8_t>("i8", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.I8.data());
+            io1D.DefineVariable<int16_t>("i16", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I16.data());
+            io1D.DefineVariable<int32_t>("i32", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I32.data());
+            io1D.DefineVariable<int64_t>("i64", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I64.data());
+
+            io1D.DefineVariable<uint8_t>("u8", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.U8.data());
+
+            io1D.DefineVariable<uint16_t>("u16", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U16.data());
+            io1D.DefineVariable<uint32_t>("u32", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U32.data());
+            io1D.DefineVariable<uint64_t>("u64", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U64.data());
+
+            io1D.DefineVariable<float>("r32", shape, start, count,
+                                       adios2::ConstantDims,
+                                       m_TestData.R32.data());
+            io1D.DefineVariable<double>("r64", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.R64.data());
+        }
+
+        // io2D variables
+        {
+            const adios2::Dims shape{Ny2D, static_cast<size_t>(Nx2D * mpiSize)};
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx2D)};
+            const adios2::Dims count{Ny2D, Nx2D};
+
+            io2D.DefineVariable<int8_t>("i8", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.I8.data());
+            io2D.DefineVariable<int16_t>("i16", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I16.data());
+            io2D.DefineVariable<int32_t>("i32", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I32.data());
+            io2D.DefineVariable<int64_t>("i64", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I64.data());
+
+            io2D.DefineVariable<uint8_t>("u8", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.U8.data());
+
+            io2D.DefineVariable<uint16_t>("u16", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U16.data());
+            io2D.DefineVariable<uint32_t>("u32", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U32.data());
+            io2D.DefineVariable<uint64_t>("u64", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U64.data());
+
+            io2D.DefineVariable<float>("r32", shape, start, count,
+                                       adios2::ConstantDims,
+                                       m_TestData.R32.data());
+            io2D.DefineVariable<double>("r64", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.R64.data());
+        }
+
+        adios2::Engine &bpWriter1D = io1D.Open("Flush1D", adios2::Mode::Write);
+        adios2::Engine &bpWriter2D = io2D.Open("Flush2D", adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps / 2; ++step)
+        {
+            UpdateSmallTestData(m_TestData, static_cast<int>(step), mpiRank,
+                                mpiSize);
+            EXPECT_EQ(bpWriter1D.CurrentStep(), step);
+            EXPECT_EQ(bpWriter2D.CurrentStep(), step);
+
+            bpWriter1D.WriteStep();
+            bpWriter2D.WriteStep();
+        }
+
+        adios.FlushAll(); // checkpoint for 1D and 2D writers
+
+        // Partial 1D read
+        {
+            adios2::IO &io = adios.DeclareIO("ReadIO1");
+
+            adios2::Engine &bpReader = io.Open("Flush1D", adios2::Mode::Read);
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            ASSERT_NE(var_i8, nullptr);
+            ASSERT_EQ(var_i8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i8->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            ASSERT_NE(var_i16, nullptr);
+            ASSERT_EQ(var_i16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i16->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            ASSERT_NE(var_i32, nullptr);
+            ASSERT_EQ(var_i32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i32->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            ASSERT_NE(var_i64, nullptr);
+            ASSERT_EQ(var_i64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i64->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            ASSERT_NE(var_u8, nullptr);
+            ASSERT_EQ(var_u8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u8->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            ASSERT_NE(var_u16, nullptr);
+            ASSERT_EQ(var_u16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u16->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            ASSERT_NE(var_u32, nullptr);
+            ASSERT_EQ(var_u32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u32->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            ASSERT_NE(var_u64, nullptr);
+            ASSERT_EQ(var_u64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u64->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            ASSERT_NE(var_r32, nullptr);
+            ASSERT_EQ(var_r32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r32->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            ASSERT_NE(var_r64, nullptr);
+            ASSERT_EQ(var_r64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r64->m_Shape[0], mpiSize * Nx1D);
+
+            std::string IString;
+            std::array<int8_t, Nx1D> I8;
+            std::array<int16_t, Nx1D> I16;
+            std::array<int32_t, Nx1D> I32;
+            std::array<int64_t, Nx1D> I64;
+            std::array<uint8_t, Nx1D> U8;
+            std::array<uint16_t, Nx1D> U16;
+            std::array<uint32_t, Nx1D> U32;
+            std::array<uint64_t, Nx1D> U64;
+            std::array<float, Nx1D> R32;
+            std::array<double, Nx1D> R64;
+
+            const adios2::Dims start{mpiRank * Nx1D};
+            const adios2::Dims count{Nx1D};
+
+            const adios2::Box<adios2::Dims> sel(start, count);
+
+            var_i8->SetSelection(sel);
+            var_i16->SetSelection(sel);
+            var_i32->SetSelection(sel);
+            var_i64->SetSelection(sel);
+
+            var_u8->SetSelection(sel);
+            var_u16->SetSelection(sel);
+            var_u32->SetSelection(sel);
+            var_u64->SetSelection(sel);
+
+            var_r32->SetSelection(sel);
+            var_r64->SetSelection(sel);
+
+            unsigned int t = 0;
+
+            while (bpReader.BeginStep() == adios2::StepStatus::OK)
+            {
+                const size_t currentStep = bpReader.CurrentStep();
+                EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+                bpReader.GetDeferred(*var_i8, I8.data());
+                bpReader.GetDeferred(*var_i16, I16.data());
+                bpReader.GetDeferred(*var_i32, I32.data());
+                bpReader.GetDeferred(*var_i64, I64.data());
+
+                bpReader.GetDeferred(*var_u8, U8.data());
+                bpReader.GetDeferred(*var_u16, U16.data());
+                bpReader.GetDeferred(*var_u32, U32.data());
+                bpReader.GetDeferred(*var_u64, U64.data());
+
+                bpReader.GetDeferred(*var_r32, R32.data());
+                bpReader.GetDeferred(*var_r64, R64.data());
+
+                bpReader.PerformGets();
+
+                bpReader.EndStep();
+
+                UpdateSmallTestData(m_OriginalData1D, static_cast<int>(t),
+                                    mpiRank, mpiSize);
+
+                for (size_t i = 0; i < Nx1D; ++i)
+                {
+                    std::stringstream ss;
+                    ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                    std::string msg = ss.str();
+
+                    EXPECT_EQ(I8[i], m_OriginalData1D.I8[i]) << msg;
+                    EXPECT_EQ(I16[i], m_OriginalData1D.I16[i]) << msg;
+                    EXPECT_EQ(I32[i], m_OriginalData1D.I32[i]) << msg;
+                    EXPECT_EQ(I64[i], m_OriginalData1D.I64[i]) << msg;
+                    EXPECT_EQ(U8[i], m_OriginalData1D.U8[i]) << msg;
+                    EXPECT_EQ(U16[i], m_OriginalData1D.U16[i]) << msg;
+                    EXPECT_EQ(U32[i], m_OriginalData1D.U32[i]) << msg;
+                    EXPECT_EQ(U64[i], m_OriginalData1D.U64[i]) << msg;
+                    EXPECT_EQ(R32[i], m_OriginalData1D.R32[i]) << msg;
+                    EXPECT_EQ(R64[i], m_OriginalData1D.R64[i]) << msg;
+                }
+                ++t;
+            }
+
+            EXPECT_EQ(t, NSteps / 2);
+
+            bpReader.Close();
+        }
+
+        // Partial 2D Read
+        {
+            adios2::IO &io = adios.DeclareIO("ReadIO2");
+
+            adios2::Engine &bpReader = io.Open("Flush2D", adios2::Mode::Read);
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            ASSERT_NE(var_i8, nullptr);
+            ASSERT_EQ(var_i8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i8->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i8->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            ASSERT_NE(var_i16, nullptr);
+            ASSERT_EQ(var_i16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i16->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i16->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            ASSERT_NE(var_i32, nullptr);
+            ASSERT_EQ(var_i32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i32->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i32->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            ASSERT_NE(var_i64, nullptr);
+            ASSERT_EQ(var_i64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i64->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i64->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            ASSERT_NE(var_u8, nullptr);
+            ASSERT_EQ(var_u8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u8->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u8->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            ASSERT_NE(var_u16, nullptr);
+            ASSERT_EQ(var_u16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u16->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u16->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            ASSERT_NE(var_u32, nullptr);
+            ASSERT_EQ(var_u32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u32->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u32->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            ASSERT_NE(var_u64, nullptr);
+            ASSERT_EQ(var_u64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u64->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u64->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            ASSERT_NE(var_r32, nullptr);
+            ASSERT_EQ(var_r32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r32->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_r32->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            ASSERT_NE(var_r64, nullptr);
+            ASSERT_EQ(var_r64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r64->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_r64->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            std::array<int8_t, Nx2D * Ny2D> I8;
+            std::array<int16_t, Nx2D * Ny2D> I16;
+            std::array<int32_t, Nx2D * Ny2D> I32;
+            std::array<int64_t, Nx2D * Ny2D> I64;
+            std::array<uint8_t, Nx2D * Ny2D> U8;
+            std::array<uint16_t, Nx2D * Ny2D> U16;
+            std::array<uint32_t, Nx2D * Ny2D> U32;
+            std::array<uint64_t, Nx2D * Ny2D> U64;
+            std::array<float, Nx2D * Ny2D> R32;
+            std::array<double, Nx2D * Ny2D> R64;
+
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx2D)};
+            const adios2::Dims count{Ny2D, Nx2D};
+
+            const adios2::Box<adios2::Dims> sel(start, count);
+
+            var_i8->SetSelection(sel);
+            var_i16->SetSelection(sel);
+            var_i32->SetSelection(sel);
+            var_i64->SetSelection(sel);
+
+            var_u8->SetSelection(sel);
+            var_u16->SetSelection(sel);
+            var_u32->SetSelection(sel);
+            var_u64->SetSelection(sel);
+
+            var_r32->SetSelection(sel);
+            var_r64->SetSelection(sel);
+
+            unsigned int t = 0;
+
+            while (bpReader.BeginStep() == adios2::StepStatus::OK)
+            {
+                const size_t currentStep = bpReader.CurrentStep();
+                EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+                bpReader.GetDeferred(*var_i8, I8.data());
+                bpReader.GetDeferred(*var_i16, I16.data());
+                bpReader.GetDeferred(*var_i32, I32.data());
+                bpReader.GetDeferred(*var_i64, I64.data());
+
+                bpReader.GetDeferred(*var_u8, U8.data());
+                bpReader.GetDeferred(*var_u16, U16.data());
+                bpReader.GetDeferred(*var_u32, U32.data());
+                bpReader.GetDeferred(*var_u64, U64.data());
+
+                bpReader.GetDeferred(*var_r32, R32.data());
+                bpReader.GetDeferred(*var_r64, R64.data());
+
+                bpReader.PerformGets();
+                bpReader.EndStep();
+
+                // Generate test data for each rank uniquely
+                UpdateSmallTestData(m_OriginalData2D, static_cast<int>(t),
+                                    mpiRank, mpiSize);
+
+                for (size_t i = 0; i < Nx2D * Ny2D; ++i)
+                {
+                    std::stringstream ss;
+                    ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                    std::string msg = ss.str();
+
+                    EXPECT_EQ(I8[i], m_OriginalData2D.I8[i]) << msg;
+                    EXPECT_EQ(I16[i], m_OriginalData2D.I16[i]) << msg;
+                    EXPECT_EQ(I32[i], m_OriginalData2D.I32[i]) << msg;
+                    EXPECT_EQ(I64[i], m_OriginalData2D.I64[i]) << msg;
+                    EXPECT_EQ(U8[i], m_OriginalData2D.U8[i]) << msg;
+                    EXPECT_EQ(U16[i], m_OriginalData2D.U16[i]) << msg;
+                    EXPECT_EQ(U32[i], m_OriginalData2D.U32[i]) << msg;
+                    EXPECT_EQ(U64[i], m_OriginalData2D.U64[i]) << msg;
+                    EXPECT_EQ(R32[i], m_OriginalData2D.R32[i]) << msg;
+                    EXPECT_EQ(R64[i], m_OriginalData2D.R64[i]) << msg;
+                }
+                ++t;
+            }
+            EXPECT_EQ(t, NSteps / 2);
+
+            bpReader.Close();
+        }
+
+        bpWriter1D.Close();
+        bpWriter2D.Close();
+    }
+}
+
+//******************************************************************************
+// main
+//******************************************************************************
+
+int main(int argc, char **argv)
+{
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}

--- a/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
@@ -470,6 +470,894 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2D)
     }
 }
 
+TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dstdio)
+{
+    int mpiRank = 0, mpiSize = 1;
+
+    const size_t Nx1D = 10;
+
+    // Number of rows
+    const std::size_t Nx2D = 4;
+
+    // Number of rows
+    const std::size_t Ny2D = 2;
+
+    // Number of steps
+    const size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using BP
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO &io1D = adios.DeclareIO("Flush1D");
+        adios2::IO &io2D = adios.DeclareIO("Flush2D");
+
+        io1D.SetParameter("FlushStepsCount", std::to_string(NSteps + 1));
+        io2D.SetParameter("FlushStepsCount", std::to_string(NSteps + 1));
+
+        io1D.AddTransport("File", {{"Library", "stdio"}});
+        io2D.AddTransport("File", {{"Library", "stdio"}});
+
+        // io1D Variables
+        {
+            const adios2::Dims shape{static_cast<size_t>(Nx1D * mpiSize)};
+            const adios2::Dims start{static_cast<size_t>(Nx1D * mpiRank)};
+            const adios2::Dims count{Nx1D};
+
+            io1D.DefineVariable<int8_t>("i8", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.I8.data());
+            io1D.DefineVariable<int16_t>("i16", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I16.data());
+            io1D.DefineVariable<int32_t>("i32", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I32.data());
+            io1D.DefineVariable<int64_t>("i64", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I64.data());
+
+            io1D.DefineVariable<uint8_t>("u8", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.U8.data());
+
+            io1D.DefineVariable<uint16_t>("u16", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U16.data());
+            io1D.DefineVariable<uint32_t>("u32", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U32.data());
+            io1D.DefineVariable<uint64_t>("u64", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U64.data());
+
+            io1D.DefineVariable<float>("r32", shape, start, count,
+                                       adios2::ConstantDims,
+                                       m_TestData.R32.data());
+            io1D.DefineVariable<double>("r64", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.R64.data());
+        }
+
+        // io2D variables
+        {
+            const adios2::Dims shape{Ny2D, static_cast<size_t>(Nx2D * mpiSize)};
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx2D)};
+            const adios2::Dims count{Ny2D, Nx2D};
+
+            io2D.DefineVariable<int8_t>("i8", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.I8.data());
+            io2D.DefineVariable<int16_t>("i16", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I16.data());
+            io2D.DefineVariable<int32_t>("i32", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I32.data());
+            io2D.DefineVariable<int64_t>("i64", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I64.data());
+
+            io2D.DefineVariable<uint8_t>("u8", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.U8.data());
+
+            io2D.DefineVariable<uint16_t>("u16", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U16.data());
+            io2D.DefineVariable<uint32_t>("u32", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U32.data());
+            io2D.DefineVariable<uint64_t>("u64", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U64.data());
+
+            io2D.DefineVariable<float>("r32", shape, start, count,
+                                       adios2::ConstantDims,
+                                       m_TestData.R32.data());
+            io2D.DefineVariable<double>("r64", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.R64.data());
+        }
+
+        adios2::Engine &bpWriter1D = io1D.Open("Flush1D", adios2::Mode::Write);
+        adios2::Engine &bpWriter2D = io2D.Open("Flush2D", adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps / 2; ++step)
+        {
+            UpdateSmallTestData(m_TestData, static_cast<int>(step), mpiRank,
+                                mpiSize);
+            EXPECT_EQ(bpWriter1D.CurrentStep(), step);
+            EXPECT_EQ(bpWriter2D.CurrentStep(), step);
+
+            bpWriter1D.WriteStep();
+            bpWriter2D.WriteStep();
+        }
+
+        adios.FlushAll(); // checkpoint for 1D and 2D writers
+
+        // Partial 1D read
+        {
+            adios2::IO &io = adios.DeclareIO("ReadIO1");
+
+            adios2::Engine &bpReader = io.Open("Flush1D", adios2::Mode::Read);
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            ASSERT_NE(var_i8, nullptr);
+            ASSERT_EQ(var_i8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i8->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            ASSERT_NE(var_i16, nullptr);
+            ASSERT_EQ(var_i16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i16->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            ASSERT_NE(var_i32, nullptr);
+            ASSERT_EQ(var_i32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i32->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            ASSERT_NE(var_i64, nullptr);
+            ASSERT_EQ(var_i64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i64->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            ASSERT_NE(var_u8, nullptr);
+            ASSERT_EQ(var_u8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u8->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            ASSERT_NE(var_u16, nullptr);
+            ASSERT_EQ(var_u16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u16->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            ASSERT_NE(var_u32, nullptr);
+            ASSERT_EQ(var_u32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u32->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            ASSERT_NE(var_u64, nullptr);
+            ASSERT_EQ(var_u64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u64->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            ASSERT_NE(var_r32, nullptr);
+            ASSERT_EQ(var_r32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r32->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            ASSERT_NE(var_r64, nullptr);
+            ASSERT_EQ(var_r64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r64->m_Shape[0], mpiSize * Nx1D);
+
+            std::string IString;
+            std::array<int8_t, Nx1D> I8;
+            std::array<int16_t, Nx1D> I16;
+            std::array<int32_t, Nx1D> I32;
+            std::array<int64_t, Nx1D> I64;
+            std::array<uint8_t, Nx1D> U8;
+            std::array<uint16_t, Nx1D> U16;
+            std::array<uint32_t, Nx1D> U32;
+            std::array<uint64_t, Nx1D> U64;
+            std::array<float, Nx1D> R32;
+            std::array<double, Nx1D> R64;
+
+            const adios2::Dims start{mpiRank * Nx1D};
+            const adios2::Dims count{Nx1D};
+
+            const adios2::Box<adios2::Dims> sel(start, count);
+
+            var_i8->SetSelection(sel);
+            var_i16->SetSelection(sel);
+            var_i32->SetSelection(sel);
+            var_i64->SetSelection(sel);
+
+            var_u8->SetSelection(sel);
+            var_u16->SetSelection(sel);
+            var_u32->SetSelection(sel);
+            var_u64->SetSelection(sel);
+
+            var_r32->SetSelection(sel);
+            var_r64->SetSelection(sel);
+
+            unsigned int t = 0;
+
+            while (bpReader.BeginStep() == adios2::StepStatus::OK)
+            {
+                const size_t currentStep = bpReader.CurrentStep();
+                EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+                bpReader.GetDeferred(*var_i8, I8.data());
+                bpReader.GetDeferred(*var_i16, I16.data());
+                bpReader.GetDeferred(*var_i32, I32.data());
+                bpReader.GetDeferred(*var_i64, I64.data());
+
+                bpReader.GetDeferred(*var_u8, U8.data());
+                bpReader.GetDeferred(*var_u16, U16.data());
+                bpReader.GetDeferred(*var_u32, U32.data());
+                bpReader.GetDeferred(*var_u64, U64.data());
+
+                bpReader.GetDeferred(*var_r32, R32.data());
+                bpReader.GetDeferred(*var_r64, R64.data());
+
+                bpReader.PerformGets();
+
+                bpReader.EndStep();
+
+                UpdateSmallTestData(m_OriginalData1D, static_cast<int>(t),
+                                    mpiRank, mpiSize);
+
+                for (size_t i = 0; i < Nx1D; ++i)
+                {
+                    std::stringstream ss;
+                    ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                    std::string msg = ss.str();
+
+                    EXPECT_EQ(I8[i], m_OriginalData1D.I8[i]) << msg;
+                    EXPECT_EQ(I16[i], m_OriginalData1D.I16[i]) << msg;
+                    EXPECT_EQ(I32[i], m_OriginalData1D.I32[i]) << msg;
+                    EXPECT_EQ(I64[i], m_OriginalData1D.I64[i]) << msg;
+                    EXPECT_EQ(U8[i], m_OriginalData1D.U8[i]) << msg;
+                    EXPECT_EQ(U16[i], m_OriginalData1D.U16[i]) << msg;
+                    EXPECT_EQ(U32[i], m_OriginalData1D.U32[i]) << msg;
+                    EXPECT_EQ(U64[i], m_OriginalData1D.U64[i]) << msg;
+                    EXPECT_EQ(R32[i], m_OriginalData1D.R32[i]) << msg;
+                    EXPECT_EQ(R64[i], m_OriginalData1D.R64[i]) << msg;
+                }
+                ++t;
+            }
+
+            EXPECT_EQ(t, NSteps / 2);
+
+            bpReader.Close();
+        }
+
+        // Partial 2D Read
+        {
+            adios2::IO &io = adios.DeclareIO("ReadIO2");
+
+            adios2::Engine &bpReader = io.Open("Flush2D", adios2::Mode::Read);
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            ASSERT_NE(var_i8, nullptr);
+            ASSERT_EQ(var_i8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i8->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i8->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            ASSERT_NE(var_i16, nullptr);
+            ASSERT_EQ(var_i16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i16->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i16->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            ASSERT_NE(var_i32, nullptr);
+            ASSERT_EQ(var_i32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i32->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i32->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            ASSERT_NE(var_i64, nullptr);
+            ASSERT_EQ(var_i64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i64->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i64->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            ASSERT_NE(var_u8, nullptr);
+            ASSERT_EQ(var_u8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u8->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u8->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            ASSERT_NE(var_u16, nullptr);
+            ASSERT_EQ(var_u16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u16->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u16->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            ASSERT_NE(var_u32, nullptr);
+            ASSERT_EQ(var_u32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u32->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u32->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            ASSERT_NE(var_u64, nullptr);
+            ASSERT_EQ(var_u64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u64->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u64->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            ASSERT_NE(var_r32, nullptr);
+            ASSERT_EQ(var_r32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r32->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_r32->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            ASSERT_NE(var_r64, nullptr);
+            ASSERT_EQ(var_r64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r64->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_r64->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            std::array<int8_t, Nx2D * Ny2D> I8;
+            std::array<int16_t, Nx2D * Ny2D> I16;
+            std::array<int32_t, Nx2D * Ny2D> I32;
+            std::array<int64_t, Nx2D * Ny2D> I64;
+            std::array<uint8_t, Nx2D * Ny2D> U8;
+            std::array<uint16_t, Nx2D * Ny2D> U16;
+            std::array<uint32_t, Nx2D * Ny2D> U32;
+            std::array<uint64_t, Nx2D * Ny2D> U64;
+            std::array<float, Nx2D * Ny2D> R32;
+            std::array<double, Nx2D * Ny2D> R64;
+
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx2D)};
+            const adios2::Dims count{Ny2D, Nx2D};
+
+            const adios2::Box<adios2::Dims> sel(start, count);
+
+            var_i8->SetSelection(sel);
+            var_i16->SetSelection(sel);
+            var_i32->SetSelection(sel);
+            var_i64->SetSelection(sel);
+
+            var_u8->SetSelection(sel);
+            var_u16->SetSelection(sel);
+            var_u32->SetSelection(sel);
+            var_u64->SetSelection(sel);
+
+            var_r32->SetSelection(sel);
+            var_r64->SetSelection(sel);
+
+            unsigned int t = 0;
+
+            while (bpReader.BeginStep() == adios2::StepStatus::OK)
+            {
+                const size_t currentStep = bpReader.CurrentStep();
+                EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+                bpReader.GetDeferred(*var_i8, I8.data());
+                bpReader.GetDeferred(*var_i16, I16.data());
+                bpReader.GetDeferred(*var_i32, I32.data());
+                bpReader.GetDeferred(*var_i64, I64.data());
+
+                bpReader.GetDeferred(*var_u8, U8.data());
+                bpReader.GetDeferred(*var_u16, U16.data());
+                bpReader.GetDeferred(*var_u32, U32.data());
+                bpReader.GetDeferred(*var_u64, U64.data());
+
+                bpReader.GetDeferred(*var_r32, R32.data());
+                bpReader.GetDeferred(*var_r64, R64.data());
+
+                bpReader.PerformGets();
+                bpReader.EndStep();
+
+                // Generate test data for each rank uniquely
+                UpdateSmallTestData(m_OriginalData2D, static_cast<int>(t),
+                                    mpiRank, mpiSize);
+
+                for (size_t i = 0; i < Nx2D * Ny2D; ++i)
+                {
+                    std::stringstream ss;
+                    ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                    std::string msg = ss.str();
+
+                    EXPECT_EQ(I8[i], m_OriginalData2D.I8[i]) << msg;
+                    EXPECT_EQ(I16[i], m_OriginalData2D.I16[i]) << msg;
+                    EXPECT_EQ(I32[i], m_OriginalData2D.I32[i]) << msg;
+                    EXPECT_EQ(I64[i], m_OriginalData2D.I64[i]) << msg;
+                    EXPECT_EQ(U8[i], m_OriginalData2D.U8[i]) << msg;
+                    EXPECT_EQ(U16[i], m_OriginalData2D.U16[i]) << msg;
+                    EXPECT_EQ(U32[i], m_OriginalData2D.U32[i]) << msg;
+                    EXPECT_EQ(U64[i], m_OriginalData2D.U64[i]) << msg;
+                    EXPECT_EQ(R32[i], m_OriginalData2D.R32[i]) << msg;
+                    EXPECT_EQ(R64[i], m_OriginalData2D.R64[i]) << msg;
+                }
+                ++t;
+            }
+            EXPECT_EQ(t, NSteps / 2);
+
+            bpReader.Close();
+        }
+
+        bpWriter1D.Close();
+        bpWriter2D.Close();
+    }
+}
+
+TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dfstream)
+{
+    int mpiRank = 0, mpiSize = 1;
+
+    const size_t Nx1D = 10;
+
+    // Number of rows
+    const std::size_t Nx2D = 4;
+
+    // Number of rows
+    const std::size_t Ny2D = 2;
+
+    // Number of steps
+    const size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using BP
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO &io1D = adios.DeclareIO("Flush1D");
+        adios2::IO &io2D = adios.DeclareIO("Flush2D");
+
+        io1D.SetParameter("FlushStepsCount", std::to_string(NSteps + 1));
+        io2D.SetParameter("FlushStepsCount", std::to_string(NSteps + 1));
+
+        io1D.AddTransport("File", {{"Library", "fstream"}});
+        io2D.AddTransport("File", {{"Library", "fstream"}});
+
+        // io1D Variables
+        {
+            const adios2::Dims shape{static_cast<size_t>(Nx1D * mpiSize)};
+            const adios2::Dims start{static_cast<size_t>(Nx1D * mpiRank)};
+            const adios2::Dims count{Nx1D};
+
+            io1D.DefineVariable<int8_t>("i8", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.I8.data());
+            io1D.DefineVariable<int16_t>("i16", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I16.data());
+            io1D.DefineVariable<int32_t>("i32", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I32.data());
+            io1D.DefineVariable<int64_t>("i64", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I64.data());
+
+            io1D.DefineVariable<uint8_t>("u8", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.U8.data());
+
+            io1D.DefineVariable<uint16_t>("u16", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U16.data());
+            io1D.DefineVariable<uint32_t>("u32", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U32.data());
+            io1D.DefineVariable<uint64_t>("u64", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U64.data());
+
+            io1D.DefineVariable<float>("r32", shape, start, count,
+                                       adios2::ConstantDims,
+                                       m_TestData.R32.data());
+            io1D.DefineVariable<double>("r64", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.R64.data());
+        }
+
+        // io2D variables
+        {
+            const adios2::Dims shape{Ny2D, static_cast<size_t>(Nx2D * mpiSize)};
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx2D)};
+            const adios2::Dims count{Ny2D, Nx2D};
+
+            io2D.DefineVariable<int8_t>("i8", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.I8.data());
+            io2D.DefineVariable<int16_t>("i16", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I16.data());
+            io2D.DefineVariable<int32_t>("i32", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I32.data());
+            io2D.DefineVariable<int64_t>("i64", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.I64.data());
+
+            io2D.DefineVariable<uint8_t>("u8", shape, start, count,
+                                         adios2::ConstantDims,
+                                         m_TestData.U8.data());
+
+            io2D.DefineVariable<uint16_t>("u16", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U16.data());
+            io2D.DefineVariable<uint32_t>("u32", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U32.data());
+            io2D.DefineVariable<uint64_t>("u64", shape, start, count,
+                                          adios2::ConstantDims,
+                                          m_TestData.U64.data());
+
+            io2D.DefineVariable<float>("r32", shape, start, count,
+                                       adios2::ConstantDims,
+                                       m_TestData.R32.data());
+            io2D.DefineVariable<double>("r64", shape, start, count,
+                                        adios2::ConstantDims,
+                                        m_TestData.R64.data());
+        }
+
+        adios2::Engine &bpWriter1D = io1D.Open("Flush1D", adios2::Mode::Write);
+        adios2::Engine &bpWriter2D = io2D.Open("Flush2D", adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps / 2; ++step)
+        {
+            UpdateSmallTestData(m_TestData, static_cast<int>(step), mpiRank,
+                                mpiSize);
+            EXPECT_EQ(bpWriter1D.CurrentStep(), step);
+            EXPECT_EQ(bpWriter2D.CurrentStep(), step);
+
+            bpWriter1D.WriteStep();
+            bpWriter2D.WriteStep();
+        }
+
+        adios.FlushAll(); // checkpoint for 1D and 2D writers
+
+        // Partial 1D read
+        {
+            adios2::IO &io = adios.DeclareIO("ReadIO1");
+
+            adios2::Engine &bpReader = io.Open("Flush1D", adios2::Mode::Read);
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            ASSERT_NE(var_i8, nullptr);
+            ASSERT_EQ(var_i8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i8->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            ASSERT_NE(var_i16, nullptr);
+            ASSERT_EQ(var_i16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i16->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            ASSERT_NE(var_i32, nullptr);
+            ASSERT_EQ(var_i32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i32->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            ASSERT_NE(var_i64, nullptr);
+            ASSERT_EQ(var_i64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i64->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            ASSERT_NE(var_u8, nullptr);
+            ASSERT_EQ(var_u8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u8->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            ASSERT_NE(var_u16, nullptr);
+            ASSERT_EQ(var_u16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u16->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            ASSERT_NE(var_u32, nullptr);
+            ASSERT_EQ(var_u32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u32->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            ASSERT_NE(var_u64, nullptr);
+            ASSERT_EQ(var_u64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u64->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            ASSERT_NE(var_r32, nullptr);
+            ASSERT_EQ(var_r32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r32->m_Shape[0], mpiSize * Nx1D);
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            ASSERT_NE(var_r64, nullptr);
+            ASSERT_EQ(var_r64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r64->m_Shape[0], mpiSize * Nx1D);
+
+            std::string IString;
+            std::array<int8_t, Nx1D> I8;
+            std::array<int16_t, Nx1D> I16;
+            std::array<int32_t, Nx1D> I32;
+            std::array<int64_t, Nx1D> I64;
+            std::array<uint8_t, Nx1D> U8;
+            std::array<uint16_t, Nx1D> U16;
+            std::array<uint32_t, Nx1D> U32;
+            std::array<uint64_t, Nx1D> U64;
+            std::array<float, Nx1D> R32;
+            std::array<double, Nx1D> R64;
+
+            const adios2::Dims start{mpiRank * Nx1D};
+            const adios2::Dims count{Nx1D};
+
+            const adios2::Box<adios2::Dims> sel(start, count);
+
+            var_i8->SetSelection(sel);
+            var_i16->SetSelection(sel);
+            var_i32->SetSelection(sel);
+            var_i64->SetSelection(sel);
+
+            var_u8->SetSelection(sel);
+            var_u16->SetSelection(sel);
+            var_u32->SetSelection(sel);
+            var_u64->SetSelection(sel);
+
+            var_r32->SetSelection(sel);
+            var_r64->SetSelection(sel);
+
+            unsigned int t = 0;
+
+            while (bpReader.BeginStep() == adios2::StepStatus::OK)
+            {
+                const size_t currentStep = bpReader.CurrentStep();
+                EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+                bpReader.GetDeferred(*var_i8, I8.data());
+                bpReader.GetDeferred(*var_i16, I16.data());
+                bpReader.GetDeferred(*var_i32, I32.data());
+                bpReader.GetDeferred(*var_i64, I64.data());
+
+                bpReader.GetDeferred(*var_u8, U8.data());
+                bpReader.GetDeferred(*var_u16, U16.data());
+                bpReader.GetDeferred(*var_u32, U32.data());
+                bpReader.GetDeferred(*var_u64, U64.data());
+
+                bpReader.GetDeferred(*var_r32, R32.data());
+                bpReader.GetDeferred(*var_r64, R64.data());
+
+                bpReader.PerformGets();
+
+                bpReader.EndStep();
+
+                UpdateSmallTestData(m_OriginalData1D, static_cast<int>(t),
+                                    mpiRank, mpiSize);
+
+                for (size_t i = 0; i < Nx1D; ++i)
+                {
+                    std::stringstream ss;
+                    ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                    std::string msg = ss.str();
+
+                    EXPECT_EQ(I8[i], m_OriginalData1D.I8[i]) << msg;
+                    EXPECT_EQ(I16[i], m_OriginalData1D.I16[i]) << msg;
+                    EXPECT_EQ(I32[i], m_OriginalData1D.I32[i]) << msg;
+                    EXPECT_EQ(I64[i], m_OriginalData1D.I64[i]) << msg;
+                    EXPECT_EQ(U8[i], m_OriginalData1D.U8[i]) << msg;
+                    EXPECT_EQ(U16[i], m_OriginalData1D.U16[i]) << msg;
+                    EXPECT_EQ(U32[i], m_OriginalData1D.U32[i]) << msg;
+                    EXPECT_EQ(U64[i], m_OriginalData1D.U64[i]) << msg;
+                    EXPECT_EQ(R32[i], m_OriginalData1D.R32[i]) << msg;
+                    EXPECT_EQ(R64[i], m_OriginalData1D.R64[i]) << msg;
+                }
+                ++t;
+            }
+
+            EXPECT_EQ(t, NSteps / 2);
+
+            bpReader.Close();
+        }
+
+        // Partial 2D Read
+        {
+            adios2::IO &io = adios.DeclareIO("ReadIO2");
+
+            adios2::Engine &bpReader = io.Open("Flush2D", adios2::Mode::Read);
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            ASSERT_NE(var_i8, nullptr);
+            ASSERT_EQ(var_i8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i8->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i8->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            ASSERT_NE(var_i16, nullptr);
+            ASSERT_EQ(var_i16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i16->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i16->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            ASSERT_NE(var_i32, nullptr);
+            ASSERT_EQ(var_i32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i32->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i32->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            ASSERT_NE(var_i64, nullptr);
+            ASSERT_EQ(var_i64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_i64->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_i64->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            ASSERT_NE(var_u8, nullptr);
+            ASSERT_EQ(var_u8->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u8->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u8->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            ASSERT_NE(var_u16, nullptr);
+            ASSERT_EQ(var_u16->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u16->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u16->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            ASSERT_NE(var_u32, nullptr);
+            ASSERT_EQ(var_u32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u32->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u32->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            ASSERT_NE(var_u64, nullptr);
+            ASSERT_EQ(var_u64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_u64->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_u64->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            ASSERT_NE(var_r32, nullptr);
+            ASSERT_EQ(var_r32->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r32->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_r32->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            ASSERT_NE(var_r64, nullptr);
+            ASSERT_EQ(var_r64->m_ShapeID, adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64->m_AvailableStepsCount, NSteps / 2);
+            ASSERT_EQ(var_r64->m_Shape[0], Ny2D);
+            ASSERT_EQ(var_r64->m_Shape[1], static_cast<size_t>(mpiSize * Nx2D));
+
+            std::array<int8_t, Nx2D * Ny2D> I8;
+            std::array<int16_t, Nx2D * Ny2D> I16;
+            std::array<int32_t, Nx2D * Ny2D> I32;
+            std::array<int64_t, Nx2D * Ny2D> I64;
+            std::array<uint8_t, Nx2D * Ny2D> U8;
+            std::array<uint16_t, Nx2D * Ny2D> U16;
+            std::array<uint32_t, Nx2D * Ny2D> U32;
+            std::array<uint64_t, Nx2D * Ny2D> U64;
+            std::array<float, Nx2D * Ny2D> R32;
+            std::array<double, Nx2D * Ny2D> R64;
+
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx2D)};
+            const adios2::Dims count{Ny2D, Nx2D};
+
+            const adios2::Box<adios2::Dims> sel(start, count);
+
+            var_i8->SetSelection(sel);
+            var_i16->SetSelection(sel);
+            var_i32->SetSelection(sel);
+            var_i64->SetSelection(sel);
+
+            var_u8->SetSelection(sel);
+            var_u16->SetSelection(sel);
+            var_u32->SetSelection(sel);
+            var_u64->SetSelection(sel);
+
+            var_r32->SetSelection(sel);
+            var_r64->SetSelection(sel);
+
+            unsigned int t = 0;
+
+            while (bpReader.BeginStep() == adios2::StepStatus::OK)
+            {
+                const size_t currentStep = bpReader.CurrentStep();
+                EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+                bpReader.GetDeferred(*var_i8, I8.data());
+                bpReader.GetDeferred(*var_i16, I16.data());
+                bpReader.GetDeferred(*var_i32, I32.data());
+                bpReader.GetDeferred(*var_i64, I64.data());
+
+                bpReader.GetDeferred(*var_u8, U8.data());
+                bpReader.GetDeferred(*var_u16, U16.data());
+                bpReader.GetDeferred(*var_u32, U32.data());
+                bpReader.GetDeferred(*var_u64, U64.data());
+
+                bpReader.GetDeferred(*var_r32, R32.data());
+                bpReader.GetDeferred(*var_r64, R64.data());
+
+                bpReader.PerformGets();
+                bpReader.EndStep();
+
+                // Generate test data for each rank uniquely
+                UpdateSmallTestData(m_OriginalData2D, static_cast<int>(t),
+                                    mpiRank, mpiSize);
+
+                for (size_t i = 0; i < Nx2D * Ny2D; ++i)
+                {
+                    std::stringstream ss;
+                    ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                    std::string msg = ss.str();
+
+                    EXPECT_EQ(I8[i], m_OriginalData2D.I8[i]) << msg;
+                    EXPECT_EQ(I16[i], m_OriginalData2D.I16[i]) << msg;
+                    EXPECT_EQ(I32[i], m_OriginalData2D.I32[i]) << msg;
+                    EXPECT_EQ(I64[i], m_OriginalData2D.I64[i]) << msg;
+                    EXPECT_EQ(U8[i], m_OriginalData2D.U8[i]) << msg;
+                    EXPECT_EQ(U16[i], m_OriginalData2D.U16[i]) << msg;
+                    EXPECT_EQ(U32[i], m_OriginalData2D.U32[i]) << msg;
+                    EXPECT_EQ(U64[i], m_OriginalData2D.U64[i]) << msg;
+                    EXPECT_EQ(R32[i], m_OriginalData2D.R32[i]) << msg;
+                    EXPECT_EQ(R64[i], m_OriginalData2D.R64[i]) << msg;
+                }
+                ++t;
+            }
+            EXPECT_EQ(t, NSteps / 2);
+
+            bpReader.Close();
+        }
+
+        bpWriter1D.Close();
+        bpWriter2D.Close();
+    }
+}
+
 //******************************************************************************
 // main
 //******************************************************************************


### PR DESCRIPTION
Explicit Flush functionality
FlushAll are single calls to flush engines within the adios or io object
scope
Added test for reading between FlushAll and Close at Write