### PR TITLE
Improve FixedSchedule optimization for In-situ MPI engine

### DIFF
--- a/examples/heatTransfer/read/heatRead.cpp
+++ b/examples/heatTransfer/read/heatRead.cpp
@@ -108,6 +108,8 @@ int main(int argc, char *argv[])
         adios2::Engine reader =
             inIO.Open(settings.inputfile, adios2::Mode::Read, mpiReaderComm);
 
+        reader.FixedSchedule();
+
         std::vector<double> Tin;
         std::vector<double> Tout;
         std::vector<double> dT;

--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -255,8 +255,12 @@ void InSituMPIReader::PerformGets()
 
     // Create read schedule per writer
     // const std::map<std::string, SubFileInfoMap> variablesSubFileInfo =
-    m_ReadScheduleMap.clear();
-    m_ReadScheduleMap = m_BP3Deserializer.PerformGetsVariablesSubFileInfo(m_IO);
+    if (m_CurrentStep == 0 || !m_FixedLocalSchedule)
+    {
+        m_ReadScheduleMap.clear();
+        m_ReadScheduleMap =
+            m_BP3Deserializer.PerformGetsVariablesSubFileInfo(m_IO);
+    }
     // bool reader_IsRowMajor = IsRowMajor(m_IO.m_HostLanguage);
     // bool writer_IsRowMajor = m_BP3Deserializer.m_IsRowMajor;
     // recalculate seek offsets to payload offset 0 (beginning of blocks)

--- a/source/adios2/engine/insitumpi/InSituMPIReader.tcc
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.tcc
@@ -76,8 +76,7 @@ void InSituMPIReader::GetDeferredCommon(Variable<T> &variable, T *data)
     {
         variable.SetData(data);
         // Create the async send for the variable now
-        const helper::SubFileInfoMap sfim =
-            m_BP3Deserializer.GetSubFileInfo(variable);
+        const helper::SubFileInfoMap sfim = m_ReadScheduleMap[variable.m_Name];
         // m_BP3Deserializer.GetSubFileInfoMap(variable.m_Name);
         /* FIXME: this only works if there is only one block read for each
          * variable.


### PR DESCRIPTION
If the schedule is fixed in In-situ MPI engine, the metadata buffer received at the first timestep is kept around over the subsequent timesteps. However, `InSituMPIReader` parses the metadata buffer at every timestep.

We can reuse the parsed metadata and reduce expensive calls to: `BP3Deserializer::PerformGetsVariablesSubFileInfo()` and `BP3Deserializer::GetSubFileInfo()` .