### PR TITLE
C bindings fixes / updates

### DIFF
--- a/bindings/C/c/adios2_c_attribute.cpp
+++ b/bindings/C/c/adios2_c_attribute.cpp
@@ -21,7 +21,6 @@ namespace
 {
 const std::map<std::string, std::vector<adios2_type>>
     adios2_attribute_types_map = {
-        {"char", {adios2_type_signed_char}},
         {"int", {adios2_type_int32_t}},
         {"float", {adios2_type_float}},
         {"double", {adios2_type_double}},
@@ -30,7 +29,7 @@ const std::map<std::string, std::vector<adios2_type>>
         {"long int", {adios2_type_int64_t}},
         {"long long int", {adios2_type_int64_t}},
         {"string", {adios2_type_string}},
-        {"unsigned char", {adios2_type_uint8_t, adios2_type_unsigned_char}},
+        {"unsigned char", {adios2_type_uint8_t}},
         {"unsigned short", {adios2_type_uint16_t}},
         {"unsigned int", {adios2_type_uint32_t}},
         {"unsigned long int", {adios2_type_uint64_t}},

--- a/bindings/C/c/adios2_c_attribute.cpp
+++ b/bindings/C/c/adios2_c_attribute.cpp
@@ -202,7 +202,7 @@ adios2_error adios2_attribute_data(void *data, size_t *size,
             *size = attributeCpp->m_Elements;                                  \
         }                                                                      \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(
+        ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(
             declare_template_instantiation)
 #undef declare_template_instantiation
 

--- a/bindings/C/c/adios2_c_engine.cpp
+++ b/bindings/C/c/adios2_c_engine.cpp
@@ -178,7 +178,7 @@ adios2_error adios2_put(adios2_engine *engine, adios2_variable *variable,
             *dynamic_cast<adios2::core::Variable<T> *>(variableBase),          \
             reinterpret_cast<const T *>(data), modeCpp);                       \
     }
-        ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
         return adios2_error_none;
@@ -226,7 +226,7 @@ adios2_error adios2_put_by_name(adios2_engine *engine,
         engineCpp.Put(variable_name, reinterpret_cast<const T *>(data),        \
                       modeCpp);                                                \
     }
-        ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
         return adios2_error_none;
     }
@@ -297,7 +297,7 @@ adios2_error adios2_get(adios2_engine *engine, adios2_variable *variable,
             *dynamic_cast<adios2::core::Variable<T> *>(variableBase),          \
             reinterpret_cast<T *>(values), modeCpp);                           \
     }
-        ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
         return adios2_error_none;
     }
@@ -342,7 +342,7 @@ adios2_error adios2_get_by_name(adios2_engine *engine,
     {                                                                          \
         engineCpp.Get(variable_name, reinterpret_cast<T *>(data), modeCpp);    \
     }
-        ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
         return adios2_error_none;
     }

--- a/bindings/C/c/adios2_c_internal.h
+++ b/bindings/C/c/adios2_c_internal.h
@@ -42,4 +42,17 @@ struct MapAdios2Type;
     MACRO(adios2_type_float_complex)                                           \
     MACRO(adios2_type_double_complex)
 
+// calls MACRO for all adios2_type attribute types except for adios2_type_string
+#define ADIOS2_FOREACH_C_ATTRIBUTE_TYPE_1ARG(MACRO)                            \
+    MACRO(adios2_type_int8_t)                                                  \
+    MACRO(adios2_type_int16_t)                                                 \
+    MACRO(adios2_type_int32_t)                                                 \
+    MACRO(adios2_type_int64_t)                                                 \
+    MACRO(adios2_type_uint8_t)                                                 \
+    MACRO(adios2_type_uint16_t)                                                \
+    MACRO(adios2_type_uint32_t)                                                \
+    MACRO(adios2_type_uint64_t)                                                \
+    MACRO(adios2_type_float)                                                   \
+    MACRO(adios2_type_double)
+
 #endif /* ADIOS2_BINDINGS_C_C_ADIOS2_C_INTERNAL_H_ */

