### PR TITLE
Modifications to make SST Engine parameters available to DP

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_reader.c
+++ b/source/adios2/toolkit/sst/cp/cp_reader.c
@@ -172,8 +172,8 @@ SstStream SstReaderOpen(const char *Name, SstParams Params, MPI_Comm comm)
     MPI_Comm_rank(Stream->mpiComm, &Stream->Rank);
     MPI_Comm_size(Stream->mpiComm, &Stream->CohortSize);
 
-    Stream->DP_Stream =
-        Stream->DP_Interface->initReader(&Svcs, Stream, &dpInfo);
+    Stream->DP_Stream = Stream->DP_Interface->initReader(&Svcs, Stream, &dpInfo,
+                                                         Stream->ConfigParams);
 
     pointers = (struct _CP_DP_PairInfo **)ParticipateInReaderInitDataExchange(
         Stream, dpInfo, &data_block);

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -578,7 +578,8 @@ SstStream SstWriterOpen(const char *Name, SstParams Params, MPI_Comm comm)
     MPI_Comm_rank(Stream->mpiComm, &Stream->Rank);
     MPI_Comm_size(Stream->mpiComm, &Stream->CohortSize);
 
-    Stream->DP_Stream = Stream->DP_Interface->initWriter(&Svcs, Stream);
+    Stream->DP_Stream =
+        Stream->DP_Interface->initWriter(&Svcs, Stream, Stream->ConfigParams);
 
     if (Stream->Rank == 0)
     {

--- a/source/adios2/toolkit/sst/dp/evpath_dp.c
+++ b/source/adios2/toolkit/sst/dp/evpath_dp.c
@@ -167,7 +167,8 @@ static void EvpathReadReplyHandler(CManager cm, CMConnection conn, void *msg_v,
                                    void *client_Data, attr_list attrs);
 
 static DP_RS_Stream EvpathInitReader(CP_Services Svcs, void *CP_Stream,
-                                     void **ReaderContactInfoPtr)
+                                     void **ReaderContactInfoPtr,
+                                     struct _SstParams *Params)
 {
     Evpath_RS_Stream Stream = malloc(sizeof(struct _Evpath_RS_Stream));
     EvpathReaderContactInfo Contact =
@@ -320,7 +321,8 @@ static void EvpathReadReplyHandler(CManager cm, CMConnection conn, void *msg_v,
     CMCondition_signal(cm, ReadReplyMsg->NotifyCondition);
 }
 
-static DP_WS_Stream EvpathInitWriter(CP_Services Svcs, void *CP_Stream)
+static DP_WS_Stream EvpathInitWriter(CP_Services Svcs, void *CP_Stream,
+                                     struct _SstParams *Params)
 {
     Evpath_WS_Stream Stream = malloc(sizeof(struct _Evpath_WS_Stream));
     CManager cm = Svcs->getCManager(CP_Stream);

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -361,7 +361,8 @@ static void RdmaReadReplyHandler(CManager cm, CMConnection conn, void *msg_v,
                                  void *client_Data, attr_list attrs);
 
 static DP_RS_Stream RdmaInitReader(CP_Services Svcs, void *CP_Stream,
-                                   void **ReaderContactInfoPtr)
+                                   void **ReaderContactInfoPtr,
+                                   struct _SstParams *Params)
 {
     Rdma_RS_Stream Stream = malloc(sizeof(struct _Rdma_RS_Stream));
     RdmaReaderContactInfo Contact =
@@ -540,7 +541,8 @@ static void RdmaReadReplyHandler(CManager cm, CMConnection conn, void *msg_v,
     CMCondition_signal(cm, ReadReplyMsg->NotifyCondition);
 }
 
-static DP_WS_Stream RdmaInitWriter(CP_Services Svcs, void *CP_Stream)
+static DP_WS_Stream RdmaInitWriter(CP_Services Svcs, void *CP_Stream,
+                                   struct _SstParams *Params)
 {
     Rdma_WS_Stream Stream = malloc(sizeof(struct _Rdma_WS_Stream));
     CManager cm = Svcs->getCManager(CP_Stream);

--- a/source/adios2/toolkit/sst/dp_interface.h
+++ b/source/adios2/toolkit/sst/dp_interface.h
@@ -67,10 +67,12 @@ typedef void *CP_PeerCohort;
  * pointed to by the void*.  The control plane will gather this information
  * for all reader ranks, transmit it to the writer cohort and provide it as
  * an array of pointers in the `providedReaderInfo` argument to
- * CP_DP_InitWriterPerReaderFunc.
+ * CP_DP_InitWriterPerReaderFunc.  Params is the set of Engine-level parameters
+ * set at the ADIOS level.
  */
 typedef DP_RS_Stream (*CP_DP_InitReaderFunc)(CP_Services Svcs, void *CP_Stream,
-                                             void **ReaderContactInfoPtr);
+                                             void **ReaderContactInfoPtr,
+                                             struct _SstParams *Params);
 
 /*!
  * CP_DP_DestroyReaderFunc is the type of a dataplane reader-side
@@ -84,12 +86,13 @@ typedef void (*CP_DP_DestroyReaderFunc)(CP_Services Svcs, DP_RS_Stream Reader);
  * initialization function.  Its return value is DP_WS_stream, an externally
  * opaque handle which is provided to the dataplane on all subsequent
  * stream-wide operations for this stream.  'stream' is an input parameter and
- * is the
- * control plane-level writer-side stream identifier.  This may be useful
+ * is the control plane-level writer-side stream identifier.  This may be useful
  * for callbacks, access to MPI communicator, EVPath info, etc. so can be
- * associated with the DP_RS_stream.
+ * associated with the DP_RS_stream.  Params is the set of Engine-level
+ * parameters set at the ADIOS level.
  */
-typedef DP_WS_Stream (*CP_DP_InitWriterFunc)(CP_Services Svcs, void *CP_Stream);
+typedef DP_WS_Stream (*CP_DP_InitWriterFunc)(CP_Services Svcs, void *CP_Stream,
+                                             struct _SstParams *Params);
 
 /*!
  * CP_DP_DestroyWriterFunc is the type of a dataplane writer-side

--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -112,30 +112,6 @@ extern void SstSetStatsSave(SstStream Stream, SstStats Save);
 
 #define SST_POSTFIX ".sst"
 
-#define SST_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                \
-    MACRO(MarshalMethod, MarshalMethod, size_t, 0)                             \
-    MACRO(RegistrationMethod, RegMethod, size_t, 0)                            \
-    MACRO(DataTransport, String, char *, NULL)                                 \
-    MACRO(RendezvousReaderCount, Int, int, 1)                                  \
-    MACRO(QueueLimit, Int, int, 0)                                             \
-    MACRO(DiscardOnQueueFull, Bool, int, 1)                                    \
-    MACRO(IsRowMajor, IsRowMajor, int, 0)
-
-typedef enum {
-    SstRegisterFile,
-    SstRegisterScreen,
-    SstRegisterCloud
-} SstRegistrationMethod;
-
-typedef enum { SstMarshalFFS, SstMarshalBP } SstMarshalMethod;
-
-struct _SstParams
-{
-#define declare_struct(Param, Type, Typedecl, Default) Typedecl Param;
-    SST_FOREACH_PARAMETER_TYPE_4ARGS(declare_struct)
-#undef declare_struct
-};
-
 #ifdef __cplusplus
 }
 #endif

--- a/source/adios2/toolkit/sst/sst_data.h
+++ b/source/adios2/toolkit/sst/sst_data.h
@@ -5,8 +5,6 @@
 #include <sys/types.h>
 #endif
 
-typedef enum { SST_UINT = 1, SST_INT = 2, SST_FLOAT = 3 } SST_BASE_TYPE;
-
 struct _SstFullMetadata
 {
     int WriterCohortSize;
@@ -24,6 +22,30 @@ struct _SstBlock
 {
     size_t BlockSize;
     char *BlockData;
+};
+
+#define SST_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                \
+    MACRO(MarshalMethod, MarshalMethod, size_t, 0)                             \
+    MACRO(RegistrationMethod, RegMethod, size_t, 0)                            \
+    MACRO(DataTransport, String, char *, NULL)                                 \
+    MACRO(RendezvousReaderCount, Int, int, 1)                                  \
+    MACRO(QueueLimit, Int, int, 0)                                             \
+    MACRO(DiscardOnQueueFull, Bool, int, 1)                                    \
+    MACRO(IsRowMajor, IsRowMajor, int, 0)
+
+typedef enum {
+    SstRegisterFile,
+    SstRegisterScreen,
+    SstRegisterCloud
+} SstRegistrationMethod;
+
+typedef enum { SstMarshalFFS, SstMarshalBP } SstMarshalMethod;
+
+struct _SstParams
+{
+#define declare_struct(Param, Type, Typedecl, Default) Typedecl Param;
+    SST_FOREACH_PARAMETER_TYPE_4ARGS(declare_struct)
+#undef declare_struct
 };
 
 #endif /* !_SST_DATA_H_ */


### PR DESCRIPTION
Modifications to make SST Engine parameters available to the Data Plane layer on Reader/Writer Init.  This also moves the declarations of the SST parameters to sst_data.h.