### PR TITLE
Added Aggregator metadata footer for each subfile

### DIFF
--- a/examples/hello/bpWriter/helloBPSubStreams.cpp
+++ b/examples/hello/bpWriter/helloBPSubStreams.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
         /*** IO class object: settings and factory of Settings: Variables,
          * Parameters, Transports, and Execution: Engines */
         adios2::IO &bpIO = adios.DeclareIO("BPFile_N2M");
-        bpIO.SetParameter("SubStreams", "12");
+        bpIO.SetParameter("SubStreams", "2");
 
         /** global array : name, { shape (total) }, { start (local) }, {
          * count

--- a/examples/hello/bpWriter/helloBPSubStreams.cpp
+++ b/examples/hello/bpWriter/helloBPSubStreams.cpp
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
         //        adios2::Variable<std::string> &bpString =
         //            bpIO.DefineVariable<std::string>("bpString");
 
+        adios2::Attribute<int> &attribute =
+            bpIO.DefineAttribute<int>("attrINT", -1);
+
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine &bpFileWriter =
             bpIO.Open("myVector_cpp.bp", adios2::Mode::Write);

--- a/source/adios2/engine/bp/BPFileWriter.cpp
+++ b/source/adios2/engine/bp/BPFileWriter.cpp
@@ -291,21 +291,22 @@ void BPFileWriter::AggregateWriteData(const bool isFinal,
                                       const int transportIndex)
 {
     m_BP3Serializer.CloseStream(m_IO, false);
-    m_BP3Serializer.AggregatorsUpdateDataAbsolutePosition();
-    // this can be launched with async and return a future
-    m_BP3Serializer.AggregatorsUpdateOffsetsInMetadata();
 
     // async?
     for (int r = 0; r < m_BP3Serializer.m_Aggregator.m_Size; ++r)
     {
-        // Isend/Irecv requests
-        std::vector<MPI_Request> requests =
-            m_BP3Serializer.AggregatorsIExchange(r);
+        std::vector<MPI_Request> dataRequests =
+            m_BP3Serializer.m_Aggregator.IExchange(m_BP3Serializer.m_Data, r);
+
+        std::vector<MPI_Request> absolutePositionRequests =
+            m_BP3Serializer.m_Aggregator.IExchangeAbsolutePosition(
+                m_BP3Serializer.m_Data, r);
 
         if (m_BP3Serializer.m_Aggregator.m_IsConsumer)
         {
             const BufferSTL &bufferSTL =
-                m_BP3Serializer.AggregatorConsumerBuffer();
+                m_BP3Serializer.m_Aggregator.GetConsumerBuffer(
+                    m_BP3Serializer.m_Data);
 
             m_FileDataManager.WriteFiles(bufferSTL.m_Buffer.data(),
                                          bufferSTL.m_Position, transportIndex);
@@ -313,11 +314,14 @@ void BPFileWriter::AggregateWriteData(const bool isFinal,
             m_FileDataManager.FlushFiles(transportIndex);
         }
 
-        m_BP3Serializer.AggregatorsWait(requests, r);
-        m_BP3Serializer.AggregatorsSwapBuffer(r);
+        m_BP3Serializer.m_Aggregator.WaitAbsolutePosition(
+            absolutePositionRequests, r);
+        m_BP3Serializer.m_Aggregator.Wait(dataRequests, r);
+        m_BP3Serializer.m_Aggregator.SwapBuffers(r);
     }
 
-    m_BP3Serializer.AggregatorsResetBuffer();
+    m_BP3Serializer.m_Aggregator.ResetBuffers();
+    m_BP3Serializer.UpdateOffsetsInMetadata();
 }
 
 } // end namespace adios2

--- a/source/adios2/engine/bp/BPFileWriter.cpp
+++ b/source/adios2/engine/bp/BPFileWriter.cpp
@@ -323,23 +323,22 @@ void BPFileWriter::AggregateWriteData(const bool isFinal,
 
     m_BP3Serializer.UpdateOffsetsInMetadata();
 
-    //    if (isFinal)
-    //    {
-    //        BufferSTL &bufferSTL = m_BP3Serializer.m_Data;
-    //        m_BP3Serializer.ResetBuffer(bufferSTL, false, false);
-    //
-    //        m_BP3Serializer.AggregateCollectiveMetadata(
-    //            m_BP3Serializer.m_Aggregator.m_Comm, bufferSTL, false);
-    //
-    //        if (m_BP3Serializer.m_Aggregator.m_IsConsumer)
-    //        {
-    //            m_FileDataManager.WriteFiles(bufferSTL.m_Buffer.data(),
-    //                                         bufferSTL.m_Position,
-    //                                         transportIndex);
-    //
-    //            m_FileDataManager.FlushFiles(transportIndex);
-    //        }
-    //    }
+    if (isFinal) // Write metadata footer
+    {
+        BufferSTL &bufferSTL = m_BP3Serializer.m_Data;
+        m_BP3Serializer.ResetBuffer(bufferSTL, false, false);
+
+        m_BP3Serializer.AggregateCollectiveMetadata(
+            m_BP3Serializer.m_Aggregator.m_Comm, bufferSTL, false);
+
+        if (m_BP3Serializer.m_Aggregator.m_IsConsumer)
+        {
+            m_FileDataManager.WriteFiles(bufferSTL.m_Buffer.data(),
+                                         bufferSTL.m_Position, transportIndex);
+
+            m_FileDataManager.FlushFiles(transportIndex);
+        }
+    }
 
     m_BP3Serializer.m_Aggregator.ResetBuffers();
 }

--- a/source/adios2/engine/bp/BPFileWriter.cpp
+++ b/source/adios2/engine/bp/BPFileWriter.cpp
@@ -237,7 +237,9 @@ void BPFileWriter::WriteProfilingJSONFile()
 
 void BPFileWriter::WriteCollectiveMetadataFile(const bool isFinal)
 {
-    m_BP3Serializer.AggregateCollectiveMetadata();
+    m_BP3Serializer.AggregateCollectiveMetadata(
+        m_MPIComm, m_BP3Serializer.m_Metadata, true);
+
     if (m_BP3Serializer.m_RankMPI == 0)
     {
         // first init metadata files

--- a/source/adios2/engine/bp/BPFileWriter.cpp
+++ b/source/adios2/engine/bp/BPFileWriter.cpp
@@ -316,12 +316,32 @@ void BPFileWriter::AggregateWriteData(const bool isFinal,
 
         m_BP3Serializer.m_Aggregator.WaitAbsolutePosition(
             absolutePositionRequests, r);
+
         m_BP3Serializer.m_Aggregator.Wait(dataRequests, r);
         m_BP3Serializer.m_Aggregator.SwapBuffers(r);
     }
 
-    m_BP3Serializer.m_Aggregator.ResetBuffers();
     m_BP3Serializer.UpdateOffsetsInMetadata();
+
+    //    if (isFinal)
+    //    {
+    //        BufferSTL &bufferSTL = m_BP3Serializer.m_Data;
+    //        m_BP3Serializer.ResetBuffer(bufferSTL, false, false);
+    //
+    //        m_BP3Serializer.AggregateCollectiveMetadata(
+    //            m_BP3Serializer.m_Aggregator.m_Comm, bufferSTL, false);
+    //
+    //        if (m_BP3Serializer.m_Aggregator.m_IsConsumer)
+    //        {
+    //            m_FileDataManager.WriteFiles(bufferSTL.m_Buffer.data(),
+    //                                         bufferSTL.m_Position,
+    //                                         transportIndex);
+    //
+    //            m_FileDataManager.FlushFiles(transportIndex);
+    //        }
+    //    }
+
+    m_BP3Serializer.m_Aggregator.ResetBuffers();
 }
 
 } // end namespace adios2

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
@@ -123,7 +123,8 @@ void InSituMPIWriter::PerformPuts()
         // Create Global metadata and send to readers
         m_BP3Serializer.SerializeData(m_IO, true); // advance timestep
         m_BP3Serializer.SerializeMetadataInData();
-        m_BP3Serializer.AggregateCollectiveMetadata();
+        m_BP3Serializer.AggregateCollectiveMetadata(
+            m_MPIComm, m_BP3Serializer.m_Metadata, true);
 
         // store length long enough to survive Isend() completion
         // so don't move this into the next if branch

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -83,7 +83,8 @@ void SstWriter::EndStep()
         };
 
         m_BP3Serializer->CloseStream(m_IO, true);
-        m_BP3Serializer->AggregateCollectiveMetadata();
+        m_BP3Serializer->AggregateCollectiveMetadata(
+            m_MPIComm, m_BP3Serializer->m_Metadata, true);
         BP3DataBlock *newblock = new BP3DataBlock;
         newblock->metadata.DataSize =
             m_BP3Serializer->m_Metadata.m_Buffer.size();

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
@@ -55,7 +55,6 @@ MPIAggregator::IExchangeAbsolutePosition(BufferSTL &bufferSTL, const int step)
     }
     else if (m_Rank == destination)
     {
-        MPI_Request absolutePositionRequest;
         CheckMPIReturn(MPI_Irecv(&bufferSTL.m_AbsolutePosition, 1,
                                  ADIOS2_MPI_SIZE_T, step, 0, m_Comm,
                                  &requests[1]),

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
@@ -39,22 +39,24 @@ std::vector<MPI_Request> MPIAggregator::IExchange(BufferSTL & /**bufferSTL*/,
 std::vector<MPI_Request>
 MPIAggregator::IExchangeAbsolutePosition(BufferSTL &bufferSTL, const int step)
 {
-    const int destination = (m_Rank != m_Size) ? m_Rank + 1 : 0;
+    const int destination = (step != m_Size - 1) ? step + 1 : 0;
     std::vector<MPI_Request> requests(2);
 
     if (m_Rank == step)
     {
-        CheckMPIReturn(MPI_Isend(&bufferSTL.m_AbsolutePosition, 1,
-                                 ADIOS2_MPI_SIZE_T, destination, 0, m_Comm,
-                                 &requests[0]),
+        const size_t position =
+            (m_Rank == 0) ? bufferSTL.m_AbsolutePosition
+                          : bufferSTL.m_AbsolutePosition + bufferSTL.m_Position;
+
+        CheckMPIReturn(MPI_Isend(&position, 1, ADIOS2_MPI_SIZE_T, destination,
+                                 0, m_Comm, &requests[0]),
                        ", aggregation Isend absolute position at iteration " +
                            std::to_string(step) + "\n");
     }
-
-    if (m_Rank == destination)
+    else if (m_Rank == destination)
     {
         MPI_Request absolutePositionRequest;
-        CheckMPIReturn(MPI_Irecv(&m_AbsolutePositionSource, 1,
+        CheckMPIReturn(MPI_Irecv(&bufferSTL.m_AbsolutePosition, 1,
                                  ADIOS2_MPI_SIZE_T, step, 0, m_Comm,
                                  &requests[1]),
                        ", aggregation Irecv absolute position at iteration " +
@@ -68,7 +70,7 @@ void MPIAggregator::WaitAbsolutePosition(std::vector<MPI_Request> &requests,
                                          const int step)
 {
     MPI_Status status;
-    const int destination = (m_Rank != m_Size) ? m_Rank + 1 : 0;
+    const int destination = (step != m_Size - 1) ? step + 1 : 0;
 
     if (m_Rank == destination)
     {

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
@@ -51,9 +51,6 @@ public:
      *  corresponds to m_Rank = 0 */
     int m_ConsumerRank = -1;
 
-    /** Used to update absolute positions */
-    size_t m_AbsolutePositionSource = 0;
-
     MPIAggregator();
 
     virtual ~MPIAggregator();

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
@@ -51,6 +51,9 @@ public:
      *  corresponds to m_Rank = 0 */
     int m_ConsumerRank = -1;
 
+    /** Used to update absolute positions */
+    size_t m_AbsolutePositionSource = 0;
+
     MPIAggregator();
 
     virtual ~MPIAggregator();
@@ -59,6 +62,12 @@ public:
 
     virtual std::vector<MPI_Request> IExchange(BufferSTL &bufferSTL,
                                                const int step);
+
+    std::vector<MPI_Request> IExchangeAbsolutePosition(BufferSTL &bufferSTL,
+                                                       const int step);
+
+    void WaitAbsolutePosition(std::vector<MPI_Request> &requests,
+                              const int step);
 
     virtual void Wait(std::vector<MPI_Request> &requests, const int step);
 

--- a/source/adios2/toolkit/format/bp3/BP3Base.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Base.cpp
@@ -209,7 +209,8 @@ size_t BP3Base::GetBPIndexSizeInData(const std::string &variableName,
 }
 
 void BP3Base::ResetBuffer(BufferSTL &bufferSTL,
-                          const bool resetAbsolutePosition)
+                          const bool resetAbsolutePosition,
+                          const bool zeroInitialize)
 {
     ProfilerStart("buffering");
     bufferSTL.m_Position = 0;
@@ -217,7 +218,10 @@ void BP3Base::ResetBuffer(BufferSTL &bufferSTL,
     {
         bufferSTL.m_AbsolutePosition = 0;
     }
-    bufferSTL.m_Buffer.assign(bufferSTL.m_Buffer.size(), '\0');
+    if (zeroInitialize)
+    {
+        bufferSTL.m_Buffer.assign(bufferSTL.m_Buffer.size(), '\0');
+    }
     ProfilerStop("buffering");
 }
 

--- a/source/adios2/toolkit/format/bp3/BP3Base.h
+++ b/source/adios2/toolkit/format/bp3/BP3Base.h
@@ -225,7 +225,8 @@ public:
      * is set to zero,
      */
     void ResetBuffer(BufferSTL &bufferSTL,
-                     const bool resetAbsolutePosition = false);
+                     const bool resetAbsolutePosition = false,
+                     const bool zeroInitialize = true);
 
     /** Return type of the CheckAllocation function. */
     enum class ResizeResult

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -300,37 +300,7 @@ void BP3Serializer::AggregateCollectiveMetadata(MPI_Comm comm,
     ProfilerStop("buffering");
 }
 
-void BP3Serializer::AggregatorsUpdateDataAbsolutePosition()
-{
-    ProfilerStart("aggregation");
-
-    size_t producerPosition = m_Data.m_Position;
-    if (m_Aggregator.m_IsConsumer)
-    {
-        producerPosition = m_Data.m_AbsolutePosition;
-    }
-
-    const std::vector<size_t> positions =
-        AllGatherValues(producerPosition, m_Aggregator.m_Comm);
-
-    // update up to previous rank
-    int upperRank = m_Aggregator.m_Rank;
-    // update with all producers sizes for next aggregation
-    if (m_Aggregator.m_IsConsumer)
-    {
-        upperRank = m_Aggregator.m_Size;
-    }
-
-    m_Data.m_AbsolutePosition = 0;
-    for (int i = 0; i < upperRank; ++i)
-    {
-        m_Data.m_AbsolutePosition += positions[i];
-    }
-
-    ProfilerStop("aggregation");
-}
-
-void BP3Serializer::AggregatorsUpdateOffsetsInMetadata()
+void BP3Serializer::UpdateOffsetsInMetadata()
 {
     if (m_Aggregator.m_IsConsumer)
     {
@@ -342,32 +312,6 @@ void BP3Serializer::AggregatorsUpdateOffsetsInMetadata()
         SerialElementIndex &index = varIndexPair.second;
         UpdateIndexOffsets(index);
     }
-}
-
-std::vector<MPI_Request> BP3Serializer::AggregatorsIExchange(const int step)
-{
-    return m_Aggregator.IExchange(m_Data, step);
-}
-
-BufferSTL &BP3Serializer::AggregatorConsumerBuffer()
-{
-    return m_Aggregator.GetConsumerBuffer(m_Data);
-}
-
-void BP3Serializer::AggregatorsWait(std::vector<MPI_Request> &requests,
-                                    const int step)
-{
-    m_Aggregator.Wait(requests, step);
-}
-
-void BP3Serializer::AggregatorsSwapBuffer(const int iteration) noexcept
-{
-    m_Aggregator.SwapBuffers(iteration);
-}
-
-void BP3Serializer::AggregatorsResetBuffer() noexcept
-{
-    m_Aggregator.ResetBuffers();
 }
 
 // PRIVATE FUNCTIONS

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.h
@@ -331,6 +331,15 @@ private:
      */
     void SerializeDataBuffer(IO &io) noexcept;
 
+    /**
+     * Puts minifooter into a bp buffer
+     * @param pgIndexStart input offset
+     * @param variablesIndexStart input offset
+     * @param attributesIndexStart input offset
+     * @param buffer  buffer to add the minifooter
+     * @param position current buffer position
+     * @param addSubfiles true: metadata file, false: data file
+     */
     void PutMinifooter(const uint64_t pgIndexStart,
                        const uint64_t variablesIndexStart,
                        const uint64_t attributesIndexStart,
@@ -393,12 +402,6 @@ private:
      */
     template <class T>
     void PutPayloadInBuffer(const Variable<T> &variable) noexcept;
-
-    /**
-     * Updates variable and payload offsets with buffer m_DataAbsolutePosition
-     * @param index
-     */
-    void UpdateIndexOffsets(SerialElementIndex &index);
 
     template <class T>
     void UpdateIndexOffsetsCharacteristics(size_t &currentPosition,

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.h
@@ -124,10 +124,14 @@ public:
     AggregateProfilingJSON(const std::string &rankProfilingJSON);
 
     /**
-     * Creates the final collective Metadata buffer in m_HeapBuffer.m_Metadata
-     * from all ranks
+     * Aggregate collective metadata
+     * @param comm input establishing domain (all or per aggregator)
+     * @param bufferSTL buffer to put the metadata
+     * @param inMetadataBuffer collective metadata from absolute rank = 0, else
+     *                         from aggregators
      */
-    void AggregateCollectiveMetadata();
+    void AggregateCollectiveMetadata(MPI_Comm comm, BufferSTL &bufferSTL,
+                                     const bool inMetadataBuffer);
 
     /**
      * Updates data absolute position based on data from other producers in
@@ -371,10 +375,13 @@ private:
 
     /**
      * Used for PG index, aggregates without merging
-     * @param index input
-     * @param count total number of indices
+     * @param index
+     * @param count
+     * @param comm
+     * @param bufferSTL
      */
-    void AggregateIndex(const SerialElementIndex &index, const size_t count);
+    void AggregateIndex(const SerialElementIndex &index, const size_t count,
+                        MPI_Comm comm, BufferSTL &bufferSTL);
 
     /**
      * Collective operation to aggregate and merge (sort) indices (variables and
@@ -382,7 +389,8 @@ private:
      * @param indices
      */
     void AggregateMergeIndex(
-        const std::unordered_map<std::string, SerialElementIndex> &indices);
+        const std::unordered_map<std::string, SerialElementIndex> &indices,
+        MPI_Comm comm, BufferSTL &bufferSTL);
 
     /**
      * Returns a serialized buffer with all indices with format:
@@ -391,8 +399,8 @@ private:
      * @return buffer with serialized indices
      */
     std::vector<char> SerializeIndices(
-        const std::unordered_map<std::string, SerialElementIndex> &indices)
-        const noexcept;
+        const std::unordered_map<std::string, SerialElementIndex> &indices,
+        MPI_Comm comm) const noexcept;
 
     /**
      * In rank=0, deserialize gathered indices
@@ -400,8 +408,8 @@ private:
      * @return hash[name][rank] = bp index buffer
      */
     std::unordered_map<std::string, std::vector<SerialElementIndex>>
-    DeserializeIndicesPerRankThreads(
-        const std::vector<char> &serializedIndices) const noexcept;
+    DeserializeIndicesPerRankThreads(const std::vector<char> &serializedIndices,
+                                     MPI_Comm comm) const noexcept;
 
     /**
      * Merge indices by time step (default) and write to m_HeapBuffer.m_Metadata
@@ -409,7 +417,8 @@ private:
      */
     void MergeSerializeIndices(
         const std::unordered_map<std::string, std::vector<SerialElementIndex>>
-            &nameRankIndices);
+            &nameRankIndices,
+        MPI_Comm comm, BufferSTL &bufferSTL);
 
     std::vector<char>
     SetCollectiveProfilingJSON(const std::string &rankLog) const;

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.h
@@ -134,47 +134,11 @@ public:
                                      const bool inMetadataBuffer);
 
     /**
-     * Updates data absolute position based on data from other producers in
-     * aggregation
+     * Updates variable and payload offsets in metadata characteristics with
+     * the updated Buffer m_DataAbsolutePosition for a particular rank. This is
+     * a local (non-MPI) operation
      */
-    void AggregatorsUpdateDataAbsolutePosition();
-
-    /** Updates variable and payload offsets in metadata characteristics with
-     * the updated Buffer m_DataAbsolutePosition. This is a local (non-MPI)
-     * operation */
-    void AggregatorsUpdateOffsetsInMetadata();
-
-    /** Sends aggregation data in non-blocking mode according to the strategy
-     * used */
-    std::vector<MPI_Request> AggregatorsIExchange(const int step);
-
-    /**
-     * reference to buffer ready to be consumed (used by transports via a
-     * transport manager).
-     * This function should be only used by aggregator with rank 0.
-     * @return reference to buffer ready for consumption
-     */
-    BufferSTL &AggregatorConsumerBuffer();
-
-    /**
-     * Wait for aggregation data in non-blocking mode according to the strategy
-     * used
-     * @param request input to wait upon
-     * @param iteration iteration process
-     */
-    void AggregatorsWait(std::vector<MPI_Request> &request,
-                         const int iteration);
-
-    /**
-     * Swap the current sender/receiver buffers
-     * @param iteration current iteration in the aggregation process
-     */
-    void AggregatorsSwapBuffer(const int iteration) noexcept;
-
-    /**
-     * Resets buffering ordering to initial state for next aggregation
-     */
-    void AggregatorsResetBuffer() noexcept;
+    void UpdateOffsetsInMetadata();
 
 private:
     /** BP format version */


### PR DESCRIPTION
Refactored metadata functions for reusability (global collective and aggregator levels).
Reformulated exchange of absolute positions for updated metadata on aggregation: changed AllGather to Isend, Irecv
Removed Aggregator functions in BP3Serializer, using public member m_Aggregator functions directly in Engine.