### PR TITLE
Sst failure check on reader side

### DIFF
--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -205,8 +205,15 @@ void SstReader::EndStep()
 {
     if (m_WriterMarshalMethod == SstMarshalFFS)
     {
+        SstStatusValue Result;
         // this does all the deferred gets and fills in the variable array data
-        SstFFSPerformGets(m_Input);
+        Result = SstFFSPerformGets(m_Input);
+        if (Result != SstSuccess)
+        {
+            // tentative, until we change EndStep so that it has a return value
+            throw std::runtime_error(
+                "ERROR:  Writer failed before returning data");
+        }
     }
     if (m_WriterMarshalMethod == SstMarshalBP)
     {

--- a/source/adios2/toolkit/sst/cp/cp_reader.c
+++ b/source/adios2/toolkit/sst/cp/cp_reader.c
@@ -78,10 +78,18 @@ static char *readContactInfo(const char *Name, SstStream Stream)
     }
 }
 
-static void ReaderConnCloseHandler(CManager cm, CMConnection closed_conn,
+static void ReaderConnCloseHandler(CManager cm, CMConnection ClosedConn,
                                    void *client_data)
 {
     SstStream Stream = (SstStream)client_data;
+    int FailedPeerRank = -1;
+    for (int i = 0; i < Stream->WriterCohortSize; i++)
+    {
+        if (Stream->ConnectionsToWriter[i].CMconn == ClosedConn)
+        {
+            FailedPeerRank = i;
+        }
+    }
 
     if (Stream->Status == Established)
     {
@@ -93,9 +101,21 @@ static void ReaderConnCloseHandler(CManager cm, CMConnection closed_conn,
         CP_verbose(Stream, "Reader-side Rank received a "
                            "connection-close event during normal "
                            "operations, peer likely failed\n");
-        Stream->Status = PeerClosed;
+        pthread_mutex_lock(&Stream->DataLock);
+        Stream->Status = PeerFailed;
+        pthread_cond_signal(&Stream->DataCondition);
+        pthread_mutex_unlock(&Stream->DataLock);
+        CP_verbose(
+            Stream,
+            "The close was for connection to writer peer %d, notifying DP\n",
+            FailedPeerRank);
+        /* notify DP of failure.  This should terminate any waits currently
+         * pending in the DP for that rank */
+        Stream->DP_Interface->notifyConnFailure(&Svcs, Stream->DP_Stream,
+                                                FailedPeerRank);
     }
-    else if ((Stream->Status == PeerClosed) || (Stream->Status == Closed))
+    else if ((Stream->Status == PeerClosed) || (Stream->Status == PeerFailed) ||
+             (Stream->Status == Closed))
     {
         /* ignore this.  We expect a close after the connection is marked closed
          */
@@ -106,11 +126,10 @@ static void ReaderConnCloseHandler(CManager cm, CMConnection closed_conn,
     else
     {
         fprintf(stderr, "Got an unexpected connection close event\n");
-        CP_verbose(Stream, "Writer-side Rank received a "
+        CP_verbose(Stream, "Reader-side Rank received a "
                            "connection-close event in unexpected "
                            "state %d\n",
                    Stream->Status);
-        Stream->Status = PeerFailed;
     }
 }
 
@@ -738,7 +757,12 @@ extern void SstReaderClose(SstStream Stream)
 
 extern SstStatusValue SstWaitForCompletion(SstStream Stream, void *handle)
 {
-    //   We need a way to return an error from DP */
-    Stream->DP_Interface->waitForCompletion(&Svcs, handle);
-    return SstSuccess;
+    if (Stream->DP_Interface->waitForCompletion(&Svcs, handle) != 1)
+    {
+        return SstFatalError;
+    }
+    else
+    {
+        return SstSuccess;
+    }
 }

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -737,9 +737,28 @@ static void *RdmaReadRemoteMemory(CP_Services Svcs, DP_RS_Stream Stream_v,
     return ret;
 }
 
-static void RdmaWaitForCompletion(CP_Services Svcs, void *Handle_v)
+static void RdmaNotifyConnFailure(CP_Services Svcs, DP_RS_Stream Stream_v,
+                                  int FailedPeerRank)
+{
+    Rdma_RS_Stream Stream = (Rdma_RS_Stream)
+        Stream_v; /* DP_RS_Stream is the return from InitReader */
+    CManager cm = Svcs->getCManager(Stream->CP_Stream);
+    Svcs->verbose(Stream->CP_Stream, "received notification that writer peer "
+                                     "%d has failed, failing any pending "
+                                     "requests\n",
+                  FailedPeerRank);
+    //   This is what EVPath does...
+    //   FailRequestsToRank(Svcs, cm, Stream, FailedPeerRank);
+}
+
+/*
+ * RdmaWaitForCompletion should return 1 if successful, but 0 if the reads
+ * failed for some reason or were aborted by RdmaNotifyConnFailure()
+ */
+static int RdmaWaitForCompletion(CP_Services Svcs, void *Handle_v)
 {
     RdmaCompletionHandle Handle = (RdmaCompletionHandle)Handle_v;
+    int Ret = 1;
     Svcs->verbose(
         Handle->CPStream,
         "Waiting for completion of memory read to rank %d, condition %d\n",
@@ -756,6 +775,7 @@ static void RdmaWaitForCompletion(CP_Services Svcs, void *Handle_v)
         Handle->Rank, Handle->CMcondition);
 
     free(Handle);
+    return Ret;
 }
 
 static void RdmaProvideTimestep(CP_Services Svcs, DP_WS_Stream Stream_v,
@@ -975,6 +995,7 @@ extern CP_DP_Interface LoadRdmaDP()
     RdmaDPInterface.provideWriterDataToReader = RdmaProvideWriterDataToReader;
     RdmaDPInterface.readRemoteMemory = RdmaReadRemoteMemory;
     RdmaDPInterface.waitForCompletion = RdmaWaitForCompletion;
+    RdmaDPInterface.notifyConnFailure = RdmaNotifyConnFailure;
     RdmaDPInterface.provideTimestep = RdmaProvideTimestep;
     RdmaDPInterface.releaseTimestep = RdmaReleaseTimestep;
     RdmaDPInterface.destroyReader = RdmaDestroyReader;

--- a/source/adios2/toolkit/sst/dp_interface.h
+++ b/source/adios2/toolkit/sst/dp_interface.h
@@ -180,9 +180,22 @@ typedef DP_CompletionHandle (*CP_DP_ReadRemoteMemoryFunc)(
  * CP_DP_WaitForCompletionFunc is the type of a dataplane function that
  * suspends the execution of the current thread until the asynchronous
  * CP_DP_ReadRemoteMemory call that returned its `handle` parameter.
+ * the return value is 0 in the event that the wait failed, 1 on success.
  */
-typedef void (*CP_DP_WaitForCompletionFunc)(CP_Services Svcs,
-                                            DP_CompletionHandle Handle);
+typedef int (*CP_DP_WaitForCompletionFunc)(CP_Services Svcs,
+                                           DP_CompletionHandle Handle);
+
+/*!
+ * CP_DP_NotifyConnFailureFunc is the type of a dataplane function which the
+ * control plane uses to notify the data plane that a CP-level connection
+ * has failed (and therefore the remote host is likely dead).  This is an
+ * informational function by the CP, but as a side effect it should cause
+ * any pending Wait operations (for ReadRemoteMemory) to complete and return
+ * an error.
+ */
+typedef void (*CP_DP_NotifyConnFailureFunc)(CP_Services Svcs,
+                                            DP_RS_Stream RS_Stream,
+                                            int FailedPeerRank);
 
 /*!
  * CP_DP_ProvideTimestepFunc is the type of a dataplane function that
@@ -226,6 +239,7 @@ struct _CP_DP_Interface
 
     CP_DP_ReadRemoteMemoryFunc readRemoteMemory;
     CP_DP_WaitForCompletionFunc waitForCompletion;
+    CP_DP_NotifyConnFailureFunc notifyConnFailure;
 
     CP_DP_ProvideTimestepFunc provideTimestep;
     CP_DP_ReleaseTimestepFunc releaseTimestep;

--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -104,7 +104,7 @@ extern void SstFFSGetDeferred(SstStream Stream, void *Variable,
                               const size_t *Start, const size_t *Count,
                               void *Data);
 
-extern void SstFFSPerformGets(SstStream Stream);
+extern SstStatusValue SstFFSPerformGets(SstStream Stream);
 
 extern int SstFFSWriterBeginStep(SstStream Stream, int mode,
                                  const float timeout_sec);


### PR DESCRIPTION
Try to actually handle reader-side notification of writer failures appropriately.  No tests for this yet, but capability (actual capability for evpath_dp, placeholders for rdma_dp).   Philip, you can fill this in based on what is in the evpath_dp.c, but these mods make rdma_dp.c continue to compile without warnings.