### PR TITLE
Support SST as a write method in adios_reorganize

### DIFF
--- a/source/utils/adios_reorganize/Reorganize.cpp
+++ b/source/utils/adios_reorganize/Reorganize.cpp
@@ -538,6 +538,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
     /*
      * Write all variables
      */
+    wStream.BeginStep();
     for (size_t varidx = 0; varidx < nvars; ++varidx)
     {
         const std::string &name = varinfo[varidx].v->m_Name;


### PR DESCRIPTION
Fixes the following error when using SST as a write method in adios_reorganize:

```
ERROR: When using the SST engine in ADIOS2, Put() calls must appear between BeginStep/EndStep pairs
```