### PR TITLE
Verbs Interface Validation

### DIFF
--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -105,6 +105,7 @@ static void init_fabric(struct fabric_state *fabric)
     hints->mode = FI_CONTEXT | FI_LOCAL_MR | FI_CONTEXT2 | FI_MSG_PREFIX |
                   FI_ASYNC_IOV | FI_RX_CQ_DATA;
     hints->domain_attr->mr_mode = FI_MR_BASIC;
+    hints->ep_attr->type = FI_EP_RDM;
 
     ifname = getenv("FABRIC_IFACE");
 
@@ -129,7 +130,7 @@ static void init_fabric(struct fabric_state *fabric)
             useinfo = info;
             break;
         }
-        if (strcmp(prov_name, "verbs") == 0 || strcmp(prov_name, "gni") == 0 ||
+        if ((strcmp(prov_name, "verbs") == 0 && info->src_addr) || strcmp(prov_name, "gni") == 0 ||
             strcmp(prov_name, "psm2") == 0 || !useinfo)
         {
             useinfo = info;
@@ -1007,6 +1008,7 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream,
     hints->mode = FI_CONTEXT | FI_LOCAL_MR | FI_CONTEXT2 | FI_MSG_PREFIX |
                   FI_ASYNC_IOV | FI_RX_CQ_DATA;
     hints->domain_attr->mr_mode = FI_MR_BASIC;
+    hints->ep_attr->type = FI_EP_RDM;
 
     ifname = getenv("FABRIC_IFACE");
 
@@ -1035,7 +1037,7 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream,
             Ret = 100;
             break;
         }
-        if (strcmp(prov_name, "verbs") == 0 || strcmp(prov_name, "gni") == 0 ||
+        if ((strcmp(prov_name, "verbs") == 0 && info->src_addr) || strcmp(prov_name, "gni") == 0 ||
             strcmp(prov_name, "psm2") == 0)
         {
 

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -130,8 +130,9 @@ static void init_fabric(struct fabric_state *fabric)
             useinfo = info;
             break;
         }
-        if ((strcmp(prov_name, "verbs") == 0 && info->src_addr) || strcmp(prov_name, "gni") == 0 ||
-            strcmp(prov_name, "psm2") == 0 || !useinfo)
+        if ((strcmp(prov_name, "verbs") == 0 && info->src_addr) ||
+            strcmp(prov_name, "gni") == 0 || strcmp(prov_name, "psm2") == 0 ||
+            !useinfo)
         {
             useinfo = info;
         }
@@ -1037,8 +1038,8 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream,
             Ret = 100;
             break;
         }
-        if ((strcmp(prov_name, "verbs") == 0 && info->src_addr) || strcmp(prov_name, "gni") == 0 ||
-            strcmp(prov_name, "psm2") == 0)
+        if ((strcmp(prov_name, "verbs") == 0 && info->src_addr) ||
+            strcmp(prov_name, "gni") == 0 || strcmp(prov_name, "psm2") == 0)
         {
 
             Svcs->verbose(CP_Stream, "RDMA Dataplane sees interface %s, "


### PR DESCRIPTION
For the RDMA data transport in SST, do not automatically choose an interface using the IB Verbs provider if it has no source address.