### PR TITLE
added sst bp compression tests

### DIFF
--- a/testing/adios2/engine/sst/CMakeLists.txt
+++ b/testing/adios2/engine/sst/CMakeLists.txt
@@ -67,6 +67,22 @@ add_test(
     -nw 3 -nr 5 -v -p TestSst -arg "MarshalMethod:BP")
 set_tests_properties(ADIOSSstTest.3x5BP PROPERTIES TIMEOUT 30) 
 
+if (ADIOS2_HAVE_ZFP)
+    add_test(
+        NAME ADIOSSstTest.3x5BP.zfp
+        COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
+        -nw 3 -nr 5 -v -p TestSst -arg "--compress_zfp MarshalMethod:BP")
+    set_tests_properties(ADIOSSstTest.3x5BP.zfp PROPERTIES TIMEOUT 30)
+endif()
+
+if (ADIOS2_HAVE_SZ)
+    add_test(
+        NAME ADIOSSstTest.3x5BP.sz
+        COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test
+        -nw 3 -nr 5 -v -p TestSst -arg "--compress_sz MarshalMethod:BP")
+    set_tests_properties(ADIOSSstTest.3x5BP.sz PROPERTIES TIMEOUT 30)
+endif()
+
 add_test(
   NAME ADIOSSstTest.5x3
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run_staging_test

--- a/testing/adios2/engine/sst/TestSstRead.cpp
+++ b/testing/adios2/engine/sst/TestSstRead.cpp
@@ -249,6 +249,14 @@ int main(int argc, char **argv)
         {
             TimeGapExpected++;
         }
+        else if (std::string(argv[1]) == "--compress_sz")
+        {
+            // CompressSz++;     Nothing on read side
+        }
+        else if (std::string(argv[1]) == "--compress_zfp")
+        {
+            // CompressZfp++;    Nothing on read side
+        }
         else
         {
             throw std::invalid_argument("Unknown argument \"" +


### PR DESCRIPTION
@eisenhauer I have added tests for ZFP and SZ. ZFP test worked. But the SZ test requires a larger dataset to work on, otherwise it will cause a segfault. This is a known bug of SZ library. 

I tried to add a dedicated variable for the SZ test but unfortunately I broke many other SST tests. So I had to roll back and leave this to you. You can look at the reader source code where I put a TODO label (Line 120).