--- a/bindings/C/c/adios2_c_internal.h
+++ b/bindings/C/c/adios2_c_internal.h
@@ -1,0 +1,45 @@
+
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adios2_c_internal.h
+ *
+ *  Created on: Feb 9, 2019
+ *      Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+ */
+
+#ifndef ADIOS2_BINDINGS_C_C_ADIOS2_C_INTERNAL_H_
+#define ADIOS2_BINDINGS_C_C_ADIOS2_C_INTERNAL_H_
+
+#include "adios2_c_types.h"
+
+namespace
+{
+/**
+ * MapAdios2Type
+ * maps the C adios2_type enum to the actual C/C++ type,
+ * except string, which needs to be handled separately
+ */
+template <int adios2_type>
+struct MapAdios2Type;
+
+} // anonymous namespace
+
+#include "adios2_c_internal.inl"
+
+#define ADIOS2_FOREACH_C_TYPE_1ARG(MACRO)                                      \
+    MACRO(adios2_type_int8_t)                                                  \
+    MACRO(adios2_type_int16_t)                                                 \
+    MACRO(adios2_type_int32_t)                                                 \
+    MACRO(adios2_type_int64_t)                                                 \
+    MACRO(adios2_type_uint8_t)                                                 \
+    MACRO(adios2_type_uint16_t)                                                \
+    MACRO(adios2_type_uint32_t)                                                \
+    MACRO(adios2_type_uint64_t)                                                \
+    MACRO(adios2_type_float)                                                   \
+    MACRO(adios2_type_double)                                                  \
+    MACRO(adios2_type_float_complex)                                           \
+    MACRO(adios2_type_double_complex)
+
+#endif /* ADIOS2_BINDINGS_C_C_ADIOS2_C_INTERNAL_H_ */

--- a/bindings/C/c/adios2_c_internal.inl
+++ b/bindings/C/c/adios2_c_internal.inl
@@ -1,0 +1,48 @@
+
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adios2_c_internal.inl
+ *
+ *  Created on: Feb 9, 2019
+ *      Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+ */
+
+#ifndef ADIOS2_BINDINGS_C_C_ADIOS2_C_INTERNAL_INL_
+#define ADIOS2_BINDINGS_C_C_ADIOS2_C_INTERNAL_INL_
+#ifndef ADIOS2_BINDINGS_C_C_ADIOS2_C_INTERNAL_H_
+#error "Inline file should only be included from its header, never on its own"
+#endif
+
+namespace
+{
+
+// no default implementation, so only type below are
+// supported
+
+#define make_MapAdios2Type(adios2_type, T)                                     \
+    template <>                                                                \
+    struct MapAdios2Type<adios2_type>                                          \
+    {                                                                          \
+        using Type = T;                                                        \
+    };
+/* clang-format off */
+make_MapAdios2Type(adios2_type_int8_t, int8_t)
+make_MapAdios2Type(adios2_type_int16_t, int16_t)
+make_MapAdios2Type(adios2_type_int32_t, int32_t)
+make_MapAdios2Type(adios2_type_int64_t, int64_t)
+make_MapAdios2Type(adios2_type_uint8_t, uint8_t)
+make_MapAdios2Type(adios2_type_uint16_t, uint16_t)
+make_MapAdios2Type(adios2_type_uint32_t, uint32_t)
+make_MapAdios2Type(adios2_type_uint64_t, uint64_t)
+make_MapAdios2Type(adios2_type_float, float)
+make_MapAdios2Type(adios2_type_double, double)
+make_MapAdios2Type(adios2_type_float_complex, std::complex<float>)
+make_MapAdios2Type(adios2_type_double_complex, std::complex<double>)
+/* clang-format on */
+#undef make_MapAdios2Type
+
+} // namespace
+
+#endif /* ADIOS2_BINDINGS_C_C_ADIOS2_C_INTERNAL_INL_ */

--- a/bindings/C/c/adios2_c_io.cpp
+++ b/bindings/C/c/adios2_c_io.cpp
@@ -15,6 +15,7 @@
 #include "adios2/ADIOSMPI.h"
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosFunctions.h" //GetType<T>
+#include "adios2_c_internal.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -149,78 +150,15 @@ adios2_define_variable(adios2_io *io, const char *name, const adios2_type type,
                 name, shapeV, startV, countV, constantSizeBool);
             break;
         }
