### PR TITLE
fixed the bp3 serializer bug in AggregateCollectiveMetadataIndices function

### DIFF
--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -1006,27 +1006,26 @@ BP3Serializer::AggregateCollectiveMetadataIndices(MPI_Comm comm,
                               localPosition, endPosition, true);
     };
 
-    auto lf_SortMergeIndices =
-        [&](const std::unordered_map<std::string,
-                                     std::vector<SerialElementIndex>>
-                &deserializedIndices) {
-            auto &position = bufferSTL.m_Position;
-            auto &buffer = bufferSTL.m_Buffer;
+    auto lf_SortMergeIndices = [&](
+        const std::unordered_map<std::string, std::vector<SerialElementIndex>>
+            &deserializedIndices) {
+        auto &position = bufferSTL.m_Position;
+        auto &buffer = bufferSTL.m_Buffer;
 
-            size_t countPosition = position;
+        size_t countPosition = position;
 
-            const uint32_t totalCountU32 =
-                static_cast<uint32_t>(deserializedIndices.size());
-            helper::CopyToBuffer(buffer, countPosition, &totalCountU32);
-            position += 12; // skip for length
+        const uint32_t totalCountU32 =
+            static_cast<uint32_t>(deserializedIndices.size());
+        helper::CopyToBuffer(buffer, countPosition, &totalCountU32);
+        position += 12; // skip for length
 
-            MergeSerializeIndices(deserializedIndices, comm, bufferSTL);
+        MergeSerializeIndices(deserializedIndices, comm, bufferSTL);
 
-            // Write length
-            const uint64_t totalLengthU64 =
-                static_cast<uint64_t>(position - countPosition - 8);
-            helper::CopyToBuffer(buffer, countPosition, &totalLengthU64);
-        };
+        // Write length
+        const uint64_t totalLengthU64 =
+            static_cast<uint64_t>(position - countPosition - 8);
+        helper::CopyToBuffer(buffer, countPosition, &totalLengthU64);
+    };
 
     // BODY of function starts here
     std::vector<size_t> indexPositions(3);
@@ -1268,129 +1267,127 @@ void BP3Serializer::MergeSerializeIndices(
         } // end switch
     };
 
