### PR TITLE
Refactor parameter parsing in SST Engine

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -87,6 +87,7 @@ if(ADIOS2_HAVE_SST)
   target_sources(adios2 PRIVATE
     engine/sst/SstReader.cpp
     engine/sst/SstWriter.cpp
+    engine/sst/SstParamParser.cpp
   )
   target_link_libraries(adios2 PRIVATE sst)
 endif()

--- a/source/adios2/engine/sst/SstParamParser.cpp
+++ b/source/adios2/engine/sst/SstParamParser.cpp
@@ -1,0 +1,152 @@
+
+#include <memory>
+#include <mpi.h>
+
+#include "SstParamParser.h"
+#include "adios2/helper/adiosFunctions.h"
+
+#include "adios2/toolkit/sst/sst.h"
+
+using namespace adios2::core;
+
+void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
+{
+    auto lf_SetBoolParameter = [&](const std::string key, int &parameter) {
+
+        auto itKey = io.m_Parameters.find(key);
+        if (itKey != io.m_Parameters.end())
+        {
+            if (itKey->second == "yes" || itKey->second == "true")
+            {
+                parameter = 1;
+            }
+            else if (itKey->second == "no" || itKey->second == "false")
+            {
+                parameter = 0;
+            }
+        }
+    };
+    auto lf_SetIntParameter = [&](const std::string key, int &parameter) {
+
+        auto itKey = io.m_Parameters.find(key);
+        if (itKey != io.m_Parameters.end())
+        {
+            parameter = std::stoi(itKey->second);
+            return true;
+        }
+        return false;
+    };
+
+    auto lf_SetStringParameter = [&](const std::string key, char *&parameter) {
+
+        auto itKey = io.m_Parameters.find(key);
+        if (itKey != io.m_Parameters.end())
+        {
+            parameter = strdup(itKey->second.c_str());
+            return true;
+        }
+        return false;
+    };
+
+    auto lf_SetRegMethodParameter = [&](const std::string key,
+                                        size_t &parameter) {
+
+        auto itKey = io.m_Parameters.find(key);
+        if (itKey != io.m_Parameters.end())
+        {
+            std::string method = itKey->second;
+            std::transform(method.begin(), method.end(), method.begin(),
+                           ::tolower);
+            if (method == "file")
+            {
+                parameter = SstRegisterFile;
+            }
+            else if (method == "screen")
+            {
+                parameter = SstRegisterScreen;
+            }
+            else if (method == "cloud")
+            {
+                parameter = SstRegisterCloud;
+                throw std::invalid_argument("ERROR: Sst RegistrationMethod "
+                                            "\"cloud\" not yet implemented");
+            }
+            else
+            {
+                throw std::invalid_argument(
+                    "ERROR: Unknown Sst RegistrationMethod parameter \"" +
+                    method + "\"");
+            }
+            return true;
+        }
+        return false;
+    };
+
+    // not really a parameter, but a convenient way to pass this around
+    auto lf_SetIsRowMajorParameter = [&](const std::string key,
+                                         int &parameter) {
+
+        parameter = adios2::helper::IsRowMajor(io.m_HostLanguage);
+        return true;
+    };
+
+    auto lf_SetMarshalMethodParameter = [&](const std::string key,
+                                            size_t &parameter) {
+        auto itKey = io.m_Parameters.find(key);
+        if (itKey != io.m_Parameters.end())
+        {
+            std::string method = itKey->second;
+            std::transform(method.begin(), method.end(), method.begin(),
+                           ::tolower);
+            if (method == "ffs")
+            {
+                parameter = SstMarshalFFS;
+            }
+            else if (method == "bp")
+            {
+                parameter = SstMarshalBP;
+            }
+            else
+            {
+                throw std::invalid_argument(
+                    "ERROR: Unknown Sst MarshalMethod parameter \"" + method +
+                    "\"");
+            }
+            return true;
+        }
+        return false;
+    };
+
+    auto lf_SetQueueFullPolicyParameter = [&](const std::string key,
+                                              size_t &parameter) {
+        auto itKey = io.m_Parameters.find(key);
+        if (itKey != io.m_Parameters.end())
+        {
+            std::string method = itKey->second;
+            std::transform(method.begin(), method.end(), method.begin(),
+                           ::tolower);
+            if (method == "block")
+            {
+                parameter = SstQueueFullBlock;
+            }
+            else if (method == "discard")
+            {
+                parameter = SstQueueFullDiscard;
+            }
+            else
+            {
+                throw std::invalid_argument(
+                    "ERROR: Unknown Sst MarshalMethod parameter \"" + method +
+                    "\"");
+            }
+            return true;
+        }
+        return false;
+    };
+
+#define get_params(Param, Type, Typedecl, Default)                             \
+    Params.Param = Default;                                                    \
+    lf_Set##Type##Parameter(#Param, Params.Param);
+    SST_FOREACH_PARAMETER_TYPE_4ARGS(get_params);
+#undef get_params
+}

