### PR TITLE
nlohmann_json: allow system package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ install(FILES ${PROJECT_BINARY_DIR}/source/adios2/ADIOSConfig.h
 #------------------------------------------------------------------------------#
 include(CTest)
 mark_as_advanced(BUILD_TESTING)
-add_subdirectory(thirdparty)
+include(thirdparty/dependencies.cmake)
 
 #------------------------------------------------------------------------------#
 # Main library source

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -104,7 +104,7 @@ target_sources(adios2 PRIVATE
     engine/dataman/DataManWriter.h
     engine/dataman/DataManWriter.tcc
 )
-target_link_libraries(adios2 PRIVATE NLohmannJson)
+target_link_libraries(adios2 PRIVATE nlohmann_json)
 
 
 if(ADIOS2_HAVE_BZip2)

--- a/source/adios2/engine/dataman/DataManCommon.h
+++ b/source/adios2/engine/dataman/DataManCommon.h
@@ -17,7 +17,7 @@
 #include "adios2/toolkit/format/bp3/BP3.h"
 #include "adios2/toolkit/transportman/dataman/DataMan.h"
 
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace adios2
 {

--- a/source/adios2/engine/dataman/DataManReader.h
+++ b/source/adios2/engine/dataman/DataManReader.h
@@ -18,7 +18,7 @@
 #include "adios2/toolkit/format/bp3/BP3.h"
 #include "adios2/toolkit/transportman/dataman/DataMan.h"
 
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace adios2
 {

--- a/source/adios2/engine/dataman/DataManWriter.h
+++ b/source/adios2/engine/dataman/DataManWriter.h
@@ -16,7 +16,7 @@
 #include "adios2/toolkit/format/bp3/BP3.h"
 #include "adios2/toolkit/transportman/dataman/DataMan.h"
 
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 
 namespace adios2
 {

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -59,7 +59,7 @@ if (ADIOS2_HAVE_ADIOS1)
   target_link_libraries(TestBPWriteReadfstream adios2 gtest_interface adios1::adios)
 
   add_executable(TestBPWriteProfilingJSON TestBPWriteProfilingJSON.cpp)
-  target_link_libraries(TestBPWriteProfilingJSON adios2 gtest_interface NLohmannJson)
+  target_link_libraries(TestBPWriteProfilingJSON adios2 gtest_interface nlohmann_json)
 
   if(ADIOS2_HAVE_MPI)
     target_link_libraries(TestBPWriteRead MPI::MPI_C)

--- a/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
@@ -19,7 +19,7 @@
 #include <adios2.h>
 
 #include <gtest/gtest.h>
-#include <json.hpp> //This fails to be included
+#include <nlohmann/json.hpp> //This fails to be included
 
 #include "../SmallTestData.h"
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,7 +1,6 @@
 include(CMakeDependentOption)
 
 add_subdirectory(KWSys)
-add_subdirectory(NLohmannJson)
 add_subdirectory(pugixml)
 
 if(BUILD_TESTING)
@@ -11,6 +10,9 @@ endif()
 if(ADIOS2_HAVE_Python)
   add_subdirectory(pybind11)
 endif()
+
+option(ADIOS2_USE_SYSTEM_JSON
+  "Use an externally supplied nlohmann-json library" OFF)
 
 cmake_dependent_option(ADIOS2_USE_SYSTEM_EVPath
   "Use an externally supplied EVPath library" OFF
@@ -32,6 +34,12 @@ cmake_dependent_option(ADIOS2_USE_SYSTEM_ENET
   "Use an externally supplied ENET library" OFF
   "NOT ADIOS2_USE_SYSTEM_EVPath" OFF
 )
+
+if(ADIOS2_USE_SYSTEM_JSON)
+  find_package(nlohmann_json 3.1.2 REQUIRED)
+else()
+  add_subdirectory(NLohmannJson)
+endif()
 
 if(ADIOS2_HAVE_SST)
   if(NOT ADIOS2_USE_SYSTEM_EVPath)

--- a/thirdparty/NLohmannJson/json/CMakeLists.txt
+++ b/thirdparty/NLohmannJson/json/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(nlohmann_json INTERFACE)
 target_include_directories(nlohmann_json INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/single_include/nlohmann>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/single_include>
 )
 install(TARGETS nlohmann_json EXPORT adios2Exports)

--- a/thirdparty/NLohmannJson/json/CMakeLists.txt
+++ b/thirdparty/NLohmannJson/json/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_library(NLohmannJson INTERFACE)
-target_include_directories(NLohmannJson INTERFACE
+add_library(nlohmann_json INTERFACE)
+target_include_directories(nlohmann_json INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/single_include/nlohmann>
 )
-install(TARGETS NLohmannJson EXPORT adios2Exports)
+install(TARGETS nlohmann_json EXPORT adios2Exports)

--- a/thirdparty/dependencies.cmake
+++ b/thirdparty/dependencies.cmake
@@ -1,14 +1,14 @@
 include(CMakeDependentOption)
 
-add_subdirectory(KWSys)
-add_subdirectory(pugixml)
+add_subdirectory(thirdparty/KWSys)
+add_subdirectory(thirdparty/pugixml)
 
 if(BUILD_TESTING)
-  add_subdirectory(GTest)
+  add_subdirectory(thirdparty/GTest)
 endif()
 
 if(ADIOS2_HAVE_Python)
-  add_subdirectory(pybind11)
+  add_subdirectory(thirdparty/pybind11)
 endif()
 
 option(ADIOS2_USE_SYSTEM_JSON
@@ -38,32 +38,32 @@ cmake_dependent_option(ADIOS2_USE_SYSTEM_ENET
 if(ADIOS2_USE_SYSTEM_JSON)
   find_package(nlohmann_json 3.1.2 REQUIRED)
 else()
-  add_subdirectory(NLohmannJson)
+  add_subdirectory(thirdparty/NLohmannJson)
 endif()
 
 if(ADIOS2_HAVE_SST)
   if(NOT ADIOS2_USE_SYSTEM_EVPath)
     if(NOT ADIOS2_USE_SYSTEM_ATL)
-      add_subdirectory(atl)
+      add_subdirectory(thirdparty/atl)
     endif()
     find_package(atl REQUIRED)
 
     if(NOT ADIOS2_USE_SYSTEM_FFS)
       if(NOT ADIOS2_USE_SYSTEM_DILL)
-        add_subdirectory(dill)
+        add_subdirectory(thirdparty/dill)
       endif()
       find_package(dill REQUIRED)
 
-      add_subdirectory(ffs)
+      add_subdirectory(thirdparty/ffs)
     endif()
     find_package(ffs REQUIRED)
 
     if(NOT ADIOS2_USE_SYSTEM_ENET)
-      add_subdirectory(enet)
+      add_subdirectory(thirdparty/enet)
     endif()
     find_package(enet REQUIRED)
 
-    add_subdirectory(EVPath)
+    add_subdirectory(thirdparty/EVPath)
   endif()
   find_package(EVPath REQUIRED)
 endif()


### PR DESCRIPTION
Add the CMake `ADIOS2_USE_SYSTEM_JSON[=OFF]` option. With this option, package system maintainers can decide to use an external [nlohmann-json](https://github.com/nlohmann/json) library, e.g. to provide bug fixes.

Defaults as before to the internally shipped json library.

### Refactoring

- **CMake:**  the self-defined name `NLohmannJSON` differed from [the official CMake target name](https://github.com/nlohmann/json/blob/v3.1.2/CMakeLists.txt#L7).
I updated the old CMake targets to stay consistent with the "upstream" name which avoids introducing aliases when using the library from an external location.
- **Include:** the official API is included via `<nlohmann/json.hpp>`. Keep the prefix to stay consistent between internally shipped and externally installed headers.

### To Do

- [ ] see inline question about robot min-version update
- [x] generally, `ADIOS2_USE_SYSTEM_...=ON` was broken since found packages were not visible in the parent scope (root `CMakeLists.txt`) -> Issue identified, fix added to last commit: [SO link](https://stackoverflow.com/a/48741931/2719194)