### PR TITLE
Changes to support regression testing for BP marshalling.

### DIFF
--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -57,8 +57,7 @@ private:
     void SstBPPerformGets();
     void Init();
     SstStream m_Input;
-    int m_WriterFFSmarshal;
-    int m_WriterBPmarshal;
+    SstMarshalMethod m_WriterMarshalMethod;
 
     /* --- Used only with BP marshaling --- */
     SstFullMetadata m_CurrentStepMetaData = NULL;

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -822,9 +822,6 @@ extern char *CP_GetContactString(SstStream Stream)
     if (strcmp(Stream->ConfigParams->ControlTransport, "enet") == 0)
     {
         set_int_attr(ContactList, CM_ENET_CONN_TIMEOUT, 60000); /* 60 seconds */
-        printf("Generated Contact list : ");
-        dump_attr_list(ContactList);
-        printf("\n");
     }
     return attr_list_to_string(ContactList);
 }

--- a/source/adios2/toolkit/sst/cp/cp_reader.c
+++ b/source/adios2/toolkit/sst/cp/cp_reader.c
@@ -352,13 +352,9 @@ SstStream SstReaderOpen(const char *Name, SstParams Params, MPI_Comm comm)
     return Stream;
 }
 
-extern void SstReaderGetParams(SstStream Stream, int *WriterFFSmarshal,
-                               int *WriterBPmarshal)
+extern void SstReaderGetParams(SstStream Stream, SstMarshalMethod *WriterMarshalMethod)
 {
-    *WriterFFSmarshal =
-        (Stream->WriterConfigParams->MarshalMethod == SstMarshalFFS);
-    *WriterBPmarshal =
-        (Stream->WriterConfigParams->MarshalMethod == SstMarshalBP);
+    *WriterMarshalMethod =Stream->WriterConfigParams->MarshalMethod;
 }
 
 void queueTimestepMetadataMsgAndNotify(SstStream Stream,

--- a/source/adios2/toolkit/sst/cp/cp_reader.c
+++ b/source/adios2/toolkit/sst/cp/cp_reader.c
@@ -352,9 +352,10 @@ SstStream SstReaderOpen(const char *Name, SstParams Params, MPI_Comm comm)
     return Stream;
 }
 
