### PR TITLE
Assign conditional priority value to RDMA DP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
       - clang-format-3.8
       - clang-tidy-3.8
       - libmpich-dev
-      - libfabric-dev
 before_install:
   - pushd ${HOME}
   - wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - clang-format-3.8
       - clang-tidy-3.8
       - libmpich-dev
+      - libfabric-dev
 before_install:
   - pushd ${HOME}
   - wget http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -1115,7 +1115,10 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream)
             "RDMA Dataplane could not find an RDMA-compatible fabric.\n");
     }
 
-    fi_freeinfo(originfo);
+    if (originfo)
+    {
+        fi_freeinfo(originfo);
+    }
 
     Svcs->verbose(
         CP_Stream,

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -114,7 +114,7 @@ static void init_fabric(struct fabric_state *fabric)
     {
         char *prov_name = info->fabric_attr->prov_name;
         char *domain_name = info->domain_attr->name;
-        
+
         if (ifname && strcmp(ifname, domain_name) == 0)
         {
             useinfo = info;

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -111,26 +111,28 @@ static void init_fabric(struct fabric_state *fabric)
 
     originfo = info;
     useinfo = NULL;
-    while(info) {
-    	prov_name = info->fabric_attr->prov_name;
-    	domain_name = info->domain_attr->name;
-    	if (ifname && strcmp(ifname, domain_name) == 0) {
-    		useinfo = info;
-    		break;
-    	}
-    	if(strcmp(prov_name, "verbs") == 0
-    			|| strcmp(prov_name, "gni") == 0
-				|| strcmp(prov_name, "psm2") == 0) {
-    		useinfo = info;
-    	}
-    	info = info->next;
+    while (info)
+    {
+        prov_name = info->fabric_attr->prov_name;
+        domain_name = info->domain_attr->name;
+        if (ifname && strcmp(ifname, domain_name) == 0)
+        {
+            useinfo = info;
+            break;
+        }
+        if (strcmp(prov_name, "verbs") == 0 || strcmp(prov_name, "gni") == 0 ||
+            strcmp(prov_name, "psm2") == 0)
+        {
+            useinfo = info;
+        }
+        info = info->next;
     }
 
     info = useinfo;
 
     if (!info)
     {
-    	return;
+        return;
     }
 
     fabric->info = fi_dupinfo(info);
@@ -1059,50 +1061,61 @@ static struct _CP_DP_Interface RdmaDPInterface;
  */
 static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream)
 {
-	struct fi_info *hints, *info, *originfo, *useinfo;
-	char *prov_name, *domain_name;
-	char *ifname;
-	int Ret = -1;
+    struct fi_info *hints, *info, *originfo, *useinfo;
+    char *prov_name, *domain_name;
+    char *ifname;
+    int Ret = -1;
 
-	    hints = fi_allocinfo();
-	    hints->caps = FI_MSG | FI_SEND | FI_RECV | FI_REMOTE_READ |
-	                  FI_REMOTE_WRITE | FI_RMA | FI_READ | FI_WRITE;
-	    hints->mode = FI_CONTEXT | FI_LOCAL_MR | FI_CONTEXT2 | FI_MSG_PREFIX |
-	                  FI_ASYNC_IOV | FI_RX_CQ_DATA;
-	    hints->domain_attr->mr_mode = FI_MR_BASIC;
+    hints = fi_allocinfo();
+    hints->caps = FI_MSG | FI_SEND | FI_RECV | FI_REMOTE_READ |
+                  FI_REMOTE_WRITE | FI_RMA | FI_READ | FI_WRITE;
+    hints->mode = FI_CONTEXT | FI_LOCAL_MR | FI_CONTEXT2 | FI_MSG_PREFIX |
+                  FI_ASYNC_IOV | FI_RX_CQ_DATA;
+    hints->domain_attr->mr_mode = FI_MR_BASIC;
 
-	    ifname = getenv("FABRIC_IFACE");
+    ifname = getenv("FABRIC_IFACE");
 
-	    fi_getinfo(FI_VERSION(1, 5), NULL, NULL, 0, hints, &info);
-	    fi_freeinfo(hints);
+    fi_getinfo(FI_VERSION(1, 5), NULL, NULL, 0, hints, &info);
+    fi_freeinfo(hints);
 
-	    if(!info) {
-	    	Svcs->verbose(CP_Stream, "RDMA Dataplane could not find any viable fabrics.\n");
-	    }
+    if (!info)
+    {
+        Svcs->verbose(CP_Stream,
+                      "RDMA Dataplane could not find any viable fabrics.\n");
+    }
 
-	    while(info) {
-	    	prov_name = info->fabric_attr->prov_name;
-	    	domain_name = info->domain_attr->name;
-	    	if (ifname && strcmp(ifname, domain_name) == 0) {
-	    		Svcs->verbose(CP_Stream, "RDMA Dataplane found the requested interface %s, provider type %s.\n", ifname, prov_name);
-	    		Ret = 100;
-	    		break;
-	    	}
-	    	if(strcmp(prov_name, "verbs") == 0
-	    			|| strcmp(prov_name, "gni") == 0
-					|| strcmp(prov_name, "psm2") == 0) {
+    while (info)
+    {
+        prov_name = info->fabric_attr->prov_name;
+        domain_name = info->domain_attr->name;
+        if (ifname && strcmp(ifname, domain_name) == 0)
+        {
+            Svcs->verbose(CP_Stream, "RDMA Dataplane found the requested "
+                                     "interface %s, provider type %s.\n",
+                          ifname, prov_name);
+            Ret = 100;
+            break;
+        }
+        if (strcmp(prov_name, "verbs") == 0 || strcmp(prov_name, "gni") == 0 ||
+            strcmp(prov_name, "psm2") == 0)
+        {
 
-	    		Svcs->verbose(CP_Stream, "RDMA Dataplane sees interface %s, provider type %s, which should work.\n", domain_name, prov_name);
-	    		Ret = 10;
-	    	}
-	    	info = info->next;
-	    }
+            Svcs->verbose(CP_Stream, "RDMA Dataplane sees interface %s, "
+                                     "provider type %s, which should work.\n",
+                          domain_name, prov_name);
+            Ret = 10;
+        }
+        info = info->next;
+    }
 
-	        	if(Ret == -1) {
-	        		Svcs->verbose(CP_Stream, "RDMA Dataplane could not find an RDMA-compatible fabric.\n");
-	        	}
+    if (Ret == -1)
+    {
+        Svcs->verbose(
+            CP_Stream,
+            "RDMA Dataplane could not find an RDMA-compatible fabric.\n");
+    }
 
-	        	fi_freeinfo(originfo);
+    fi_freeinfo(originfo);
 
     Svcs->verbose(
         CP_Stream,

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -93,7 +93,6 @@ static void init_fabric(struct fabric_state *fabric)
     struct fi_av_attr av_attr = {0};
     struct fi_cq_attr cq_attr = {0};
     char *ifname;
-    char *domain_name, *prov_name;
 
     hints = fi_allocinfo();
     hints->caps = FI_MSG | FI_SEND | FI_RECV | FI_REMOTE_READ |
@@ -113,8 +112,9 @@ static void init_fabric(struct fabric_state *fabric)
     useinfo = NULL;
     while (info)
     {
-        prov_name = info->fabric_attr->prov_name;
-        domain_name = info->domain_attr->name;
+        char *prov_name = info->fabric_attr->prov_name;
+        char *domain_name = info->domain_attr->name;
+        
         if (ifname && strcmp(ifname, domain_name) == 0)
         {
             useinfo = info;
@@ -1062,7 +1062,6 @@ static struct _CP_DP_Interface RdmaDPInterface;
 static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream)
 {
     struct fi_info *hints, *info, *originfo, *useinfo;
-    char *prov_name, *domain_name;
     char *ifname;
     int Ret = -1;
 
@@ -1084,8 +1083,12 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream)
                       "RDMA Dataplane could not find any viable fabrics.\n");
     }
 
+    originfo = info;
+
     while (info)
     {
+        char *prov_name, *domain_name;
+
         prov_name = info->fabric_attr->prov_name;
         domain_name = info->domain_attr->name;
         if (ifname && strcmp(ifname, domain_name) == 0)


### PR DESCRIPTION
This conditionally provides a positive priority to the DP, if a 'valid' provider is detected by LibFabric. Valid is currently verbs, gni, and psm2. We are excluding non-RDMA transports by default because this need is covered by the EVPath DP.