### PR TITLE
#712 Reduce redundant attributes in metadata

### DIFF
--- a/source/adios2/toolkit/format/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.h
@@ -360,11 +360,18 @@ private:
     /**
      * Collective operation to aggregate and merge (sort) indices (variables and
      * attributes)
-     * @param indices
+     * @param indices has containing indices per unique variable/attribute name
+     * @param comm communicator domain, allows reusing the function in
+     * aggregation
+     * @param bufferSTL buffer where merged indices will be placed (metadata or
+     * data footer in aggregation)
+     * @param isRankConstant true: use for attributes as values are constant
+     * across all ranks, false: default used for variables as values  can vary
+     * across ranks
      */
     void AggregateMergeIndex(
         const std::unordered_map<std::string, SerialElementIndex> &indices,
-        MPI_Comm comm, BufferSTL &bufferSTL);
+        MPI_Comm comm, BufferSTL &bufferSTL, const bool isRankConstant = false);
 
     /**
      * Returns a serialized buffer with all indices with format:
@@ -379,11 +386,15 @@ private:
     /**
      * In rank=0, deserialize gathered indices
      * @param serializedIndices input gathered indices
+     * @param comm establishes MPI domain
+     * @param true: constant across ranks, no need to merge (attributes), false:
+     * variable across ranks, can merge (variables)
      * @return hash[name][rank] = bp index buffer
      */
     std::unordered_map<std::string, std::vector<SerialElementIndex>>
     DeserializeIndicesPerRankThreads(const std::vector<char> &serializedIndices,
-                                     MPI_Comm comm) const noexcept;
+                                     MPI_Comm comm,
+                                     const bool isRankConstant) const noexcept;
 
     /**
      * Merge indices by time step (default) and write to m_HeapBuffer.m_Metadata


### PR DESCRIPTION
Only save one attribute entity in metadata from any rank.