### PR TITLE
Write side Put multiblock

### DIFF
--- a/bindings/C/c/adios2_c_io.cpp
+++ b/bindings/C/c/adios2_c_io.cpp
@@ -20,7 +20,7 @@ adios2_variable *
 adios2_define_variable(adios2_io *io, const char *name, const adios2_type type,
                        const size_t ndims, const size_t *shape,
                        const size_t *start, const size_t *count,
-                       const adios2_constant_dims constant_dims, void *data)
+                       const adios2_constant_dims constant_dims)
 {
     adios2::CheckForNullptr(io,
                             "for adios2_io, in call to adios2_define_variable");
@@ -60,99 +60,85 @@ adios2_define_variable(adios2_io *io, const char *name, const adios2_type type,
     case (adios2_type_char):
     {
         variable = &ioCpp.DefineVariable<char>(name, shapeV, startV, countV,
-                                               constantSizeBool,
-                                               reinterpret_cast<char *>(data));
+                                               constantSizeBool);
         break;
     }
     case (adios2_type_signed_char):
     {
-        variable = &ioCpp.DefineVariable<signed char>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<signed char *>(data));
+        variable = &ioCpp.DefineVariable<signed char>(name, shapeV, startV,
+                                                      countV, constantSizeBool);
         break;
     }
     case (adios2_type_short):
     {
-        variable = &ioCpp.DefineVariable<short>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<short *>(data));
+        variable = &ioCpp.DefineVariable<short>(name, shapeV, startV, countV,
+                                                constantSizeBool);
         break;
     }
     case (adios2_type_int):
     {
         variable = &ioCpp.DefineVariable<int>(name, shapeV, startV, countV,
-                                              constantSizeBool,
-                                              reinterpret_cast<int *>(data));
+                                              constantSizeBool);
         break;
     }
     case (adios2_type_long_int):
     {
-        variable = &ioCpp.DefineVariable<long int>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<long int *>(data));
+        variable = &ioCpp.DefineVariable<long int>(name, shapeV, startV, countV,
+                                                   constantSizeBool);
         break;
     }
     case (adios2_type_long_long_int):
     {
         variable = &ioCpp.DefineVariable<long long int>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<long long int *>(data));
+            name, shapeV, startV, countV, constantSizeBool);
         break;
     }
     case (adios2_type_unsigned_char):
     {
         variable = &ioCpp.DefineVariable<unsigned char>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<unsigned char *>(data));
+            name, shapeV, startV, countV, constantSizeBool);
         break;
     }
     case (adios2_type_unsigned_short):
     {
         variable = &ioCpp.DefineVariable<unsigned short>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<unsigned short *>(data));
+            name, shapeV, startV, countV, constantSizeBool);
         break;
     }
     case (adios2_type_unsigned_int):
     {
         variable = &ioCpp.DefineVariable<unsigned int>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<unsigned int *>(data));
+            name, shapeV, startV, countV, constantSizeBool);
         break;
     }
     case (adios2_type_unsigned_long_int):
     {
         variable = &ioCpp.DefineVariable<unsigned long int>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<unsigned long int *>(data));
+            name, shapeV, startV, countV, constantSizeBool);
         break;
     }
     case (adios2_type_unsigned_long_long_int):
     {
         variable = &ioCpp.DefineVariable<unsigned long long int>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<unsigned long long int *>(data));
+            name, shapeV, startV, countV, constantSizeBool);
         break;
     }
     case (adios2_type_float):
     {
-        variable = &ioCpp.DefineVariable<float>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<float *>(data));
+        variable = &ioCpp.DefineVariable<float>(name, shapeV, startV, countV,
+                                                constantSizeBool);
         break;
     }
     case (adios2_type_double):
     {
-        variable = &ioCpp.DefineVariable<double>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<double *>(data));
+        variable = &ioCpp.DefineVariable<double>(name, shapeV, startV, countV,
+                                                 constantSizeBool);
         break;
     }
     case (adios2_type_float_complex):
     {
         variable = &ioCpp.DefineVariable<std::complex<float>>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<std::complex<float> *>(data));
+            name, shapeV, startV, countV, constantSizeBool);
         break;
     }
     case (adios2_type_double_complex):
@@ -164,59 +150,51 @@ adios2_define_variable(adios2_io *io, const char *name, const adios2_type type,
     case (adios2_type_int8_t):
     {
 
-        variable = &ioCpp.DefineVariable<int8_t>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<int8_t *>(data));
+        variable = &ioCpp.DefineVariable<int8_t>(name, shapeV, startV, countV,
+                                                 constantSizeBool);
         break;
     }
     case (adios2_type_int16_t):
     {
-        variable = &ioCpp.DefineVariable<int16_t>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<int16_t *>(data));
+        variable = &ioCpp.DefineVariable<int16_t>(name, shapeV, startV, countV,
+                                                  constantSizeBool);
         break;
     }
     case (adios2_type_int32_t):
     {
-        variable = &ioCpp.DefineVariable<int32_t>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<int32_t *>(data));
+        variable = &ioCpp.DefineVariable<int32_t>(name, shapeV, startV, countV,
+                                                  constantSizeBool);
         break;
     }
     case (adios2_type_int64_t):
     {
-        variable = &ioCpp.DefineVariable<int64_t>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<int64_t *>(data));
+        variable = &ioCpp.DefineVariable<int64_t>(name, shapeV, startV, countV,
+                                                  constantSizeBool);
         break;
     }
     case (adios2_type_uint8_t):
     {
 
-        variable = &ioCpp.DefineVariable<uint8_t>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<uint8_t *>(data));
+        variable = &ioCpp.DefineVariable<uint8_t>(name, shapeV, startV, countV,
+                                                  constantSizeBool);
         break;
     }
     case (adios2_type_uint16_t):
     {
-        variable = &ioCpp.DefineVariable<uint16_t>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<uint16_t *>(data));
+        variable = &ioCpp.DefineVariable<uint16_t>(name, shapeV, startV, countV,
+                                                   constantSizeBool);
         break;
     }
     case (adios2_type_uint32_t):
     {
-        variable = &ioCpp.DefineVariable<uint32_t>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<uint32_t *>(data));
+        variable = &ioCpp.DefineVariable<uint32_t>(name, shapeV, startV, countV,
+                                                   constantSizeBool);
         break;
     }
     case (adios2_type_uint64_t):
     {
-        variable = &ioCpp.DefineVariable<uint64_t>(
-            name, shapeV, startV, countV, constantSizeBool,
-            reinterpret_cast<uint64_t *>(data));
+        variable = &ioCpp.DefineVariable<uint64_t>(name, shapeV, startV, countV,
+                                                   constantSizeBool);
         break;
     }
     default:

