### PR TITLE
SST transport specification changes.

### DIFF
--- a/docs/user_guide/source/engines/sst.rst
+++ b/docs/user_guide/source/engines/sst.rst
@@ -152,7 +152,19 @@ applications running on different interconnects, the Wide Area Network
 (WAN) option should be chosen.  This value is interpreted by both SST
 Writer and Reader engines.
 
-5. **NetworkInterface**: Default **NULL**.  In situations in which
+6. **DataTransport**: Default **tcp**.  This string value specifies
+the underlying network communication mechanism to use for performing
+control operations in SST.  SST can be configured to standard TCP
+sockets, which are very reliable and efficient, but which are limited
+in their scalability.  Alternatively, SST can use a reliable UDP
+protocol, that is more scalable, but as of ADIOS2 Release 2.3.1 still
+suffers from some reliability problems.  (**sockets** is accepted as
+equivalent to **tcp** and **udp**, **rudp**, and **enet** are
+equivalent to **scalable**.  Generally both the reader and writer
+should be using the same control transport.  This value is interpreted
+by both SST Writer and Reader engines.
+
+7. **NetworkInterface**: Default **NULL**.  In situations in which
 there are multiple possible network interfaces available to SST, this
 string value specifies which should be used to generate SST's contact
 information for writers.  Generally this should *NOT* be specified
@@ -173,5 +185,6 @@ This value is interpreted by only by the SST Writer engine.
  QueueLimit               integer               **0** (no queue limits)
  QueueFullPolicy          string                **Block**, Discard
  DataTransport            string                **default varies by platform**, RDMA, WAN
+ ControlTransport         string                **TCP**, Scalable
  NetworkInterface         string                **NULL**
 =======================  ===================== =========================================================

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -42,11 +42,10 @@ void CP_validateParams(SstStream Stream, SstParams Params, int Writer)
     }
     Stream->QueueFullPolicy = Params->QueueFullPolicy;
     Stream->RegistrationMethod = Params->RegistrationMethod;
-    char *SelectedTransport = NULL;
     if (Params->DataTransport != NULL)
     {
         int i;
-        SelectedTransport = malloc(strlen(Params->DataTransport) + 1);
+        char *SelectedTransport = malloc(strlen(Params->DataTransport) + 1);
         for (i = 0; Params->DataTransport[i] != 0; i++)
         {
             SelectedTransport[i] = tolower(Params->DataTransport[i]);
@@ -69,8 +68,33 @@ void CP_validateParams(SstStream Stream, SstParams Params, int Writer)
     }
     if (Params->ControlTransport == NULL)
     {
-        /* determine reasonable default, now "enet" */
-        Params->ControlTransport = strdup("enet");
+        /* determine reasonable default, now "sockets" */
+        Params->ControlTransport = strdup("sockets");
+    }
+    else
+    {
+        int i;
+        char *SelectedTransport = malloc(strlen(Params->ControlTransport) + 1);
+        for (i = 0; Params->ControlTransport[i] != 0; i++)
+        {
+            SelectedTransport[i] = tolower(Params->ControlTransport[i]);
+        }
+        SelectedTransport[i] = 0;
+
+        /* canonicalize SelectedTransport */
+        if ((strcmp(SelectedTransport, "sockets") == 0) ||
+            (strcmp(SelectedTransport, "tcp") == 0))
+        {
+            Params->ControlTransport = strdup("sockets");
+        }
+        else if ((strcmp(SelectedTransport, "udp") == 0) ||
+                 (strcmp(SelectedTransport, "rudp") == 0) ||
+                 (strcmp(SelectedTransport, "scalable") == 0) ||
+                 (strcmp(SelectedTransport, "enet") == 0))
+        {
+            Params->ControlTransport = strdup("enet");
+        }
+        free(SelectedTransport);
     }
     Stream->ConnectionUsleepMultiplier = 50;
     if ((strcmp(Params->ControlTransport, "enet") == 0) &&

--- a/source/adios2/toolkit/sst/dp/dp.c
+++ b/source/adios2/toolkit/sst/dp/dp.c
@@ -64,6 +64,7 @@ CP_DP_Interface SelectDP(CP_Services Svcs, void *CP_Stream,
     int BestPriority = -1;
     int BestPrioDP = -1;
     int i = 0;
+    int FoundPreferred = 0;
     if (Params->DataTransport)
     {
         Svcs->verbose(CP_Stream, "Prefered dataplane name is \"%s\"\n",
@@ -79,8 +80,18 @@ CP_DP_Interface SelectDP(CP_Services Svcs, void *CP_Stream,
         {
             if (strcasecmp(List[i].Name, Params->DataTransport) == 0)
             {
-                SelectedDP = i;
-                break;
+                FoundPreferred = 1;
+                if (List[i].Priority >= 0)
+                {
+                    SelectedDP = i;
+                    break;
+                }
+                else
+                {
+                    fprintf(stderr, "Warning:  Perferred DataPlane \"%s\" is "
+                                    "not available.",
+                            List[i].Name);
+                }
             }
         }
         if (List[i].Priority > BestPriority)
@@ -89,6 +100,11 @@ CP_DP_Interface SelectDP(CP_Services Svcs, void *CP_Stream,
             BestPrioDP = i;
         }
         i++;
+    }
+    if (Params->DataTransport && (FoundPreferred == 0))
+    {
+        fprintf(stderr, "Warning:  Preferred DataPlane \"%s\" not found.",
+                Params->DataTransport);
     }
     if (SelectedDP != -1)
     {
@@ -115,6 +131,13 @@ CP_DP_Interface SelectDP(CP_Services Svcs, void *CP_Stream,
         }
         i++;
     }
+
+    if (Params->DataTransport)
+    {
+        free(Params->DataTransport);
+    }
+    Params->DataTransport = strdup(List[SelectedDP].Name);
+
     Ret = List[SelectedDP].Interface;
     free(List);
     return Ret;


### PR DESCRIPTION
Tweak SST Data transport so that if a transport is unavailable, we don't use it even if preferred.  Set SST Control transport to default to sockets.  Establish nicer aliases for Control transports.  Document control transport specification.