-        case (adios2_type_float):
-        {
-            variableCpp = &ioCpp.DefineVariable<float>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_double):
-        {
-            variableCpp = &ioCpp.DefineVariable<double>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_float_complex):
-        {
-            variableCpp = &ioCpp.DefineVariable<std::complex<float>>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_double_complex):
-        {
-            variableCpp = &ioCpp.DefineVariable<std::complex<double>>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_int8_t):
-        {
-            variableCpp = &ioCpp.DefineVariable<int8_t>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_int16_t):
-        {
-            variableCpp = &ioCpp.DefineVariable<int16_t>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_int32_t):
-        {
-            variableCpp = &ioCpp.DefineVariable<int32_t>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_int64_t):
-        {
-            variableCpp = &ioCpp.DefineVariable<int64_t>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_uint8_t):
-        {
-            variableCpp = &ioCpp.DefineVariable<uint8_t>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_uint16_t):
-        {
-            variableCpp = &ioCpp.DefineVariable<uint16_t>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_uint32_t):
-        {
-            variableCpp = &ioCpp.DefineVariable<uint32_t>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
-        case (adios2_type_uint64_t):
-        {
-            variableCpp = &ioCpp.DefineVariable<uint64_t>(
-                name, shapeV, startV, countV, constantSizeBool);
-            break;
-        }
+#define make_case(adios2_type)                                                 \
+    case (adios2_type):                                                        \
+    {                                                                          \
+        variableCpp = &ioCpp.DefineVariable<MapAdios2Type<adios2_type>::Type>( \
+            name, shapeV, startV, countV, constantSizeBool);                   \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_C_TYPE_1ARG(make_case)
+#undef make_case
         default:
         {
             throw std::invalid_argument("ERROR: unsupported type " +

--- a/bindings/C/c/adios2_c_io.cpp
+++ b/bindings/C/c/adios2_c_io.cpp
@@ -315,76 +315,17 @@ adios2_attribute *adios2_define_variable_attribute(
                 name, singleString, variable_name, separator);
             break;
         }
-        case (adios2_type_float):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<float>(
-                name, *reinterpret_cast<const float *>(value), variable_name,
-                separator);
-            break;
-        }
-        case (adios2_type_double):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<double>(
-                name, *reinterpret_cast<const double *>(value), variable_name,
-                separator);
-            break;
-        }
-        case (adios2_type_int8_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<int8_t>(
-                name, *reinterpret_cast<const int8_t *>(value), variable_name,
-                separator);
-            break;
-        }
-        case (adios2_type_int16_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<int16_t>(
-                name, *reinterpret_cast<const int16_t *>(value), variable_name,
-                separator);
-            break;
-        }
-        case (adios2_type_int32_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<int32_t>(
-                name, *reinterpret_cast<const int32_t *>(value), variable_name,
-                separator);
-            break;
-        }
-        case (adios2_type_int64_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<int64_t>(
-                name, *reinterpret_cast<const int64_t *>(value), variable_name,
-                separator);
-            break;
-        }
-        case (adios2_type_uint8_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<uint8_t>(
-                name, *reinterpret_cast<const uint8_t *>(value), variable_name,
-                separator);
-            break;
-        }
-        case (adios2_type_uint16_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<uint16_t>(
-                name, *reinterpret_cast<const uint16_t *>(value), variable_name,
-                separator);
-            break;
-        }
-        case (adios2_type_uint32_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<uint32_t>(
-                name, *reinterpret_cast<const uint32_t *>(value), variable_name,
-                separator);
-            break;
-        }
-        case (adios2_type_uint64_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<uint64_t>(
-                name, *reinterpret_cast<const uint64_t *>(value), variable_name,
-                separator);
-            break;
-        }
+#define make_case(adios2_type)                                                 \
+    case (adios2_type):                                                        \
+    {                                                                          \
+        attributeCpp = &ioCpp.DefineAttribute(                                 \
+            name, *reinterpret_cast<const MapAdios2Type<adios2_type>::Type *>( \
+                      value),                                                  \
+            variable_name, separator);                                         \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_C_ATTRIBUTE_TYPE_1ARG(make_case)
+#undef make_case
         default:
         {
             throw std::invalid_argument("ERROR: unsupported type " +
@@ -445,76 +386,17 @@ adios2_attribute *adios2_define_variable_attribute_array(
                 separator);
             break;
         }
-        case (adios2_type_float):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<float>(
-                name, reinterpret_cast<const float *>(data), size,
-                variable_name, separator);
-            break;
-        }
-        case (adios2_type_double):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<double>(
-                name, reinterpret_cast<const double *>(data), size,
-                variable_name, separator);
-            break;
-        }
-        case (adios2_type_int8_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<int8_t>(
-                name, reinterpret_cast<const int8_t *>(data), size,
-                variable_name, separator);
-            break;
-        }
-        case (adios2_type_int16_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<int16_t>(
-                name, reinterpret_cast<const int16_t *>(data), size,
-                variable_name, separator);
-            break;
-        }
-        case (adios2_type_int32_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<int32_t>(
-                name, reinterpret_cast<const int32_t *>(data), size,
-                variable_name, separator);
-            break;
-        }
-        case (adios2_type_int64_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<int64_t>(
-                name, reinterpret_cast<const int64_t *>(data), size,
-                variable_name, separator);
-            break;
-        }
-        case (adios2_type_uint8_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<uint8_t>(
-                name, reinterpret_cast<const uint8_t *>(data), size,
-                variable_name, separator);
-            break;
-        }
-        case (adios2_type_uint16_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<uint16_t>(
-                name, reinterpret_cast<const uint16_t *>(data), size,
-                variable_name, separator);
-            break;
-        }
-        case (adios2_type_uint32_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<uint32_t>(
-                name, reinterpret_cast<const uint32_t *>(data), size,
-                variable_name, separator);
-            break;
-        }
-        case (adios2_type_uint64_t):
-        {
-            attributeCpp = &ioCpp.DefineAttribute<uint64_t>(
-                name, reinterpret_cast<const uint64_t *>(data), size,
-                variable_name, separator);
-            break;
-        }
+#define make_case(adios2_type)                                                 \
+    case (adios2_type):                                                        \
+    {                                                                          \
+        attributeCpp = &ioCpp.DefineAttribute(                                 \
+            name,                                                              \
+            reinterpret_cast<const MapAdios2Type<adios2_type>::Type *>(data),  \
+            size, variable_name, separator);                                   \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_C_ATTRIBUTE_TYPE_1ARG(make_case)
+#undef make_case
         default:
         {
             throw std::invalid_argument(

--- a/bindings/C/c/adios2_c_io.cpp
+++ b/bindings/C/c/adios2_c_io.cpp
@@ -209,7 +209,7 @@ adios2_variable *adios2_inquire_variable(adios2_io *io, const char *name)
     {                                                                          \
         variableCpp = ioCpp.InquireVariable<T>(name);                          \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
         variable = reinterpret_cast<adios2_variable *>(variableCpp);
@@ -253,7 +253,7 @@ adios2_error adios2_inquire_all_variables(adios2_variable ***variables,
         variable = ioCpp.InquireVariable<T>(name);                             \
         list[n] = reinterpret_cast<adios2_variable *>(variable);               \
     }
-            ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+            ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
             n++;
@@ -449,7 +449,7 @@ adios2_attribute *adios2_inquire_attribute(adios2_io *io, const char *name)
     {                                                                          \
         attributeCpp = ioCpp.InquireAttribute<T>(name);                        \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
         attribute = reinterpret_cast<adios2_attribute *>(attributeCpp);
@@ -504,7 +504,8 @@ adios2_error adios2_inquire_all_attributes(adios2_attribute ***attributes,
         attribute = ioCpp.InquireAttribute<T>(name);                           \
         list[n] = reinterpret_cast<adios2_attribute *>(attribute);             \
     }
-            ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
+            ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(
+                declare_template_instantiation)
 #undef declare_template_instantiation
 
             n++;

--- a/bindings/C/c/adios2_c_types.h
+++ b/bindings/C/c/adios2_c_types.h
@@ -92,9 +92,6 @@ typedef enum {
     adios2_type_uint16_t = 10,
     adios2_type_uint32_t = 11,
     adios2_type_uint64_t = 12,
-
-    adios2_type_signed_char = 5,
-    adios2_type_unsigned_char = 9,
 } adios2_type;
 
 typedef enum {

--- a/bindings/C/c/adios2_c_variable.cpp
+++ b/bindings/C/c/adios2_c_variable.cpp
@@ -17,19 +17,18 @@ namespace
 {
 const std::map<std::string, std::vector<adios2_type>>
     adios2_variable_types_map = {
-        {"char", {adios2_type_signed_char}},
         {"int", {adios2_type_int32_t}},
         {"float", {adios2_type_float}},
         {"double", {adios2_type_double}},
         {"float complex", {adios2_type_float_complex}},
         {"double complex", {adios2_type_double_complex}},
-        {"signed char", {adios2_type_int8_t, adios2_type_signed_char}},
+        {"signed char", {adios2_type_int8_t}},
         {"short", {adios2_type_int16_t}},
         {"long int", {adios2_type_int64_t}},
         {"long long int", {adios2_type_int64_t}},
         {"string", {adios2_type_string}},
         // TODO {"string array", {adios2_type_string_array}},
-        {"unsigned char", {adios2_type_unsigned_char, adios2_type_uint8_t}},
+        {"unsigned char", {adios2_type_uint8_t}},
         {"unsigned short", {adios2_type_uint16_t}},
         {"unsigned int", {adios2_type_uint32_t}},
         {"unsigned long int", {adios2_type_uint64_t}},

--- a/bindings/C/c/adios2_c_variable.cpp
+++ b/bindings/C/c/adios2_c_variable.cpp
@@ -12,29 +12,10 @@
 
 #include "adios2/core/Variable.h"
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2_c_internal.h"
 
 namespace
 {
-const std::map<std::string, std::vector<adios2_type>>
-    adios2_variable_types_map = {
-        {"int", {adios2_type_int32_t}},
-        {"float", {adios2_type_float}},
-        {"double", {adios2_type_double}},
-        {"float complex", {adios2_type_float_complex}},
-        {"double complex", {adios2_type_double_complex}},
-        {"signed char", {adios2_type_int8_t}},
-        {"short", {adios2_type_int16_t}},
-        {"long int", {adios2_type_int64_t}},
-        {"long long int", {adios2_type_int64_t}},
-        {"string", {adios2_type_string}},
-        // TODO {"string array", {adios2_type_string_array}},
-        {"unsigned char", {adios2_type_uint8_t}},
-        {"unsigned short", {adios2_type_uint16_t}},
-        {"unsigned int", {adios2_type_uint32_t}},
-        {"unsigned long int", {adios2_type_uint64_t}},
-        {"unsigned long long int", {adios2_type_uint64_t}},
-};
-
 adios2_shapeid adios2_ToShapeID(const adios2::ShapeID shapeIDCpp,
                                 const std::string &hint)
 {
@@ -241,10 +222,19 @@ adios2_error adios2_variable_type(adios2_type *type,
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
 
-        auto itType = adios2_variable_types_map.find(variableBase->m_Type);
-        *type = (itType == adios2_variable_types_map.end())
-                    ? adios2_type_unknown
-                    : itType->second.front();
+        auto type_s = variableBase->m_Type;
+        if (type_s == adios2::helper::GetType<std::string>())
+        {
+            *type = adios2_type_string;
+        }
+#define make_case(T)                                                           \
+    else if (type_s == adios2::helper::GetType<MapAdios2Type<T>::Type>())      \
+    {                                                                          \
+        *type = T;                                                             \
+    }
+        ADIOS2_FOREACH_C_TYPE_1ARG(make_case)
+#undef make_case
+        else { *type = adios2_type_unknown; }
         return adios2_error_none;
     }
     catch (...)

--- a/bindings/C/c/adios2_c_variable.cpp
+++ b/bindings/C/c/adios2_c_variable.cpp
@@ -530,7 +530,7 @@ adios2_error adios2_variable_min(void *min, const adios2_variable *variable)
             dynamic_cast<const adios2::core::Variable<T> *>(variableBase);     \
         *minT = variableT->m_Min;                                              \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
         return adios2_error_none;
     }
@@ -567,7 +567,7 @@ adios2_error adios2_variable_max(void *max, const adios2_variable *variable)
             dynamic_cast<const adios2::core::Variable<T> *>(variableBase);     \
         *maxT = variableT->m_Max;                                              \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
         return adios2_error_none;
     }

--- a/bindings/Matlab/adiosopenc.c
+++ b/bindings/Matlab/adiosopenc.c
@@ -544,11 +544,8 @@ mxClassID adiostypeToMatlabClass(adios2_type adiostype,
     *complexity = mxREAL;
     switch (adiostype)
     {
-    case adios2_type_unsigned_char:
     case adios2_type_uint8_t:
         return mxUINT8_CLASS;
-    case adios2_type_char:
-    case adios2_type_signed_char:
     case adios2_type_int8_t:
         return mxINT8_CLASS;
 
@@ -556,35 +553,18 @@ mxClassID adiostypeToMatlabClass(adios2_type adiostype,
     /* case adios2_type_string_array: */
         return mxCHAR_CLASS;
 
-    case adios2_type_unsigned_short:
     case adios2_type_uint16_t:
         return mxUINT16_CLASS;
-    case adios2_type_short:
     case adios2_type_int16_t:
         return mxINT16_CLASS;
 
-    case adios2_type_unsigned_int:
     case adios2_type_uint32_t:
         return mxUINT32_CLASS;
-    case adios2_type_int:
     case adios2_type_int32_t:
         return mxINT32_CLASS;
 
-    case adios2_type_unsigned_long_int:
-        if (sizeof(long int) == 4)
-            return mxUINT32_CLASS;
-        else
-            return mxUINT64_CLASS;
-    case adios2_type_long_int:
-        if (sizeof(long int) == 4)
-            return mxINT32_CLASS;
-        else
-            return mxINT64_CLASS;
-
-    case adios2_type_unsigned_long_long_int:
     case adios2_type_uint64_t:
         return mxUINT64_CLASS;
-    case adios2_type_long_long_int:
     case adios2_type_int64_t:
         return mxINT64_CLASS;
 
@@ -614,10 +594,7 @@ size_t adiostypeToMemSize(adios2_type adiostype)
 {
     switch (adiostype)
     {
-    case adios2_type_unsigned_char:
     case adios2_type_uint8_t:
-    case adios2_type_char:
-    case adios2_type_signed_char:
     case adios2_type_int8_t:
         return sizeof(char);
 
@@ -625,28 +602,15 @@ size_t adiostypeToMemSize(adios2_type adiostype)
     /* case adios2_type_string_array: */
         return sizeof(char);
 
-    case adios2_type_unsigned_short:
     case adios2_type_uint16_t:
-    case adios2_type_short:
     case adios2_type_int16_t:
         return sizeof(int16_t);
 
-    case adios2_type_unsigned_int:
     case adios2_type_uint32_t:
-    case adios2_type_int:
     case adios2_type_int32_t:
         return sizeof(int32_t);
 
-    case adios2_type_unsigned_long_int:
-    case adios2_type_long_int:
-        if (sizeof(long int) == 4)
-            return sizeof(int32_t);
-        else
-            return sizeof(int64_t);
-
-    case adios2_type_unsigned_long_long_int:
     case adios2_type_uint64_t:
-    case adios2_type_long_long_int:
     case adios2_type_int64_t:
         return sizeof(int64_t);
 

--- a/bindings/Matlab/adiosreadc.c
+++ b/bindings/Matlab/adiosreadc.c
@@ -340,11 +340,8 @@ mxClassID adiostypeToMatlabClass(adios2_type adiostype,
     *complexity = mxREAL;
     switch (adiostype)
     {
-    case adios2_type_unsigned_char:
     case adios2_type_uint8_t:
         return mxUINT8_CLASS;
-    case adios2_type_char:
-    case adios2_type_signed_char:
     case adios2_type_int8_t:
         return mxINT8_CLASS;
 
@@ -352,35 +349,18 @@ mxClassID adiostypeToMatlabClass(adios2_type adiostype,
     /* case adios2_type_string_array: */
         return mxCHAR_CLASS;
 
-    case adios2_type_unsigned_short:
     case adios2_type_uint16_t:
         return mxUINT16_CLASS;
-    case adios2_type_short:
     case adios2_type_int16_t:
         return mxINT16_CLASS;
 
-    case adios2_type_unsigned_int:
     case adios2_type_uint32_t:
         return mxUINT32_CLASS;
-    case adios2_type_int:
     case adios2_type_int32_t:
         return mxINT32_CLASS;
 
-    case adios2_type_unsigned_long_int:
-        if (sizeof(long int) == 4)
-            return mxUINT32_CLASS;
-        else
-            return mxUINT64_CLASS;
-    case adios2_type_long_int:
-        if (sizeof(long int) == 4)
-            return mxINT32_CLASS;
-        else
-            return mxINT64_CLASS;
-
-    case adios2_type_unsigned_long_long_int:
     case adios2_type_uint64_t:
         return mxUINT64_CLASS;
-    case adios2_type_long_long_int:
     case adios2_type_int64_t:
         return mxINT64_CLASS;
 

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -31,6 +31,32 @@
    #undef instantiate_foo
  </pre>
 */
+#define ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(MACRO)                 \
+    MACRO(int8_t)                                                              \
+    MACRO(int16_t)                                                             \
+    MACRO(int32_t)                                                             \
+    MACRO(int64_t)                                                             \
+    MACRO(uint8_t)                                                             \
+    MACRO(uint16_t)                                                            \
+    MACRO(uint32_t)                                                            \
+    MACRO(uint64_t)                                                            \
+    MACRO(float)                                                               \
+    MACRO(double)                                                              \
+    MACRO(long double)
+
+#define ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)                           \
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(MACRO)                     \
+    MACRO(std::complex<float>)                                                 \
+    MACRO(std::complex<double>)
+
+#define ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(MACRO)                           \
+    MACRO(std::string)                                                         \
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(MACRO)
+
+#define ADIOS2_FOREACH_STDTYPE_1ARG(MACRO)                                     \
+    MACRO(std::string)                                                         \
+    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)
+
 #define ADIOS2_FOREACH_TYPE_1ARG(MACRO)                                        \
     MACRO(std::string)                                                         \
     MACRO(char)                                                                \

--- a/testing/utils/TestUtilsCWriter.bplsla.expected.txt
+++ b/testing/utils/TestUtilsCWriter.bplsla.expected.txt
@@ -12,14 +12,11 @@
   int             nwriters  attr   = 1
   unsigned short  shape2D   attr   = {4, 5}
   string          strarray  attr   = {"first", "second", "third", "fourth"}
-  signed char     varChar   {10} = 97 / 106
   short           varI16    {10} = -510 / 521
   int             varI32    {10} = -131070 / 131081
   signed char     varI8     {10} = -8 / 9
   float           varR32    {10} = 0 / 9
   double          varR64    {10} = 0 / 9
-  signed char     varSChar  {10} = 97 / 106
   unsigned short  varU16    {10} = 32768 / 32777
   unsigned int    varU32    {10} = 2147483648 / 2147483657
   unsigned char   varU8     {10} = 128 / 137
-  unsigned char   varUChar  {10} = 97 / 106

--- a/testing/utils/TestUtilsCWriter.bplsldDav.expected.txt
+++ b/testing/utils/TestUtilsCWriter.bplsldDav.expected.txt
@@ -1,5 +1,5 @@
 File info:
-  of variables:  13
+  of variables:  10
   of attributes: 12
   statistics:    Min / Max 
 
@@ -25,11 +25,6 @@ File info:
   int             nwriters  attr   = 1
   unsigned short  shape2D   attr   = {4, 5}
   string          strarray  attr   = {"first", "second", "third", "fourth"}
-  signed char     varChar   {10} = 97 / 106
-        step 0: 
-          block 0: [0:9] = 97 / 106
-    (0)    97 98 99 100 101 102
-    (6)    103 104 105 106 
   short           varI16    {10} = -510 / 521
         step 0: 
           block 0: [0:9] = -510 / 521
@@ -55,11 +50,6 @@ File info:
           block 0: [0:9] = 0 / 9
     (0)    0 1 2 3 4 5
     (6)    6 7 8 9 
-  signed char     varSChar  {10} = 97 / 106
-        step 0: 
-          block 0: [0:9] = 97 / 106
-    (0)    97 98 99 100 101 102
-    (6)    103 104 105 106 
   unsigned short  varU16    {10} = 32768 / 32777
         step 0: 
           block 0: [0:9] = 32768 / 32777
@@ -75,8 +65,3 @@ File info:
           block 0: [0:9] = 128 / 137
     (0)    128 129 130 131 132 133
     (6)    134 135 136 137 
-  unsigned char   varUChar  {10} = 97 / 106
-        step 0: 
-          block 0: [0:9] = 97 / 106
-    (0)    97 98 99 100 101 102
-    (6)    103 104 105 106 

--- a/testing/utils/TestUtilsCWriter.bplsldDavvv.expected.txt
+++ b/testing/utils/TestUtilsCWriter.bplsldDavvv.expected.txt
@@ -10,7 +10,7 @@ Settings :
 ADIOS Open: read header info from TestUtilsCWriter.bp
 Try BPFile engine to open the file...
 File info:
-  of variables:  13
+  of variables:  10
   of attributes: 12
   statistics:    Min / Max 
 
@@ -48,20 +48,6 @@ set selection:   start = { 0 0 }  count = { 4 5 }
   int             nwriters  attr   = 1
   unsigned short  shape2D   attr   = {4, 5}
   string          strarray  attr   = {"first", "second", "third", "fourth"}
-  signed char     varChar   {10} = 97 / 106
-        step 0: 
-          block 0: [0:9] = 97 / 106
-    j=0, st=0 ct=10
-    s[0]=0, c[0]=10, n=10
- total size of data to read = 10
-Read size strategy:
-    dim 0: read 10 elements
-    read 10 elements at once, 10 in total (nelems=10)
-adios_read_var name=varChar   start = { 0 }  count = { 10 }  read 10 elems
-    read block 0 from offset 0 nelems 10)
-set selection:   start = { 0 }  count = { 10 }
-    (0)    97 98 99 100 101 102
-    (6)    103 104 105 106 
   short           varI16    {10} = -510 / 521
         step 0: 
           block 0: [0:9] = -510 / 521
@@ -132,20 +118,6 @@ adios_read_var name=varR64   start = { 0 }  count = { 10 }  read 10 elems
 set selection:   start = { 0 }  count = { 10 }
     (0)    0 1 2 3 4 5
     (6)    6 7 8 9 
-  signed char     varSChar  {10} = 97 / 106
-        step 0: 
-          block 0: [0:9] = 97 / 106
-    j=0, st=0 ct=10
-    s[0]=0, c[0]=10, n=10
- total size of data to read = 10
-Read size strategy:
-    dim 0: read 10 elements
-    read 10 elements at once, 10 in total (nelems=10)
-adios_read_var name=varSChar   start = { 0 }  count = { 10 }  read 10 elems
-    read block 0 from offset 0 nelems 10)
-set selection:   start = { 0 }  count = { 10 }
-    (0)    97 98 99 100 101 102
-    (6)    103 104 105 106 
   unsigned short  varU16    {10} = 32768 / 32777
         step 0: 
           block 0: [0:9] = 32768 / 32777
@@ -188,17 +160,3 @@ adios_read_var name=varU8   start = { 0 }  count = { 10 }  read 10 elems
 set selection:   start = { 0 }  count = { 10 }
     (0)    128 129 130 131 132 133
     (6)    134 135 136 137 
-  unsigned char   varUChar  {10} = 97 / 106
-        step 0: 
-          block 0: [0:9] = 97 / 106
-    j=0, st=0 ct=10
-    s[0]=0, c[0]=10, n=10
- total size of data to read = 10
-Read size strategy:
-    dim 0: read 10 elements
-    read 10 elements at once, 10 in total (nelems=10)
-adios_read_var name=varUChar   start = { 0 }  count = { 10 }  read 10 elems
-    read block 0 from offset 0 nelems 10)
-set selection:   start = { 0 }  count = { 10 }
-    (0)    97 98 99 100 101 102
-    (6)    103 104 105 106 

--- a/testing/utils/TestUtilsCWriter.c
+++ b/testing/utils/TestUtilsCWriter.c
@@ -63,13 +63,6 @@ int main(int argc, char *argv[])
     // Define variables in ioH
     adios2_define_variable(ioH, "nproc", adios2_type_int32_t, 0, NULL, NULL,
                            NULL, adios2_constant_dims_true);
-    adios2_define_variable(ioH, "varChar", adios2_type_signed_char, 1, shape,
-                           start, count, adios2_constant_dims_true);
-
-    adios2_define_variable(ioH, "varSChar", adios2_type_signed_char, 1, shape,
-                           start, count, adios2_constant_dims_true);
-    adios2_define_variable(ioH, "varUChar", adios2_type_unsigned_char, 1, shape,
-                           start, count, adios2_constant_dims_true);
 
     adios2_define_variable(ioH, "varI8", adios2_type_int8_t, 1, shape, start,
                            count, adios2_constant_dims_true);
@@ -121,9 +114,6 @@ int main(int argc, char *argv[])
 
     // inquire variables
     adios2_variable *varNproc = adios2_inquire_variable(ioH, "nproc");
-    adios2_variable *varChar = adios2_inquire_variable(ioH, "varChar");
-    adios2_variable *varSChar = adios2_inquire_variable(ioH, "varSChar");
-    adios2_variable *varUChar = adios2_inquire_variable(ioH, "varUChar");
     adios2_variable *varI8 = adios2_inquire_variable(ioH, "varI8");
     adios2_variable *varI16 = adios2_inquire_variable(ioH, "varI16");
     adios2_variable *varI32 = adios2_inquire_variable(ioH, "varI32");
@@ -140,12 +130,6 @@ int main(int argc, char *argv[])
         adios2_open(ioH, "TestUtilsCWriter.bp", adios2_mode_write);
 
     adios2_put(engineH, varNproc, &nproc, adios2_mode_deferred);
-    adios2_put(engineH, varChar, "abcdefghijklmnopqrstuvwxyz",
-               adios2_mode_deferred);
-    adios2_put(engineH, varSChar, "abcdefghijklmnopqrstuvwxyz",
-               adios2_mode_deferred);
-    adios2_put(engineH, varUChar, "abcdefghijklmnopqrstuvwxyz",
-               adios2_mode_deferred);
     adios2_put(engineH, varI8, data_I8, adios2_mode_deferred);
     adios2_put(engineH, varI16, data_I16, adios2_mode_deferred);
     adios2_put(engineH, varI32, data_I32, adios2_mode_deferred);


### PR DESCRIPTION
Originally, this work had meant to do the same kind of type mapping as the cxx11 interface, that is,
map, e.g., `adios2_type_unsigned_long_long` and `adios2_type_unsigned_long` (on Mac/Linux-64) to the same underlying `uint64_t` for core adios2.

That part is actually not needed anymore, since in master those primitive variable based types are mostly gone. So this is mostly some cleanup and consistency improvements.

* fix the Matlab interface which got broken by changes in master that removed the primitive adios2_types (untested, though, and it looks like the CI doesn't build it, either.)
* remove 'adios2_type_{un,}signed_char`, since all the other primitive types are already gone
* get rid of the type-string to adios_type maps, which were at least slightly broken because of a hardcoded mapping of `unsigned long` to always `uint64_t`
```cxx
       {"unsigned long int", {adios2_type_uint64_t}},
```
* change the various macro if-loops to only iterate over the actual stdint-based types, rather than primitive types
* reintroduce `adios2_type_long_double`. I'm not sure this was intended to be dropped, I don't personally care about it, but it's supported by core and cxx11, so why just drop it from the C interface?