--- a/bindings/C/c/adios2_c_io.h
+++ b/bindings/C/c/adios2_c_io.h
@@ -25,7 +25,7 @@ extern "C" {
  * Defines a variable inside a corresponding io handler
  * @param io handler that owns the variable
  * @param name unique variable name inside IO handler
- * @param type primitive type
+ * @param type primitive type from enum adios2_type_*
  * @param ndims number of dimensions
  * @param shape total MPI dimensions
  * @param start local MPI start (offset)
@@ -39,7 +39,7 @@ adios2_variable *
 adios2_define_variable(adios2_io *io, const char *name, const adios2_type type,
                        const size_t ndims, const size_t *shape,
                        const size_t *start, const size_t *count,
-                       const adios2_constant_dims constant_dims, void *data);
+                       const adios2_constant_dims constant_dims);
 
 /**
  * Returns a handler to a previously defined variable identified by a unique

--- a/bindings/CXX98/cxx98/cxx98IO.h
+++ b/bindings/CXX98/cxx98/cxx98IO.h
@@ -38,7 +38,7 @@ public:
     Variable<T>
     DefineVariable(const std::string &name, const Dims &shape = Dims(),
                    const Dims &start = Dims(), const Dims &count = Dims(),
-                   const bool constantDims = false, T *data = NULL);
+                   const bool constantDims = false);
 
     template <class T>
     Variable<T> InquireVariable(const std::string &name);

--- a/bindings/CXX98/cxx98/cxx98IO.tcc
+++ b/bindings/CXX98/cxx98/cxx98IO.tcc
@@ -34,174 +34,174 @@ adios2_constant_dims GetConstantDims(const bool constantDims)
 
 // DefineVariable
 template <>
-Variable<std::string>
-IO::DefineVariable(const std::string &name, const Dims &shape,
-                   const Dims &start, const Dims &count,
-                   const bool constantDims, std::string *data)
+Variable<std::string> IO::DefineVariable(const std::string &name,
+                                         const Dims &shape, const Dims &start,
+                                         const Dims &count,
+                                         const bool constantDims)
 {
     return Variable<std::string>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_string, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<char> IO::DefineVariable(const std::string &name, const Dims &shape,
                                   const Dims &start, const Dims &count,
-                                  const bool constantDims, char *data)
+                                  const bool constantDims)
 {
     return Variable<char>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_char, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
-Variable<signed char>
-IO::DefineVariable(const std::string &name, const Dims &shape,
-                   const Dims &start, const Dims &count,
-                   const bool constantDims, signed char *data)
+Variable<signed char> IO::DefineVariable(const std::string &name,
+                                         const Dims &shape, const Dims &start,
+                                         const Dims &count,
+                                         const bool constantDims)
 {
     return Variable<signed char>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_signed_char, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
-Variable<unsigned char>
-IO::DefineVariable(const std::string &name, const Dims &shape,
-                   const Dims &start, const Dims &count,
-                   const bool constantDims, unsigned char *data)
+Variable<unsigned char> IO::DefineVariable(const std::string &name,
+                                           const Dims &shape, const Dims &start,
+                                           const Dims &count,
+                                           const bool constantDims)
 {
     return Variable<unsigned char>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_unsigned_char, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<short> IO::DefineVariable(const std::string &name, const Dims &shape,
                                    const Dims &start, const Dims &count,
-                                   const bool constantDims, short *data)
+                                   const bool constantDims)
 {
     return Variable<short>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_short, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<unsigned short>
 IO::DefineVariable(const std::string &name, const Dims &shape,
                    const Dims &start, const Dims &count,
-                   const bool constantDims, unsigned short *data)
+                   const bool constantDims)
 {
     return Variable<unsigned short>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_unsigned_short, count.size(),
-        V0(shape), V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(shape), V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<int> IO::DefineVariable(const std::string &name, const Dims &shape,
                                  const Dims &start, const Dims &count,
-                                 const bool constantDims, int *data)
+                                 const bool constantDims)
 {
     return Variable<int>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_int, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
-Variable<unsigned int>
-IO::DefineVariable(const std::string &name, const Dims &shape,
-                   const Dims &start, const Dims &count,
-                   const bool constantDims, unsigned int *data)
+Variable<unsigned int> IO::DefineVariable(const std::string &name,
+                                          const Dims &shape, const Dims &start,
+                                          const Dims &count,
+                                          const bool constantDims)
 {
     return Variable<unsigned int>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_unsigned_int, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<long int> IO::DefineVariable(const std::string &name,
                                       const Dims &shape, const Dims &start,
                                       const Dims &count,
-                                      const bool constantDims, long int *data)
+                                      const bool constantDims)
 {
     return Variable<long int>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_long_int, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<unsigned long int>
 IO::DefineVariable(const std::string &name, const Dims &shape,
                    const Dims &start, const Dims &count,
-                   const bool constantDims, unsigned long int *data)
+                   const bool constantDims)
 {
     return Variable<unsigned long int>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_unsigned_long_int, count.size(),
-        V0(shape), V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(shape), V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
-Variable<long long int>
-IO::DefineVariable(const std::string &name, const Dims &shape,
-                   const Dims &start, const Dims &count,
-                   const bool constantDims, long long int *data)
+Variable<long long int> IO::DefineVariable(const std::string &name,
+                                           const Dims &shape, const Dims &start,
+                                           const Dims &count,
+                                           const bool constantDims)
 {
     return Variable<long long int>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_long_long_int, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<unsigned long long int>
 IO::DefineVariable(const std::string &name, const Dims &shape,
                    const Dims &start, const Dims &count,
-                   const bool constantDims, unsigned long long int *data)
+                   const bool constantDims)
 {
     return Variable<unsigned long long int>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_unsigned_long_long_int, count.size(),
-        V0(shape), V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(shape), V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<float> IO::DefineVariable(const std::string &name, const Dims &shape,
                                    const Dims &start, const Dims &count,
-                                   const bool constantDims, float *data)
+                                   const bool constantDims)
 {
     return Variable<float>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_float, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<double> IO::DefineVariable(const std::string &name, const Dims &shape,
                                     const Dims &start, const Dims &count,
-                                    const bool constantDims, double *data)
+                                    const bool constantDims)
 {
     return Variable<double>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_double, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<std::complex<float>>
 IO::DefineVariable(const std::string &name, const Dims &shape,
                    const Dims &start, const Dims &count,
-                   const bool constantDims, std::complex<float> *data)
+                   const bool constantDims)
 {
     return Variable<std::complex<float>>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_float_complex, count.size(), V0(shape),
-        V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 template <>
 Variable<std::complex<double>>
 IO::DefineVariable(const std::string &name, const Dims &shape,
                    const Dims &start, const Dims &count,
-                   const bool constantDims, std::complex<double> *data)
+                   const bool constantDims)
 {
     return Variable<std::complex<double>>(adios2_define_variable(
         &m_IO, name.c_str(), adios2_type_double_complex, count.size(),
-        V0(shape), V0(start), V0(count), GetConstantDims(constantDims), data));
+        V0(shape), V0(start), V0(count), GetConstantDims(constantDims)));
 }
 
 // DefineAttribute

--- a/bindings/Fortran/f2c/adios2_f2c_io.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_io.cpp
@@ -106,7 +106,7 @@ void FC_GLOBAL(adios2_define_global_variable_f2c,
     {
         *variable = adios2_define_variable(
             *io, name, static_cast<adios2_type>(*type), 0, nullptr, nullptr,
-            nullptr, adios2_constant_dims_true, nullptr);
+            nullptr, adios2_constant_dims_true);
     }
     catch (std::exception &e)
     {
@@ -163,7 +163,7 @@ void FC_GLOBAL(adios2_define_variable_f2c, ADIOS2_DEFINE_VARIABLE_F2C)(
             *variable = adios2_define_variable(
                 *io, name, static_cast<adios2_type>(*type), *ndims, nullptr,
                 nullptr, countV.data(),
-                static_cast<adios2_constant_dims>(*constant_dims), nullptr);
+                static_cast<adios2_constant_dims>(*constant_dims));
             return;
         }
 
@@ -175,8 +175,7 @@ void FC_GLOBAL(adios2_define_variable_f2c, ADIOS2_DEFINE_VARIABLE_F2C)(
         *variable = adios2_define_variable(
             *io, name, static_cast<adios2_type>(*type),
             static_cast<size_t>(*ndims), shapeV.data(), startV.data(),
-            countV.data(), static_cast<adios2_constant_dims>(*constant_dims),
-            nullptr);
+            countV.data(), static_cast<adios2_constant_dims>(*constant_dims));
     }
     catch (std::exception &e)
     {

--- a/bindings/Python/py11IO.cpp
+++ b/bindings/Python/py11IO.cpp
@@ -47,10 +47,10 @@ unsigned int IO::AddTransport(const std::string type, const Params &parameters)
 }
 
 VariableBase *IO::DefineVariable(const std::string &name,
-                                 std::string &stringValue)
+                                 std::string & /*stringValue*/)
 {
     return &m_IO.DefineVariable<std::string>(name, Dims(), Dims(), Dims(),
-                                             false, &stringValue);
+                                             false);
 }
 
 VariableBase *IO::DefineVariable(const std::string &name, const Dims &shape,
@@ -67,9 +67,8 @@ VariableBase *IO::DefineVariable(const std::string &name, const Dims &shape,
     else if (pybind11::isinstance<                                             \
                  pybind11::array_t<T, pybind11::array::c_style>>(array))       \
     {                                                                          \
-        variable = &m_IO.DefineVariable<T>(                                    \
-            name, shape, start, count, isConstantDims,                         \
-            reinterpret_cast<T *>(const_cast<void *>(array.data())));          \
+        variable = &m_IO.DefineVariable<T>(name, shape, start, count,          \
+                                           isConstantDims);                    \
     }
     ADIOS2_FOREACH_NUMPY_TYPE_1ARG(declare_type)
 #undef declare_type

--- a/examples/hello/bpWriter/helloBPWriter.c
+++ b/examples/hello/bpWriter/helloBPWriter.c
@@ -43,9 +43,9 @@ int main(int argc, char *argv[])
     size_t count[1];
     count[0] = Nx;
 
-    adios2_variable *variableH = adios2_define_variable(
-        ioH, "bpFloats", adios2_type_float, 1, shape, start, count,
-        adios2_constant_dims_true, myFloats);
+    adios2_variable *variableH =
+        adios2_define_variable(ioH, "bpFloats", adios2_type_float, 1, shape,
+                               start, count, adios2_constant_dims_true);
 
     adios2_engine *engineH =
         adios2_open(ioH, "myVector_c.bp", adios2_mode_write);

--- a/examples/hello/bpWriter/helloBPWriter_nompi.c
+++ b/examples/hello/bpWriter/helloBPWriter_nompi.c
@@ -32,9 +32,9 @@ int main(int argc, char *argv[])
     size_t count[1];
     count[0] = Nx;
 
-    adios2_variable *variableH = adios2_define_variable(
-        ioH, "bpFloats", adios2_type_float, 1, NULL, NULL, count,
-        adios2_constant_dims_true, myFloats);
+    adios2_variable *variableH =
+        adios2_define_variable(ioH, "bpFloats", adios2_type_float, 1, NULL,
+                               NULL, count, adios2_constant_dims_true);
 
     adios2_engine *engineH =
         adios2_open(ioH, "myVector_c.bp", adios2_mode_write);

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -70,6 +70,11 @@
     MACRO(std::complex<double>)                                                \
     MACRO(std::complex<long double>)
 
+#define ADIOS2_FOREACH_COMPLEX_PRIMITIVE_TYPE_1ARG(MACRO)                      \
+    MACRO(float)                                                               \
+    MACRO(double)                                                              \
+    MACRO(long double)
+
 #define ADIOS2_FOREACH_CHAR_TYPE_1ARG(MACRO)                                   \
     MACRO(char)                                                                \
     MACRO(signed char)                                                         \

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -554,9 +554,9 @@ void IO::CheckTransportType(const std::string type) const
 
 // Explicitly instantiate the necessary public template implementations
 #define define_template_instantiation(T)                                       \
-    template Variable<T> &IO::DefineVariable<T>(                               \
-        const std::string &, const Dims &, const Dims &, const Dims &,         \
-        const bool, T *);                                                      \
+    template Variable<T> &IO::DefineVariable<T>(const std::string &,           \
+                                                const Dims &, const Dims &,    \
+                                                const Dims &, const bool);     \
     template Variable<T> *IO::InquireVariable<T>(const std::string &) noexcept;
 
 ADIOS2_FOREACH_TYPE_1ARG(define_template_instantiation)

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -154,9 +154,9 @@ public:
      */
     template <class T>
     Variable<T> &
-    DefineVariable(const std::string &name, const Dims &shape = Dims{},
-                   const Dims &start = Dims{}, const Dims &count = Dims{},
-                   const bool constantDims = false, T *data = nullptr);
+    DefineVariable(const std::string &name, const Dims &shape = Dims(),
+                   const Dims &start = Dims(), const Dims &count = Dims(),
+                   const bool constantDims = false);
 
     /**
      * @brief Define array attribute
@@ -455,7 +455,7 @@ private:
 #define declare_template_instantiation(T)                                      \
     extern template Variable<T> &IO::DefineVariable<T>(                        \
         const std::string &, const Dims &, const Dims &, const Dims &,         \
-        const bool, T *);                                                      \
+        const bool);                                                           \
     extern template Variable<T> *IO::InquireVariable<T>(                       \
         const std::string &name) noexcept;
 

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -28,7 +28,7 @@ namespace adios2
 template <class T>
 Variable<T> &IO::DefineVariable(const std::string &name, const Dims &shape,
                                 const Dims &start, const Dims &count,
-                                const bool constantDims, T *data)
+                                const bool constantDims)
 {
     if (m_DebugMode)
     {
@@ -45,7 +45,7 @@ Variable<T> &IO::DefineVariable(const std::string &name, const Dims &shape,
     const unsigned int size = static_cast<unsigned int>(variableMap.size());
     auto itVariablePair =
         variableMap.emplace(size, Variable<T>(name, shape, start, count,
-                                              constantDims, data, m_DebugMode));
+                                              constantDims, m_DebugMode));
     m_Variables.emplace(name, std::make_pair(GetType<T>(), size));
     return itVariablePair.first->second;
 }

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <ostream> //std::ostream in MonitorGroups
 #include <string>
+#include <unordered_map>
 #include <vector>
 /// \endcond
 
@@ -32,28 +33,40 @@ class Variable : public VariableBase
 {
 
 public:
-    typename TypeInfo<T>::ValueType m_Min;
-    typename TypeInfo<T>::ValueType m_Max;
-    typename TypeInfo<T>::ValueType m_Value;
+    /** current reference to data */
+    T *m_Data = nullptr;
+    /** absolute minimum */
+    T m_Min = T();
+    /** absolute maximum */
+    T m_Max = T();
+    /** current value */
+    T m_Value = T();
+
+    struct Info
+    {
+        Dims Shape;
+        Dims Start;
+        Dims Count;
+        T *Data = nullptr;
+
+        T Min = T();
+        T Max = T();
+        T Value = T();
+    };
+
+    std::unordered_map<size_t, std::map<size_t, Info>> m_StepBlocksInfo;
 
     Variable<T>(const std::string &name, const Dims &shape, const Dims &start,
-                const Dims &count, const bool constantShape, T *data,
+                const Dims &count, const bool constantShape,
                 const bool debugMode);
 
     ~Variable<T>() = default;
 
-    /** Gets current data pointer for this Variable object */
+    Info &SetStepBlockInfo(const T *data, const size_t step) noexcept;
+
+    void SetData(const T *data) noexcept;
+
     T *GetData() const noexcept;
-
-    /** Sets current data pointer for this Variable object */
-    void SetData(const T *) noexcept;
-
-private:
-    /** TODO: used for allocating memory from ADIOS2 */
-    std::vector<T> m_AllocatedData;
-
-    /** reference to data */
-    T *m_Data = nullptr;
 };
 
 } // end namespace adios2

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -24,24 +24,35 @@ namespace adios2
     template <>                                                                \
     Variable<T>::Variable(const std::string &name, const Dims &shape,          \
                           const Dims &start, const Dims &count,                \
-                          const bool constantDims, T *data,                    \
-                          const bool debugMode)                                \
+                          const bool constantDims, const bool debugMode)       \
     : VariableBase(name, GetType<T>(), sizeof(T), shape, start, count,         \
-                   constantDims, debugMode),                                   \
-      m_Data(data), m_Min(), m_Max(), m_Value()                                \
+                   constantDims, debugMode)                                    \
     {                                                                          \
     }                                                                          \
                                                                                \
     template <>                                                                \