--- a/source/adios2/engine/sst/SstParamParser.h
+++ b/source/adios2/engine/sst/SstParamParser.h
@@ -1,0 +1,19 @@
+#ifndef ADIOS2_ENGINE_SST_SSTPARAMPARSER_H_
+#define ADIOS2_ENGINE_SST_SSTPARAMPARSER_H_
+
+#include "adios2/ADIOSConfig.h"
+#include "adios2/core/IO.h"
+#include <iostream>
+#include <unistd.h>
+
+#include "adios2/toolkit/sst/sst.h"
+
+using namespace adios2::core;
+
+class SstParamParser
+{
+public:
+    void ParseParams(adios2::core::IO &io, struct _SstParams &Params);
+};
+
+#endif

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <mpi.h>
 
+#include "SstParamParser.h"
 #include "SstWriter.h"
 #include "SstWriter.tcc"
 
@@ -110,121 +111,13 @@ void SstWriter::PerformPuts() {}
 // PRIVATE functions below
 void SstWriter::Init()
 {
-    auto lf_SetBoolParameter = [&](const std::string key, int &parameter) {
+    SstParamParser Parser;
 
-        auto itKey = m_IO.m_Parameters.find(key);
-        if (itKey != m_IO.m_Parameters.end())
-        {
-            if (itKey->second == "yes" || itKey->second == "true")
-            {
-                parameter = 1;
-            }
-            else if (itKey->second == "no" || itKey->second == "false")
-            {
-                parameter = 0;
-            }
-        }
-    };
-    auto lf_SetIntParameter = [&](const std::string key, int &parameter) {
+    Parser.ParseParams(m_IO, Params);
 
-        auto itKey = m_IO.m_Parameters.find(key);
-        if (itKey != m_IO.m_Parameters.end())
-        {
-            parameter = std::stoi(itKey->second);
-            return true;
-        }
-        return false;
-    };
-
-    auto lf_SetStringParameter = [&](const std::string key, char *&parameter) {
-
-        auto itKey = m_IO.m_Parameters.find(key);
-        if (itKey != m_IO.m_Parameters.end())
-        {
-            parameter = strdup(itKey->second.c_str());
-            return true;
-        }
-        return false;
-    };
-
-    auto lf_SetRegMethodParameter = [&](const std::string key,
-                                        size_t &parameter) {
-
-        auto itKey = m_IO.m_Parameters.find(key);
-        if (itKey != m_IO.m_Parameters.end())
-        {
-            std::string method = itKey->second;
-            std::transform(method.begin(), method.end(), method.begin(),
-                           ::tolower);
-            if (method == "file")
-            {
-                parameter = SstRegisterFile;
-            }
-            else if (method == "screen")
-            {
-                parameter = SstRegisterScreen;
-            }
-            else if (method == "cloud")
-            {
-                parameter = SstRegisterCloud;
-                throw std::invalid_argument("ERROR: Sst RegistrationMethod "
-                                            "\"cloud\" not yet implemented" +
-                                            m_EndMessage);
-            }
-            else
-            {
-                throw std::invalid_argument(
-                    "ERROR: Unknown Sst RegistrationMethod parameter \"" +
-                    method + "\"" + m_EndMessage);
-            }
-            return true;
-        }
-        return false;
-    };
-
-    // not really a parameter, but a convenient way to pass this around
-    auto lf_SetIsRowMajorParameter = [&](const std::string key,
-                                         int &parameter) {
-
-        parameter = adios2::helper::IsRowMajor(m_IO.m_HostLanguage);
-        return true;
-    };
-
-    auto lf_SetMarshalMethodParameter = [&](const std::string key,
-                                            size_t &parameter) {
-        auto itKey = m_IO.m_Parameters.find(key);
-        if (itKey != m_IO.m_Parameters.end())
-        {
-            std::string method = itKey->second;
-            std::transform(method.begin(), method.end(), method.begin(),
-                           ::tolower);
-            if (method == "ffs")
-            {
-                parameter = SstMarshalFFS;
-            }
-            else if (method == "bp")
-            {
-                parameter = SstMarshalBP;
-            }
-            else
-            {
-                throw std::invalid_argument(
-                    "ERROR: Unknown Sst MarshalMethod parameter \"" + method +
-                    "\"" + m_EndMessage);
-            }
-            return true;
-        }
-        return false;
-    };
-
-#define get_params(Param, Type, Typedecl, Default)                             \
-    lf_Set##Type##Parameter(#Param, m_##Param);
-    SST_FOREACH_PARAMETER_TYPE_4ARGS(get_params);
-#undef get_params
-#define set_params(Param, Type, Typedecl, Default) Params.Param = m_##Param;
+#define set_params(Param, Type, Typedecl, Default) m_##Param = Params.Param;
     SST_FOREACH_PARAMETER_TYPE_4ARGS(set_params);
 #undef set_params
-    m_IsRowMajor = adios2::helper::IsRowMajor(m_IO.m_HostLanguage);
 }
 
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/sst/SstWriter.h
+++ b/source/adios2/engine/sst/SstWriter.h
@@ -67,7 +67,7 @@ private:
     format::BP3Serializer *m_BP3Serializer;
 
     SstStream m_Output;
