### PR TITLE
Allow specifying read/write method parameters in adios_reorganize

### DIFF
--- a/source/utils/adios_reorganize/Reorganize.h
+++ b/source/utils/adios_reorganize/Reorganize.h
@@ -66,14 +66,15 @@ private:
                         const core::DataMap &attributes, int step);
     int ReadWrite(core::Engine &rStream, core::Engine &wStream, core::IO &io,
                   const core::DataMap &variables, int step);
+    Params parseParams(const std::string &param_str);
 
     // Input arguments
-    std::string infilename;    // File/stream to read
-    std::string outfilename;   // File to write
-    std::string wmethodname;   // ADIOS write method
-    std::string wmethodparams; // ADIOS write method
-    std::string rmethodname;   // ADIOS read method
-    std::string rmethodparams; // ADIOS read method
+    std::string infilename;       // File/stream to read
+    std::string outfilename;      // File to write
+    std::string wmethodname;      // ADIOS write method
+    std::string wmethodparam_str; // ADIOS write method parameter string
+    std::string rmethodname;      // ADIOS read method
+    std::string rmethodparam_str; // ADIOS read method parameter string
 
     static const int max_read_buffer_size = 1024 * 1024 * 1024;
     static const int max_write_buffer_size = 1024 * 1024 * 1024;
@@ -85,6 +86,10 @@ private:
     int rank = 0;
     int numproc = 1;
     MPI_Comm comm;
+
+    // Read/write method parameters
+    Params rmethodparams;
+    Params wmethodparams;
 
     uint64_t write_total = 0;   // data size read/written by one processor
     uint64_t largest_block = 0; // the largest variable block one process reads


### PR DESCRIPTION
adios_reorganize --help says read/write method parameters can be specified through command line argument, but it's not implemented.

```
Usage: adios_reorganize input output rmethod "params" wmethod "params" <decomposition>
    input   Input stream path
    output  Output file path
    rmethod ADIOS method to read with
            Supported read methods: BPFile, HDF5, SST, DataMan, InSituMPI
    params  Read method parameters (in quotes; comma-separated list)
    wmethod ADIOS method to write with
    params  Write method parameters (in quotes; comma-separated list)
    <decomposition>    list of numbers e.g. 32 8 4
            Decomposition values in each dimension of an array
            The product of these number must be less then the number
            of processes. Processes whose rank is higher than the
            product, will not write anything.
               Arrays with less dimensions than the number of values,
            will be decomposed with using the appropriate number of
            values.
```