-    auto lf_MergeRankSerial =
-        [&](const std::vector<SerialElementIndex> &indices,
-            BufferSTL &bufferSTL) {
-            auto &bufferOut = bufferSTL.m_Buffer;
-            auto &positionOut = bufferSTL.m_Position;
+    auto lf_MergeRankSerial = [&](
+        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL) {
+        auto &bufferOut = bufferSTL.m_Buffer;
+        auto &positionOut = bufferSTL.m_Position;
 
-            // extract header
-            ElementIndexHeader header;
-            // index non-empty buffer
-            size_t firstRank = 0;
-            // index positions per rank
-            std::vector<size_t> positions(indices.size(), 0);
-            // merge index length
-            size_t headerSize = 0;
+        // extract header
+        ElementIndexHeader header;
+        // index non-empty buffer
+        size_t firstRank = 0;
+        // index positions per rank
+        std::vector<size_t> positions(indices.size(), 0);
+        // merge index length
+        size_t headerSize = 0;
 
-            for (size_t r = 0; r < indices.size(); ++r)
+        for (size_t r = 0; r < indices.size(); ++r)
+        {
+            const auto &buffer = indices[r].Buffer;
+            if (buffer.empty())
+            {
+                continue;
+            }
+            size_t &position = positions[r];
+
+            header = ReadElementIndexHeader(buffer, position);
+            firstRank = r;
+
+            headerSize = position;
+            break;
+        }
+
+        if (m_DebugMode)
+        {
+            if (header.DataType == std::numeric_limits<uint8_t>::max() - 1)
+            {
+                throw std::runtime_error(
+                    "ERROR: invalid data type for variable " + header.Name +
+                    "when writing metadata index\n");
+            }
+        }
+
+        // move all positions to headerSize
+        for (size_t r = 0; r < indices.size(); ++r)
+        {
+            const auto &buffer = indices[r].Buffer;
+            if (buffer.empty())
+            {
+                continue;
+            }
+            positions[r] = headerSize;
+        }
+
+        uint64_t setsCount = 0;
+        unsigned int currentTimeStep = 1;
+        bool marching = true;
+
+        const size_t entryLengthPosition = positionOut;
+        positionOut += headerSize;
+
+        while (marching)
+        {
+            marching = false;
+
+            for (size_t r = firstRank; r < indices.size(); ++r)
             {
                 const auto &buffer = indices[r].Buffer;
                 if (buffer.empty())
                 {
                     continue;
                 }
-                size_t &position = positions[r];
 
-                header = ReadElementIndexHeader(buffer, position);
-                firstRank = r;
-
-                headerSize = position;
-                break;
-            }
-
-            if (m_DebugMode)
-            {
-                if (header.DataType == std::numeric_limits<uint8_t>::max() - 1)
+                auto &position = positions[r];
+                if (position < buffer.size())
                 {
-                    throw std::runtime_error(
-                        "ERROR: invalid data type for variable " + header.Name +
-                        "when writing metadata index\n");
+                    marching = true;
                 }
-            }
-
-            // move all positions to headerSize
-            for (size_t r = 0; r < indices.size(); ++r)
-            {
-                const auto &buffer = indices[r].Buffer;
-                if (buffer.empty())
+                else
                 {
                     continue;
                 }
-                positions[r] = headerSize;
-            }
 
-            uint64_t setsCount = 0;
-            unsigned int currentTimeStep = 1;
-            bool marching = true;
+                uint8_t count = 0;
+                uint32_t length = 0;
+                uint32_t timeStep = static_cast<uint32_t>(currentTimeStep);
 
-            const size_t entryLengthPosition = positionOut;
-            positionOut += headerSize;
-
-            while (marching)
-            {
-                marching = false;
-
-                for (size_t r = firstRank; r < indices.size(); ++r)
+                while (timeStep == currentTimeStep)
                 {
-                    const auto &buffer = indices[r].Buffer;
-                    if (buffer.empty())
+                    size_t localPosition = position;
+                    lf_GetCharacteristics(buffer, localPosition,
+                                          header.DataType, count, length,
+                                          timeStep);
+
+                    if (timeStep != currentTimeStep)
                     {
-                        continue;
+                        break;
                     }
 
-                    auto &position = positions[r];
-                    if (position < buffer.size())
+                    ++setsCount;
+
+                    helper::CopyToBuffer(bufferOut, positionOut,
+                                         &buffer[position], length + 5);
+
+                    position += length + 5;
+
+                    if (position >= buffer.size())
                     {
-                        marching = true;
-                    }
-                    else
-                    {
-                        continue;
-                    }
-
-                    uint8_t count = 0;
-                    uint32_t length = 0;
-                    uint32_t timeStep = static_cast<uint32_t>(currentTimeStep);
-
-                    while (timeStep == currentTimeStep)
-                    {
-                        size_t localPosition = position;
-                        lf_GetCharacteristics(buffer, localPosition,
-                                              header.DataType, count, length,
-                                              timeStep);
-
-                        if (timeStep != currentTimeStep)
-                        {
-                            break;
-                        }
-
-                        ++setsCount;
-
-                        helper::CopyToBuffer(bufferOut, positionOut,
-                                             &buffer[position], length + 5);
-
-                        position += length + 5;
-
-                        if (position >= buffer.size())
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
-                ++currentTimeStep;
             }
+            ++currentTimeStep;
+        }
 
-            const uint32_t entryLength =
-                static_cast<uint32_t>(positionOut - entryLengthPosition - 4);
+        const uint32_t entryLength =
+            static_cast<uint32_t>(positionOut - entryLengthPosition - 4);
 
-            size_t backPosition = entryLengthPosition;
-            helper::CopyToBuffer(bufferOut, backPosition, &entryLength);
-            helper::CopyToBuffer(bufferOut, backPosition,
-                                 &indices[firstRank].Buffer[4],
-                                 headerSize - 8 - 4);
-            helper::CopyToBuffer(bufferOut, backPosition, &setsCount);
-        };
+        size_t backPosition = entryLengthPosition;
+        helper::CopyToBuffer(bufferOut, backPosition, &entryLength);
+        helper::CopyToBuffer(bufferOut, backPosition,
+                             &indices[firstRank].Buffer[4], headerSize - 8 - 4);
+        helper::CopyToBuffer(bufferOut, backPosition, &setsCount);
+    };
 
     auto lf_MergeRank = [&](const std::vector<SerialElementIndex> &indices,
                             BufferSTL &bufferSTL) {
@@ -1516,11 +1513,11 @@ void BP3Serializer::MergeSerializeIndices(
         }
     };
 
-    auto lf_MergeRankRange =
-        [&](const std::unordered_map<
-                std::string, std::vector<SerialElementIndex>> &nameRankIndices,
-            const std::vector<std::string> &names, const size_t start,
-            const size_t end, BufferSTL &bufferSTL)
+    auto lf_MergeRankRange = [&](
+        const std::unordered_map<std::string, std::vector<SerialElementIndex>>
+            &nameRankIndices,
+        const std::vector<std::string> &names, const size_t start,
+        const size_t end, BufferSTL &bufferSTL)
 
     {
         for (auto i = start; i < end; ++i)


### PR DESCRIPTION
This is a performance bug. Before being fixed, the complexity of generating the collective metadata indices is n^2, where n is the number of writers. Now the complexity is n.