### PR TITLE
Sst failure handling

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -35,8 +35,7 @@ void CP_validateParams(SstStream Stream, SstParams Params, int Writer)
                 "Invalid QueueLimit parameter value (%d) for SST Stream %s\n",
                 Params->QueueLimit, Stream->Filename);
     }
-    Stream->DiscardOnQueueFull =
-        (Params->QueueFullPolicy == SstQueueFullDiscard);
+    Stream->QueueFullPolicy = Params->QueueFullPolicy;
     Stream->RegistrationMethod = Params->RegistrationMethod;
     char *SelectedTransport = NULL;
     if (Params->DataTransport != NULL)

--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -56,6 +56,7 @@ typedef struct _WS_ReaderInfo
     enum StreamStatus ReaderStatus;
     long StartingTimestep;
     long LastSentTimestep;
+    long OldestUnreleasedTimestep;
     void *DP_WSR_Stream;
     void *RS_StreamID;
     int ReaderCohortSize;
@@ -126,7 +127,7 @@ struct _SstStream
     CPTimestepList QueuedTimesteps;
     int QueuedTimestepCount;
     int QueueLimit;
-    int DiscardOnQueueFull;
+    SstQueueFullPolicy QueueFullPolicy;
     int LastProvidedTimestep;
     int NewReaderPresent;
 

--- a/testing/adios2/engine/sst/TestSstRead.cpp
+++ b/testing/adios2/engine/sst/TestSstRead.cpp
@@ -66,7 +66,7 @@ TEST_F(SstReadTest, ADIOS2SstRead1D8)
     int mpiRank = 0, mpiSize = 1;
 
     // Number of steps
-    const std::size_t NSteps = 1;
+    const std::size_t NSteps = 10;
 
 #ifdef ADIOS2_HAVE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);

--- a/testing/adios2/engine/sst/TestSstWrite.cpp
+++ b/testing/adios2/engine/sst/TestSstWrite.cpp
@@ -65,7 +65,7 @@ TEST_F(SstWriteTest, ADIOS2SstWrite)
     int mpiRank = 0, mpiSize = 1;
 
     // Number of steps
-    const std::size_t NSteps = 1;
+    const std::size_t NSteps = 10;
 
 #ifdef ADIOS2_HAVE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);

--- a/testing/adios2/engine/sst/TestSstWriteF.f90
+++ b/testing/adios2/engine/sst/TestSstWriteF.f90
@@ -24,7 +24,7 @@ program TestSstWrite
   call MPI_Comm_size(MPI_COMM_WORLD, isize, ierr)
 
   !Application variables 
-  insteps = 1;
+  insteps = 10;
 
   !Variable dimensions 
   shape_dims(1) = isize * nx

--- a/thirdparty/EVPath/EVPath/cm.c
+++ b/thirdparty/EVPath/EVPath/cm.c
@@ -104,6 +104,7 @@ struct CMtrans_services_s CMstatic_trans_svcs = {INT_CMmalloc, INT_CMrealloc, IN
 						 add_buffer_to_pending_queue,
 						 INT_CMConnection_dereference,
 						 INT_CMConnection_add_reference,
+						 INT_CMConnection_failed,
 						 CMwake_server_thread
 };
 static void INT_CMControlList_close(CMControlList cl, CManager cm);

--- a/thirdparty/EVPath/EVPath/cm_transport.h
+++ b/thirdparty/EVPath/EVPath/cm_transport.h
@@ -87,6 +87,7 @@ typedef struct CMtrans_services_s {
     CMTransport_add_buffer_to_pending_queue add_buffer_to_pending_queue;
     CMTransport_connection_close connection_deref;
     CMTransport_connection_close connection_addref;
+    CMTransport_connection_close connection_fail;
     CMTransport_wake_comm_thread_func wake_comm_thread;
 } *CMtrans_services;
 #define DROP_CM_LOCK(svc, cm) (svc)->drop_CM_lock((cm), __FILE__, __LINE__)


### PR DESCRIPTION
Tweaks to SST writer side to properly deal with connection failures and timeout on reader close even in the case of abnormal reader termination.  This depends upon tweaks to the underlying enet transport to detect and report keepalive failures to evpath.