### PR TITLE
Change SST marshaling (FFS or BP) specification method

### DIFF
--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -33,14 +33,14 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
         variable.m_Start.assign(variable.m_Count.size(), 0);
     }
 
-    if (m_FFSmarshal)
+    if (m_MarshalMethod == SstMarshalFFS)
     {
         SstFFSMarshal(m_Output, (void *)&variable, variable.m_Name.c_str(),
                       variable.m_Type.c_str(), variable.m_ElementSize,
                       variable.m_Shape.size(), variable.m_Shape.data(),
                       variable.m_Count.data(), variable.m_Start.data(), values);
     }
-    else if (m_BPmarshal)
+    else if (m_MarshalMethod == SstMarshalBP)
     {
         if (!m_BP3Serializer->m_MetadataSet.DataPGIsOpen)
         {

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -742,7 +742,8 @@ extern void SstStreamDestroy(SstStream Stream)
         free(FFSList);
         FFSList = Tmp;
     }
-    if ((Stream->Role == WriterRole) && Stream->WriterParams->FFSmarshal)
+    if ((Stream->Role == WriterRole) &&
+        (Stream->WriterParams->MarshalMethod == SstMarshalFFS))
     {
         FFSFreeMarshalData(Stream);
         if (Stream->M)

--- a/source/adios2/toolkit/sst/cp/cp_reader.c
+++ b/source/adios2/toolkit/sst/cp/cp_reader.c
@@ -277,11 +277,11 @@ SstStream SstReaderOpen(const char *Name, SstParams Params, MPI_Comm comm)
 
     Stream->WriterCohortSize = ReturnData->WriterCohortSize;
     Stream->WriterConfigParams = ReturnData->WriterConfigParams;
-    if (Stream->WriterConfigParams->FFSmarshal)
+    if (Stream->WriterConfigParams->MarshalMethod == SstMarshalFFS)
     {
         CP_verbose(Stream, "Writer is doing FFS-based marshalling\n");
     }
-    if (Stream->WriterConfigParams->BPmarshal)
+    if (Stream->WriterConfigParams->MarshalMethod == SstMarshalBP)
     {
         CP_verbose(Stream, "Writer is doing BP-based marshalling\n");
     }
@@ -344,8 +344,10 @@ SstStream SstReaderOpen(const char *Name, SstParams Params, MPI_Comm comm)
 extern void SstReaderGetParams(SstStream Stream, int *WriterFFSmarshal,
                                int *WriterBPmarshal)
 {
-    *WriterFFSmarshal = Stream->WriterConfigParams->FFSmarshal;
-    *WriterBPmarshal = Stream->WriterConfigParams->BPmarshal;
+    *WriterFFSmarshal =
+        (Stream->WriterConfigParams->MarshalMethod == SstMarshalFFS);
+    *WriterBPmarshal =
+        (Stream->WriterConfigParams->MarshalMethod == SstMarshalBP);
 }
 
 void queueTimestepMetadataMsgAndNotify(SstStream Stream,
@@ -635,7 +637,7 @@ extern void SstReleaseStep(SstStream Stream)
     sendOneToEachWriterRank(Stream, Stream->CPInfo->ReleaseTimestepFormat, &Msg,
                             &Msg.WSR_Stream);
 
-    if (Stream->WriterConfigParams->FFSmarshal)
+    if (Stream->WriterConfigParams->MarshalMethod == SstMarshalFFS)
     {
         FFSClearTimestepData(Stream);
     }
@@ -661,7 +663,7 @@ extern SstStatusValue SstAdvanceStep(SstStream Stream, int mode,
 
     if (Entry)
     {
-        if (Stream->WriterConfigParams->FFSmarshal)
+        if (Stream->WriterConfigParams->MarshalMethod == SstMarshalFFS)
         {
             FFSMarshalInstallMetadata(Stream, Entry->MetadataMsg);
         }

--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -113,10 +113,9 @@ extern void SstSetStatsSave(SstStream Stream, SstStats Save);
 #define SST_POSTFIX ".sst"
 
 #define SST_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                \
-    MACRO(FFSmarshal, Bool, int, true)                                         \
+    MACRO(MarshalMethod, MarshalMethod, size_t, 0)                             \
     MACRO(RegistrationMethod, RegMethod, size_t, 0)                            \
     MACRO(DataTransport, String, char *, NULL)                                 \
-    MACRO(BPmarshal, Bool, int, false)                                         \
     MACRO(RendezvousReaderCount, Int, int, 1)                                  \
     MACRO(QueueLimit, Int, int, 0)                                             \
     MACRO(DiscardOnQueueFull, Bool, int, 1)
@@ -126,6 +125,8 @@ typedef enum {
     SstRegisterScreen,
     SstRegisterCloud
 } SstRegistrationMethod;
+
+typedef enum { SstMarshalFFS, SstMarshalBP } SstMarshalMethod;
 
 struct _SstParams
 {


### PR DESCRIPTION
Change SST marshaling (FFS or BP) from being controlled by two booleans to being one enumeration value.   (Jason, just cleaning this up in preparation for enabling tests.)