### PR TITLE
Sst fix multi-connection bug

### DIFF
--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -359,6 +359,7 @@ void SstReader::DoClose(const int transportIndex) { SstReaderClose(m_Input); }
         {                                                                      \
             return m_BP3Deserializer->AllStepsBlocksInfo(variable);            \
         }                                                                      \
+	throw std::invalid_argument("ERROR: Unknown marshal mechanism in DoAllStepsBlocksInfo\n");\
     }                                                                          \
                                                                                \
     std::vector<typename Variable<T>::Info> SstReader::DoBlocksInfo(           \
@@ -373,6 +374,7 @@ void SstReader::DoClose(const int transportIndex) { SstReaderClose(m_Input); }
         {                                                                      \
             return m_BP3Deserializer->BlocksInfo(variable, step);              \
         }                                                                      \
+	throw std::invalid_argument("ERROR: Unknown marshal mechanism in DoBlocksInfo\n");\
     }
 
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -359,7 +359,8 @@ void SstReader::DoClose(const int transportIndex) { SstReaderClose(m_Input); }
         {                                                                      \
             return m_BP3Deserializer->AllStepsBlocksInfo(variable);            \
         }                                                                      \
-	throw std::invalid_argument("ERROR: Unknown marshal mechanism in DoAllStepsBlocksInfo\n");\
+        throw std::invalid_argument(                                           \
+            "ERROR: Unknown marshal mechanism in DoAllStepsBlocksInfo\n");     \
     }                                                                          \
                                                                                \
     std::vector<typename Variable<T>::Info> SstReader::DoBlocksInfo(           \
@@ -374,7 +375,8 @@ void SstReader::DoClose(const int transportIndex) { SstReaderClose(m_Input); }
         {                                                                      \
             return m_BP3Deserializer->BlocksInfo(variable, step);              \
         }                                                                      \
-	throw std::invalid_argument("ERROR: Unknown marshal mechanism in DoBlocksInfo\n");\
+        throw std::invalid_argument(                                           \
+            "ERROR: Unknown marshal mechanism in DoBlocksInfo\n");             \
     }
 
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -811,6 +811,7 @@ extern void SstStreamDestroy(SstStream Stream)
             free_FMfield_list(CP_SstParamsList);
         CP_SstParamsList = NULL;
     }