-    T *Variable<T>::GetData() const noexcept                                   \
+    typename Variable<T>::Info &Variable<T>::SetStepBlockInfo(                 \
+        const T *data, const size_t step) noexcept                             \
     {                                                                          \
-        return m_Data;                                                         \
+        const size_t block = m_StepBlocksInfo[step].size();                    \
+        auto &stepBlockInfo = m_StepBlocksInfo[step][block];                   \
+        stepBlockInfo.Data = const_cast<T *>(data);                            \
+        stepBlockInfo.Shape = m_Shape;                                         \
+        stepBlockInfo.Start = m_Start;                                         \
+        stepBlockInfo.Count = m_Count;                                         \
+        return stepBlockInfo;                                                  \
     }                                                                          \
                                                                                \
     template <>                                                                \
     void Variable<T>::SetData(const T *data) noexcept                          \
     {                                                                          \
         m_Data = const_cast<T *>(data);                                        \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    T *Variable<T>::GetData() const noexcept                                   \
+    {                                                                          \
+        return m_Data;                                                         \
     }
 
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)

--- a/source/adios2/engine/bp/BPFileReader.tcc
+++ b/source/adios2/engine/bp/BPFileReader.tcc
@@ -20,14 +20,14 @@ template <>
 inline void BPFileReader::GetSyncCommon(Variable<std::string> &variable,
                                         std::string *data)
 {
-    variable.SetData(data);
+    variable.m_Data = data;
     m_BP3Deserializer.GetValueFromMetadata(variable);
 }
 
 template <class T>
 inline void BPFileReader::GetSyncCommon(Variable<T> &variable, T *data)
 {
-    variable.SetData(data);
+    variable.m_Data = data;
 
     if (variable.m_SingleValue)
     {
@@ -44,7 +44,7 @@ inline void BPFileReader::GetSyncCommon(Variable<T> &variable, T *data)
 template <class T>
 void BPFileReader::GetDeferredCommon(Variable<T> &variable, T *data)
 {
-    // returns immediately
+    // returns immediately without populating data
     m_BP3Deserializer.GetDeferredVariable(variable, data);
     m_BP3Deserializer.m_PerformedGets = false;
 }

--- a/source/adios2/engine/bp/BPFileWriter.h
+++ b/source/adios2/engine/bp/BPFileWriter.h
@@ -72,10 +72,11 @@ private:
      * @param values
      */
     template <class T>
-    void PutSyncCommon(Variable<T> &variable, const T *values);
+    void PutSyncCommon(Variable<T> &variable,
+                       const typename Variable<T>::Info &blockInfo);
 
     template <class T>
-    void PutDeferredCommon(Variable<T> &variable, const T *values);
+    void PutDeferredCommon(Variable<T> &variable, const T *data);
 
     void DoFlush(const bool isFinal = false, const int transportIndex = -1);
 

--- a/source/adios2/engine/dataman/DataManWriter.h
+++ b/source/adios2/engine/dataman/DataManWriter.h
@@ -58,7 +58,8 @@ private:
     void PutDeferredCommon(Variable<T> &variable, const T *values);
 
     template <class T>
-    void PutSyncCommonBP(Variable<T> &variable, const T *values);
+    void PutSyncCommonBP(Variable<T> &variable,
+                         const typename Variable<T>::Info &blockInfo);
 
     template <class T>
     void PutSyncCommonDataMan(Variable<T> &variable, const T *values);

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -102,7 +102,7 @@ void HDF5WriterP::DoPutSyncCommon(Variable<T> &variable, const T *values)
 
             Variable<T> dup =
                 Variable<T>(variable.m_Name, c_shape, c_offset, c_count,
-                            variable.IsConstantDims(), NULL, false);
+                            variable.IsConstantDims(), false);
 
             /*
              * duplicate var attributes and convert to c order before saving.

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.h
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.h
@@ -91,10 +91,11 @@ private:
     /**
      * Common function for primitive PutSync, puts variables in buffer
      * @param variable
-     * @param values
+     * @param blockInfo current block info
      */
     template <class T>
-    void PutSyncCommon(Variable<T> &variable, const T *values);
+    void PutSyncCommon(Variable<T> &variable,
+                       const typename Variable<T>::Info &blockInfo);
 
     template <class T>
     void PutDeferredCommon(Variable<T> &variable, const T *values);
@@ -104,7 +105,8 @@ private:
      * void AsyncSendVariable(const std::string &varName);
      */
     template <class T>
-    void AsyncSendVariable(Variable<T> &);
+    void AsyncSendVariable(Variable<T> &variable,
+                           const typename Variable<T>::Info &blockInfo);
 
     void AsyncSendVariable(std::string variableName);
 };