-    size_t m_WriterStep = -1;
+    long m_WriterStep = -1;
     struct _SstParams Params;
 #define declare_locals(Param, Type, Typedecl, Default)                         \
     Typedecl m_##Param = Default;

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -35,7 +35,8 @@ void CP_validateParams(SstStream Stream, SstParams Params, int Writer)
                 "Invalid QueueLimit parameter value (%d) for SST Stream %s\n",
                 Params->QueueLimit, Stream->Filename);
     }
-    Stream->DiscardOnQueueFull = Params->DiscardOnQueueFull;
+    Stream->DiscardOnQueueFull =
+        (Params->QueueFullPolicy == SstQueueFullDiscard);
     Stream->RegistrationMethod = Params->RegistrationMethod;
     char *SelectedTransport = NULL;
     if (Params->DataTransport != NULL)

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -500,6 +500,7 @@ static void waitForReaderResponseAndSendQueued(WS_ReaderInfo Reader)
     pthread_mutex_lock(&Stream->DataLock);
     while (Reader->ReaderStatus != Established)
     {
+        /* NEED TO HANDLE FAILURE HERE */
         CP_verbose(Stream, "Waiting for Reader ready on WSR %p.\n", Reader);
         pthread_cond_wait(&Stream->DataCondition, &Stream->DataLock);
     }
@@ -663,6 +664,7 @@ void SstWriterClose(SstStream Stream)
                    "Waiting for timesteps to be released in WriterClose\n");
         CP_verbose(Stream, "The first timestep still queued is %d\n",
                    Stream->QueuedTimesteps->Timestep);
+        /* NEED TO HANDLE FAILURE HERE */
         pthread_cond_wait(&Stream->DataCondition, &Stream->DataLock);
     }
     pthread_mutex_unlock(&Stream->DataLock);

--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -45,6 +45,11 @@ typedef struct _SstParams *SstParams;
 
 typedef enum { SstMarshalFFS, SstMarshalBP } SstMarshalMethod;
 
+typedef enum {
+    SstQueueFullBlock = 0,
+    SstQueueFullDiscard = 1
+} SstQueueFullPolicy;
+
 /*
  *  Writer-side operations
  */

--- a/source/adios2/toolkit/sst/sst_data.h
+++ b/source/adios2/toolkit/sst/sst_data.h
@@ -30,7 +30,7 @@ struct _SstBlock
     MACRO(DataTransport, String, char *, NULL)                                 \
     MACRO(RendezvousReaderCount, Int, int, 1)                                  \
     MACRO(QueueLimit, Int, int, 0)                                             \
-    MACRO(DiscardOnQueueFull, Bool, int, 1)                                    \
+    MACRO(QueueFullPolicy, QueueFullPolicy, size_t, 0)                         \
     MACRO(IsRowMajor, IsRowMajor, int, 0)                                      \
     MACRO(ControlTransport, String, char *, NULL)
 

