### PR TITLE
Issue #548 check for null pointer in C Fortran bindings

### DIFF
--- a/bindings/C/adios2/adios2_c_FILE.cpp
+++ b/bindings/C/adios2/adios2_c_FILE.cpp
@@ -10,13 +10,14 @@
 
 #include "adios2_c_FILE.h"
 
-#include <adios2/highlevelapi/fstream/Stream.h>
 #include <cstring> //strcpy
 
 #include "adios2/ADIOSMPI.h"
 #include "adios2/adios2_c_glue.h"
 #include "adios2/adios2_c_io.h"
 #include "adios2/core/Variable.h"
+#include "adios2/helper/adiosFunctions.h" //CheckForNullptr
+#include "adios2/highlevelapi/fstream/Stream.h"
 
 #ifdef _WIN32
 #pragma warning(disable : 4297) // Windows noexcept default functions
@@ -54,6 +55,10 @@ void adios2_fwrite(adios2_FILE *stream, const char *name,
                    const size_t *shape, const size_t *start,
                    const size_t *count, const int end_step)
 {
+    adios2::CheckForNullptr(stream, "null adios2_FILE for variable " +
+                                        std::string(name) +
+                                        ", in call to adios2_fwrite\n");
+
     std::vector<size_t> shapeV, startV, countV;
 
     if (shape != nullptr)
@@ -273,12 +278,9 @@ void adios2_fread(adios2_FILE *stream, const char *name, const adios2_type type,
                   void *data, const size_t ndims, const size_t *selection_start,
                   const size_t *selection_count, const int end_step)
 {
-    if (stream == nullptr)
-    {
-        throw std::invalid_argument("ERROR: null adios2_FILE for variable " +
-                                    std::string(name) +
-                                    ", in call to adios2_fread\n");
-    }
+    adios2::CheckForNullptr(stream, "null adios2_FILE for variable " +
+                                        std::string(name) +
+                                        ", in call to adios2_fread\n");
 
     std::vector<size_t> startV, countV;
 
@@ -477,12 +479,9 @@ void adios2_fread_steps(adios2_FILE *stream, const char *name,
                         const size_t step_selection_start,
                         const size_t step_selection_count)
 {
-    if (stream == nullptr)
-    {
-        throw std::invalid_argument("ERROR: null adios2_FILE for variable " +
-                                    std::string(name) +
-                                    ", in call to adios2_fread_steps\n");
-    }
+    adios2::CheckForNullptr(stream, "null adios2_FILE for variable " +
+                                        std::string(name) +
+                                        ", in call to adios2_fread_steps\n");
 
     std::vector<size_t> startV, countV;
 
@@ -717,6 +716,9 @@ void adios2_fread_steps(adios2_FILE *stream, const char *name,
 
 void adios2_fclose(adios2_FILE *stream)
 {
+    adios2::CheckForNullptr(stream,
+                            "null adios2_FILE, in call to adios2_fclose\n");
+
     adios2::Stream &streamCpp = *reinterpret_cast<adios2::Stream *>(stream);
     streamCpp.Close();
     delete reinterpret_cast<adios2::Stream *>(stream);

--- a/source/adios2/helper/adiosType.inl
+++ b/source/adios2/helper/adiosType.inl
@@ -281,7 +281,7 @@ void CheckForNullptr(const T *pointer, const std::string hint)
 {
     if (pointer == nullptr)
     {
-        std::invalid_argument("ERROR: found null pointer " + hint + "\n");
+        throw std::invalid_argument("ERROR: found null pointer " + hint + "\n");
     }
 }
 

--- a/testing/adios2/engine/bp/TestBPWriteAggregateRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteAggregateRead.cpp
@@ -48,7 +48,7 @@ TEST_F(BPWriteAggregateReadTest, ADIOS2BPWriteAggregateRead1D8)
     adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
     {
         adios2::IO &io = adios.DeclareIO("TestIO");
-        io.SetParameter("Substreams", "2");
+        io.SetParameter("Substreams", "1");
 
         // Declare 1D variables (NumOfProcesses * Nx)
         // The local process' part (start, count) can be defined now or later
@@ -346,7 +346,7 @@ TEST_F(BPWriteAggregateReadTest, ADIOS2BPWriteAggregateRead2D2x4)
     adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
     {
         adios2::IO &io = adios.DeclareIO("TestIO");
-        io.SetParameter("Substreams", "2");
+        io.SetParameter("Substreams", "1");
 
         // Declare 2D variables (Ny * (NumOfProcesses * Nx))
         // The local process' part (start, count) can be defined now or later
@@ -638,7 +638,7 @@ TEST_F(BPWriteAggregateReadTest, ADIOS2BPWriteAggregateRead2D4x2)
     adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
     {
         adios2::IO &io = adios.DeclareIO("TestIO");
-        io.SetParameter("Substreams", "2");
+        io.SetParameter("Substreams", "1");
 
         // Declare 2D variables (4 * (NumberOfProcess * Nx))
         // The local process' part (start, count) can be defined now or later


### PR DESCRIPTION
Bug in CheckForNull function, missing throw
Substreams to 1 for failed tests