### PR TITLE
Eliminate .sst postfix

### DIFF
--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -119,7 +119,7 @@ extern void SstSetStatsSave(SstStream Stream, SstStats Save);
 
 #include "sst_data.h"
 
-#define SST_POSTFIX ".sst"
+#define SST_POSTFIX ""
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
SST files are only used to setup initial communication and are not designed to be usable/examined by third parties.  But we can eliminate the postfix if desired.  It's all in a #define, so trivial.