### PR TITLE
Allow TestStagingMPMD to handle engine parameters

### DIFF
--- a/testing/adios2/engine/staging-common/TestStagingMPMD.cpp
+++ b/testing/adios2/engine/staging-common/TestStagingMPMD.cpp
@@ -10,6 +10,7 @@
 #include <ios>      //std::ios_base::failure
 #include <iostream> //std::cout
 #include <numeric>
+#include <sstream>
 #include <stdexcept> //std::invalid_argument std::exception
 #include <string>
 #include <thread>
@@ -21,7 +22,8 @@
 #include <adios2.h>
 
 static int numprocs, wrank;
-std::string engineName; // comes from command line
+std::string engineName;           // comes from command line
+adios2::Params engineParams = {}; // parsed from command line
 
 struct RunParams
 {
@@ -62,6 +64,40 @@ std::vector<RunParams> CreateRunParams()
     return params;
 }
 
+std::string Trim(std::string &str)
+{
+    size_t first = str.find_first_not_of(' ');
+    size_t last = str.find_last_not_of(' ');
+    return str.substr(first, (last - first + 1));
+}
+
+/*
+ * Engine parameters spec is a poor-man's JSON.  name:value pairs are separated
+ * by commas.  White space is trimmed off front and back.  No quotes or anything
+ * fancy allowed.
+ */
+adios2::Params ParseEngineParams(std::string Input)
+{
+    std::istringstream ss(Input);
+    std::string Param;
+    adios2::Params Ret = {};
+
+    while (std::getline(ss, Param, ','))
+    {
+        std::istringstream ss2(Param);
+        std::string ParamName;
+        std::string ParamValue;
+        std::getline(ss2, ParamName, ':');
+        if (!std::getline(ss2, ParamValue, ':'))
+        {
+            throw std::invalid_argument("Engine parameter \"" + Param +
+                                        "\" missing value");
+        }
+        Ret[Trim(ParamName)] = Trim(ParamValue);
+    }
+    return Ret;
+}
+
 class TestStagingMPMD : public ::testing::TestWithParam<RunParams>
 {
 public:
@@ -92,6 +128,7 @@ public:
         adios2::ADIOS adios(comm);
         adios2::IO &io = adios.DeclareIO("writer");
         io.SetEngine(engineName);
+        io.SetParameters(engineParams);
 
         adios2::Variable<float> &varArray =
             io.DefineVariable<float>("myArray", {gndx, gndy}, {offsx, offsy},
@@ -172,6 +209,7 @@ public:
         adios2::ADIOS adios(comm);
         adios2::IO &io = adios.DeclareIO("reader");
         io.SetEngine(engineName);
+        io.SetParameters(engineParams);
         adios2::Engine &reader = io.Open(streamName, adios2::Mode::Read, comm);
 
         size_t posx = rank % npx;
@@ -338,6 +376,10 @@ int main(int argc, char **argv)
     MPI_Comm_size(MPI_COMM_WORLD, &numprocs);
 
     engineName = std::string(argv[1]);
+    if (argc > 2)
+    {
+        engineParams = ParseEngineParams(argv[2]);
+    }
 
     if (!wrank)
     {


### PR DESCRIPTION
Allow TestStagingMPMD to process engine parameters specified on the command line.