--- a/source/adios2/engine/skeleton/SkeletonReader.tcc
+++ b/source/adios2/engine/skeleton/SkeletonReader.tcc
@@ -22,7 +22,7 @@ template <>
 inline void SkeletonReader::GetSyncCommon(Variable<std::string> &variable,
                                           std::string *data)
 {
-    variable.SetData(data);
+    variable.m_Data = data;
     if (m_Verbosity == 5)
     {
         std::cout << "Skeleton Reader " << m_ReaderRank << "     GetSync("
@@ -33,7 +33,7 @@ inline void SkeletonReader::GetSyncCommon(Variable<std::string> &variable,
 template <class T>
 inline void SkeletonReader::GetSyncCommon(Variable<T> &variable, T *data)
 {
-    variable.SetData(data);
+    variable.m_Data = data;
     if (m_Verbosity == 5)
     {
         std::cout << "Skeleton Reader " << m_ReaderRank << "     GetSync("

--- a/source/adios2/engine/skeleton/SkeletonWriter.cpp
+++ b/source/adios2/engine/skeleton/SkeletonWriter.cpp
@@ -70,13 +70,15 @@ void SkeletonWriter::EndStep()
 // PRIVATE
 
 #define declare_type(T)                                                        \
-    void SkeletonWriter::DoPutSync(Variable<T> &variable, const T *values)     \
+    void SkeletonWriter::DoPutSync(Variable<T> &variable, const T *data)       \
     {                                                                          \
-        PutSyncCommon(variable, values);                                       \
+        PutSyncCommon(variable,                                                \
+                      variable.SetStepBlockInfo(data, CurrentStep()));         \
+        variable.m_StepBlocksInfo.clear();                                     \
     }                                                                          \
-    void SkeletonWriter::DoPutDeferred(Variable<T> &variable, const T *values) \
+    void SkeletonWriter::DoPutDeferred(Variable<T> &variable, const T *data)   \
     {                                                                          \
-        PutDeferredCommon(variable, values);                                   \
+        PutDeferredCommon(variable, data);                                     \
     }
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type

--- a/source/adios2/engine/skeleton/SkeletonWriter.h
+++ b/source/adios2/engine/skeleton/SkeletonWriter.h
@@ -71,7 +71,8 @@ private:
      * @param values
      */
     template <class T>
-    void PutSyncCommon(Variable<T> &variable, const T *values);
+    void PutSyncCommon(Variable<T> &variable,
+                       const typename Variable<T>::Info &blockInfo);
 
     template <class T>
     void PutDeferredCommon(Variable<T> &variable, const T *values);

--- a/source/adios2/engine/skeleton/SkeletonWriter.tcc
+++ b/source/adios2/engine/skeleton/SkeletonWriter.tcc
@@ -18,10 +18,9 @@ namespace adios2
 {
 
 template <class T>
-void SkeletonWriter::PutSyncCommon(Variable<T> &variable, const T *values)
+void SkeletonWriter::PutSyncCommon(Variable<T> &variable,
+                                   const typename Variable<T>::Info &blockInfo)
 {
-    // set variable
-    variable.SetData(values);
     if (m_Verbosity == 5)
     {
         std::cout << "Skeleton Writer " << m_WriterRank << "     PutSync("
@@ -30,9 +29,10 @@ void SkeletonWriter::PutSyncCommon(Variable<T> &variable, const T *values)
 }
 
 template <class T>
-void SkeletonWriter::PutDeferredCommon(Variable<T> &variable, const T *values)
+void SkeletonWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
 {
-    variable.SetData(values);
+    variable.SetStepBlockInfo(data, CurrentStep());
+
     if (m_Verbosity == 5)
     {
         std::cout << "Skeleton Writer " << m_WriterRank << "     PutDeferred("

--- a/source/adios2/helper/adiosMath.h
+++ b/source/adios2/helper/adiosMath.h
@@ -48,8 +48,8 @@ void GetMinMax(const T *values, const size_t size, T &min, T &max) noexcept;
  * @param max modulus from values
  */
 template <class T>
-void GetMinMaxComplex(const std::complex<T> *values, const size_t size, T &min,
-                      T &max) noexcept;
+void GetMinMaxComplex(const std::complex<T> *values, const size_t size,
+                      std::complex<T> &min, std::complex<T> &max) noexcept;
 
 /**
  * Threaded version of GetMinMax.
@@ -157,6 +157,28 @@ bool IsIntersectionContiguousSubarray(const Box<Dims> &blockBox,
  */
 size_t LinearIndex(const Box<Dims> &localBox, const Dims &point,
                    const bool isRowMajor) noexcept;
+
+/**
+ * Specialized for std::complex to do a comparison by std::norm.
+ * Similar to operator < for other types
+ * @param input1
+ * @param input2
+ * @return true if input1 < input2 or complex: std::norm(input1) <
+ * std::norm(input2), false otherwise
+ */
+template <class T>
+bool LessThan(const T input1, const T input2) noexcept;
+
+/**
+ * Specialized for std::complex types to do a comparison by std::norm.
+ * Similar to operator > for other types
+ * @param input1
+ * @param input2
+ * @return true if input1 > input2 or complex: std::norm(input1) >
+ * std::norm(input2), false otherwise
+ */
+template <class T>
+bool GreaterThan(const T input1, const T input2) noexcept;
 
 } // end namespace adios2
 

--- a/source/adios2/highlevelapi/fstream/Stream.tcc
+++ b/source/adios2/highlevelapi/fstream/Stream.tcc
@@ -19,7 +19,7 @@ namespace adios2
 {
 
 template <class T>
-void Stream::Write(const std::string &name, const T *values, const Dims &shape,
+void Stream::Write(const std::string &name, const T *data, const Dims &shape,
                    const Dims &start, const Dims &count, const bool endStep)
 {
     ThrowIfNotOpen("variable " + name + ", in call to write\n");
@@ -28,8 +28,7 @@ void Stream::Write(const std::string &name, const T *values, const Dims &shape,
 
     if (variable == nullptr)
     {
-        variable = &m_IO->DefineVariable(name, shape, start, count, false,
-                                         const_cast<T *>(values));
+        variable = &m_IO->DefineVariable<T>(name, shape, start, count, false);
     }
     else
     {
@@ -44,7 +43,7 @@ void Stream::Write(const std::string &name, const T *values, const Dims &shape,
         }
     }
 
-    m_Engine->Put(*variable, values, adios2::Mode::Sync);
+    m_Engine->Put(*variable, data, adios2::Mode::Sync);
 
     if (endStep)
     {
@@ -54,10 +53,10 @@ void Stream::Write(const std::string &name, const T *values, const Dims &shape,
 }
 
 template <class T>
-void Stream::Write(const std::string &name, const T &value, const bool endStep)
+void Stream::Write(const std::string &name, const T &datum, const bool endStep)
 {
-    const T valueLocal = value;
-    Write(name, &valueLocal, {}, {}, {}, endStep);
+    const T datumLocal = datum;
+    Write(name, &datumLocal, {}, {}, {}, endStep);
 }
 
 template <class T>

--- a/source/adios2/toolkit/format/bp3/BP3Base.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Base.cpp
@@ -175,13 +175,13 @@ std::string BP3Base::GetBPSubFileName(const std::string &name,
 }
 
 size_t BP3Base::GetBPIndexSizeInData(const std::string &variableName,
-                                     const Dims &variableCount) const noexcept
+                                     const Dims &count) const noexcept
 {
     size_t indexSize = 23; // header
     indexSize += variableName.size();
 
     // characteristics 3 and 4, check variable number of dimensions
-    const size_t dimensions = variableCount.size();
+    const size_t dimensions = count.size();
     indexSize += 28 * dimensions; // 28 bytes per dimension
     indexSize += 1;               // id
 

--- a/source/adios2/toolkit/format/bp3/BP3Base.h
+++ b/source/adios2/toolkit/format/bp3/BP3Base.h
@@ -211,10 +211,10 @@ public:
      * Returns the estimated variable index size. Used by ResizeBuffer public
      * function
      * @param variableName input
-     * @param variableCount input
+     * @param count input variable local dimensions
      */
     size_t GetBPIndexSizeInData(const std::string &variableName,
-                                const Dims &variableCount) const noexcept;
+                                const Dims &count) const noexcept;
 
     /**
      * Sets buffer's positions to zero and fill buffer with zero char
@@ -394,7 +394,7 @@ protected:
     template <class T>
     struct Characteristics
     {
-        Stats<typename TypeInfo<T>::ValueType> Statistics;
+        Stats<T> Statistics;
         Dims Shape;
         Dims Start;
         Dims Count;

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -1594,11 +1594,11 @@ size_t BP3Serializer::GetAttributesSizeInData(IO &io) const noexcept
 // Explicit instantiation of only public templates
 
 #define declare_template_instantiation(T)                                      \
-    template void BP3Serializer::PutVariableMetadata(                          \
-        const Variable<T> &variable) noexcept;                                 \
-                                                                               \
     template void BP3Serializer::PutVariablePayload(                           \
-        const Variable<T> &variable) noexcept;
+        const Variable<T> &, const typename Variable<T>::Info &) noexcept;     \
+                                                                               \
+    template void BP3Serializer::PutVariableMetadata(                          \
+        const Variable<T> &, const typename Variable<T>::Info &) noexcept;
 
 ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -55,27 +55,27 @@ TEST_F(BPWriteTypes, ADIOS2BPWriteTypes)
     {
 
         adios2_define_variable(ioH, "varI8", adios2_type_int8_t, 1, NULL, NULL,
-                               count, adios2_constant_dims_true, NULL);
+                               count, adios2_constant_dims_true);
         adios2_define_variable(ioH, "varI16", adios2_type_int16_t, 1, NULL,
-                               NULL, count, adios2_constant_dims_true, NULL);
+                               NULL, count, adios2_constant_dims_true);
         adios2_define_variable(ioH, "varI32", adios2_type_int32_t, 1, NULL,
-                               NULL, count, adios2_constant_dims_true, NULL);
+                               NULL, count, adios2_constant_dims_true);
         adios2_define_variable(ioH, "varI64", adios2_type_int64_t, 1, NULL,
-                               NULL, count, adios2_constant_dims_true, NULL);
+                               NULL, count, adios2_constant_dims_true);
 
         adios2_define_variable(ioH, "varU8", adios2_type_uint8_t, 1, NULL, NULL,
-                               count, adios2_constant_dims_true, NULL);
+                               count, adios2_constant_dims_true);
         adios2_define_variable(ioH, "varU16", adios2_type_uint16_t, 1, NULL,
-                               NULL, count, adios2_constant_dims_true, NULL);
+                               NULL, count, adios2_constant_dims_true);
         adios2_define_variable(ioH, "varU32", adios2_type_uint32_t, 1, NULL,
-                               NULL, count, adios2_constant_dims_true, NULL);
+                               NULL, count, adios2_constant_dims_true);
         adios2_define_variable(ioH, "varU64", adios2_type_uint64_t, 1, NULL,
-                               NULL, count, adios2_constant_dims_true, NULL);
+                               NULL, count, adios2_constant_dims_true);
 
         adios2_define_variable(ioH, "varR32", adios2_type_float, 1, NULL, NULL,
-                               count, adios2_constant_dims_true, NULL);
+                               count, adios2_constant_dims_true);
         adios2_define_variable(ioH, "varR64", adios2_type_double, 1, NULL, NULL,
-                               count, adios2_constant_dims_true, NULL);
+                               count, adios2_constant_dims_true);
     }
     // inquire variables
     adios2_variable *varI8 = adios2_inquire_variable(ioH, "varI8");

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -27,6 +27,9 @@ target_link_libraries(TestStreamWriteReadHighLevelAPI adios2 gtest)
 add_executable(TestBPWriteFlushRead TestBPWriteFlushRead.cpp)
 target_link_libraries(TestBPWriteFlushRead adios2 gtest)
 
+add_executable(TestBPWriteMultiblockRead TestBPWriteMultiblockRead.cpp)
+target_link_libraries(TestBPWriteMultiblockRead adios2 gtest)
+
 if(ADIOS2_HAVE_MPI)
 
   target_link_libraries(TestBPWriteReadADIOS2 MPI::MPI_C)
@@ -35,6 +38,7 @@ if(ADIOS2_HAVE_MPI)
   target_link_libraries(TestBPWriteReadAttributesADIOS2 MPI::MPI_C)
   target_link_libraries(TestStreamWriteReadHighLevelAPI MPI::MPI_C)
   target_link_libraries(TestBPWriteFlushRead MPI::MPI_C)
+  target_link_libraries(TestBPWriteMultiblockRead MPI::MPI_C)
   
   add_executable(TestBPWriteAggregateRead TestBPWriteAggregateRead.cpp)
   target_link_libraries(TestBPWriteAggregateRead
@@ -52,6 +56,7 @@ gtest_add_tests(TARGET TestBPWriteReadAsStreamADIOS2_Threads ${extra_test_args})
 gtest_add_tests(TARGET TestBPWriteReadAttributesADIOS2 ${extra_test_args})
 gtest_add_tests(TARGET TestStreamWriteReadHighLevelAPI ${extra_test_args})
 gtest_add_tests(TARGET TestBPWriteFlushRead ${extra_test_args})
+gtest_add_tests(TARGET TestBPWriteMultiblockRead ${extra_test_args})
   
 if (ADIOS2_HAVE_ADIOS1)
   add_executable(TestBPWriteRead TestBPWriteRead.cpp)

--- a/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
@@ -70,38 +70,28 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2D)
             const adios2::Dims count{Nx1D};
 
             io1D.DefineVariable<int8_t>("i8", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.I8.data());
+                                        adios2::ConstantDims);
             io1D.DefineVariable<int16_t>("i16", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I16.data());
+                                         adios2::ConstantDims);
             io1D.DefineVariable<int32_t>("i32", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I32.data());
+                                         adios2::ConstantDims);
             io1D.DefineVariable<int64_t>("i64", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I64.data());
+                                         adios2::ConstantDims);
 
             io1D.DefineVariable<uint8_t>("u8", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.U8.data());
+                                         adios2::ConstantDims);
 
             io1D.DefineVariable<uint16_t>("u16", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U16.data());
+                                          adios2::ConstantDims);
             io1D.DefineVariable<uint32_t>("u32", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U32.data());
+                                          adios2::ConstantDims);
             io1D.DefineVariable<uint64_t>("u64", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U64.data());
+                                          adios2::ConstantDims);
 
             io1D.DefineVariable<float>("r32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.R32.data());
+                                       adios2::ConstantDims);
             io1D.DefineVariable<double>("r64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.R64.data());
+                                        adios2::ConstantDims);
         }
 
         // io2D variables
@@ -111,38 +101,28 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2D)
             const adios2::Dims count{Ny2D, Nx2D};
 
             io2D.DefineVariable<int8_t>("i8", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.I8.data());
+                                        adios2::ConstantDims);
             io2D.DefineVariable<int16_t>("i16", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I16.data());
+                                         adios2::ConstantDims);
             io2D.DefineVariable<int32_t>("i32", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I32.data());
+                                         adios2::ConstantDims);
             io2D.DefineVariable<int64_t>("i64", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I64.data());
+                                         adios2::ConstantDims);
 
             io2D.DefineVariable<uint8_t>("u8", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.U8.data());
+                                         adios2::ConstantDims);
 
             io2D.DefineVariable<uint16_t>("u16", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U16.data());
+                                          adios2::ConstantDims);
             io2D.DefineVariable<uint32_t>("u32", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U32.data());
+                                          adios2::ConstantDims);
             io2D.DefineVariable<uint64_t>("u64", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U64.data());
+                                          adios2::ConstantDims);
 
             io2D.DefineVariable<float>("r32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.R32.data());
+                                       adios2::ConstantDims);
             io2D.DefineVariable<double>("r64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.R64.data());
+                                        adios2::ConstantDims);
         }
 
         adios2::Engine &bpWriter1D = io1D.Open("Flush1D", adios2::Mode::Write);
@@ -538,38 +518,28 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dstdio)
             const adios2::Dims count{Nx1D};
 
             io1D.DefineVariable<int8_t>("i8", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.I8.data());
+                                        adios2::ConstantDims);
             io1D.DefineVariable<int16_t>("i16", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I16.data());
+                                         adios2::ConstantDims);
             io1D.DefineVariable<int32_t>("i32", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I32.data());
+                                         adios2::ConstantDims);
             io1D.DefineVariable<int64_t>("i64", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I64.data());
+                                         adios2::ConstantDims);
 
             io1D.DefineVariable<uint8_t>("u8", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.U8.data());
+                                         adios2::ConstantDims);
 
             io1D.DefineVariable<uint16_t>("u16", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U16.data());
+                                          adios2::ConstantDims);
             io1D.DefineVariable<uint32_t>("u32", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U32.data());
+                                          adios2::ConstantDims);
             io1D.DefineVariable<uint64_t>("u64", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U64.data());
+                                          adios2::ConstantDims);
 
             io1D.DefineVariable<float>("r32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.R32.data());
+                                       adios2::ConstantDims);
             io1D.DefineVariable<double>("r64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.R64.data());
+                                        adios2::ConstantDims);
         }
 
         // io2D variables
@@ -579,38 +549,28 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dstdio)
             const adios2::Dims count{Ny2D, Nx2D};
 
             io2D.DefineVariable<int8_t>("i8", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.I8.data());
+                                        adios2::ConstantDims);
             io2D.DefineVariable<int16_t>("i16", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I16.data());
+                                         adios2::ConstantDims);
             io2D.DefineVariable<int32_t>("i32", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I32.data());
+                                         adios2::ConstantDims);
             io2D.DefineVariable<int64_t>("i64", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I64.data());
+                                         adios2::ConstantDims);
 
             io2D.DefineVariable<uint8_t>("u8", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.U8.data());
+                                         adios2::ConstantDims);
 
             io2D.DefineVariable<uint16_t>("u16", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U16.data());
+                                          adios2::ConstantDims);
             io2D.DefineVariable<uint32_t>("u32", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U32.data());
+                                          adios2::ConstantDims);
             io2D.DefineVariable<uint64_t>("u64", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U64.data());
+                                          adios2::ConstantDims);
 
             io2D.DefineVariable<float>("r32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.R32.data());
+                                       adios2::ConstantDims);
             io2D.DefineVariable<double>("r64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.R64.data());
+                                        adios2::ConstantDims);
         }
 
         adios2::Engine &bpWriter1D =
@@ -1010,38 +970,28 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dfstream)
             const adios2::Dims count{Nx1D};
 
             io1D.DefineVariable<int8_t>("i8", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.I8.data());
+                                        adios2::ConstantDims);
             io1D.DefineVariable<int16_t>("i16", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I16.data());
+                                         adios2::ConstantDims);
             io1D.DefineVariable<int32_t>("i32", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I32.data());
+                                         adios2::ConstantDims);
             io1D.DefineVariable<int64_t>("i64", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I64.data());
+                                         adios2::ConstantDims);
 
             io1D.DefineVariable<uint8_t>("u8", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.U8.data());
+                                         adios2::ConstantDims);
 
             io1D.DefineVariable<uint16_t>("u16", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U16.data());
+                                          adios2::ConstantDims);
             io1D.DefineVariable<uint32_t>("u32", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U32.data());
+                                          adios2::ConstantDims);
             io1D.DefineVariable<uint64_t>("u64", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U64.data());
+                                          adios2::ConstantDims);
 
             io1D.DefineVariable<float>("r32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.R32.data());
+                                       adios2::ConstantDims);
             io1D.DefineVariable<double>("r64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.R64.data());
+                                        adios2::ConstantDims);
         }
 
         // io2D variables
@@ -1051,38 +1001,28 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dfstream)
             const adios2::Dims count{Ny2D, Nx2D};
 
             io2D.DefineVariable<int8_t>("i8", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.I8.data());
+                                        adios2::ConstantDims);
             io2D.DefineVariable<int16_t>("i16", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I16.data());
+                                         adios2::ConstantDims);
             io2D.DefineVariable<int32_t>("i32", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I32.data());
+                                         adios2::ConstantDims);
             io2D.DefineVariable<int64_t>("i64", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.I64.data());
+                                         adios2::ConstantDims);
 
             io2D.DefineVariable<uint8_t>("u8", shape, start, count,
-                                         adios2::ConstantDims,
-                                         m_TestData.U8.data());
+                                         adios2::ConstantDims);
 
             io2D.DefineVariable<uint16_t>("u16", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U16.data());
+                                          adios2::ConstantDims);
             io2D.DefineVariable<uint32_t>("u32", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U32.data());
+                                          adios2::ConstantDims);
             io2D.DefineVariable<uint64_t>("u64", shape, start, count,
-                                          adios2::ConstantDims,
-                                          m_TestData.U64.data());
+                                          adios2::ConstantDims);
 
             io2D.DefineVariable<float>("r32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.R32.data());
+                                       adios2::ConstantDims);
             io2D.DefineVariable<double>("r64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.R64.data());
+                                        adios2::ConstantDims);
         }
 
         adios2::Engine &bpWriter1D =

--- a/testing/adios2/engine/bp/TestBPWriteMultiblockRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteMultiblockRead.cpp
@@ -1,0 +1,1018 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#include "../SmallTestData.h"
+
+class BPWriteMultiblockReadTest : public ::testing::Test
+{
+public:
+    BPWriteMultiblockReadTest() = default;
+
+    SmallTestData m_TestData;
+};
+
+//******************************************************************************
+// 1D 1x8 test data
+//******************************************************************************
+
+// ADIOS2 BP write, native ADIOS1 read
+TEST_F(BPWriteMultiblockReadTest, ADIOS2BPWriteMultiblockRead1D8)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("ADIOS2BPWriteMultiblockRead1D8.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 8;
+
+    // Number of steps
+    const size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using BP
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO &io = adios.DeclareIO("TestIO");
+
+        // Declare 1D variables (NumOfProcesses * Nx)
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
+        {
+            const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize)};
+            const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
+            const adios2::Dims count{Nx};
+
+            auto &var_iString = io.DefineVariable<std::string>("iString");
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
+            auto &var_i16 =
+                io.DefineVariable<int16_t>("i16", shape, start, count);
+            auto &var_i32 =
+                io.DefineVariable<int32_t>("i32", shape, start, count);
+            auto &var_i64 =
+                io.DefineVariable<int64_t>("i64", shape, start, count);
+            auto &var_u8 =
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
+            auto &var_u16 =
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
+            auto &var_u32 =
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
+            auto &var_u64 =
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
+            auto &var_r32 =
+                io.DefineVariable<float>("r32", shape, start, count);
+            auto &var_r64 =
+                io.DefineVariable<double>("r64", shape, start, count);
+        }
+
+        // Create the BP Engine
+        io.SetEngine("BPFile");
+
+        io.AddTransport("file");
+
+        // QUESTION: It seems that BPFilterWriter cannot overwrite existing
+        // files
+        // Ex. if you tune Nx and NSteps, the test would fail. But if you clear
+        // the cache in
+        // ${adios2Build}/testing/adios2/engine/bp/ADIOS2BPWriteADIOS1Read1D8.bp.dir,
+        // then it works
+        adios2::Engine &bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            // Retrieve the variables that previously went out of scope
+            auto &var_iString = *io.InquireVariable<std::string>("iString");
+            auto &var_i8 = *io.InquireVariable<int8_t>("i8");
+            auto &var_i16 = *io.InquireVariable<int16_t>("i16");
+            auto &var_i32 = *io.InquireVariable<int32_t>("i32");
+            auto &var_i64 = *io.InquireVariable<int64_t>("i64");
+            auto &var_u8 = *io.InquireVariable<uint8_t>("u8");
+            auto &var_u16 = *io.InquireVariable<uint16_t>("u16");
+            auto &var_u32 = *io.InquireVariable<uint32_t>("u32");
+            auto &var_u64 = *io.InquireVariable<uint64_t>("u64");
+            auto &var_r32 = *io.InquireVariable<float>("r32");
+            auto &var_r64 = *io.InquireVariable<double>("r64");
+
+            // Make a 1D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            const adios2::Box<adios2::Dims> sel1({mpiRank * Nx}, {Nx / 2});
+            const adios2::Box<adios2::Dims> sel2({mpiRank * Nx + Nx / 2},
+                                                 {Nx - Nx / 2});
+
+            bpWriter.BeginStep();
+            bpWriter.Put(var_iString, currentTestData.S1);
+
+            var_i8.SetSelection(sel1);
+            bpWriter.Put(var_i8, currentTestData.I8.data());
+            var_i8.SetSelection(sel2);
+            bpWriter.Put(var_i8, currentTestData.I8.data() + Nx / 2);
+
+            var_i16.SetSelection(sel1);
+            bpWriter.Put(var_i16, currentTestData.I16.data());
+            var_i16.SetSelection(sel2);
+            bpWriter.Put(var_i16, currentTestData.I16.data() + Nx / 2);
+
+            var_i32.SetSelection(sel1);
+            bpWriter.Put(var_i32, currentTestData.I32.data());
+            var_i32.SetSelection(sel2);
+            bpWriter.Put(var_i32, currentTestData.I32.data() + Nx / 2);
+
+            var_i64.SetSelection(sel1);
+            bpWriter.Put(var_i64, currentTestData.I64.data());
+            var_i64.SetSelection(sel2);
+            bpWriter.Put(var_i64, currentTestData.I64.data() + Nx / 2);
+
+            var_u8.SetSelection(sel1);
+            bpWriter.Put(var_u8, currentTestData.U8.data());
+            var_u8.SetSelection(sel2);
+            bpWriter.Put(var_u8, currentTestData.U8.data() + Nx / 2);
+
+            var_u16.SetSelection(sel1);
+            bpWriter.Put(var_u16, currentTestData.U16.data());
+            var_u16.SetSelection(sel2);
+            bpWriter.Put(var_u16, currentTestData.U16.data() + Nx / 2);
+
+            var_u32.SetSelection(sel1);
+            bpWriter.Put(var_u32, currentTestData.U32.data());
+            var_u32.SetSelection(sel2);
+            bpWriter.Put(var_u32, currentTestData.U32.data() + Nx / 2);
+
+            var_u64.SetSelection(sel1);
+            bpWriter.Put(var_u64, currentTestData.U64.data());
+            var_u64.SetSelection(sel2);
+            bpWriter.Put(var_u64, currentTestData.U64.data() + Nx / 2);
+
+            var_r32.SetSelection(sel1);
+            bpWriter.Put(var_r32, currentTestData.R32.data());
+            var_r32.SetSelection(sel2);
+            bpWriter.Put(var_r32, currentTestData.R32.data() + Nx / 2);
+
+            var_r64.SetSelection(sel1);
+            bpWriter.Put(var_r64, currentTestData.R64.data());
+            var_r64.SetSelection(sel2);
+            bpWriter.Put(var_r64, currentTestData.R64.data() + Nx / 2);
+
+            bpWriter.EndStep();
+        }
+
+        // Close the file
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO &io = adios.DeclareIO("ReadIO");
+
+        adios2::Engine &bpReader = io.Open(fname, adios2::Mode::Read);
+
+        auto var_iString = io.InquireVariable<std::string>("iString");
+        ASSERT_NE(var_iString, nullptr);
+        ASSERT_EQ(var_iString->m_Shape.size(), 0);
+        ASSERT_EQ(var_iString->m_AvailableStepsCount, NSteps);
+
+        auto var_i8 = io.InquireVariable<int8_t>("i8");
+        ASSERT_NE(var_i8, nullptr);
+        ASSERT_EQ(var_i8->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i8->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i8->m_Shape[0], mpiSize * Nx);
+
+        auto var_i16 = io.InquireVariable<int16_t>("i16");
+        ASSERT_NE(var_i16, nullptr);
+        ASSERT_EQ(var_i16->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i16->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i16->m_Shape[0], mpiSize * Nx);
+
+        auto var_i32 = io.InquireVariable<int32_t>("i32");
+        ASSERT_NE(var_i32, nullptr);
+        ASSERT_EQ(var_i32->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i32->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i32->m_Shape[0], mpiSize * Nx);
+
+        auto var_i64 = io.InquireVariable<int64_t>("i64");
+        ASSERT_NE(var_i64, nullptr);
+        ASSERT_EQ(var_i64->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i64->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i64->m_Shape[0], mpiSize * Nx);
+
+        auto var_u8 = io.InquireVariable<uint8_t>("u8");
+        ASSERT_NE(var_u8, nullptr);
+        ASSERT_EQ(var_u8->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u8->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u8->m_Shape[0], mpiSize * Nx);
+
+        auto var_u16 = io.InquireVariable<uint16_t>("u16");
+        ASSERT_NE(var_u16, nullptr);
+        ASSERT_EQ(var_u16->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u16->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u16->m_Shape[0], mpiSize * Nx);
+
+        auto var_u32 = io.InquireVariable<uint32_t>("u32");
+        ASSERT_NE(var_u32, nullptr);
+        ASSERT_EQ(var_u32->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u32->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u32->m_Shape[0], mpiSize * Nx);
+
+        auto var_u64 = io.InquireVariable<uint64_t>("u64");
+        ASSERT_NE(var_u64, nullptr);
+        ASSERT_EQ(var_u64->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u64->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u64->m_Shape[0], mpiSize * Nx);
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        ASSERT_NE(var_r32, nullptr);
+        ASSERT_EQ(var_r32->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_r32->m_Shape[0], mpiSize * Nx);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        ASSERT_NE(var_r64, nullptr);
+        ASSERT_EQ(var_r64->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_r64->m_Shape[0], mpiSize * Nx);
+
+        // TODO: other types
+
+        SmallTestData testData;
+
+        std::string IString;
+        std::array<int8_t, Nx> I8;
+        std::array<int16_t, Nx> I16;
+        std::array<int32_t, Nx> I32;
+        std::array<int64_t, Nx> I64;
+        std::array<uint8_t, Nx> U8;
+        std::array<uint16_t, Nx> U16;
+        std::array<uint32_t, Nx> U32;
+        std::array<uint64_t, Nx> U64;
+        std::array<float, Nx> R32;
+        std::array<double, Nx> R64;
+
+        const adios2::Dims start{mpiRank * Nx};
+        const adios2::Dims count{Nx};
+
+        const adios2::Box<adios2::Dims> sel(start, count);
+
+        var_i8->SetSelection(sel);
+        var_i16->SetSelection(sel);
+        var_i32->SetSelection(sel);
+        var_i64->SetSelection(sel);
+
+        var_u8->SetSelection(sel);
+        var_u16->SetSelection(sel);
+        var_u32->SetSelection(sel);
+        var_u64->SetSelection(sel);
+
+        var_r32->SetSelection(sel);
+        var_r64->SetSelection(sel);
+
+        for (size_t t = 0; t < NSteps; ++t)
+        {
+            var_i8->SetStepSelection({t, 1});
+            var_i16->SetStepSelection({t, 1});
+            var_i32->SetStepSelection({t, 1});
+            var_i64->SetStepSelection({t, 1});
+
+            var_u8->SetStepSelection({t, 1});
+            var_u16->SetStepSelection({t, 1});
+            var_u32->SetStepSelection({t, 1});
+            var_u64->SetStepSelection({t, 1});
+
+            var_r32->SetStepSelection({t, 1});
+            var_r64->SetStepSelection({t, 1});
+
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(t), mpiRank, mpiSize);
+
+            bpReader.Get(*var_iString, IString);
+
+            bpReader.Get(*var_i8, I8.data());
+            bpReader.Get(*var_i16, I16.data());
+            bpReader.Get(*var_i32, I32.data());
+            bpReader.Get(*var_i64, I64.data());
+
+            bpReader.Get(*var_u8, U8.data());
+            bpReader.Get(*var_u16, U16.data());
+            bpReader.Get(*var_u32, U32.data());
+            bpReader.Get(*var_u64, U64.data());
+
+            bpReader.Get(*var_r32, R32.data());
+            bpReader.Get(*var_r64, R64.data());
+
+            bpReader.PerformGets();
+
+            EXPECT_EQ(IString, currentTestData.S1);
+
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+            }
+        }
+        bpReader.Close();
+    }
+}
+
+//******************************************************************************
+// 2D 2x4 test data
+//******************************************************************************
+
+// ADIOS2 BP write, native ADIOS1 read
+TEST_F(BPWriteMultiblockReadTest, ADIOS2BPWriteMultiblockRead2D2x4)
+{
+    // Each process would write a 2x4 array and all processes would
+    // form a 2D 2 * (numberOfProcess*Nx) matrix where Nx is 4 here
+    const std::string fname("ADIOS2BPWriteMultiblockRead2D2x4Test.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 4;
+
+    // Number of rows
+    const std::size_t Ny = 2;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using ADIOS2
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO &io = adios.DeclareIO("TestIO");
+
+        // Declare 2D variables (Ny * (NumOfProcesses * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
+        {
+            const adios2::Dims shape{Ny, static_cast<size_t>(Nx * mpiSize)};
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
+            const adios2::Dims count{Ny, Nx};
+
+            auto &var_iString = io.DefineVariable<std::string>("iString");
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
+            auto &var_i16 =
+                io.DefineVariable<int16_t>("i16", shape, start, count);
+            auto &var_i32 =
+                io.DefineVariable<int32_t>("i32", shape, start, count);
+            auto &var_i64 =
+                io.DefineVariable<int64_t>("i64", shape, start, count);
+            auto &var_u8 =
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
+            auto &var_u16 =
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
+            auto &var_u32 =
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
+            auto &var_u64 =
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
+            auto &var_r32 =
+                io.DefineVariable<float>("r32", shape, start, count);
+            auto &var_r64 =
+                io.DefineVariable<double>("r64", shape, start, count);
+        }
+
+        // Create the BP Engine
+        io.SetEngine("BPFile");
+        io.AddTransport("file");
+
+        adios2::Engine &bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            // Retrieve the variables that previously went out of scope
+            auto &var_iString = *io.InquireVariable<std::string>("iString");
+            auto &var_i8 = *io.InquireVariable<int8_t>("i8");
+            auto &var_i16 = *io.InquireVariable<int16_t>("i16");
+            auto &var_i32 = *io.InquireVariable<int32_t>("i32");
+            auto &var_i64 = *io.InquireVariable<int64_t>("i64");
+            auto &var_u8 = *io.InquireVariable<uint8_t>("u8");
+            auto &var_u16 = *io.InquireVariable<uint16_t>("u16");
+            auto &var_u32 = *io.InquireVariable<uint32_t>("u32");
+            auto &var_u64 = *io.InquireVariable<uint64_t>("u64");
+            auto &var_r32 = *io.InquireVariable<float>("r32");
+            auto &var_r64 = *io.InquireVariable<double>("r64");
+
+            // Make a 2D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            const adios2::Box<adios2::Dims> sel1(
+                {0, static_cast<size_t>(mpiRank * Nx)}, {Ny / 2, Nx});
+
+            const adios2::Box<adios2::Dims> sel2(
+                {Ny / 2, static_cast<size_t>(mpiRank * Nx)}, {Ny - Ny / 2, Nx});
+
+            bpWriter.BeginStep();
+            bpWriter.Put(var_iString, currentTestData.S1);
+
+            var_i8.SetSelection(sel1);
+            bpWriter.Put(var_i8, currentTestData.I8.data());
+            var_i8.SetSelection(sel2);
+            bpWriter.Put(var_i8, currentTestData.I8.data() + Ny * Nx / 2);
+
+            var_i16.SetSelection(sel1);
+            bpWriter.Put(var_i16, currentTestData.I16.data());
+            var_i16.SetSelection(sel2);
+            bpWriter.Put(var_i16, currentTestData.I16.data() + Ny * Nx / 2);
+
+            var_i32.SetSelection(sel1);
+            bpWriter.Put(var_i32, currentTestData.I32.data());
+            var_i32.SetSelection(sel2);
+            bpWriter.Put(var_i32, currentTestData.I32.data() + Ny * Nx / 2);
+
+            var_i64.SetSelection(sel1);
+            bpWriter.Put(var_i64, currentTestData.I64.data());
+            var_i64.SetSelection(sel2);
+            bpWriter.Put(var_i64, currentTestData.I64.data() + Ny * Nx / 2);
+
+            var_u8.SetSelection(sel1);
+            bpWriter.Put(var_u8, currentTestData.U8.data());
+            var_u8.SetSelection(sel2);
+            bpWriter.Put(var_u8, currentTestData.U8.data() + Ny * Nx / 2);
+
+            var_u16.SetSelection(sel1);
+            bpWriter.Put(var_u16, currentTestData.U16.data());
+            var_u16.SetSelection(sel2);
+            bpWriter.Put(var_u16, currentTestData.U16.data() + Ny * Nx / 2);
+
+            var_u32.SetSelection(sel1);
+            bpWriter.Put(var_u32, currentTestData.U32.data());
+            var_u32.SetSelection(sel2);
+            bpWriter.Put(var_u32, currentTestData.U32.data() + Ny * Nx / 2);
+
+            var_u64.SetSelection(sel1);
+            bpWriter.Put(var_u64, currentTestData.U64.data());
+            var_u64.SetSelection(sel2);
+            bpWriter.Put(var_u64, currentTestData.U64.data() + Ny * Nx / 2);
+
+            var_r32.SetSelection(sel1);
+            bpWriter.Put(var_r32, currentTestData.R32.data());
+            var_r32.SetSelection(sel2);
+            bpWriter.Put(var_r32, currentTestData.R32.data() + Ny * Nx / 2);
+
+            var_r64.SetSelection(sel1);
+            bpWriter.Put(var_r64, currentTestData.R64.data());
+            var_r64.SetSelection(sel2);
+            bpWriter.Put(var_r64, currentTestData.R64.data() + Ny * Nx / 2);
+
+            bpWriter.EndStep();
+        }
+
+        // Close the file
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO &io = adios.DeclareIO("ReadIO");
+
+        adios2::Engine &bpReader = io.Open(fname, adios2::Mode::Read);
+
+        auto var_iString = io.InquireVariable<std::string>("iString");
+        ASSERT_NE(var_iString, nullptr);
+        ASSERT_EQ(var_iString->m_Shape.size(), 0);
+        ASSERT_EQ(var_iString->m_AvailableStepsCount, NSteps);
+
+        auto var_i8 = io.InquireVariable<int8_t>("i8");
+        ASSERT_NE(var_i8, nullptr);
+        ASSERT_EQ(var_i8->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i8->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i8->m_Shape[0], Ny);
+        ASSERT_EQ(var_i8->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_i16 = io.InquireVariable<int16_t>("i16");
+        ASSERT_NE(var_i16, nullptr);
+        ASSERT_EQ(var_i16->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i16->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i16->m_Shape[0], Ny);
+        ASSERT_EQ(var_i16->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_i32 = io.InquireVariable<int32_t>("i32");
+        ASSERT_NE(var_i32, nullptr);
+        ASSERT_EQ(var_i32->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i32->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i32->m_Shape[0], Ny);
+        ASSERT_EQ(var_i32->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_i64 = io.InquireVariable<int64_t>("i64");
+        ASSERT_NE(var_i64, nullptr);
+        ASSERT_EQ(var_i64->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i64->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i64->m_Shape[0], Ny);
+        ASSERT_EQ(var_i64->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_u8 = io.InquireVariable<uint8_t>("u8");
+        ASSERT_NE(var_u8, nullptr);
+        ASSERT_EQ(var_u8->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u8->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u8->m_Shape[0], Ny);
+        ASSERT_EQ(var_u8->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_u16 = io.InquireVariable<uint16_t>("u16");
+        ASSERT_NE(var_u16, nullptr);
+        ASSERT_EQ(var_u16->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u16->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u16->m_Shape[0], Ny);
+        ASSERT_EQ(var_u16->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_u32 = io.InquireVariable<uint32_t>("u32");
+        ASSERT_NE(var_u32, nullptr);
+        ASSERT_EQ(var_u32->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u32->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u32->m_Shape[0], Ny);
+        ASSERT_EQ(var_u32->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_u64 = io.InquireVariable<uint64_t>("u64");
+        ASSERT_NE(var_u64, nullptr);
+        ASSERT_EQ(var_u64->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u64->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u64->m_Shape[0], Ny);
+        ASSERT_EQ(var_u64->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        ASSERT_NE(var_r32, nullptr);
+        ASSERT_EQ(var_r32->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_r32->m_Shape[0], Ny);
+        ASSERT_EQ(var_r32->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        ASSERT_NE(var_r64, nullptr);
+        ASSERT_EQ(var_r64->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_r64->m_Shape[0], Ny);
+        ASSERT_EQ(var_r64->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        std::string IString;
+        std::array<int8_t, Nx * Ny> I8;
+        std::array<int16_t, Nx * Ny> I16;
+        std::array<int32_t, Nx * Ny> I32;
+        std::array<int64_t, Nx * Ny> I64;
+        std::array<uint8_t, Nx * Ny> U8;
+        std::array<uint16_t, Nx * Ny> U16;
+        std::array<uint32_t, Nx * Ny> U32;
+        std::array<uint64_t, Nx * Ny> U64;
+        std::array<float, Nx * Ny> R32;
+        std::array<double, Nx * Ny> R64;
+
+        const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
+        const adios2::Dims count{Ny, Nx};
+
+        const adios2::Box<adios2::Dims> sel(start, count);
+
+        var_i8->SetSelection(sel);
+        var_i16->SetSelection(sel);
+        var_i32->SetSelection(sel);
+        var_i64->SetSelection(sel);
+
+        var_u8->SetSelection(sel);
+        var_u16->SetSelection(sel);
+        var_u32->SetSelection(sel);
+        var_u64->SetSelection(sel);
+
+        var_r32->SetSelection(sel);
+        var_r64->SetSelection(sel);
+
+        for (size_t t = 0; t < NSteps; ++t)
+        {
+            var_i8->SetStepSelection({t, 1});
+            var_i16->SetStepSelection({t, 1});
+            var_i32->SetStepSelection({t, 1});
+            var_i64->SetStepSelection({t, 1});
+
+            var_u8->SetStepSelection({t, 1});
+            var_u16->SetStepSelection({t, 1});
+            var_u32->SetStepSelection({t, 1});
+            var_u64->SetStepSelection({t, 1});
+
+            var_r32->SetStepSelection({t, 1});
+            var_r64->SetStepSelection({t, 1});
+
+            bpReader.Get(*var_iString, IString);
+
+            bpReader.Get(*var_i8, I8.data());
+            bpReader.Get(*var_i16, I16.data());
+            bpReader.Get(*var_i32, I32.data());
+            bpReader.Get(*var_i64, I64.data());
+
+            bpReader.Get(*var_u8, U8.data());
+            bpReader.Get(*var_u16, U16.data());
+            bpReader.Get(*var_u32, U32.data());
+            bpReader.Get(*var_u64, U64.data());
+
+            bpReader.Get(*var_r32, R32.data());
+            bpReader.Get(*var_r64, R64.data());
+
+            bpReader.PerformGets();
+
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(t), mpiRank, mpiSize);
+
+            EXPECT_EQ(IString, currentTestData.S1);
+
+            for (size_t i = 0; i < Nx * Ny; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+            }
+        }
+        bpReader.Close();
+    }
+}
+
+//******************************************************************************
+// 2D 4x2 test data
+//******************************************************************************
+
+TEST_F(BPWriteMultiblockReadTest, ADIOS2BPWriteMultiblockRead2D4x2)
+{
+    // Each process would write a 4x2 array and all processes would
+    // form a 2D 4 * (NumberOfProcess * Nx) matrix where Nx is 2 here
+    const std::string fname("ADIOS2BPWriteMultiblockRead2D4x2Test.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 2;
+    // Number of cols
+    const std::size_t Ny = 4;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using ADIOS2
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO &io = adios.DeclareIO("TestIO");
+
+        // Declare 2D variables (4 * (NumberOfProcess * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
+        {
+            adios2::Dims shape{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(mpiSize * Nx)};
+            adios2::Dims start{static_cast<unsigned int>(0),
+                               static_cast<unsigned int>(mpiRank * Nx)};
+            adios2::Dims count{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx)};
+            auto &var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
+            auto &var_i16 =
+                io.DefineVariable<int16_t>("i16", shape, start, count);
+            auto &var_i32 =
+                io.DefineVariable<int32_t>("i32", shape, start, count);
+            auto &var_i64 =
+                io.DefineVariable<int64_t>("i64", shape, start, count);
+            auto &var_u8 =
+                io.DefineVariable<uint8_t>("u8", shape, start, count);
+            auto &var_u16 =
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
+            auto &var_u32 =
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
+            auto &var_u64 =
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
+            auto &var_r32 =
+                io.DefineVariable<float>("r32", shape, start, count);
+            auto &var_r64 =
+                io.DefineVariable<double>("r64", shape, start, count);
+        }
+
+        // Create the BP Engine
+        io.SetEngine("BPFile");
+
+        io.AddTransport("file");
+
+        adios2::Engine &bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            // Retrieve the variables that previously went out of scope
+            auto &var_i8 = *io.InquireVariable<int8_t>("i8");
+            auto &var_i16 = *io.InquireVariable<int16_t>("i16");
+            auto &var_i32 = *io.InquireVariable<int32_t>("i32");
+            auto &var_i64 = *io.InquireVariable<int64_t>("i64");
+            auto &var_u8 = *io.InquireVariable<uint8_t>("u8");
+            auto &var_u16 = *io.InquireVariable<uint16_t>("u16");
+            auto &var_u32 = *io.InquireVariable<uint32_t>("u32");
+            auto &var_u64 = *io.InquireVariable<uint64_t>("u64");
+            auto &var_r32 = *io.InquireVariable<float>("r32");
+            auto &var_r64 = *io.InquireVariable<double>("r64");
+
+            // Make a 2D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            const adios2::Box<adios2::Dims> sel1(
+                {0, static_cast<size_t>(mpiRank * Nx)}, {Ny / 2, Nx});
+
+            const adios2::Box<adios2::Dims> sel2(
+                {Ny / 2, static_cast<size_t>(mpiRank * Nx)}, {Ny - Ny / 2, Nx});
+
+            bpWriter.BeginStep();
+
+            var_i8.SetSelection(sel1);
+            bpWriter.Put(var_i8, currentTestData.I8.data());
+            var_i8.SetSelection(sel2);
+            bpWriter.Put(var_i8, currentTestData.I8.data() + Ny * Nx / 2);
+
+            var_i16.SetSelection(sel1);
+            bpWriter.Put(var_i16, currentTestData.I16.data());
+            var_i16.SetSelection(sel2);
+            bpWriter.Put(var_i16, currentTestData.I16.data() + Ny * Nx / 2);
+
+            var_i32.SetSelection(sel1);
+            bpWriter.Put(var_i32, currentTestData.I32.data());
+            var_i32.SetSelection(sel2);
+            bpWriter.Put(var_i32, currentTestData.I32.data() + Ny * Nx / 2);
+
+            var_i64.SetSelection(sel1);
+            bpWriter.Put(var_i64, currentTestData.I64.data());
+            var_i64.SetSelection(sel2);
+            bpWriter.Put(var_i64, currentTestData.I64.data() + Ny * Nx / 2);
+
+            var_u8.SetSelection(sel1);
+            bpWriter.Put(var_u8, currentTestData.U8.data());
+            var_u8.SetSelection(sel2);
+            bpWriter.Put(var_u8, currentTestData.U8.data() + Ny * Nx / 2);
+
+            var_u16.SetSelection(sel1);
+            bpWriter.Put(var_u16, currentTestData.U16.data());
+            var_u16.SetSelection(sel2);
+            bpWriter.Put(var_u16, currentTestData.U16.data() + Ny * Nx / 2);
+
+            var_u32.SetSelection(sel1);
+            bpWriter.Put(var_u32, currentTestData.U32.data());
+            var_u32.SetSelection(sel2);
+            bpWriter.Put(var_u32, currentTestData.U32.data() + Ny * Nx / 2);
+
+            var_u64.SetSelection(sel1);
+            bpWriter.Put(var_u64, currentTestData.U64.data());
+            var_u64.SetSelection(sel2);
+            bpWriter.Put(var_u64, currentTestData.U64.data() + Ny * Nx / 2);
+
+            var_r32.SetSelection(sel1);
+            bpWriter.Put(var_r32, currentTestData.R32.data());
+            var_r32.SetSelection(sel2);
+            bpWriter.Put(var_r32, currentTestData.R32.data() + Ny * Nx / 2);
+
+            var_r64.SetSelection(sel1);
+            bpWriter.Put(var_r64, currentTestData.R64.data());
+            var_r64.SetSelection(sel2);
+            bpWriter.Put(var_r64, currentTestData.R64.data() + Ny * Nx / 2);
+
+            bpWriter.EndStep();
+        }
+
+        // Close the file
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO &io = adios.DeclareIO("ReadIO");
+
+        adios2::Engine &bpReader = io.Open(fname, adios2::Mode::Read);
+
+        auto var_i8 = io.InquireVariable<int8_t>("i8");
+        ASSERT_NE(var_i8, nullptr);
+        ASSERT_EQ(var_i8->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i8->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i8->m_Shape[0], Ny);
+        ASSERT_EQ(var_i8->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_i16 = io.InquireVariable<int16_t>("i16");
+        ASSERT_NE(var_i16, nullptr);
+        ASSERT_EQ(var_i16->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i16->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i16->m_Shape[0], Ny);
+        ASSERT_EQ(var_i16->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_i32 = io.InquireVariable<int32_t>("i32");
+        ASSERT_NE(var_i32, nullptr);
+        ASSERT_EQ(var_i32->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i32->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i32->m_Shape[0], Ny);
+        ASSERT_EQ(var_i32->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_i64 = io.InquireVariable<int64_t>("i64");
+        ASSERT_NE(var_i64, nullptr);
+        ASSERT_EQ(var_i64->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i64->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_i64->m_Shape[0], Ny);
+        ASSERT_EQ(var_i64->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_u8 = io.InquireVariable<uint8_t>("u8");
+        ASSERT_NE(var_u8, nullptr);
+        ASSERT_EQ(var_u8->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u8->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u8->m_Shape[0], Ny);
+        ASSERT_EQ(var_u8->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_u16 = io.InquireVariable<uint16_t>("u16");
+        ASSERT_NE(var_u16, nullptr);
+        ASSERT_EQ(var_u16->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u16->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u16->m_Shape[0], Ny);
+        ASSERT_EQ(var_u16->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_u32 = io.InquireVariable<uint32_t>("u32");
+        ASSERT_NE(var_u32, nullptr);
+        ASSERT_EQ(var_u32->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u32->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u32->m_Shape[0], Ny);
+        ASSERT_EQ(var_u32->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_u64 = io.InquireVariable<uint64_t>("u64");
+        ASSERT_NE(var_u64, nullptr);
+        ASSERT_EQ(var_u64->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u64->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_u64->m_Shape[0], Ny);
+        ASSERT_EQ(var_u64->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        ASSERT_NE(var_r32, nullptr);
+        ASSERT_EQ(var_r32->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_r32->m_Shape[0], Ny);
+        ASSERT_EQ(var_r32->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        ASSERT_NE(var_r64, nullptr);
+        ASSERT_EQ(var_r64->m_ShapeID, adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64->m_AvailableStepsCount, NSteps);
+        ASSERT_EQ(var_r64->m_Shape[0], Ny);
+        ASSERT_EQ(var_r64->m_Shape[1], static_cast<size_t>(mpiSize * Nx));
+
+        // If the size of the array is smaller than the data
+        // the result is weird... double and uint64_t would get
+        // completely garbage data
+        std::array<int8_t, Nx * Ny> I8;
+        std::array<int16_t, Nx * Ny> I16;
+        std::array<int32_t, Nx * Ny> I32;
+        std::array<int64_t, Nx * Ny> I64;
+        std::array<uint8_t, Nx * Ny> U8;
+        std::array<uint16_t, Nx * Ny> U16;
+        std::array<uint32_t, Nx * Ny> U32;
+        std::array<uint64_t, Nx * Ny> U64;
+        std::array<float, Nx * Ny> R32;
+        std::array<double, Nx * Ny> R64;
+
+        const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
+        const adios2::Dims count{Ny, Nx};
+
+        const adios2::Box<adios2::Dims> sel(start, count);
+
+        var_i8->SetSelection(sel);
+        var_i16->SetSelection(sel);
+        var_i32->SetSelection(sel);
+        var_i64->SetSelection(sel);
+
+        var_u8->SetSelection(sel);
+        var_u16->SetSelection(sel);
+        var_u32->SetSelection(sel);
+        var_u64->SetSelection(sel);
+
+        var_r32->SetSelection(sel);
+        var_r64->SetSelection(sel);
+
+        for (size_t t = 0; t < NSteps; ++t)
+        {
+            var_i8->SetStepSelection({t, 1});
+            var_i16->SetStepSelection({t, 1});
+            var_i32->SetStepSelection({t, 1});
+            var_i64->SetStepSelection({t, 1});
+
+            var_u8->SetStepSelection({t, 1});
+            var_u16->SetStepSelection({t, 1});
+            var_u32->SetStepSelection({t, 1});
+            var_u64->SetStepSelection({t, 1});
+
+            var_r32->SetStepSelection({t, 1});
+            var_r64->SetStepSelection({t, 1});
+
+            bpReader.Get(*var_i8, I8.data());
+            bpReader.Get(*var_i16, I16.data());
+            bpReader.Get(*var_i32, I32.data());
+            bpReader.Get(*var_i64, I64.data());
+
+            bpReader.Get(*var_u8, U8.data());
+            bpReader.Get(*var_u16, U16.data());
+            bpReader.Get(*var_u32, U32.data());
+            bpReader.Get(*var_u64, U64.data());
+
+            bpReader.Get(*var_r32, R32.data());
+            bpReader.Get(*var_r64, R64.data());
+
+            bpReader.PerformGets();
+
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(t), mpiRank, mpiSize);
+
+            for (size_t i = 0; i < Nx * Ny; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+            }
+        }
+        bpReader.Close();
+    }
+}
+
+//******************************************************************************
+// main
+//******************************************************************************
+
+int main(int argc, char **argv)
+{
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+    result = RUN_ALL_TESTS();
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
@@ -314,38 +314,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D2x4)
             const adios2::Dims count{Ny, Nx};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine
@@ -579,38 +569,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D4x2)
                                static_cast<unsigned int>(Nx)};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine
@@ -840,38 +820,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead1D8MissingPerformGets)
             const adios2::Dims count{Nx};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine
@@ -1103,38 +1073,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D2x4MissingPerformGets)
             const adios2::Dims count{Ny, Nx};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine
@@ -1368,38 +1328,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D4x2MissingPerformGets)
                                static_cast<unsigned int>(Nx)};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
@@ -64,38 +64,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead1D8)
             const adios2::Dims count{Nx};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine
@@ -320,38 +310,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D2x4)
             const adios2::Dims count{Ny, Nx};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine
@@ -586,38 +566,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D4x2)
                                static_cast<unsigned int>(Nx)};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine
@@ -848,38 +818,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads,
             const adios2::Dims count{Nx};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine
@@ -1112,38 +1072,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads,
             const adios2::Dims count{Ny, Nx};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine
@@ -1378,38 +1328,28 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads,
                                static_cast<unsigned int>(Nx)};
 
             io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.I8.data());
+                                      adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I16.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I32.data());
+                                       adios2::ConstantDims);
             io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.I64.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims,
-                                       m_TestData.U8.data());
+                                       adios2::ConstantDims);
 
             io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U16.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U32.data());
+                                        adios2::ConstantDims);
             io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims,
-                                        m_TestData.U64.data());
+                                        adios2::ConstantDims);
 
             io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims,
-                                     m_TestData.R32.data());
+                                     adios2::ConstantDims);
             io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims,
-                                      m_TestData.R64.data());
+                                      adios2::ConstantDims);
         }
 
         // Create the BP Engine

--- a/testing/adios2/performance/manyvars/manyVars.c
+++ b/testing/adios2/performance/manyvars/manyVars.c
@@ -257,9 +257,9 @@ void define_vars()
      * Offsets will change at writing for each block. */
     for (i = 0; i < NVARS; i++)
     {
-        varW[i] = adios2_define_variable(ioW, varnames[i], adios2_type_int, 2,
-                                         shape, start, count,
-                                         adios2_constant_dims_false, a2);
+        varW[i] =
+            adios2_define_variable(ioW, varnames[i], adios2_type_int, 2, shape,
+                                   start, count, adios2_constant_dims_false);
     }
 }
 

--- a/testing/adios2/performance/manyvars/manyVars.cpp
+++ b/testing/adios2/performance/manyvars/manyVars.cpp
@@ -303,7 +303,7 @@ public:
         {
             varW[i] = adios2_define_variable(ioW, varnames[i], adios2_type_int,
                                              2, shape, start, count,
-                                             adios2_constant_dims_false, a2);
+                                             adios2_constant_dims_false);
         }
     }
 


### PR DESCRIPTION
Related to #335
Refactored BP3 Serializer to allow multiblock
Added multiblock info data structure in Variable
DefineVariable pointer removed for type except in Python
APIs: numpy array or string in define variable.
Tests added

TO DO:
    read multiblock (separate branch)