### PR TITLE
Fix duplicate filenames used by different tests

### DIFF
--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -9,13 +9,19 @@ target_link_libraries(TestBPWriteReadADIOS2 adios2 gtest)
 add_executable(TestBPWriteReadAsStreamADIOS2 TestBPWriteReadAsStreamADIOS2.cpp)
 target_link_libraries(TestBPWriteReadAsStreamADIOS2 adios2 gtest)
 
-add_executable(TestBPWriteReadAsStreamADIOS2_Threads TestBPWriteReadAsStreamADIOS2_Threads.cpp)
+add_executable(TestBPWriteReadAsStreamADIOS2_Threads
+  TestBPWriteReadAsStreamADIOS2_Threads.cpp
+)
 target_link_libraries(TestBPWriteReadAsStreamADIOS2_Threads adios2 gtest)
 
-add_executable(TestBPWriteReadAttributesADIOS2 TestBPWriteReadAttributesADIOS2.cpp)
+add_executable(TestBPWriteReadAttributesADIOS2
+  TestBPWriteReadAttributesADIOS2.cpp
+)
 target_link_libraries(TestBPWriteReadAttributesADIOS2 adios2 gtest)
 
-add_executable(TestStreamWriteReadHighLevelAPI TestStreamWriteReadHighLevelAPI.cpp)
+add_executable(TestStreamWriteReadHighLevelAPI
+  TestStreamWriteReadHighLevelAPI.cpp
+)
 target_link_libraries(TestStreamWriteReadHighLevelAPI adios2 gtest)
 
 add_executable(TestBPWriteFlushRead TestBPWriteFlushRead.cpp)
@@ -31,7 +37,9 @@ if(ADIOS2_HAVE_MPI)
   target_link_libraries(TestBPWriteFlushRead MPI::MPI_C)
   
   add_executable(TestBPWriteAggregateRead TestBPWriteAggregateRead.cpp)
-  target_link_libraries(TestBPWriteAggregateRead adios2 gtest_interface MPI::MPI_C)
+  target_link_libraries(TestBPWriteAggregateRead
+    adios2 gtest_interface MPI::MPI_C
+  )
   
   set(extra_test_args EXEC_WRAPPER ${MPIEXEC_COMMAND})
   gtest_add_tests(TARGET TestBPWriteAggregateRead ${extra_test_args})
@@ -50,17 +58,24 @@ if (ADIOS2_HAVE_ADIOS1)
   target_link_libraries(TestBPWriteRead adios2 gtest_interface adios1::adios)
 
   add_executable(TestBPWriteReadAttributes TestBPWriteReadAttributes.cpp)
-  target_link_libraries(TestBPWriteReadAttributes adios2 gtest_interface adios1::adios)
+  target_link_libraries(TestBPWriteReadAttributes
+    adios2 gtest_interface adios1::adios
+  )
 
   add_executable(TestBPWriteReadstdio TestBPWriteReadstdio.cpp)
-  target_link_libraries(TestBPWriteReadstdio adios2 gtest_interface adios1::adios)
+  target_link_libraries(TestBPWriteReadstdio
+    adios2 gtest_interface adios1::adios
+  )
 
   add_executable(TestBPWriteReadfstream TestBPWriteReadfstream.cpp)
-  target_link_libraries(TestBPWriteReadfstream adios2 gtest_interface adios1::adios)
+  target_link_libraries(TestBPWriteReadfstream
+    adios2 gtest_interface adios1::adios
+  )
 
   add_executable(TestBPWriteProfilingJSON TestBPWriteProfilingJSON.cpp)
-  target_link_libraries(TestBPWriteProfilingJSON adios2 gtest_interface
-    adios2::thirdparty::nlohmann_json)
+  target_link_libraries(TestBPWriteProfilingJSON
+    adios2 gtest_interface adios2::thirdparty::nlohmann_json
+  )
 
   if(ADIOS2_HAVE_MPI)
     target_link_libraries(TestBPWriteRead MPI::MPI_C)

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
@@ -32,7 +32,7 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead1D8)
 {
     // Each process would write a 1x8 array and all processes would
     // form a mpiSize * Nx 1D array
-    const std::string fname("ADIOS2BPWriteReadAsStream1D8.bp");
+    const std::string fname("ADIOS2BPWriteReadAsStream_Threads1D8.bp");
 
     int mpiRank = 0, mpiSize = 1;
     // Number of rows
@@ -274,7 +274,7 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D2x4)
 {
     // Each process would write a 2x4 array and all processes would
     // form a 2D 2 * (numberOfProcess*Nx) matrix where Nx is 4 here
-    const std::string fname("ADIOS2BPWriteReadAsStream2D2x4Test.bp");
+    const std::string fname("ADIOS2BPWriteReadAsStream_Threads2D2x4Test.bp");
 
     int mpiRank = 0, mpiSize = 1;
     // Number of rows
@@ -526,7 +526,7 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D4x2)
 {
     // Each process would write a 4x2 array and all processes would
     // form a 2D 4 * (NumberOfProcess * Nx) matrix where Nx is 2 here
-    const std::string fname("ADIOS2BPWriteReadAsStream2D4x2Test.bp");
+    const std::string fname("ADIOS2BPWriteReadAsStream_Threads2D4x2Test.bp");
 
     int mpiRank = 0, mpiSize = 1;
     // Number of rows


### PR DESCRIPTION
Having the same filename used by different tests will cause data corruption
and false test failures when the two tests are run in parallel.