### PR TITLE
Add test for BP marshalling 

### DIFF
--- a/testing/adios2/engine/staging-common/CMakeLists.txt
+++ b/testing/adios2/engine/staging-common/CMakeLists.txt
@@ -17,6 +17,9 @@ if(ADIOS2_HAVE_SST)
 gtest_add_tests(TARGET TestStagingMPMD ${extra_test_args} 
                 EXTRA_ARGS "SST"
                 TEST_SUFFIX _SST)
+gtest_add_tests(TARGET TestStagingMPMD ${extra_test_args} 
+                EXTRA_ARGS "SST" "MarshalMethod:BP"
+                TEST_SUFFIX _SST_BP)
 endif()
 
 if(ADIOS2_HAVE_MPI)


### PR DESCRIPTION
Add test for BP marshalling by specifying engine parameters on the command line