--- a/testing/adios2/engine/sst/CMakeLists.txt
+++ b/testing/adios2/engine/sst/CMakeLists.txt
@@ -40,66 +40,85 @@ configure_file(
 add_test(
   NAME ADIOSSstTest.Simple_1x1
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 1 -nw 1 -v -p TestSst)
+    -nw 1 -nr 1 -v -p TestSst)
+set_tests_properties(ADIOSSstTest.Simple_1x1 PROPERTIES TIMEOUT 30) 
 
 add_test(
   NAME ADIOSSstTest.2x1
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 2 -nw 1 -v -p TestSst)
+    -nw 2 -nr 1 -v -p TestSst)
+set_tests_properties(ADIOSSstTest.2x1 PROPERTIES TIMEOUT 30) 
 
 add_test(
   NAME ADIOSSstTest.1x2
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 1 -nw 2 -v -p TestSst)
+    -nw 1 -nr 2 -v -p TestSst)
+set_tests_properties(ADIOSSstTest.1x2 PROPERTIES TIMEOUT 30) 
 
 add_test(
   NAME ADIOSSstTest.3x5
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 3 -nw 5 -v -p TestSst)
+    -nw 3 -nr 5 -v -p TestSst)
+set_tests_properties(ADIOSSstTest.3x5 PROPERTIES TIMEOUT 30) 
 
 add_test(
   NAME ADIOSSstTest.3x5BP
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 3 -nw 5 -v -p TestSst -arg "MarshalMethod:BP")
+    -nw 3 -nr 5 -v -p TestSst -arg "MarshalMethod:BP")
+set_tests_properties(ADIOSSstTest.3x5BP PROPERTIES TIMEOUT 30) 
 
 add_test(
   NAME ADIOSSstTest.5x3
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 5 -nw 3 -v -p TestSst)
+    -nw 5 -nr 3 -v -p TestSst)
+set_tests_properties(ADIOSSstTest.5x3 PROPERTIES TIMEOUT 30) 
 
 if(ADIOS2_HAVE_Fortran)
   add_test(
     NAME ADIOSSstTest.FtoC_1x1
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 1 -nw 1 -v -w TestSstWrite_f -r TestSstRead)
+    -nw 1 -nr 1 -v -w TestSstWrite_f -r TestSstRead)
+  set_tests_properties(ADIOSSstTest.FtoC_1x1 PROPERTIES TIMEOUT 30) 
+
   add_test(
     NAME ADIOSSstTest.FtoC_1x1BP
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 1 -nw 1 -v -w TestSstWrite_f -r TestSstRead -arg "MarshalMethod:BP")
+    -nw 1 -nr 1 -v -w TestSstWrite_f -r TestSstRead -arg "MarshalMethod:BP")
+  set_tests_properties(ADIOSSstTest.FtoC_1x1BP PROPERTIES TIMEOUT 30) 
+
   add_test(
     NAME ADIOSSstTest.CtoF_1x1
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 1 -nw 1 -v -w TestSstWrite -r TestSstRead_f)
+    -nw 1 -nr 1 -v -w TestSstWrite -r TestSstRead_f)
+  set_tests_properties(ADIOSSstTest.CtoF_1x1 PROPERTIES TIMEOUT 30) 
+
   add_test(
     NAME ADIOSSstTest.FtoF_1x1
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 1 -nw 1 -v -w TestSstWrite_f -r TestSstRead_f)
+    -nw 1 -nr 1 -v -w TestSstWrite_f -r TestSstRead_f)
+  set_tests_properties(ADIOSSstTest.FtoF_1x1 PROPERTIES TIMEOUT 30) 
+
   add_test(
     NAME ADIOSSstTest.FtoC_3x5
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 3 -nw 5 -v -w TestSstWrite_f -r TestSstRead)
+    -nw 3 -nr 5 -v -w TestSstWrite_f -r TestSstRead)
+  set_tests_properties(ADIOSSstTest.FtoC_3x5 PROPERTIES TIMEOUT 30) 
+
   add_test(
     NAME ADIOSSstTest.FtoC_3x5BP
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 3 -nw 5 -v -w TestSstWrite_f -r TestSstRead -arg "MarshalMethod:BP")
+    -nw 3 -nr 5 -v -w TestSstWrite_f -r TestSstRead -arg "MarshalMethod:BP")
+  set_tests_properties(ADIOSSstTest.FtoC_3x5BP PROPERTIES TIMEOUT 30) 
   
 
   add_test(
     NAME ADIOSSstTest.CtoF_3x5
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 3 -nw 5 -v -w TestSstWrite -r TestSstRead_f)
+    -nw 3 -nr 5 -v -w TestSstWrite -r TestSstRead_f)
+  set_tests_properties(ADIOSSstTest.CtoF_3x5 PROPERTIES TIMEOUT 30) 
   add_test(
     NAME ADIOSSstTest.FtoF_3x5
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
-    -nr 3 -nw 5 -v -w TestSstWrite_f -r TestSstRead_f)
+    -nw 3 -nr 5 -v -w TestSstWrite_f -r TestSstRead_f)
+  set_tests_properties(ADIOSSstTest.FtoF_3x5 PROPERTIES TIMEOUT 30) 
 endif()


### PR DESCRIPTION
Refactor parameter parsing in SST Engine so we're not duplicating code.  Change queue full behaviour to an enum.  Add timeouts to SST tests.