### PR TITLE
Add support for no MPI build for RDMA DP

### DIFF
--- a/examples/heatTransfer/TestSSTBPRDMAMxN.cmake
+++ b/examples/heatTransfer/TestSSTBPRDMAMxN.cmake
@@ -20,7 +20,7 @@ add_test(NAME HeatTransfer.SST.BP.RDMA.Dump.MxN
     -DARGS=-d 
     -DINPUT_FILE=HeatTransfer.SST.BP.RDMA.Read.MxN.bp
     -DOUTPUT_FILE=HeatTransfer.SST.BP.RDMA.Dump.MxN.txt
-    -P "${PROJECT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bpls.cmake"
+    -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 set_property(TEST HeatTransfer.SST.BP.RDMA.Dump.MxN
   PROPERTY DEPENDS HeatTransfer.SST.BP.RDMA.Read.MxN

--- a/examples/heatTransfer/TestSSTFFSRDMAMxN.cmake
+++ b/examples/heatTransfer/TestSSTFFSRDMAMxN.cmake
@@ -20,7 +20,7 @@ add_test(NAME HeatTransfer.SST.FFS.RDMA.Dump.MxN
     -DARGS=-d 
     -DINPUT_FILE=HeatTransfer.SST.FFS.RDMA.Read.MxN.bp
     -DOUTPUT_FILE=HeatTransfer.SST.FFS.RDMA.Dump.MxN.txt
-    -P "${PROJECT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bpls.cmake"
+    -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 set_property(TEST HeatTransfer.SST.FFS.RDMA.Dump.MxN
   PROPERTY DEPENDS HeatTransfer.SST.FFS.RDMA.Read.MxN

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -4,9 +4,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "adios2/ADIOSConfig.h"
 #include <atl.h>
 #include <evpath.h>
+#ifdef ADIOS2_HAVE_MPI
 #include <mpi.h>
+#else
+#include "sstmpidummy.h"
+#endif
 
 #include <SSTConfig.h>
 

--- a/source/adios2/toolkit/sst/sstmpidummy.h
+++ b/source/adios2/toolkit/sst/sstmpidummy.h
@@ -1,6 +1,8 @@
 #ifndef SSTMPIDUMMY_H_
 #define SSTMPIDUMMY_H_
 
+#include <sys/time.h>
+
 typedef int MPI_Comm;
 typedef int MPI_Status;
 typedef int MPI_request;
@@ -216,6 +218,19 @@ static int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
                      MPI_Comm comm)
 {
     return MPI_SUCCESS;
+}
+
+static double MPI_Wtime()
+{
+    struct timeval tv;
+
+    if (gettimeofday(&tv, NULL) < 0)
+    {
+        perror("could not get time");
+        return (0.);
+    }
+
+    return (tv.tv_sec + ((double)tv.tv_usec / 1000000.));
 }
 
 #endif


### PR DESCRIPTION
Use the mpi dummy functions in the RDMA DP if we don't have real MPI available.