+    CP_verbose(Stream, "SstStreamDestroy successful, returning\n");
 }
 
 extern char *CP_GetContactString(SstStream Stream)

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -24,6 +24,14 @@ static void sendOneToEachWriterRank(SstStream s, CMFormat f, void *Msg,
 static void CP_PeerFailCloseWSReader(WS_ReaderInfo CP_WSR_Stream,
                                      enum StreamStatus NewState);
 
+#ifdef MUTEX_DEBUG
+#define PTHREAD_MUTEX_LOCK(lock) printf("Trying lock line %d\n",  __LINE__ ); pthread_mutex_lock(lock);printf("Got lock\n");
+#define PTHREAD_MUTEX_UNLOCK(lock) printf("UNlocking line %d\n", __LINE__ ); pthread_mutex_unlock(lock);
+#else
+#define PTHREAD_MUTEX_LOCK(lock) pthread_mutex_lock(lock);
+#define PTHREAD_MUTEX_UNLOCK(lock) pthread_mutex_unlock(lock);
+#endif
+
 static char *buildContactInfo(SstStream Stream)
 {
     char *Contact = CP_GetContactString(Stream);
@@ -117,7 +125,7 @@ static void WriterConnCloseHandler(CManager cm, CMConnection closed_conn,
     WS_ReaderInfo WSreader = (WS_ReaderInfo)client_data;
     SstStream ParentWriterStream = WSreader->ParentStream;
 
-    pthread_mutex_lock(&ParentWriterStream->DataLock);
+    PTHREAD_MUTEX_LOCK(&ParentWriterStream->DataLock);
     if (WSreader->ReaderStatus == Established)
     {
         /*
@@ -128,9 +136,9 @@ static void WriterConnCloseHandler(CManager cm, CMConnection closed_conn,
         CP_verbose(ParentWriterStream, "Writer-side Rank received a "
                                        "connection-close event during normal "
                                        "operations, peer likely failed\n");
-        pthread_mutex_unlock(&ParentWriterStream->DataLock);
+        PTHREAD_MUTEX_UNLOCK(&ParentWriterStream->DataLock);
         CP_PeerFailCloseWSReader(WSreader, PeerFailed);
-        pthread_mutex_lock(&ParentWriterStream->DataLock);
+        PTHREAD_MUTEX_LOCK(&ParentWriterStream->DataLock);
         ParentWriterStream->GlobalOpRequired = 1;
     }
     else if ((WSreader->ReaderStatus == PeerClosed) ||
@@ -149,13 +157,13 @@ static void WriterConnCloseHandler(CManager cm, CMConnection closed_conn,
                                        "connection-close event in unexpected "
                                        "state %d\n",
                    WSreader->ReaderStatus);
-        pthread_mutex_unlock(&ParentWriterStream->DataLock);
+        PTHREAD_MUTEX_UNLOCK(&ParentWriterStream->DataLock);
         CP_PeerFailCloseWSReader(WSreader, PeerFailed);
-        pthread_mutex_lock(&ParentWriterStream->DataLock);
+        PTHREAD_MUTEX_LOCK(&ParentWriterStream->DataLock);
     }
     /* main thread might be waiting on status change */
     pthread_cond_signal(&ParentWriterStream->DataCondition);
-    pthread_mutex_unlock(&ParentWriterStream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&ParentWriterStream->DataLock);
 }
 
 static int initWSReader(WS_ReaderInfo reader, int ReaderSize,
@@ -239,7 +247,7 @@ static long earliestAvailableTimestepNumber(SstStream Stream,
 {
     long Ret = CurrentTimestep;
     CPTimestepList List = Stream->QueuedTimesteps;
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     while (List)
     {
         if (List->Timestep < Ret)
@@ -248,14 +256,14 @@ static long earliestAvailableTimestepNumber(SstStream Stream,
         }
         List = List->Next;
     }
-    pthread_mutex_unlock(&Stream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
     return Ret;
 }
 
 static void AddRefRangeTimestep(SstStream Stream, long LowRange, long HighRange)
 {
     CPTimestepList List;
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     List = Stream->QueuedTimesteps;
     while (List)
     {
@@ -265,7 +273,7 @@ static void AddRefRangeTimestep(SstStream Stream, long LowRange, long HighRange)
         }
         List = List->Next;
     }
-    pthread_mutex_unlock(&Stream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
 }
 
 static void SubRefRangeTimestep(SstStream Stream, long LowRange, long HighRange)
@@ -324,7 +332,7 @@ static void KillZeroRefTimesteps(SstStream Stream)
 {
     CPTimestepList Last = NULL, List;
     int AnythingRemoved = 0;
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     List = Stream->QueuedTimesteps;
     while (List)
     {
@@ -362,7 +370,7 @@ static void KillZeroRefTimesteps(SstStream Stream)
         /* main thread might be waiting on timesteps going away */
         pthread_cond_signal(&Stream->DataCondition);
     }
-    pthread_mutex_unlock(&Stream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
 }
 
 WS_ReaderInfo WriterParticipateInReaderOpen(SstStream Stream)
@@ -377,12 +385,12 @@ WS_ReaderInfo WriterParticipateInReaderOpen(SstStream Stream)
     CP_verbose(Stream, "Beginning writer-side reader open protocol\n");
     if (Stream->Rank == 0)
     {
-        pthread_mutex_lock(&Stream->DataLock);
+        PTHREAD_MUTEX_LOCK(&Stream->DataLock);
         assert((Stream->ReadRequestQueue));
         Req = Stream->ReadRequestQueue;
         Stream->ReadRequestQueue = Req->Next;
         Req->Next = NULL;
-        pthread_mutex_unlock(&Stream->DataLock);
+        PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
         struct _CombinedReaderInfo reader_data;
         memset(&reader_data, 0, sizeof(reader_data));
         reader_data.ReaderCohortSize = Req->Msg->ReaderCohortSize;
@@ -531,7 +539,7 @@ void sendOneToWSRCohort(WS_ReaderInfo CP_WSR_Stream, CMFormat f, void *Msg,
 static void waitForReaderResponseAndSendQueued(WS_ReaderInfo Reader)
 {
     SstStream Stream = Reader->ParentStream;
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     while (Reader->ReaderStatus != Established)
     {
         /* NEED TO HANDLE FAILURE HERE */
@@ -539,7 +547,7 @@ static void waitForReaderResponseAndSendQueued(WS_ReaderInfo Reader)
         pthread_cond_wait(&Stream->DataCondition, &Stream->DataLock);
     }
     assert(Reader->ReaderStatus == Established);
-    pthread_mutex_unlock(&Stream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
 
     /* send any queued metadata necessary */
     Reader->OldestUnreleasedTimestep = Reader->StartingTimestep;
@@ -629,13 +637,13 @@ SstStream SstWriterOpen(const char *Name, SstParams Params, MPI_Comm comm)
                    Stream->RendezvousReaderCount);
         if (Stream->Rank == 0)
         {
-            pthread_mutex_lock(&Stream->DataLock);
+            PTHREAD_MUTEX_LOCK(&Stream->DataLock);
             if (Stream->ReadRequestQueue == NULL)
             {
                 pthread_cond_wait(&Stream->DataCondition, &Stream->DataLock);
             }
             assert(Stream->ReadRequestQueue);
-            pthread_mutex_unlock(&Stream->DataLock);
+            PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
         }
         MPI_Barrier(Stream->mpiComm);
 
@@ -693,7 +701,7 @@ static void CP_PeerFailCloseWSReader(WS_ReaderInfo CP_WSR_Stream,
                                      enum StreamStatus NewState)
 {
     SstStream ParentStream = CP_WSR_Stream->ParentStream;
-    pthread_mutex_lock(&ParentStream->DataLock);
+    PTHREAD_MUTEX_LOCK(&ParentStream->DataLock);
     if ((NewState == PeerClosed) || (NewState == Closed))
     {
         SubRefRangeTimestep(CP_WSR_Stream->ParentStream,
@@ -708,7 +716,7 @@ static void CP_PeerFailCloseWSReader(WS_ReaderInfo CP_WSR_Stream,
     CP_WSR_Stream->ReaderStatus = NewState;
     /* main thread might be waiting on timesteps going away */
     pthread_cond_signal(&ParentStream->DataCondition);
-    pthread_mutex_unlock(&ParentStream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&ParentStream->DataLock);
 }
 
 void SstWriterClose(SstStream Stream)
@@ -722,7 +730,7 @@ void SstWriterClose(SstStream Stream)
     KillZeroRefTimesteps(Stream);
 
     /* wait until all queued data is sent */
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     while (Stream->QueuedTimesteps)
     {
         CP_verbose(Stream,
@@ -732,7 +740,7 @@ void SstWriterClose(SstStream Stream)
         /* NEED TO HANDLE FAILURE HERE */
         pthread_cond_wait(&Stream->DataCondition, &Stream->DataLock);
     }
-    pthread_mutex_unlock(&Stream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
 
     gettimeofday(&CloseTime, NULL);
     timersub(&CloseTime, &Stream->ValidStartTime, &Diff);
@@ -895,7 +903,7 @@ static void DoWriterSideGlobalOp(SstStream Stream, int *DiscardIncomingTimestep)
     int *RecvBlock =
         malloc(sizeof(SendBlock[0]) * SendBlockSize * Stream->CohortSize);
 
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     CP_verbose(Stream, "Initiating Writer Side global operation\n");
     Stream->GlobalOpRequired = 0; //  reset if set
     RequestQueue ArrivingReader = Stream->ReadRequestQueue;
@@ -954,7 +962,9 @@ static void DoWriterSideGlobalOp(SstStream Stream, int *DiscardIncomingTimestep)
                                "%d\n",
                        i, Stream->Readers[i]->StartingTimestep,
                        Stream->Readers[i]->LastSentTimestep);
+            PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
             CP_PeerFailCloseWSReader(Stream->Readers[i], Closed);
+            PTHREAD_MUTEX_LOCK(&Stream->DataLock);
         }
         if (Stream->Readers[i]->ReaderStatus == Established)
             ActiveReaderCount++;
@@ -970,6 +980,9 @@ static void DoWriterSideGlobalOp(SstStream Stream, int *DiscardIncomingTimestep)
         if (RecvBlock[i * SendBlockSize + 1] > 0)
             OverLimit++;
     }
+    /* we've got all the state we need to know, release data lock */
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
+
     for (int i = 0; i < RecvBlock[0]; i++)
     {
         WS_ReaderInfo reader;
@@ -999,8 +1012,6 @@ static void DoWriterSideGlobalOp(SstStream Stream, int *DiscardIncomingTimestep)
           else if there are active readers, we must discard the currently
      arriving timestep.
      */
-    /* we've got all the state we need to know, release data lock */
-    pthread_mutex_unlock(&Stream->DataLock);
     if (OverLimit)
     {
         if (Stream->QueueFullPolicy == SstQueueFullBlock)
@@ -1012,13 +1023,13 @@ static void DoWriterSideGlobalOp(SstStream Stream, int *DiscardIncomingTimestep)
                     WS_ReaderInfo reader;
                     if (Stream->Rank == 0)
                     {
-                        pthread_mutex_lock(&Stream->DataLock);
+                        PTHREAD_MUTEX_LOCK(&Stream->DataLock);
                         while (Stream->ReadRequestQueue == NULL)
                         {
                             pthread_cond_wait(&Stream->DataCondition,
                                               &Stream->DataLock);
                         }
-                        pthread_mutex_unlock(&Stream->DataLock);
+                        PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
                     }
                     MPI_Barrier(Stream->mpiComm);
                     CP_verbose(Stream, "Writer side Global operation blocking "
@@ -1037,7 +1048,7 @@ static void DoWriterSideGlobalOp(SstStream Stream, int *DiscardIncomingTimestep)
             else
             {
                 /* wait until enough queued data is sent */
-                pthread_mutex_lock(&Stream->DataLock);
+                PTHREAD_MUTEX_LOCK(&Stream->DataLock);
                 while (Stream->QueueLimit &&
                        (Stream->QueuedTimestepCount > Stream->QueueLimit))
                 {
@@ -1051,7 +1062,7 @@ static void DoWriterSideGlobalOp(SstStream Stream, int *DiscardIncomingTimestep)
                     pthread_cond_wait(&Stream->DataCondition,
                                       &Stream->DataLock);
                 }
-                pthread_mutex_unlock(&Stream->DataLock);
+                PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
             }
         }
         else
@@ -1089,7 +1100,7 @@ extern void SstInternalProvideTimestep(SstStream Stream, SstData LocalMetadata,
     int GlobalOpRequired = 0;
 
     memset(Msg, 0, sizeof(*Msg));
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     Stream->WriterTimestep = Timestep;
     if ((Stream->QueueLimit > 0) &&
         (Stream->QueuedTimestepCount >= Stream->QueueLimit))
@@ -1097,7 +1108,7 @@ extern void SstInternalProvideTimestep(SstStream Stream, SstData LocalMetadata,
         CP_verbose(Stream, "Requesting global op because of queue limit\n");
         GlobalOpRequested = 1;
     }
-    pthread_mutex_unlock(&Stream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
     GlobalOpRequested |= Stream->GlobalOpRequired;
     if (Stream->ReadRequestQueue != NULL)
     {
@@ -1206,7 +1217,7 @@ extern void SstInternalProvideTimestep(SstStream Stream, SstData LocalMetadata,
     /*
      * lock this Stream's data and queue the timestep
      */
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     for (int i = 0; i < Stream->ReaderCount; i++)
     {
         if (Stream->Readers[i]->ReaderStatus == Established)
@@ -1230,7 +1241,7 @@ extern void SstInternalProvideTimestep(SstStream Stream, SstData LocalMetadata,
     /* no one waits on timesteps being added, so no condition signal to note
      * change */
 
-    pthread_mutex_unlock(&Stream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
 
     CP_verbose(Stream, "Sending TimestepMetadata for timestep %d (ref count "
                        "%d), one to each reader\n",
@@ -1264,7 +1275,7 @@ void queueReaderRegisterMsgAndNotify(SstStream Stream,
                                      struct _ReaderRegisterMsg *Req,
                                      CMConnection conn)
 {
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     RequestQueue New = malloc(sizeof(struct _RequestQueue));
     New->Msg = Req;
     New->Conn = conn;
@@ -1283,7 +1294,7 @@ void queueReaderRegisterMsgAndNotify(SstStream Stream,
         Stream->ReadRequestQueue = New;
     }
     pthread_cond_signal(&Stream->DataCondition);
-    pthread_mutex_unlock(&Stream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
 }
 
 void CP_ReaderCloseHandler(CManager cm, CMConnection conn, void *Msg_v,
@@ -1338,20 +1349,20 @@ void CP_ReaderActivateHandler(CManager cm, CMConnection conn, void *Msg_v,
     CP_verbose(CP_WSR_Stream->ParentStream,
                "Parent stream reader count is now %d.\n",
                CP_WSR_Stream->ParentStream->ReaderCount);
-    pthread_mutex_lock(&CP_WSR_Stream->ParentStream->DataLock);
+    PTHREAD_MUTEX_LOCK(&CP_WSR_Stream->ParentStream->DataLock);
     CP_WSR_Stream->ReaderStatus = Established;
     /*
      * the main thread might be waiting for this
      */
     pthread_cond_signal(&CP_WSR_Stream->ParentStream->DataCondition);
-    pthread_mutex_unlock(&CP_WSR_Stream->ParentStream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&CP_WSR_Stream->ParentStream->DataLock);
 }
 
 extern CPTimestepList dequeueTimestep(SstStream Stream, long Timestep)
 {
     CPTimestepList Ret = NULL;
     CPTimestepList List;
-    pthread_mutex_lock(&Stream->DataLock);
+    PTHREAD_MUTEX_LOCK(&Stream->DataLock);
     List = Stream->QueuedTimesteps;
     if (Stream->QueuedTimesteps->Timestep == Timestep)
     {
@@ -1386,7 +1397,7 @@ extern CPTimestepList dequeueTimestep(SstStream Stream, long Timestep)
     Stream->QueuedTimestepCount--;
     /* main thread might be waiting on timesteps going away */
     pthread_cond_signal(&Stream->DataCondition);
-    pthread_mutex_unlock(&Stream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
     return NULL;
 }
 
@@ -1404,9 +1415,9 @@ extern void CP_ReleaseTimestepHandler(CManager cm, CMConnection conn,
                Msg->Timestep);
 
     /* decrement the reference count for the released timestep */
-    pthread_mutex_lock(&ParentStream->DataLock);
+    PTHREAD_MUTEX_LOCK(&ParentStream->DataLock);
     SubRefRangeTimestep(ParentStream, Msg->Timestep, Msg->Timestep);
     Reader->OldestUnreleasedTimestep = Msg->Timestep++;
     pthread_cond_signal(&ParentStream->DataCondition);
-    pthread_mutex_unlock(&ParentStream->DataLock);
+    PTHREAD_MUTEX_UNLOCK(&ParentStream->DataLock);
 }

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -25,8 +25,13 @@ static void CP_PeerFailCloseWSReader(WS_ReaderInfo CP_WSR_Stream,
                                      enum StreamStatus NewState);
 
 #ifdef MUTEX_DEBUG
-#define PTHREAD_MUTEX_LOCK(lock) printf("Trying lock line %d\n",  __LINE__ ); pthread_mutex_lock(lock);printf("Got lock\n");
-#define PTHREAD_MUTEX_UNLOCK(lock) printf("UNlocking line %d\n", __LINE__ ); pthread_mutex_unlock(lock);
+#define PTHREAD_MUTEX_LOCK(lock)                                               \
+    printf("Trying lock line %d\n", __LINE__);                                 \
+    pthread_mutex_lock(lock);                                                  \
+    printf("Got lock\n");
+#define PTHREAD_MUTEX_UNLOCK(lock)                                             \
+    printf("UNlocking line %d\n", __LINE__);                                   \
+    pthread_mutex_unlock(lock);
 #else
 #define PTHREAD_MUTEX_LOCK(lock) pthread_mutex_lock(lock);
 #define PTHREAD_MUTEX_UNLOCK(lock) pthread_mutex_unlock(lock);

--- a/source/adios2/toolkit/sst/dp/evpath_dp.c
+++ b/source/adios2/toolkit/sst/dp/evpath_dp.c
@@ -573,6 +573,8 @@ static void *EvpathReadRemoteMemory(CP_Services Svcs, DP_RS_Stream Stream_v,
     ret->cm = cm;
     ret->Buffer = Buffer;
     ret->Rank = Rank;
+    ret->Failed = 0;
+
     /*
      * set the completion handle as client Data on the condition so that
      * handler has access to it.

--- a/testing/adios2/engine/sst/CMakeLists.txt
+++ b/testing/adios2/engine/sst/CMakeLists.txt
@@ -161,3 +161,10 @@ if(ADIOS2_HAVE_ZFP)
     -nw 3 -nr 5 -v -p TestSst -arg 'CompressionMethod:zfp' )
   set_tests_properties(ADIOSSstZFPCompression.3x5 PROPERTIES TIMEOUT 30) 
 endif()
+
+add_test(
+  NAME ADIOSSstKillReadersTest
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_multi_test -test_protocol kill_readers
+    -nw 3 -nr 2 -warg 'RendezvousReaderCount:0' -rarg '--ignore_time_gap')
+set_tests_properties(ADIOSSstKillReadersTest PROPERTIES TIMEOUT 120) 
+

--- a/testing/adios2/engine/sst/CMakeLists.txt
+++ b/testing/adios2/engine/sst/CMakeLists.txt
@@ -162,9 +162,9 @@ if(ADIOS2_HAVE_ZFP)
   set_tests_properties(ADIOSSstZFPCompression.3x5 PROPERTIES TIMEOUT 30) 
 endif()
 
-add_test(
-  NAME ADIOSSstKillReadersTest.Serialized
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_multi_test -test_protocol kill_readers
-    -nw 3 -nr 2 -max_readers 1 -warg 'RendezvousReaderCount:0' -rarg '--ignore_time_gap')
-set_tests_properties(ADIOSSstKillReadersTest.Serialized PROPERTIES TIMEOUT 240) 
+#add_test(
+#  NAME ADIOSSstKillReadersTest.Serialized
+#  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_multi_test -test_protocol kill_readers
+#    -nw 3 -nr 2 -max_readers 1 -warg 'RendezvousReaderCount:0' -rarg '--ignore_time_gap')
+#set_tests_properties(ADIOSSstKillReadersTest.Serialized PROPERTIES TIMEOUT 240) 
 

--- a/testing/adios2/engine/sst/CMakeLists.txt
+++ b/testing/adios2/engine/sst/CMakeLists.txt
@@ -163,8 +163,8 @@ if(ADIOS2_HAVE_ZFP)
 endif()
 
 add_test(
-  NAME ADIOSSstKillReadersTest
+  NAME ADIOSSstKillReadersTest.Serialized
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_multi_test -test_protocol kill_readers
-    -nw 3 -nr 2 -warg 'RendezvousReaderCount:0' -rarg '--ignore_time_gap')
-set_tests_properties(ADIOSSstKillReadersTest PROPERTIES TIMEOUT 120) 
+    -nw 3 -nr 2 -max_readers 1 -warg 'RendezvousReaderCount:0' -rarg '--ignore_time_gap')
+set_tests_properties(ADIOSSstKillReadersTest.Serialized PROPERTIES TIMEOUT 240) 
 

--- a/testing/adios2/engine/sst/CMakeLists.txt
+++ b/testing/adios2/engine/sst/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 add_executable(TestSstWrite TestSstWrite.cpp)
 add_executable(TestSstRead TestSstRead.cpp)
+add_executable(TestSstServer TestSstServer.cpp)
+add_executable(TestSstClient TestSstClient.cpp)
 if(ADIOS2_HAVE_Fortran)
   add_library(TestData_f OBJECT TestData_mod.f90)
   add_executable(TestSstWrite_f TestSstWriteF.f90 $<TARGET_OBJECTS:TestData_f>)
@@ -17,13 +19,19 @@ endif()
 if(SST_INCLUDE_DIRS)
   target_include_directories(TestSstWrite PRIVATE ${SST_INCLUDE_DIRS})
   target_include_directories(TestSstRead PRIVATE ${SST_INCLUDE_DIRS})
+  target_include_directories(TestSstServer PRIVATE ${SST_INCLUDE_DIRS})
+  target_include_directories(TestSstClient PRIVATE ${SST_INCLUDE_DIRS})
 endif()
 target_link_libraries(TestSstWrite adios2 gtest_interface ${Sst_LIBRARY})
 target_link_libraries(TestSstRead adios2 gtest_interface ${Sst_LIBRARY})
+target_link_libraries(TestSstServer adios2 gtest_interface ${Sst_LIBRARY})
+target_link_libraries(TestSstClient adios2 gtest_interface ${Sst_LIBRARY})
 
 if(ADIOS2_HAVE_MPI)
   target_link_libraries(TestSstWrite MPI::MPI_C)
   target_link_libraries(TestSstRead MPI::MPI_C)
+  target_link_libraries(TestSstServer MPI::MPI_C)
+  target_link_libraries(TestSstClient MPI::MPI_C)
   set(extra_test_args EXEC_WRAPPER ${MPIEXEC_COMMAND})
   if(ADIOS2_HAVE_Fortran)
     target_link_libraries(TestSstWrite_f MPI::MPI_Fortran)
@@ -34,6 +42,12 @@ endif()
 configure_file(
   run_staging_test.in
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
+  @ONLY
+)
+
+configure_file(
+  run_multi_test.in
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_multi_test
   @ONLY
 )
 

--- a/testing/adios2/engine/sst/TestSstClient.cpp
+++ b/testing/adios2/engine/sst/TestSstClient.cpp
@@ -24,7 +24,7 @@ adios2::Params engineParams = {}; // parsed from command line
 int TimeGapExpected = 0;
 int IgnoreTimeGap = 1;
 // Number of steps
-std::size_t NSteps = -1;
+std::size_t NSteps = 200;
 
 static std::string Trim(std::string &str)
 {
@@ -209,10 +209,13 @@ TEST_F(SstReadTest, ADIOS2SstRead)
         engine.Get(var_r64_2d_rev, in_R64_2d_rev.data());
         std::time_t write_time;
         engine.Get(var_time, (int64_t *)&write_time);
-        engine.EndStep();
+	try {
+	    engine.EndStep();
 
-        EXPECT_EQ(validateSstTestData(myStart, myLength, t), 0);
-        write_times.push_back(write_time);
+	    EXPECT_EQ(validateSstTestData(myStart, myLength, t), 0);
+	    write_times.push_back(write_time);
+	} catch (...) {std::cout << "Exception in EndStep, writer failed";}
+
         ++t;
         if (NSteps != -1)
         {

--- a/testing/adios2/engine/sst/TestSstClient.cpp
+++ b/testing/adios2/engine/sst/TestSstClient.cpp
@@ -98,7 +98,8 @@ TEST_F(SstReadTest, ADIOS2SstRead)
     {
         const size_t currentStep = engine.CurrentStep();
 
-	if (t == -1) t = currentStep;   // starting out 
+        if (t == -1)
+            t = currentStep; // starting out
 
         EXPECT_EQ(currentStep, static_cast<size_t>(t));
 
@@ -213,12 +214,14 @@ TEST_F(SstReadTest, ADIOS2SstRead)
         EXPECT_EQ(validateSstTestData(myStart, myLength, t), 0);
         write_times.push_back(write_time);
         ++t;
-	if (NSteps != -1) {
-	    NSteps--;
-	    if (NSteps == 0) {
-		break;
-	    }
-	}
+        if (NSteps != -1)
+        {
+            NSteps--;
+            if (NSteps == 0)
+            {
+                break;
+            }
+        }
     }
 
     if ((write_times.back() - write_times.front()) > 1)
@@ -226,15 +229,16 @@ TEST_F(SstReadTest, ADIOS2SstRead)
         TimeGapDetected++;
     }
 
-    if (!IgnoreTimeGap) {
-	if (TimeGapExpected)
-	    {
-		EXPECT_TRUE(TimeGapDetected);
-	    }
-	else
-	    {
-		EXPECT_FALSE(TimeGapDetected);
-	    }
+    if (!IgnoreTimeGap)
+    {
+        if (TimeGapExpected)
+        {
+            EXPECT_TRUE(TimeGapDetected);
+        }
+        else
+        {
+            EXPECT_FALSE(TimeGapDetected);
+        }
     }
     // Close the file
     engine.Close();
@@ -257,21 +261,25 @@ int main(int argc, char **argv)
     {
         if (std::string(argv[1]) == "--num_steps")
         {
-	    std::istringstream ss(argv[2]);
+            std::istringstream ss(argv[2]);
             if (!(ss >> NSteps))
-		std::cerr << "Invalid number for num_steps " << argv[1] << '\n';
+                std::cerr << "Invalid number for num_steps " << argv[1] << '\n';
             argv++;
             argc--;
-	    std::cout << "Done, Nsteps was " << NSteps << " argc now " << argc << std::endl;
-        } else if (std::string(argv[1]) == "--expect_time_gap")
+            std::cout << "Done, Nsteps was " << NSteps << " argc now " << argc
+                      << std::endl;
+        }
+        else if (std::string(argv[1]) == "--expect_time_gap")
         {
             TimeGapExpected++;
-	    IgnoreTimeGap = 0;
-        } else if (std::string(argv[1]) == "--expect_contiguous_time")
+            IgnoreTimeGap = 0;
+        }
+        else if (std::string(argv[1]) == "--expect_contiguous_time")
         {
             TimeGapExpected = 0;
-	    IgnoreTimeGap = 0;
-        } else if (std::string(argv[1]) == "--ignore_time_gap")
+            IgnoreTimeGap = 0;
+        }
+        else if (std::string(argv[1]) == "--ignore_time_gap")
         {
             IgnoreTimeGap++;
         }

--- a/testing/adios2/engine/sst/TestSstClient.cpp
+++ b/testing/adios2/engine/sst/TestSstClient.cpp
@@ -1,0 +1,298 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#include "TestData.h"
+
+class SstReadTest : public ::testing::Test
+{
+public:
+    SstReadTest() = default;
+};
+
+adios2::Params engineParams = {}; // parsed from command line
+int TimeGapExpected = 0;
+int IgnoreTimeGap = 1;
+// Number of steps
+std::size_t NSteps = -1;
+
+static std::string Trim(std::string &str)
+{
+    size_t first = str.find_first_not_of(' ');
+    size_t last = str.find_last_not_of(' ');
+    return str.substr(first, (last - first + 1));
+}
+
+/*
+ * Engine parameters spec is a poor-man's JSON.  name:value pairs are separated
+ * by commas.  White space is trimmed off front and back.  No quotes or anything
+ * fancy allowed.
+ */
+static adios2::Params ParseEngineParams(std::string Input)
+{
+    std::istringstream ss(Input);
+    std::string Param;
+    adios2::Params Ret = {};
+
+    while (std::getline(ss, Param, ','))
+    {
+        std::istringstream ss2(Param);
+        std::string ParamName;
+        std::string ParamValue;
+        std::getline(ss2, ParamName, ':');
+        if (!std::getline(ss2, ParamValue, ':'))
+        {
+            throw std::invalid_argument("Engine parameter \"" + Param +
+                                        "\" missing value");
+        }
+        Ret[Trim(ParamName)] = Trim(ParamValue);
+    }
+    return Ret;
+}
+
+// ADIOS2 Sst read
+TEST_F(SstReadTest, ADIOS2SstRead)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname = "ADIOS2SstServer";
+
+    int mpiRank = 0, mpiSize = 1;
+
+    int TimeGapDetected = 0;
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using ADIOS2
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    adios2::IO io = adios.DeclareIO("TestIO");
+
+    // Create the Engine
+    io.SetEngine("Sst");
+    io.SetParameters(engineParams);
+
+    adios2::Engine engine = io.Open(fname, adios2::Mode::Read);
+
+    unsigned int t = -1;
+
+    std::vector<std::time_t> write_times;
+
+    while (engine.BeginStep() == adios2::StepStatus::OK)
+    {
+        const size_t currentStep = engine.CurrentStep();
+
+	if (t == -1) t = currentStep;   // starting out 
+
+        EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+        int writerSize;
+
+        auto var_i8 = io.InquireVariable<int8_t>("i8");
+        EXPECT_TRUE(var_i8);
+        ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+        /* must be a multiple of Nx */
+        ASSERT_EQ(var_i8.Shape()[0] % Nx, 0);
+
+        /* take the first size as something that gives us writer size */
+        writerSize = var_i8.Shape()[0] / 10;
+
+        auto var_i16 = io.InquireVariable<int16_t>("i16");
+        EXPECT_TRUE(var_i16);
+        ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i16.Shape()[0], writerSize * Nx);
+
+        auto var_i32 = io.InquireVariable<int32_t>("i32");
+        EXPECT_TRUE(var_i32);
+        ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i32.Shape()[0], writerSize * Nx);
+
+        auto var_i64 = io.InquireVariable<int64_t>("i64");
+        EXPECT_TRUE(var_i64);
+        ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i64.Shape()[0], writerSize * Nx);
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        EXPECT_TRUE(var_r32);
+        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32.Shape()[0], writerSize * Nx);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Shape()[0], writerSize * Nx);
+
+        auto var_r64_2d = io.InquireVariable<double>("r64_2d");
+        EXPECT_TRUE(var_r64_2d);
+        ASSERT_EQ(var_r64_2d.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64_2d.Shape()[0], writerSize * Nx);
+        ASSERT_EQ(var_r64_2d.Shape()[1], 2);
+
+        auto var_r64_2d_rev = io.InquireVariable<double>("r64_2d_rev");
+        EXPECT_TRUE(var_r64_2d_rev);
+        ASSERT_EQ(var_r64_2d_rev.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64_2d_rev.Shape()[0], 2);
+        ASSERT_EQ(var_r64_2d_rev.Shape()[1], writerSize * Nx);
+
+        auto var_time = io.InquireVariable<int64_t>("time");
+        EXPECT_TRUE(var_time);
+        ASSERT_EQ(var_time.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_time.Shape()[0], writerSize);
+
+        long unsigned int myStart = (writerSize * Nx / mpiSize) * mpiRank;
+        long unsigned int myLength =
+            ((writerSize * Nx + mpiSize - 1) / mpiSize);
+
+        if (myStart + myLength > writerSize * Nx)
+        {
+            myLength = writerSize * Nx - myStart;
+        }
+        const adios2::Dims start{myStart};
+        const adios2::Dims count{myLength};
+        const adios2::Dims start2{myStart, 0};
+        const adios2::Dims count2{myLength, 2};
+        const adios2::Dims start3{0, myStart};
+        const adios2::Dims count3{2, myLength};
+        const adios2::Dims start_time{myStart};
+        const adios2::Dims count_time{1};
+
+        const adios2::Box<adios2::Dims> sel(start, count);
+        const adios2::Box<adios2::Dims> sel2(start2, count2);
+        const adios2::Box<adios2::Dims> sel3(start3, count3);
+        const adios2::Box<adios2::Dims> sel_time(start_time, count_time);
+
+        var_i8.SetSelection(sel);
+        var_i16.SetSelection(sel);
+        var_i32.SetSelection(sel);
+        var_i64.SetSelection(sel);
+
+        var_r32.SetSelection(sel);
+        var_r64.SetSelection(sel);
+        var_r64_2d.SetSelection(sel2);
+        var_r64_2d_rev.SetSelection(sel3);
+
+        var_time.SetSelection(sel_time);
+
+        in_I8.reserve(myLength);
+        in_I16.reserve(myLength);
+        in_I32.reserve(myLength);
+        in_I64.reserve(myLength);
+        in_R32.reserve(myLength);
+        in_R64.reserve(myLength);
+        in_R64_2d.reserve(myLength * 2);
+        in_R64_2d_rev.reserve(myLength * 2);
+        engine.Get(var_i8, in_I8.data());
+        engine.Get(var_i16, in_I16.data());
+        engine.Get(var_i32, in_I32.data());
+        engine.Get(var_i64, in_I64.data());
+
+        engine.Get(var_r32, in_R32.data());
+        engine.Get(var_r64, in_R64.data());
+        engine.Get(var_r64_2d, in_R64_2d.data());
+        engine.Get(var_r64_2d_rev, in_R64_2d_rev.data());
+        std::time_t write_time;
+        engine.Get(var_time, (int64_t *)&write_time);
+        engine.EndStep();
+
+        EXPECT_EQ(validateSstTestData(myStart, myLength, t), 0);
+        write_times.push_back(write_time);
+        ++t;
+	if (NSteps != -1) {
+	    NSteps--;
+	    if (NSteps == 0) {
+		break;
+	    }
+	}
+    }
+
+    if ((write_times.back() - write_times.front()) > 1)
+    {
+        TimeGapDetected++;
+    }
+
+    if (!IgnoreTimeGap) {
+	if (TimeGapExpected)
+	    {
+		EXPECT_TRUE(TimeGapDetected);
+	    }
+	else
+	    {
+		EXPECT_FALSE(TimeGapDetected);
+	    }
+    }
+    // Close the file
+    engine.Close();
+}
+
+//******************************************************************************
+// main
+//******************************************************************************
+
+int main(int argc, char **argv)
+{
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    while ((argc > 1) && (argv[1][0] == '-'))
+    {
+        if (std::string(argv[1]) == "--num_steps")
+        {
+	    std::istringstream ss(argv[2]);
+            if (!(ss >> NSteps))
+		std::cerr << "Invalid number for num_steps " << argv[1] << '\n';
+            argv++;
+            argc--;
+	    std::cout << "Done, Nsteps was " << NSteps << " argc now " << argc << std::endl;
+        } else if (std::string(argv[1]) == "--expect_time_gap")
+        {
+            TimeGapExpected++;
+	    IgnoreTimeGap = 0;
+        } else if (std::string(argv[1]) == "--expect_contiguous_time")
+        {
+            TimeGapExpected = 0;
+	    IgnoreTimeGap = 0;
+        } else if (std::string(argv[1]) == "--ignore_time_gap")
+        {
+            IgnoreTimeGap++;
+        }
+        else
+        {
+            throw std::invalid_argument("Unknown argument \"" +
+                                        std::string(argv[1]) + "\"");
+        }
+        argv++;
+        argc--;
+    }
+    if (argc > 1)
+    {
+        engineParams = ParseEngineParams(argv[1]);
+    }
+
+    result = RUN_ALL_TESTS();
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}

--- a/testing/adios2/engine/sst/TestSstClient.cpp
+++ b/testing/adios2/engine/sst/TestSstClient.cpp
@@ -209,12 +209,17 @@ TEST_F(SstReadTest, ADIOS2SstRead)
         engine.Get(var_r64_2d_rev, in_R64_2d_rev.data());
         std::time_t write_time;
         engine.Get(var_time, (int64_t *)&write_time);
-	try {
-	    engine.EndStep();
+        try
+        {
+            engine.EndStep();
 
-	    EXPECT_EQ(validateSstTestData(myStart, myLength, t), 0);
-	    write_times.push_back(write_time);
-	} catch (...) {std::cout << "Exception in EndStep, writer failed";}
+            EXPECT_EQ(validateSstTestData(myStart, myLength, t), 0);
+            write_times.push_back(write_time);
+        }
+        catch (...)
+        {
+            std::cout << "Exception in EndStep, writer failed";
+        }
 
         ++t;
         if (NSteps != -1)

--- a/testing/adios2/engine/sst/TestSstServer.cpp
+++ b/testing/adios2/engine/sst/TestSstServer.cpp
@@ -66,7 +66,7 @@ TEST_F(SstWriteTest, ADIOS2SstServer)
 
     int mpiRank = 0, mpiSize = 1;
 
-    // Number of steps
+// Number of steps
 
 #ifdef ADIOS2_HAVE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
@@ -115,7 +115,7 @@ TEST_F(SstWriteTest, ADIOS2SstServer)
 
     adios2::Engine engine = io.Open(fname, adios2::Mode::Write);
 
-        // Advance to the next time step
+    // Advance to the next time step
     std::time_t EndTime = std::time(NULL) + DurationSeconds;
     size_t step = 0;
 
@@ -171,8 +171,8 @@ TEST_F(SstWriteTest, ADIOS2SstServer)
         std::time_t localtime = std::time(NULL);
         engine.Put(var_time, (int64_t *)&localtime);
         engine.EndStep();
-        usleep(1000*100);  /* sleep for .1 seconds */
-	step++;
+        usleep(1000 * 100); /* sleep for .1 seconds */
+        step++;
     }
 
     // Close the file
@@ -192,16 +192,17 @@ int main(int argc, char **argv)
     {
         if (std::string(argv[1]) == "--duration")
         {
-	    std::istringstream ss(argv[2]);
+            std::istringstream ss(argv[2]);
             if (!(ss >> DurationSeconds))
-		std::cerr << "Invalid number for duration " << argv[1] << '\n';
+                std::cerr << "Invalid number for duration " << argv[1] << '\n';
             argv++;
             argc--;
         }
-        else if (std::string(argv[1]) == "--engine_params") {
+        else if (std::string(argv[1]) == "--engine_params")
+        {
             engineParams = ParseEngineParams(argv[2]);
-        } 
-        else 
+        }
+        else
         {
             throw std::invalid_argument("Unknown argument \"" +
                                         std::string(argv[1]) + "\"");

--- a/testing/adios2/engine/sst/TestSstServer.cpp
+++ b/testing/adios2/engine/sst/TestSstServer.cpp
@@ -1,0 +1,223 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+#include <ctime>
+
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#include "TestData.h"
+
+class SstWriteTest : public ::testing::Test
+{
+public:
+    SstWriteTest() = default;
+};
+
+adios2::Params engineParams = {}; // parsed from command line
+int DurationSeconds = 100;
+
+static std::string Trim(std::string &str)
+{
+    size_t first = str.find_first_not_of(' ');
+    size_t last = str.find_last_not_of(' ');
+    return str.substr(first, (last - first + 1));
+}
+
+/*
+ * Engine parameters spec is a poor-man's JSON.  name:value pairs are separated
+ * by commas.  White space is trimmed off front and back.  No quotes or anything
+ * fancy allowed.
+ */
+static adios2::Params ParseEngineParams(std::string Input)
+{
+    std::istringstream ss(Input);
+    std::string Param;
+    adios2::Params Ret = {};
+
+    while (std::getline(ss, Param, ','))
+    {
+        std::istringstream ss2(Param);
+        std::string ParamName;
+        std::string ParamValue;
+        std::getline(ss2, ParamName, ':');
+        if (!std::getline(ss2, ParamValue, ':'))
+        {
+            throw std::invalid_argument("Engine parameter \"" + Param +
+                                        "\" missing value");
+        }
+        Ret[Trim(ParamName)] = Trim(ParamValue);
+    }
+    return Ret;
+}
+
+// ADIOS2 SST write
+TEST_F(SstWriteTest, ADIOS2SstServer)
+{
+    const std::string fname = "ADIOS2SstServer";
+
+    int mpiRank = 0, mpiSize = 1;
+
+    // Number of steps
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using ADIOS2
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    adios2::IO io = adios.DeclareIO("TestIO");
+
+    // Declare 1D variables (NumOfProcesses * Nx)
+    // The local process' part (start, count) can be defined now or later
+    // before Write().
+    {
+        adios2::Dims shape{static_cast<unsigned int>(Nx * mpiSize)};
+        adios2::Dims start{static_cast<unsigned int>(Nx * mpiRank)};
+        adios2::Dims count{static_cast<unsigned int>(Nx)};
+        adios2::Dims shape2{static_cast<unsigned int>(Nx * mpiSize), 2};
+        adios2::Dims start2{static_cast<unsigned int>(Nx * mpiRank), 0};
+        adios2::Dims count2{static_cast<unsigned int>(Nx), 2};
+        adios2::Dims shape3{2, static_cast<unsigned int>(Nx * mpiSize)};
+        adios2::Dims start3{0, static_cast<unsigned int>(Nx * mpiRank)};
+        adios2::Dims count3{2, static_cast<unsigned int>(Nx)};
+        adios2::Dims time_shape{static_cast<unsigned int>(mpiSize)};
+        adios2::Dims time_start{static_cast<unsigned int>(mpiRank)};
+        adios2::Dims time_count{1};
+        io.DefineVariable<int8_t>("i8", shape, start, count);
+        io.DefineVariable<int16_t>("i16", shape, start, count);
+        io.DefineVariable<int32_t>("i32", shape, start, count);
+        io.DefineVariable<int64_t>("i64", shape, start, count);
+        io.DefineVariable<float>("r32", shape, start, count);
+        io.DefineVariable<double>("r64", shape, start, count);
+        io.DefineVariable<double>("r64_2d", shape2, start2, count2);
+        io.DefineVariable<double>("r64_2d_rev", shape3, start3, count3);
+        io.DefineVariable<int64_t>("time", time_shape, time_start, time_count);
+    }
+
+    // Create the Engine
+    io.SetEngine("Sst");
+    io.SetParameters(engineParams);
+
+    adios2::Engine engine = io.Open(fname, adios2::Mode::Write);
+
+        // Advance to the next time step
+    std::time_t EndTime = std::time(NULL) + DurationSeconds;
+    size_t step = 0;
+
+    while (std::time(NULL) < EndTime)
+    {
+        // Generate test data for each process uniquely
+        generateSstTestData(step, mpiRank, mpiSize);
+
+        engine.BeginStep();
+        // Retrieve the variables that previously went out of scope
+        auto var_i8 = io.InquireVariable<int8_t>("i8");
+        auto var_i16 = io.InquireVariable<int16_t>("i16");
+        auto var_i32 = io.InquireVariable<int32_t>("i32");
+        auto var_i64 = io.InquireVariable<int64_t>("i64");
+        auto var_u8 = io.InquireVariable<uint8_t>("u8");
+        auto var_r32 = io.InquireVariable<float>("r32");
+        auto var_r64 = io.InquireVariable<double>("r64");
+        auto var_r64_2d = io.InquireVariable<double>("r64_2d");
+        auto var_r64_2d_rev = io.InquireVariable<double>("r64_2d_rev");
+        auto var_time = io.InquireVariable<int64_t>("time");
+
+        // Make a 1D selection to describe the local dimensions of the
+        // variable we write and its offsets in the global spaces
+        adios2::Box<adios2::Dims> sel({mpiRank * Nx}, {Nx});
+        adios2::Box<adios2::Dims> sel2({mpiRank * Nx, 0}, {Nx, 2});
+        adios2::Box<adios2::Dims> sel3({0, mpiRank * Nx}, {2, Nx});
+        adios2::Box<adios2::Dims> sel_time(
+            {static_cast<unsigned long>(mpiRank)}, {1});
+        var_i8.SetSelection(sel);
+        var_i16.SetSelection(sel);
+        var_i32.SetSelection(sel);
+        var_i64.SetSelection(sel);
+        var_r32.SetSelection(sel);
+        var_r64.SetSelection(sel);
+        var_r64_2d.SetSelection(sel2);
+        var_r64_2d_rev.SetSelection(sel3);
+        var_time.SetSelection(sel_time);
+
+        // Write each one
+        // fill in the variable with values from starting index to
+        // starting index + count
+        const adios2::Mode sync = adios2::Mode::Sync;
+
+        engine.Put(var_i8, data_I8.data(), sync);
+        engine.Put(var_i16, data_I16.data(), sync);
+        engine.Put(var_i32, data_I32.data(), sync);
+        engine.Put(var_i64, data_I64.data(), sync);
+        engine.Put(var_r32, data_R32.data(), sync);
+        engine.Put(var_r64, data_R64.data(), sync);
+        engine.Put(var_r64_2d, &data_R64_2d[0][0], sync);
+        engine.Put(var_r64_2d_rev, &data_R64_2d_rev[0][0], sync);
+        // Advance to the next time step
+        std::time_t localtime = std::time(NULL);
+        engine.Put(var_time, (int64_t *)&localtime);
+        engine.EndStep();
+        usleep(1000*100);  /* sleep for .1 seconds */
+	step++;
+    }
+
+    // Close the file
+    engine.Close();
+}
+
+int main(int argc, char **argv)
+{
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    while ((argc > 1) && (argv[1][0] == '-'))
+    {
+        if (std::string(argv[1]) == "--duration")
+        {
+	    std::istringstream ss(argv[2]);
+            if (!(ss >> DurationSeconds))
+		std::cerr << "Invalid number for duration " << argv[1] << '\n';
+            argv++;
+            argc--;
+        }
+        else if (std::string(argv[1]) == "--engine_params") {
+            engineParams = ParseEngineParams(argv[2]);
+        } 
+        else 
+        {
+            throw std::invalid_argument("Unknown argument \"" +
+                                        std::string(argv[1]) + "\"");
+        }
+        argv++;
+        argc--;
+    }
+    if (argc > 1)
+    {
+    }
+
+    result = RUN_ALL_TESTS();
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}

--- a/testing/adios2/engine/sst/run_multi_test.in
+++ b/testing/adios2/engine/sst/run_multi_test.in
@@ -43,30 +43,34 @@ defined(my $writer_pid = fork) or die "Cannot fork $!";
 unless($writer_pid)
   {
     #Child process is here
-    exec ("@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $num_writers $my_dirname/$writer_prog --duration $duration" . join(" ", @$writer_args));
+    print "TestDriver: EXEC $my_dirname/$writer_prog\n" if $verbose;
+    exec ("@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $num_writers $my_dirname/$writer_prog " . join(" ", @$writer_args));
     die "Can't exec @MPIEXEC@! $!";
   }
-print "Writer PID: $writer_pid\n" if $verbose;
+print "TestDriver: Writer PID: $writer_pid\n" if $verbose;
         
+my $endtime = time() + $duration;
 
 if ($test_protocol == "kill_readers") {
   
   my @ReaderPIDs;
-  print "Duration at beginning is $duration\n" if $verbose;
-  while ($duration > 0) {
+  print "TestDriver: Duration at beginning is $duration\n" if $verbose;
+
+  while (time() < $endtime) {
+    my $this_start = time();
     my $r = rand();
-    print "Start, number of readers is $#ReaderPIDs\n" if $verbose;
+    print "TestDriver: Start, number of readers is $#ReaderPIDs, max readers is $max_readers\n" if $verbose;
     if ((($#ReaderPIDs <= 0) || ($r < 0.5))  && ($#ReaderPIDs != $max_readers)){
       # fork a reader
       defined(my $reader_pid = fork) or die "Cannot fork $!";
       unless($reader_pid)
 	{
 	  #Child process is here
-	  print "EXEC $my_dirname/$reader_prog\n" if $verbose;
+	  print "TestDriver: EXEC $my_dirname/$reader_prog\n" if $verbose;
 	  exec ("@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $num_readers $my_dirname/$reader_prog " . join(" ", @$reader_args));
 	  die "Can't exec @MPIEXEC@! $!";
 	}
-      print "Reader PID: $reader_pid\n" if $verbose;
+      print "TestDriver: Reader PID: $reader_pid\n" if $verbose;
       push @ReaderPIDs, $reader_pid;
     } else {
       # kill a reader 
@@ -74,31 +78,37 @@ if ($test_protocol == "kill_readers") {
       @ReaderPIDs = shuffle @ReaderPIDs;
       my $readerToKill = shift @ReaderPIDs;
       kill 'KILL', $readerToKill;
-      print "KILLED Reader PID: $readerToKill\n" if $verbose;
+      print "TestDriver: KILLED Reader PID: $readerToKill\n" if $verbose;
       waitpid($readerToKill, 0);
-      print "Status of killed reader was $?\n" if $verbose;
+      print "TestDriver: Status of killed reader was $?\n" if $verbose;
       if (($? != 0) && ($? != 9)) {
 	$exit_value = 1; #failure
-	print "Setting failure return because of bad exit status of killed reader\n";
+	print "TestDriver: Setting failure return because of bad exit status of killed reader\n";
       }
     }
-    sleep $interval;
-    $duration -= $interval;
-    print "Duration is now $duration\n" if $verbose;
+    my $sleep_time = ($this_start + $interval) - time();
+    print "TestDriver: TEST SLEEP TIME IS $sleep_time\n";
+    if ($sleep_time > 0) {
+      sleep $sleep_time;
+    }
+    my $time_remaining = $endtime - time();
+    print "TestDriver: TEST TIME REMAINING is $time_remaining \n";
   }
+  print "TestDriver: Killing the writer\n";
+  kill 'USR1', $writer_pid;
   foreach my $readerPID (@ReaderPIDs) {
       waitpid($readerPID, 0);
-      print "Status of final reader was $?\n" if $verbose;
+      print "TestDriver: Status of final reader was $?\n" if $verbose;
       if ($? != 0) {
 	$exit_value = 1; #failure
-	print "Setting failure return because of bad exit status on normal reader\n";
+	print "TestDriver: Setting failure return because of bad exit status on normal reader\n";
       }
   }    
   waitpid($writer_pid, 0);
-  print "Status of writer was $?\n" if $verbose;
+  print "TestDriver: Status of writer was $?\n" if $verbose;
   if ($? != 0) {
     $exit_value = 1; #failure
-    print "Setting failure return because of bad exit status of writer\n";
+    print "TestDriver: Setting failure return because of bad exit status of writer\n";
   }
   exit $exit_value;
 } # end kill_readers protocol

--- a/testing/adios2/engine/sst/run_multi_test.in
+++ b/testing/adios2/engine/sst/run_multi_test.in
@@ -1,0 +1,102 @@
+#!/usr/bin/perl
+# This script has been build to run the tests in the bin directory.
+use Getopt::Long;
+use List::Util qw(shuffle);
+use strict;
+
+##Parse Args
+my $verbose = '';	# option variable with default value (false)
+my $writer_prog = "bin/TestSstServer";
+my $reader_prog = "bin/TestSstClient";
+my $writer_args = "";
+my $reader_args = "";
+my $num_writers = 3;
+my $num_readers = 2;
+my $max_readers = 3;
+my $test_protocol = 'kill_readers';
+my $duration = 60;
+my $interval = 5;
+my $exit_value = 0;
+
+GetOptions ('verbose!' => \$verbose, 
+	    'writer=s' => \$writer_prog,
+	    'reader=s' => \$reader_prog,
+	    'warg=s@' => \$writer_args,
+	    'rarg=s@' => \$reader_args,
+	    'nw=i' => \$num_writers,
+	    'nr=i' => \$num_readers,
+	    'duration=i' => \$duration,
+	    'interval=i' => \$interval,
+	    'max_readers=i' => \$num_readers,
+	    'test_protocol=s' => \$test_protocol)
+  or die("Error in command line arguments\n");
+
+
+my $writer_output = "";
+my $reader_output = "";
+my $result = 1;
+
+defined(my $writer_pid = fork) or die "Cannot fork $!";
+unless($writer_pid)
+  {
+    #Child process is here
+    exec ("mpirun -n $num_writers ./$writer_prog --duration $duration $writer_args");
+    die "Can't exec mpirun! $!";
+  }
+print "Writer PID: $writer_pid\n" if $verbose;
+        
+
+if ($test_protocol == "kill_readers") {
+  
+  my @ReaderPIDs;
+  print "Duration at beginning is $duration\n" if $verbose;
+  while ($duration > 0) {
+    my $r = rand();
+    print "Start, number of readers is $#ReaderPIDs\n" if $verbose;
+    if ((($#ReaderPIDs <= 0) || ($r < 0.5))  && ($#ReaderPIDs != $max_readers)){
+      # fork a reader
+      defined(my $reader_pid = fork) or die "Cannot fork $!";
+      unless($reader_pid)
+	{
+	  #Child process is here
+	  print "EXEC $reader_prog\n" if $verbose;
+	  exec ("mpirun -n $num_readers $reader_prog $reader_args");
+	  die "Can't exec mpirun! $!";
+	}
+      print "Reader PID: $reader_pid\n" if $verbose;
+      push @ReaderPIDs, $reader_pid;
+    } else {
+      # kill a reader 
+      my $readerToKill;
+      @ReaderPIDs = shuffle @ReaderPIDs;
+      my $readerToKill = shift @ReaderPIDs;
+      kill 'KILL', $readerToKill;
+      print "KILLED Reader PID: $readerToKill\n" if $verbose;
+      waitpid($readerToKill, 0);
+      print "Status of killed reader was $?\n" if $verbose;
+      if (($? != 0) || ($? != 9)) {
+	$exit_value = 1; #failure
+	print "Setting failure return because of bad exit status of killed reader\n";
+      }
+    }
+    sleep $interval;
+    $duration -= $interval;
+    print "Duration is now $duration\n" if $verbose;
+  }
+  foreach my $readerPID (@ReaderPIDs) {
+      waitpid($readerPID, 0);
+      print "Status of final reader was $?\n" if $verbose;
+      if ($? != 0) {
+	$exit_value = 1; #failure
+	print "Setting failure return because of bad exit status on normal reader\n";
+      }
+  }    
+  waitpid($writer_pid, 0);
+  print "Status of writer was $?\n" if $verbose;
+  if ($? != 0) {
+    $exit_value = 1; #failure
+    print "Setting failure return because of bad exit status of writer\n";
+  }
+  exit $exit_value;
+} # end kill_readers protocol
+

--- a/testing/adios2/engine/sst/run_multi_test.in
+++ b/testing/adios2/engine/sst/run_multi_test.in
@@ -5,9 +5,9 @@ use List::Util qw(shuffle);
 use strict;
 
 ##Parse Args
-my $verbose = '';	# option variable with default value (false)
-my $writer_prog = "bin/TestSstServer";
-my $reader_prog = "bin/TestSstClient";
+my $verbose = 0;	# option variable with default value (false)
+my $writer_prog = "TestSstServer";
+my $reader_prog = "TestSstClient";
 my $writer_args = "";
 my $reader_args = "";
 my $num_writers = 3;
@@ -17,6 +17,9 @@ my $test_protocol = 'kill_readers';
 my $duration = 60;
 my $interval = 5;
 my $exit_value = 0;
+
+use File::Basename;
+my $my_dirname = dirname(__FILE__);
 
 GetOptions ('verbose!' => \$verbose, 
 	    'writer=s' => \$writer_prog,
@@ -40,8 +43,8 @@ defined(my $writer_pid = fork) or die "Cannot fork $!";
 unless($writer_pid)
   {
     #Child process is here
-    exec ("mpirun -n $num_writers ./$writer_prog --duration $duration $writer_args");
-    die "Can't exec mpirun! $!";
+    exec ("@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $num_writers $my_dirname/$writer_prog --duration $duration" . join(" ", @$writer_args));
+    die "Can't exec @MPIEXEC@! $!";
   }
 print "Writer PID: $writer_pid\n" if $verbose;
         
@@ -59,9 +62,9 @@ if ($test_protocol == "kill_readers") {
       unless($reader_pid)
 	{
 	  #Child process is here
-	  print "EXEC $reader_prog\n" if $verbose;
-	  exec ("mpirun -n $num_readers $reader_prog $reader_args");
-	  die "Can't exec mpirun! $!";
+	  print "EXEC $my_dirname/$reader_prog\n" if $verbose;
+	  exec ("@MPIEXEC@ @MPIEXEC_NUMPROC_FLAG@ $num_readers $my_dirname/$reader_prog " . join(" ", @$reader_args));
+	  die "Can't exec @MPIEXEC@! $!";
 	}
       print "Reader PID: $reader_pid\n" if $verbose;
       push @ReaderPIDs, $reader_pid;
@@ -74,7 +77,7 @@ if ($test_protocol == "kill_readers") {
       print "KILLED Reader PID: $readerToKill\n" if $verbose;
       waitpid($readerToKill, 0);
       print "Status of killed reader was $?\n" if $verbose;
-      if (($? != 0) || ($? != 9)) {
+      if (($? != 0) && ($? != 9)) {
 	$exit_value = 1; #failure
 	print "Setting failure return because of bad exit status of killed reader\n";
       }

--- a/testing/adios2/engine/sst/run_staging_test.in
+++ b/testing/adios2/engine/sst/run_staging_test.in
@@ -73,7 +73,7 @@ if [ "$writer_prog" == "UNSET" ]; then
 fi
 
 # remove any lingering sst contact files
-rm -f *.bpflx
+rm -f *.sst
 
 # Spawn the writer
 if [ $vflag == "yes" ]; then


### PR DESCRIPTION
This PR adds a 60-second SST test of a "server" which periodically produces data and "clients" which join to read data for a while and are sometimes killed (to test write-side response to reader-side failures).  RNG is a factor here, so test results aren't purely deterministic.