### PR TITLE
adios2: consistent copy/move constructors and assignment

### DIFF
--- a/bindings/CXX11/cxx11/ADIOS.h
+++ b/bindings/CXX11/cxx11/ADIOS.h
@@ -94,8 +94,24 @@ public:
      * memory. Create a separate object for independent tasks */
     ADIOS(const ADIOS &) = delete;
 
+    /**
+     * default move constructor exists to allow for
+     * auto ad = ADIOS(...) initialization
+     */
+    ADIOS(ADIOS &&) = default;
+
     /** Using RAII STL containers only */
     ~ADIOS() = default;
+
+    /**
+     * copy assignment is forbidden for the same reason as copy constructor
+     */
+    ADIOS& operator=(const ADIOS &) = delete;
+
+    /**
+     * move assignment is allowed, though, to be consistent with move constructor
+     */
+    ADIOS& operator=(ADIOS &&) = default;
 
     /**
      * Declares a new IO class object

--- a/bindings/CXX11/cxx11/ADIOS.h
+++ b/bindings/CXX11/cxx11/ADIOS.h
@@ -106,12 +106,13 @@ public:
     /**
      * copy assignment is forbidden for the same reason as copy constructor
      */
-    ADIOS& operator=(const ADIOS &) = delete;
+    ADIOS &operator=(const ADIOS &) = delete;
 
     /**
-     * move assignment is allowed, though, to be consistent with move constructor
+     * move assignment is allowed, though, to be consistent with move
+     * constructor
      */
-    ADIOS& operator=(ADIOS &&) = default;
+    ADIOS &operator=(ADIOS &&) = default;
 
     /**
      * Declares a new IO class object


### PR DESCRIPTION
This commit consistently disallows copy construction and assignment, but
allows move construction and move assignment in adios2's cxx11 interface.

adios2's cxx11 interfaces deletes the copy constructor to guard against
accidentally creating a copy of the ADIOS object. Unfortunately that also
disallows the syntax
```cxx
  auto ad = adios2::ADIOS(comm, ...);
```
which is otherwise equivalent to 
```cxx
  adios2::ADIOS ad(comm, ...);
```

While admittedly minor, it's a bit inconvenient for someone used to the former way. It's also inconsistent that the copy constructor is deleted, but copy assignment is allowed, so copies can be generated after all:

```cxx
adios2::ADIOS ad;
adios2::ADIOS ad2 = ad;
```
will give an error, but
```cxx
adios2::ADIOS ad;
adios2::ADIOS ad2;
ad2 = ad;
```
will succeed.

This PR consistently disallows copy construct and copy assignment, but it allows move construct and move assignment. So it actually prevents any copies of the ADIOS object, while allowing both ways of initializing an ADIOS type variable.

This PR may, however break existing application code that relies on copy assignment. It should be easy to fix by adding `std::move`. 