-extern void SstReaderGetParams(SstStream Stream, SstMarshalMethod *WriterMarshalMethod)
+extern void SstReaderGetParams(SstStream Stream,
+                               SstMarshalMethod *WriterMarshalMethod)
 {
-    *WriterMarshalMethod =Stream->WriterConfigParams->MarshalMethod;
+    *WriterMarshalMethod = Stream->WriterConfigParams->MarshalMethod;
 }
 
 void queueTimestepMetadataMsgAndNotify(SstStream Stream,

--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -43,6 +43,8 @@ typedef struct _SstStats
 
 typedef struct _SstParams *SstParams;
 
+typedef enum { SstMarshalFFS, SstMarshalBP } SstMarshalMethod;
+
 /*
  *  Writer-side operations
  */
@@ -62,8 +64,8 @@ extern void SstWriterClose(SstStream stream);
  */
 extern SstStream SstReaderOpen(const char *filename, SstParams Params,
                                MPI_Comm comm);
-extern void SstReaderGetParams(SstStream stream, int *WriterFFSmarshal,
-                               int *WriterBPmarshal);
+extern void SstReaderGetParams(SstStream stream,
+                               SstMarshalMethod *WriterMarshalMethod);
 extern SstFullMetadata SstGetCurMetadata(SstStream stream);
 extern void *SstReadRemoteMemory(SstStream s, int rank, long timestep,
                                  size_t offset, size_t length, void *buffer,

--- a/source/adios2/toolkit/sst/sst_data.h
+++ b/source/adios2/toolkit/sst/sst_data.h
@@ -40,8 +40,6 @@ typedef enum {
     SstRegisterCloud
 } SstRegistrationMethod;
 
-typedef enum { SstMarshalFFS, SstMarshalBP } SstMarshalMethod;
-
 struct _SstParams
 {
 #define declare_struct(Param, Type, Typedecl, Default) Typedecl Param;

--- a/testing/adios2/engine/sst/CMakeLists.txt
+++ b/testing/adios2/engine/sst/CMakeLists.txt
@@ -58,6 +58,11 @@ add_test(
     -nr 3 -nw 5 -v -p TestSst)
 
 add_test(
+  NAME ADIOSSstTest.3x5BP
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
+    -nr 3 -nw 5 -v -p TestSst -arg "MarshalMethod:BP")
+
+add_test(
   NAME ADIOSSstTest.5x3
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
     -nr 5 -nw 3 -v -p TestSst)
@@ -67,6 +72,10 @@ if(ADIOS2_HAVE_Fortran)
     NAME ADIOSSstTest.FtoC_1x1
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
     -nr 1 -nw 1 -v -w TestSstWrite_f -r TestSstRead)
+  add_test(
+    NAME ADIOSSstTest.FtoC_1x1BP
+    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
+    -nr 1 -nw 1 -v -w TestSstWrite_f -r TestSstRead -arg "MarshalMethod:BP")
   add_test(
     NAME ADIOSSstTest.CtoF_1x1
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
@@ -79,6 +88,12 @@ if(ADIOS2_HAVE_Fortran)
     NAME ADIOSSstTest.FtoC_3x5
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
     -nr 3 -nw 5 -v -w TestSstWrite_f -r TestSstRead)
+  add_test(
+    NAME ADIOSSstTest.FtoC_3x5BP
+    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
+    -nr 3 -nw 5 -v -w TestSstWrite_f -r TestSstRead -arg "MarshalMethod:BP")
+  
+
   add_test(
     NAME ADIOSSstTest.CtoF_3x5
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test

--- a/testing/adios2/engine/sst/run_staging_test.in
+++ b/testing/adios2/engine/sst/run_staging_test.in
@@ -26,6 +26,7 @@ EO
 	-n <count> & number of nodes to run both sides
 	-nw <count> & number of nodes to run write side
 	-nr <count> & number of nodes to run read side
+	-arg <str> & pass <arg> on the command line to the executables
 	-q & be quiet
 EO
 }
@@ -34,6 +35,8 @@ PROGNAME=${0##*/}
 
 reader_prog="UNSET"
 writer_prog="UNSET"
+
+args=""
 
 while [ $# -gt 0 ]
 do
@@ -50,6 +53,7 @@ do
     (-p) prefix="$2"; shift;;
     (-nw) nw="$2"; shift;;
     (-nr) nr="$2"; shift;;
+    (-arg) args="$args $2"; shift;;
     (--) shift; break;;
     (-*) echo "$0: error - unrecognized option $1" ; usage; 1>&2; exit 1;;
     (*)  break;;
@@ -71,15 +75,15 @@ rm -f *.bpflx
 
 # Spawn the writer
 if [ $vflag == "yes" ]; then
-    echo "Doing        (@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $nw ./$writer_prog ) & writer_pid=$!"
+    echo "Doing        (@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $nw ./$writer_prog $args) & writer_pid=$!"
 fi
-(@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $nw ./$writer_prog ) & writer_pid=$!
+(@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $nw ./$writer_prog $args ) & writer_pid=$!
 
 # Spawn the reader
 if [ $vflag == "yes" ]; then
-    echo "Doing (@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $nr ./$reader_prog 2>&1 1>/dev/null) & reader_pid=$!"
+    echo "Doing (@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $nr ./$reader_prog $args 2>&1 1>/dev/null) & reader_pid=$!"
 fi
-(@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $nr ./$reader_prog 2>&1 1>/dev/null) & reader_pid=$!
+(@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $nr ./$reader_prog $args 2>&1 1>/dev/null) & reader_pid=$!
 
 
 


### PR DESCRIPTION
Cleanup of marshal method handling on the reader side to guarantee use of the writer-specified method.  Mod away from two booleans towards an enumeration of marshaling methods.  Change run_staging_test to allow argument specifications.  Add new tests specifying BP marshaling to CMakeLists.txt