### PR TITLE
change core etc to explicitly only handle stdint-based types

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -247,7 +247,7 @@ private:
 #define declare_explicit_instantiation(T)       \
     extern template void Foo::Bar1<T>();
 
-ADIOS_FOREACH_TYPE_1ARG(declare_explicit_instantiation)
+ADIOS_FOREACH_STDTYPE_1ARG(declare_explicit_instantiation)
 #undef(declare_explicit_instantiation)
 } // end namespace adios
 
@@ -339,7 +339,7 @@ void Foo::Bar3Helper()
 #define define_explicit_instantiation(T)  \
     template void Foo::Bar1<T>();
 
-ADIOS_FOREACH_TYPE_1ARG(define_explicit_instantiation)
+ADIOS_FOREACH_STDTYPE_1ARG(define_explicit_instantiation)
 #undef(define_explicit_instantiation)
 
 } // end namespace adios

--- a/bindings/Matlab/adiosopenc.c
+++ b/bindings/Matlab/adiosopenc.c
@@ -50,8 +50,6 @@ static int verbose = 0;
 
 mxClassID adiostypeToMatlabClass(int adiostype, mxComplexity *complexity);
 size_t adiostypeToMemSize(adios2_type adiostype);
-mxClassID adiostypestringToMatlabClass(const char *type,
-                                       mxComplexity *complexity);
 mxArray *valueToMatlabValue(const void *data, mxClassID mxtype,
                             mxComplexity complexFlag);
 mxArray *arrayToMatlabArray(const void *data, const size_t nelems, mxClassID mxtype,
@@ -630,63 +628,6 @@ size_t adiostypeToMemSize(adios2_type adiostype)
                           adiostype);
         break;
     }
-    return 0; /* just to avoid warnings. never executed */
-}
-
-/** return the appropriate class for an adios type (and complexity too) */
-mxClassID adiostypestringToMatlabClass(const char *type,
-                                       mxComplexity *complexity)
-{
-    *complexity = mxREAL;
-    if (!strcmp(type, "char"))
-        return mxINT8_CLASS;
-    else if (!strcmp(type, "unsigned char"))
-        return mxUINT8_CLASS;
-    else if (!strcmp(type, "short"))
-        return mxINT16_CLASS;
-    else if (!strcmp(type, "unsigned short"))
-        return mxUINT16_CLASS;
-    else if (!strcmp(type, "int"))
-        return mxINT32_CLASS;
-    else if (!strcmp(type, "unsigned int"))
-        return mxUINT32_CLASS;
-    else if (!strcmp(type, "long int"))
-    {
-        if (sizeof(long int) == 4)
-            return mxINT32_CLASS;
-        else
-            return mxINT64_CLASS;
-    }
-    else if (!strcmp(type, "unsigned long int"))
-    {
-        if (sizeof(long int) == 4)
-            return mxUINT32_CLASS;
-        else
-            return mxUINT64_CLASS;
-    }
-    else if (!strcmp(type, "long long int"))
-        return mxINT64_CLASS;
-    else if (!strcmp(type, "unsigned long long int"))
-        return mxUINT64_CLASS;
-    else if (!strcmp(type, "float"))
-        return mxSINGLE_CLASS;
-    else if (!strcmp(type, "double"))
-        return mxDOUBLE_CLASS;
-    else if (!strcmp(type, "float complex"))
-    {
-        *complexity = mxCOMPLEX;
-        return mxSINGLE_CLASS;
-    }
-    else if (!strcmp(type, "double complex"))
-    {
-        *complexity = mxCOMPLEX;
-        return mxDOUBLE_CLASS;
-    }
-    else if (!strcmp(type, "string"))
-        return mxCHAR_CLASS;
-    else if (!strcmp(type, "string array"))
-        return mxCHAR_CLASS;
-
     return 0; /* just to avoid warnings. never executed */
 }
 

--- a/bindings/Python/py11IO.cpp
+++ b/bindings/Python/py11IO.cpp
@@ -203,7 +203,7 @@ Attribute IO::InquireAttribute(const std::string &name)
     {                                                                          \
         attribute = m_IO->InquireAttribute<T>(name);                           \
     }
-    ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
+    ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
     return Attribute(attribute);

--- a/bindings/Python/py11types.h
+++ b/bindings/Python/py11types.h
@@ -19,57 +19,13 @@ namespace py11
 {
 
 #define ADIOS2_FOREACH_PYTHON_TYPE_1ARG(MACRO)                                 \
-    MACRO(std::string)                                                         \
-    MACRO(char)                                                                \
-    MACRO(signed char)                                                         \
-    MACRO(unsigned char)                                                       \
-    MACRO(short)                                                               \
-    MACRO(unsigned short)                                                      \
-    MACRO(int)                                                                 \
-    MACRO(unsigned int)                                                        \
-    MACRO(long int)                                                            \
-    MACRO(long long int)                                                       \
-    MACRO(unsigned long int)                                                   \
-    MACRO(unsigned long long int)                                              \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(long double)                                                         \
-    MACRO(std::complex<float>)                                                 \
-    MACRO(std::complex<double>)
+    ADIOS2_FOREACH_STDTYPE_1ARG(MACRO)
 
 #define ADIOS2_FOREACH_NUMPY_TYPE_1ARG(MACRO)                                  \
-    MACRO(char)                                                                \
-    MACRO(signed char)                                                         \
-    MACRO(unsigned char)                                                       \
-    MACRO(short)                                                               \
-    MACRO(unsigned short)                                                      \
-    MACRO(int)                                                                 \
-    MACRO(unsigned int)                                                        \
-    MACRO(long int)                                                            \
-    MACRO(long long int)                                                       \
-    MACRO(unsigned long int)                                                   \
-    MACRO(unsigned long long int)                                              \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(long double)                                                         \
-    MACRO(std::complex<float>)                                                 \
-    MACRO(std::complex<double>)
+    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)
 
 #define ADIOS2_FOREACH_NUMPY_ATTRIBUTE_TYPE_1ARG(MACRO)                        \
-    MACRO(char)                                                                \
-    MACRO(signed char)                                                         \
-    MACRO(unsigned char)                                                       \
-    MACRO(short)                                                               \
-    MACRO(unsigned short)                                                      \
-    MACRO(int)                                                                 \
-    MACRO(unsigned int)                                                        \
-    MACRO(long int)                                                            \
-    MACRO(long long int)                                                       \
-    MACRO(unsigned long int)                                                   \
-    MACRO(unsigned long long int)                                              \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(long double)
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(MACRO)
 
 } // end namespace py11
 } // end namespace adios2

--- a/examples/hello/datamanReader/DataManCallbackReceiver.cpp
+++ b/examples/hello/datamanReader/DataManCallbackReceiver.cpp
@@ -61,7 +61,7 @@ void UserCallBack(void *data, const std::string &doid, const std::string &var,
         }                                                                      \
         std::cout << std::endl;                                                \
     }
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 }
 

--- a/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
+++ b/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
@@ -105,7 +105,7 @@ ProcessMetadata(int rank, const adios2::Engine &reader, adios2::IO &io,
     {                                                                          \
         ProcessVariableMetadata<T>(rank, name, type, reader, io, varinfos);    \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }
 #ifdef ADIOS2_HAVE_MPI

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -201,7 +201,7 @@
    virtual std::complex<double>& foo_CDouble(std::string bar);
   </pre>
 */
-#define ADIOS2_FOREACH_TYPE_2ARGS(MACRO)                                       \
+#define ADIOS2_FOREACH_ATTRIBUTE_TYPE_2ARGS(MACRO)                             \
     MACRO(std::string, String)                                                 \
     MACRO(char, Char)                                                          \
     MACRO(signed char, SChar)                                                  \
@@ -216,7 +216,10 @@
     MACRO(unsigned long long int, ULLInt)                                      \
     MACRO(float, Float)                                                        \
     MACRO(double, Double)                                                      \
-    MACRO(long double, LDouble)                                                \
+    MACRO(long double, LDouble)
+
+#define ADIOS2_FOREACH_TYPE_2ARGS(MACRO)                                       \
+    ADIOS2_FOREACH_ATTRIBUTE_TYPE_2ARGS(MACRO)                                 \
     MACRO(std::complex<float>, CFloat)                                         \
     MACRO(std::complex<double>, CDouble)
 

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -202,23 +202,23 @@
   </pre>
 */
 #define ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)                          \
-    MACRO(std::string, String)                                                 \
-    MACRO(int8_t, SChar)                                                       \
-    MACRO(uint8_t, UChar)                                                      \
-    MACRO(int16_t, Short)                                                      \
-    MACRO(uint16_t, UShort)                                                    \
-    MACRO(int32_t, Int)                                                        \
-    MACRO(uint32_t, UInt)                                                      \
-    MACRO(int64_t, LLInt)                                                      \
-    MACRO(uint64_t, ULLInt)                                                    \
-    MACRO(float, Float)                                                        \
-    MACRO(double, Double)                                                      \
-    MACRO(long double, LDouble)
+    MACRO(std::string, string)                                                 \
+    MACRO(int8_t, int8)                                                        \
+    MACRO(uint8_t, uint8)                                                      \
+    MACRO(int16_t, int16)                                                      \
+    MACRO(uint16_t, uint16)                                                    \
+    MACRO(int32_t, int32)                                                      \
+    MACRO(uint32_t, uint32)                                                    \
+    MACRO(int64_t, int64)                                                      \
+    MACRO(uint64_t, uint64)                                                    \
+    MACRO(float, float)                                                        \
+    MACRO(double, double)                                                      \
+    MACRO(long double, ldouble)
 
 #define ADIOS2_FOREACH_STDTYPE_2ARGS(MACRO)                                    \
     ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)                              \
-    MACRO(std::complex<float>, CFloat)                                         \
-    MACRO(std::complex<double>, CDouble)
+    MACRO(std::complex<float>, cfloat)                                         \
+    MACRO(std::complex<double>, cdouble)
 
 #define ADIOS2_FOREACH_COMPLEX_TYPE_2ARGS(MACRO)                               \
     MACRO(std::complex<float>, CFloat)                                         \

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -220,21 +220,24 @@
     MACRO(std::complex<float>, CFloat)                                         \
     MACRO(std::complex<double>, CDouble)
 
-#define ADIOS2_FOREACH_PRIMITIVE_TYPE_2ARGS(MACRO)                             \
-    MACRO(char, Char)                                                          \
-    MACRO(signed char, Char)                                                   \
-    MACRO(unsigned char, UChar)                                                \
-    MACRO(short, Short)                                                        \
-    MACRO(unsigned short, UShort)                                              \
-    MACRO(int, Int)                                                            \
-    MACRO(unsigned int, UInt)                                                  \
-    MACRO(long int, LInt)                                                      \
-    MACRO(long long int, LLInt)                                                \
-    MACRO(unsigned long int, ULInt)                                            \
-    MACRO(unsigned long long int, ULLInt)                                      \
+#define ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)                          \
+    MACRO(std::string, String)                                                 \
+    MACRO(int8_t, SChar)                                                       \
+    MACRO(uint8_t, UChar)                                                      \
+    MACRO(int16_t, Short)                                                      \
+    MACRO(uint16_t, UShort)                                                    \
+    MACRO(int32_t, Int)                                                        \
+    MACRO(uint32_t, UInt)                                                      \
+    MACRO(int64_t, LLInt)                                                      \
+    MACRO(uint64_t, ULLInt)                                                    \
     MACRO(float, Float)                                                        \
     MACRO(double, Double)                                                      \
     MACRO(long double, LDouble)
+
+#define ADIOS2_FOREACH_STDTYPE_2ARGS(MACRO)                                    \
+    ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)                              \
+    MACRO(std::complex<float>, CFloat)                                         \
+    MACRO(std::complex<double>, CDouble)
 
 #define ADIOS2_FOREACH_COMPLEX_TYPE_2ARGS(MACRO)                               \
     MACRO(std::complex<float>, CFloat)                                         \

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -179,7 +179,7 @@
 
 /**
  <pre>
- The ADIOS_FOREACH_TYPE_2ARGS macro assumes the given argument is a macro
+ The ADIOS2_FOREACH_STDTYPE_2ARGS macro assumes the given argument is a macro
  which takes two arguments, the first being a type, and the second being a
  label for that type, i.e. std::complex<float> and CFloat.
 
@@ -188,7 +188,7 @@
  For example:
 
    #define declare_foo(T,L) virtual const T& foo ## L (std::string bar);
-   ADIOS_FOREACH_TYPE_2ARGS(declare_foo)
+   ADIOS2_FOREACH_STDTYPE_2ARGS(declare_foo)
    #undef declare_foo
 
    is equivalent to:
@@ -201,28 +201,6 @@
    virtual std::complex<double>& foo_CDouble(std::string bar);
   </pre>
 */
-#define ADIOS2_FOREACH_ATTRIBUTE_TYPE_2ARGS(MACRO)                             \
-    MACRO(std::string, String)                                                 \
-    MACRO(char, Char)                                                          \
-    MACRO(signed char, SChar)                                                  \
-    MACRO(unsigned char, UChar)                                                \
-    MACRO(short, Short)                                                        \
-    MACRO(unsigned short, UShort)                                              \
-    MACRO(int, Int)                                                            \
-    MACRO(unsigned int, UInt)                                                  \
-    MACRO(long int, LInt)                                                      \
-    MACRO(long long int, LLInt)                                                \
-    MACRO(unsigned long int, ULInt)                                            \
-    MACRO(unsigned long long int, ULLInt)                                      \
-    MACRO(float, Float)                                                        \
-    MACRO(double, Double)                                                      \
-    MACRO(long double, LDouble)
-
-#define ADIOS2_FOREACH_TYPE_2ARGS(MACRO)                                       \
-    ADIOS2_FOREACH_ATTRIBUTE_TYPE_2ARGS(MACRO)                                 \
-    MACRO(std::complex<float>, CFloat)                                         \
-    MACRO(std::complex<double>, CDouble)
-
 #define ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)                          \
     MACRO(std::string, String)                                                 \
     MACRO(int8_t, SChar)                                                       \

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -254,7 +254,7 @@ Operator *ADIOS::InquireOperator(const std::string name) noexcept
         return *itPair.first->second;                                          \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 Operator &ADIOS::DefineCallBack(

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -156,7 +156,7 @@ public:
                                  const Dims &)> &function,                     \
         const Params &parameters);
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /** define CallBack2 */

--- a/source/adios2/core/Attribute.cpp
+++ b/source/adios2/core/Attribute.cpp
@@ -34,7 +34,7 @@ namespace core
     {                                                                          \
     }
 
-ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 } // end namespace core

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -90,7 +90,7 @@ void Engine::InitTransports() {}
     {                                                                          \
         ThrowUp("DoPutDeferred");                                              \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 // DoGet*
@@ -105,7 +105,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
         return nullptr;                                                        \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 #define declare_type(T)                                                        \
@@ -130,7 +130,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
         return std::vector<typename Variable<T>::Info>();                      \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 // PRIVATE
@@ -187,7 +187,7 @@ void Engine::CheckOpenModes(const std::set<Mode> &modes,
     template std::vector<typename Variable<T>::Info> Engine::BlocksInfo(       \
         const Variable<T> &, const size_t) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace core

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -437,7 +437,7 @@ protected:
 #define declare_type(T)                                                        \
     virtual void DoPutSync(Variable<T> &, const T *);                          \
     virtual void DoPutDeferred(Variable<T> &, const T *);
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 // Get
@@ -445,7 +445,7 @@ protected:
     virtual void DoGetSync(Variable<T> &, T *);                                \
     virtual void DoGetDeferred(Variable<T> &, T *);                            \
     virtual typename Variable<T>::Info *DoGetBlockSync(Variable<T> &);
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     virtual void DoClose(const int transportIndex) = 0;
@@ -471,7 +471,7 @@ protected:
     virtual std::vector<typename Variable<T>::Info> DoBlocksInfo(              \
         const Variable<T> &variable, const size_t step) const;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 private:
@@ -539,7 +539,7 @@ private:
     extern template std::vector<typename Variable<T>::Info>                    \
     Engine::BlocksInfo(const Variable<T> &, const size_t) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace core

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -717,7 +717,7 @@ void IO::CheckTransportType(const std::string type) const
                                                 const Dims &, const bool);     \
     template Variable<T> *IO::InquireVariable<T>(const std::string &) noexcept;
 
-ADIOS2_FOREACH_TYPE_1ARG(define_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(define_template_instantiation)
 #undef define_template_instatiation
 
 #define declare_template_instantiation(T)                                      \

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -169,7 +169,7 @@ bool IO::RemoveVariable(const std::string &name) noexcept
         variableMap.erase(index);                                              \
         isRemoved = true;                                                      \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 
@@ -185,7 +185,7 @@ void IO::RemoveAllVariables() noexcept
 {
     m_Variables.clear();
 #define declare_type(T) GetVariableMap<T>().clear();
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     m_Compound.clear();
 }
@@ -212,7 +212,7 @@ bool IO::RemoveAttribute(const std::string &name) noexcept
         variableMap.erase(index);                                              \
         isRemoved = true;                                                      \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 
@@ -229,7 +229,7 @@ void IO::RemoveAllAttributes() noexcept
     m_Attributes.clear();
 
 #define declare_type(T) GetAttributeMap<T>().clear();
-    ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
 #undef declare_type
 }
 
@@ -267,7 +267,7 @@ std::map<std::string, Params> IO::GetAvailableVariables() noexcept
                 helper::ValueToString(variable.m_Max);                         \
         }                                                                      \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }
 
@@ -328,7 +328,7 @@ IO::GetAvailableAttributes(const std::string &variableName,
                 "{ " + helper::VectorToCSV(attribute.m_DataArray) + " }";      \
         }                                                                      \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
     } // end for
@@ -361,7 +361,7 @@ std::string IO::InquireVariableType(const std::string &name) const noexcept
             return std::string();                                              \
         }                                                                      \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }
 
@@ -659,7 +659,7 @@ void IO::ResetVariablesStepSelection(const bool zeroStart,
         variable->ResetStepsSelection(zeroStart);                              \
         variable->m_RandomAccess = false;                                      \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 }
@@ -730,7 +730,7 @@ ADIOS2_FOREACH_STDTYPE_1ARG(define_template_instantiation)
     template Attribute<T> *IO::InquireAttribute<T>(                            \
         const std::string &, const std::string &, const std::string) noexcept;
 
-ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace core

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -437,7 +437,7 @@ private:
 
     /** Variable containers based on fixed-size type */
 #define declare_map(T, NAME) std::map<unsigned int, Variable<T>> m_##NAME;
-    ADIOS2_FOREACH_TYPE_2ARGS(declare_map)
+    ADIOS2_FOREACH_STDTYPE_2ARGS(declare_map)
 #undef declare_map
 
     std::map<unsigned int, VariableCompound> m_Compound;
@@ -459,7 +459,7 @@ private:
     DataMap m_Attributes;
 
 #define declare_map(T, NAME) std::map<unsigned int, Attribute<T>> m_##NAME##A;
-    ADIOS2_FOREACH_ATTRIBUTE_TYPE_2ARGS(declare_map)
+    ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(declare_map)
 #undef declare_map
 
     template <class T>
@@ -516,7 +516,7 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
     extern template Attribute<T> *IO::InquireAttribute<T>(                     \
         const std::string &, const std::string &, const std::string) noexcept;
 
-ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace core

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -528,7 +528,7 @@ private:
     extern template Variable<T> *IO::InquireVariable<T>(                       \
         const std::string &name) noexcept;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 #define declare_template_instantiation(T)                                      \

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -436,23 +436,10 @@ private:
     DataMap m_Variables;
 
     /** Variable containers based on fixed-size type */
-    std::map<unsigned int, Variable<std::string>> m_String;
-    std::map<unsigned int, Variable<char>> m_Char;
-    std::map<unsigned int, Variable<signed char>> m_SChar;
-    std::map<unsigned int, Variable<unsigned char>> m_UChar;
-    std::map<unsigned int, Variable<short>> m_Short;
-    std::map<unsigned int, Variable<unsigned short>> m_UShort;
-    std::map<unsigned int, Variable<int>> m_Int;
-    std::map<unsigned int, Variable<unsigned int>> m_UInt;
-    std::map<unsigned int, Variable<long int>> m_LInt;
-    std::map<unsigned int, Variable<unsigned long int>> m_ULInt;
-    std::map<unsigned int, Variable<long long int>> m_LLInt;
-    std::map<unsigned int, Variable<unsigned long long int>> m_ULLInt;
-    std::map<unsigned int, Variable<float>> m_Float;
-    std::map<unsigned int, Variable<double>> m_Double;
-    std::map<unsigned int, Variable<long double>> m_LDouble;
-    std::map<unsigned int, Variable<cfloat>> m_CFloat;
-    std::map<unsigned int, Variable<cdouble>> m_CDouble;
+#define declare_map(T, NAME) std::map<unsigned int, Variable<T>> m_##NAME;
+    ADIOS2_FOREACH_TYPE_2ARGS(declare_map)
+#undef declare_map
+
     std::map<unsigned int, VariableCompound> m_Compound;
 
     /** Gets the internal reference to a variable map for type T
@@ -471,21 +458,9 @@ private:
      */
     DataMap m_Attributes;
 
-    std::map<unsigned int, Attribute<std::string>> m_StringA;
-    std::map<unsigned int, Attribute<char>> m_CharA;
-    std::map<unsigned int, Attribute<signed char>> m_SCharA;
-    std::map<unsigned int, Attribute<unsigned char>> m_UCharA;
-    std::map<unsigned int, Attribute<short>> m_ShortA;
-    std::map<unsigned int, Attribute<unsigned short>> m_UShortA;
-    std::map<unsigned int, Attribute<int>> m_IntA;
-    std::map<unsigned int, Attribute<unsigned int>> m_UIntA;
-    std::map<unsigned int, Attribute<long int>> m_LIntA;
-    std::map<unsigned int, Attribute<unsigned long int>> m_ULIntA;
-    std::map<unsigned int, Attribute<long long int>> m_LLIntA;
-    std::map<unsigned int, Attribute<unsigned long long int>> m_ULLIntA;
-    std::map<unsigned int, Attribute<float>> m_FloatA;
-    std::map<unsigned int, Attribute<double>> m_DoubleA;
-    std::map<unsigned int, Attribute<long double>> m_LDoubleA;
+#define declare_map(T, NAME) std::map<unsigned int, Attribute<T>> m_##NAME##A;
+    ADIOS2_FOREACH_ATTRIBUTE_TYPE_2ARGS(declare_map)
+#undef declare_map
 
     template <class T>
     std::map<unsigned int, Attribute<T>> &GetAttributeMap() noexcept;

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -194,8 +194,7 @@ Attribute<T> *IO::InquireAttribute(const std::string &name,
     {                                                                          \
         return m_##NAME;                                                       \
     }
-
-ADIOS2_FOREACH_TYPE_2ARGS(make_GetVariableMap)
+ADIOS2_FOREACH_STDTYPE_2ARGS(make_GetVariableMap)
 #undef make_GetVariableMap
 
 // GetAttributeMap
@@ -205,8 +204,7 @@ ADIOS2_FOREACH_TYPE_2ARGS(make_GetVariableMap)
     {                                                                          \
         return m_##NAME##A;                                                    \
     }
-
-ADIOS2_FOREACH_ATTRIBUTE_TYPE_2ARGS(make_GetAttributeMap)
+ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(make_GetAttributeMap)
 #undef make_GetAttributeMap
 
 } // end namespace core

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -186,203 +186,28 @@ Attribute<T> *IO::InquireAttribute(const std::string &name,
 }
 
 // PRIVATE
-template <>
-std::map<unsigned int, Variable<std::string>> &IO::GetVariableMap() noexcept
-{
-    return m_String;
-}
 
-template <>
-std::map<unsigned int, Variable<char>> &IO::GetVariableMap() noexcept
-{
-    return m_Char;
-}
+// GetVariableMap
+#define make_GetVariableMap(T, NAME)                                           \
+    template <>                                                                \
+    std::map<unsigned int, Variable<T>> &IO::GetVariableMap() noexcept         \
+    {                                                                          \
+        return m_##NAME;                                                       \
+    }
 
-template <>
-std::map<unsigned int, Variable<signed char>> &IO::GetVariableMap() noexcept
-{
-    return m_SChar;
-}
+ADIOS2_FOREACH_TYPE_2ARGS(make_GetVariableMap)
+#undef make_GetVariableMap
 
-template <>
-std::map<unsigned int, Variable<unsigned char>> &IO::GetVariableMap() noexcept
-{
-    return m_UChar;
-}
+// GetAttributeMap
+#define make_GetAttributeMap(T, NAME)                                          \
+    template <>                                                                \
+    std::map<unsigned int, Attribute<T>> &IO::GetAttributeMap() noexcept       \
+    {                                                                          \
+        return m_##NAME##A;                                                    \
+    }
 
-template <>
-std::map<unsigned int, Variable<short>> &IO::GetVariableMap() noexcept
-{
-    return m_Short;
-}
-
-template <>
-std::map<unsigned int, Variable<unsigned short>> &IO::GetVariableMap() noexcept
-{
-    return m_UShort;
-}
-
-template <>
-std::map<unsigned int, Variable<int>> &IO::GetVariableMap() noexcept
-{
-    return m_Int;
-}
-
-template <>
-std::map<unsigned int, Variable<unsigned int>> &IO::GetVariableMap() noexcept
-{
-    return m_UInt;
-}
-
-template <>
-std::map<unsigned int, Variable<long int>> &IO::GetVariableMap() noexcept
-{
-    return m_LInt;
-}
-
-template <>
-std::map<unsigned int, Variable<unsigned long int>> &
-IO::GetVariableMap() noexcept
-{
-    return m_ULInt;
-}
-
-template <>
-std::map<unsigned int, Variable<long long int>> &IO::GetVariableMap() noexcept
-{
-    return m_LLInt;
-}
-
-template <>
-std::map<unsigned int, Variable<unsigned long long int>> &
-IO::GetVariableMap() noexcept
-{
-    return m_ULLInt;
-}
-
-template <>
-std::map<unsigned int, Variable<float>> &IO::GetVariableMap() noexcept
-{
-    return m_Float;
-}
-
-template <>
-std::map<unsigned int, Variable<double>> &IO::GetVariableMap() noexcept
-{
-    return m_Double;
-}
-
-template <>
-std::map<unsigned int, Variable<long double>> &IO::GetVariableMap() noexcept
-{
-    return m_LDouble;
-}
-
-template <>
-std::map<unsigned int, Variable<cfloat>> &IO::GetVariableMap() noexcept
-{
-    return m_CFloat;
-}
-
-template <>
-std::map<unsigned int, Variable<cdouble>> &IO::GetVariableMap() noexcept
-{
-    return m_CDouble;
-}
-
-// attributes
-template <>
-std::map<unsigned int, Attribute<std::string>> &IO::GetAttributeMap() noexcept
-{
-    return m_StringA;
-}
-
-template <>
-std::map<unsigned int, Attribute<char>> &IO::GetAttributeMap() noexcept
-{
-    return m_CharA;
-}
-
-template <>
-std::map<unsigned int, Attribute<signed char>> &IO::GetAttributeMap() noexcept
-{
-    return m_SCharA;
-}
-
-template <>
-std::map<unsigned int, Attribute<unsigned char>> &IO::GetAttributeMap() noexcept
-{
-    return m_UCharA;
-}
-
-template <>
-std::map<unsigned int, Attribute<short>> &IO::GetAttributeMap() noexcept
-{
-    return m_ShortA;
-}
-
-template <>
-std::map<unsigned int, Attribute<unsigned short>> &
-IO::GetAttributeMap() noexcept
-{
-    return m_UShortA;
-}
-
-template <>
-std::map<unsigned int, Attribute<int>> &IO::GetAttributeMap() noexcept
-{
-    return m_IntA;
-}
-
-template <>
-std::map<unsigned int, Attribute<unsigned int>> &IO::GetAttributeMap() noexcept
-{
-    return m_UIntA;
-}
-
-template <>
-std::map<unsigned int, Attribute<long int>> &IO::GetAttributeMap() noexcept
-{
-    return m_LIntA;
-}
-
-template <>
-std::map<unsigned int, Attribute<unsigned long int>> &
-IO::GetAttributeMap() noexcept
-{
-    return m_ULIntA;
-}
-
-template <>
-std::map<unsigned int, Attribute<long long int>> &IO::GetAttributeMap() noexcept
-{
-    return m_LLIntA;
-}
-
-template <>
-std::map<unsigned int, Attribute<unsigned long long int>> &
-IO::GetAttributeMap() noexcept
-{
-    return m_ULLIntA;
-}
-
-template <>
-std::map<unsigned int, Attribute<float>> &IO::GetAttributeMap() noexcept
-{
-    return m_FloatA;
-}
-
-template <>
-std::map<unsigned int, Attribute<double>> &IO::GetAttributeMap() noexcept
-{
-    return m_DoubleA;
-}
-
-template <>
-std::map<unsigned int, Attribute<long double>> &IO::GetAttributeMap() noexcept
-{
-    return m_LDoubleA;
-}
+ADIOS2_FOREACH_ATTRIBUTE_TYPE_2ARGS(make_GetAttributeMap)
+#undef make_GetAttributeMap
 
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/core/Operator.cpp
+++ b/source/adios2/core/Operator.cpp
@@ -41,7 +41,7 @@ Params &Operator::GetParameters() noexcept { return m_Parameters; }
     {                                                                          \
         CheckCallbackType("Callback1");                                        \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void Operator::RunCallback2(void *arg0, const std::string &arg1,

--- a/source/adios2/core/Operator.h
+++ b/source/adios2/core/Operator.h
@@ -53,7 +53,7 @@ public:
                               const std::string &, const std::string &,        \
                               const size_t, const Dims &, const Dims &,        \
                               const Dims &) const;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     virtual void RunCallback2(void *, const std::string &, const std::string &,

--- a/source/adios2/core/Stream.cpp
+++ b/source/adios2/core/Stream.cpp
@@ -152,7 +152,7 @@ void Stream::CheckOpen()
     template void Stream::ReadAttribute(                                       \
         const std::string &, T *, const std::string &, const std::string);
 
-ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 #define declare_template_instantiation(T)                                      \
@@ -185,7 +185,7 @@ ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
     template std::vector<T> Stream::Read<T>(const std::string &,               \
                                             const Box<Dims> &);
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace core

--- a/source/adios2/core/Stream.h
+++ b/source/adios2/core/Stream.h
@@ -160,7 +160,7 @@ private:
     extern template void Stream::ReadAttribute(                                \
         const std::string &, T *, const std::string &, const std::string);
 
-ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 // Explicit declaration of the public template methods
@@ -195,7 +195,7 @@ ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
     extern template std::vector<T> Stream::Read<T>(const std::string &,        \
                                                    const Box<Dims> &);
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace core

--- a/source/adios2/core/Variable.cpp
+++ b/source/adios2/core/Variable.cpp
@@ -97,7 +97,7 @@ namespace core
         return DoAllStepsBlocksInfo();                                         \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 } // end namespace core

--- a/source/adios2/core/VariableCompound.cpp
+++ b/source/adios2/core/VariableCompound.cpp
@@ -31,7 +31,7 @@ VariableCompound::VariableCompound(const std::string &name,
 #define declare_template_instantiation(T)                                      \
     template void VariableCompound::InsertMember<T>(const std::string &,       \
                                                     const size_t);
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace core

--- a/source/adios2/core/VariableCompound.h
+++ b/source/adios2/core/VariableCompound.h
@@ -60,7 +60,7 @@ public:
 #define declare_template_instantiation(T)                                      \
     extern template void VariableCompound::InsertMember<T>(                    \
         const std::string &, const size_t);
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace core

--- a/source/adios2/engine/bp3/BP3Reader.cpp
+++ b/source/adios2/engine/bp3/BP3Reader.cpp
@@ -105,7 +105,7 @@ void BP3Reader::PerformGets()
         ReadVariableBlocks(variable);                                          \
         variable.m_BlocksInfo.clear();                                         \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 
@@ -179,7 +179,7 @@ void BP3Reader::InitBuffer()
     {                                                                          \
         GetDeferredCommon(variable, data);                                     \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void BP3Reader::DoClose(const int transportIndex)
@@ -208,7 +208,7 @@ void BP3Reader::DoClose(const int transportIndex)
         return m_BP3Deserializer.BlocksInfo(variable, step);                   \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 } // end namespace engine

--- a/source/adios2/engine/bp3/BP3Reader.h
+++ b/source/adios2/engine/bp3/BP3Reader.h
@@ -64,7 +64,7 @@ private:
 #define declare_type(T)                                                        \
     void DoGetSync(Variable<T> &, T *) final;                                  \
     void DoGetDeferred(Variable<T> &, T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     void DoClose(const int transportIndex = -1) final;
@@ -88,7 +88,7 @@ private:
     std::vector<typename Variable<T>::Info> DoBlocksInfo(                      \
         const Variable<T> &variable, const size_t step) const final;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 };
 

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -80,7 +80,7 @@ void BP3Writer::PerformPuts()
         variable.m_BlocksInfo.clear();                                         \
     }
 
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }
     m_BP3Serializer.m_DeferredVariables.clear();
@@ -135,7 +135,7 @@ void BP3Writer::Init()
         PutDeferredCommon(variable, data);                                     \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void BP3Writer::InitParameters()

--- a/source/adios2/engine/bp3/BP3Writer.h
+++ b/source/adios2/engine/bp3/BP3Writer.h
@@ -68,7 +68,7 @@ private:
     void DoPutSync(Variable<T> &, const T *) final;                            \
     void DoPutDeferred(Variable<T> &, const T *) final;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /**

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -90,7 +90,7 @@ StepStatus BP4Reader::BeginStep(StepMode mode, const float timeoutSeconds)
             variable->SetStepSelection({m_CurrentStep, 1});                    \
         }                                                                      \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
     */
@@ -129,7 +129,7 @@ void BP4Reader::PerformGets()
         ReadVariableBlocks(variable);                                          \
         variable.m_BlocksInfo.clear();                                         \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 
@@ -225,7 +225,7 @@ void BP4Reader::InitBuffer()
     {                                                                          \
         GetDeferredCommon(variable, data);                                     \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void BP4Reader::DoClose(const int transportIndex)
@@ -248,7 +248,7 @@ void BP4Reader::DoClose(const int transportIndex)
         return m_BP4Deserializer.BlocksInfo(variable, step);                   \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 } // end namespace engine

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -66,7 +66,7 @@ private:
 #define declare_type(T)                                                        \
     void DoGetSync(Variable<T> &, T *) final;                                  \
     void DoGetDeferred(Variable<T> &, T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     void DoClose(const int transportIndex = -1) final;
@@ -87,7 +87,7 @@ private:
     std::vector<typename Variable<T>::Info> DoBlocksInfo(                      \
         const Variable<T> &variable, const size_t step) const final;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 };
 

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -82,7 +82,7 @@ void BP4Writer::PerformPuts()
         variable.m_BlocksInfo.clear();                                         \
     }
 
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }
     m_BP4Serializer.m_DeferredVariables.clear();
@@ -137,7 +137,7 @@ void BP4Writer::Init()
         PutDeferredCommon(variable, data);                                     \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void BP4Writer::InitParameters()

--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -71,7 +71,7 @@ private:
     void DoPutSync(Variable<T> &, const T *) final;                            \
     void DoPutDeferred(Variable<T> &, const T *) final;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /**

--- a/source/adios2/engine/dataman/DataManReader.cpp
+++ b/source/adios2/engine/dataman/DataManReader.cpp
@@ -126,7 +126,7 @@ StepStatus DataManReader::BeginStep(StepMode stepMode,
     {                                                                          \
         CheckIOVariable<T>(i.name, i.shape, i.start, i.count);                 \
     }
-            ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+            ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
             else
             {
@@ -202,7 +202,7 @@ void DataManReader::IOThread(std::shared_ptr<transportman::WANMan> man)
     {                                                                          \
         return BlocksInfoCommon(variable, step);                               \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void DataManReader::DoClose(const int transportIndex)

--- a/source/adios2/engine/dataman/DataManReader.h
+++ b/source/adios2/engine/dataman/DataManReader.h
@@ -57,7 +57,7 @@ private:
     DoAllStepsBlocksInfo(const Variable<T> &variable) const final;             \
     std::vector<typename Variable<T>::Info> DoBlocksInfo(                      \
         const Variable<T> &variable, const size_t step) const final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     template <class T>

--- a/source/adios2/engine/dataman/DataManWriter.cpp
+++ b/source/adios2/engine/dataman/DataManWriter.cpp
@@ -140,7 +140,7 @@ void DataManWriter::IOThread(std::shared_ptr<transportman::WANMan> man) {}
     {                                                                          \
         PutDeferredCommon(variable, values);                                   \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void DataManWriter::DoClose(const int transportIndex)

--- a/source/adios2/engine/dataman/DataManWriter.h
+++ b/source/adios2/engine/dataman/DataManWriter.h
@@ -49,7 +49,7 @@ private:
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &, const T *) final;                            \
     void DoPutDeferred(Variable<T> &, const T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     template <class T>

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -324,7 +324,7 @@ void HDF5ReaderP::PerformGets()
             }                                                                  \
         }                                                                      \
     }
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     //
@@ -357,7 +357,7 @@ void HDF5ReaderP::PerformGets()
         return GetBlocksInfo(variable, step);                                  \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void HDF5ReaderP::DoClose(const int transportIndex)

--- a/source/adios2/engine/hdf5/HDF5ReaderP.h
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.h
@@ -65,7 +65,7 @@ private:
                                                                                \
     std::vector<typename Variable<T>::Info> DoBlocksInfo(                      \
         const Variable<T> &variable, const size_t step) const final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     void DoClose(const int transportIndex = -1) final;

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -89,7 +89,7 @@ void HDF5WriterP::Init()
     {                                                                          \
         DoPutSyncCommon(variable, values);                                     \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 template <class T>

--- a/source/adios2/engine/hdf5/HDF5WriterP.h
+++ b/source/adios2/engine/hdf5/HDF5WriterP.h
@@ -57,7 +57,7 @@ private:
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &variable, const T *values) final;              \
     void DoPutDeferred(Variable<T> &variable, const T *values) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     template <class T>

--- a/source/adios2/engine/inline/InlineReader.cpp
+++ b/source/adios2/engine/inline/InlineReader.cpp
@@ -110,7 +110,7 @@ void InlineReader::EndStep()
         return GetBlockSyncCommon(variable);                                   \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 // Design note: Returns a copy. Instead, could return a reference, then
@@ -130,7 +130,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
         return variable.m_BlocksInfo;                                          \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void InlineReader::Init()

--- a/source/adios2/engine/inline/InlineReader.h
+++ b/source/adios2/engine/inline/InlineReader.h
@@ -69,7 +69,7 @@ private:
     void DoGetSync(Variable<T> &, T *) final;                                  \
     void DoGetDeferred(Variable<T> &, T *) final;                              \
     typename Variable<T>::Info *DoGetBlockSync(Variable<T> &) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     void DoClose(const int transportIndex = -1);
@@ -90,7 +90,7 @@ private:
     std::vector<typename Variable<T>::Info> DoBlocksInfo(                      \
         const Variable<T> &variable, const size_t step) const final;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 };
 

--- a/source/adios2/engine/inline/InlineWriter.cpp
+++ b/source/adios2/engine/inline/InlineWriter.cpp
@@ -64,7 +64,7 @@ StepStatus InlineWriter::BeginStep(StepMode mode, const float timeoutSeconds)
         Variable<T> &variable = FindVariable<T>(name, "in call to BeginStep"); \
         variable.m_BlocksInfo.clear();                                         \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 
@@ -124,7 +124,7 @@ void InlineWriter::Flush(const int transportIndex)
     {                                                                          \
         PutDeferredCommon(variable, data);                                     \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void InlineWriter::Init()

--- a/source/adios2/engine/inline/InlineWriter.h
+++ b/source/adios2/engine/inline/InlineWriter.h
@@ -69,7 +69,7 @@ private:
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &, const T *) final;                            \
     void DoPutDeferred(Variable<T> &, const T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /**

--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -488,7 +488,7 @@ void InSituMPIReader::AsyncRecvAllVariables()
         AsyncRecvVariable<T>(*variable, variablePair.second);                  \
     }
 
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }
 }
@@ -535,7 +535,7 @@ void InSituMPIReader::ProcessReceives()
     {                                                                          \
         GetDeferredCommon(variable, data);                                     \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void InSituMPIReader::Init()
@@ -602,7 +602,7 @@ void InSituMPIReader::DoClose(const int transportIndex)
         return m_BP3Deserializer.BlocksInfo(variable, step);                   \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 } // end namespace engine

--- a/source/adios2/engine/insitumpi/InSituMPIReader.h
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.h
@@ -97,7 +97,7 @@ private:
     std::vector<typename Variable<T>::Info> DoBlocksInfo(                      \
         const Variable<T> &variable, const size_t step) const final;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     template <class T>

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
@@ -293,7 +293,7 @@ void InSituMPIWriter::AsyncSendVariable(std::string variableName)
         variable->m_BlocksInfo.clear();                                        \
     }
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 }
 
@@ -341,7 +341,7 @@ void InSituMPIWriter::EndStep()
     {                                                                          \
         PutDeferredCommon(variable, values);                                   \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void InSituMPIWriter::Init()

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.h
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.h
@@ -92,7 +92,7 @@ private:
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &, const T *) final;                            \
     void DoPutDeferred(Variable<T> &, const T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /**

--- a/source/adios2/engine/mixer/HDFMixer.cpp
+++ b/source/adios2/engine/mixer/HDFMixer.cpp
@@ -52,7 +52,7 @@ void HDFMixer::Init()
     {                                                                          \
         DoPutSyncCommon(variable, values);                                     \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 StepStatus HDFMixer::BeginStep(StepMode mode, const float timeout_sec)

--- a/source/adios2/engine/mixer/HDFMixer.h
+++ b/source/adios2/engine/mixer/HDFMixer.h
@@ -89,7 +89,7 @@ private:
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &variable, const T *values) /*final */;         \
     void DoPutDeferred(Variable<T> &variable, const T *values) /*final */;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /**

--- a/source/adios2/engine/skeleton/SkeletonReader.cpp
+++ b/source/adios2/engine/skeleton/SkeletonReader.cpp
@@ -117,7 +117,7 @@ void SkeletonReader::EndStep()
         GetDeferredCommon(variable, data);                                     \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void SkeletonReader::Init()

--- a/source/adios2/engine/skeleton/SkeletonReader.h
+++ b/source/adios2/engine/skeleton/SkeletonReader.h
@@ -66,7 +66,7 @@ private:
 #define declare_type(T)                                                        \
     void DoGetSync(Variable<T> &, T *) final;                                  \
     void DoGetDeferred(Variable<T> &, T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     void DoClose(const int transportIndex = -1);

--- a/source/adios2/engine/skeleton/SkeletonWriter.cpp
+++ b/source/adios2/engine/skeleton/SkeletonWriter.cpp
@@ -100,7 +100,7 @@ void SkeletonWriter::Flush(const int transportIndex)
     {                                                                          \
         PutDeferredCommon(variable, data);                                     \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void SkeletonWriter::Init()

--- a/source/adios2/engine/skeleton/SkeletonWriter.h
+++ b/source/adios2/engine/skeleton/SkeletonWriter.h
@@ -61,7 +61,7 @@ private:
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &, const T *) final;                            \
     void DoPutDeferred(Variable<T> &, const T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /**

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -67,7 +67,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
         return (void *)variable;                                               \
     }
 
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
         return (void *)NULL;
@@ -102,7 +102,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
         Reader->m_IO.DefineAttribute<T>(attrName, *(T *)data);                 \
     }
 
-            ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(declare_type)
+            ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type)
 #undef declare_type
             else
             {
@@ -149,7 +149,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
         variable->m_AvailableStepsCount = 1;                                   \
         return (void *)variable;                                               \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
         return (void *)NULL;
     };
@@ -374,7 +374,7 @@ void SstReader::Init()
             }                                                                  \
         }                                                                      \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_gets)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_gets)
 #undef declare_gets
 
 void SstReader::PerformGets()
@@ -409,7 +409,7 @@ void SstReader::PerformGets()
         ReadVariableBlocks(variable);                                          \
         variable.m_BlocksInfo.clear();                                         \
     }
-            ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+            ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
         }
 
@@ -456,7 +456,7 @@ void SstReader::DoClose(const int transportIndex) { SstReaderClose(m_Input); }
             "ERROR: Unknown marshal mechanism in DoBlocksInfo\n");             \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 } // end namespace engine

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -82,7 +82,7 @@ private:
     std::vector<typename Variable<T>::Info> DoBlocksInfo(                      \
         const Variable<T> &variable, const size_t step) const final;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     void DoClose(const int transportIndex = -1) final;

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -111,7 +111,7 @@ void SstWriter::FFSMarshalAttributes()
                                data_addr);                                     \
     }
 
-        ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 }
@@ -192,7 +192,7 @@ void SstWriter::Init()
         PutSyncCommon(variable, values);                                       \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void SstWriter::DoClose(const int transportIndex) { SstWriterClose(m_Output); }

--- a/source/adios2/engine/sst/SstWriter.h
+++ b/source/adios2/engine/sst/SstWriter.h
@@ -48,7 +48,7 @@ private:
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &variable, const T *values) final;              \
     void DoPutDeferred(Variable<T> &, const T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     template <class T>

--- a/source/adios2/engine/wdm/WdmReader.cpp
+++ b/source/adios2/engine/wdm/WdmReader.cpp
@@ -139,7 +139,7 @@ StepStatus WdmReader::BeginStep(const StepMode stepMode,
     {                                                                          \
         CheckIOVariable<T>(i.name, i.shape, i.start, i.count);                 \
     }
-                ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+                ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
                 else
                 {
@@ -239,7 +239,7 @@ void WdmReader::PerformGets()
                    " from serializer",                                         \
             true, true);                                                       \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 
@@ -274,7 +274,7 @@ void WdmReader::EndStep()
         GetDeferredCommon(variable, data);                                     \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void WdmReader::Init()

--- a/source/adios2/engine/wdm/WdmReader.h
+++ b/source/adios2/engine/wdm/WdmReader.h
@@ -76,7 +76,7 @@ private:
 #define declare_type(T)                                                        \
     void DoGetSync(Variable<T> &, T *) final;                                  \
     void DoGetDeferred(Variable<T> &, T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     void DoClose(const int transportIndex = -1);

--- a/source/adios2/engine/wdm/WdmWriter.cpp
+++ b/source/adios2/engine/wdm/WdmWriter.cpp
@@ -100,7 +100,7 @@ void WdmWriter::Flush(const int transportIndex) {}
     {                                                                          \
         PutDeferredCommon(variable, data);                                     \
     }
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 void WdmWriter::Init()

--- a/source/adios2/engine/wdm/WdmWriter.h
+++ b/source/adios2/engine/wdm/WdmWriter.h
@@ -72,7 +72,7 @@ private:
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &, const T *) final;                            \
     void DoPutDeferred(Variable<T> &, const T *) final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /**

--- a/source/adios2/operator/callback/Signature1.cpp
+++ b/source/adios2/operator/callback/Signature1.cpp
@@ -26,7 +26,7 @@ namespace callback
     : Operator("Signature1", parameters, debugMode), m_Function##L(function)   \
     {                                                                          \
     }
-ADIOS2_FOREACH_TYPE_2ARGS(declare_type)
+ADIOS2_FOREACH_STDTYPE_2ARGS(declare_type)
 #undef declare_type
 
 #define declare_type(T, L)                                                     \
@@ -46,7 +46,7 @@ ADIOS2_FOREACH_TYPE_2ARGS(declare_type)
                                      " callback function failed\n");           \
         }                                                                      \
     }
-ADIOS2_FOREACH_TYPE_2ARGS(declare_type)
+ADIOS2_FOREACH_STDTYPE_2ARGS(declare_type)
 #undef declare_type
 
 } // end namespace callback

--- a/source/adios2/operator/callback/Signature1.h
+++ b/source/adios2/operator/callback/Signature1.h
@@ -31,7 +31,7 @@ public:
                    const Dims &, const Dims &)> &function,                     \
                const Params &parameters, const bool debugMode);
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     ~Signature1() = default;
@@ -40,7 +40,7 @@ public:
     void RunCallback1(const T *, const std::string &, const std::string &,     \
                       const std::string &, const size_t, const Dims &,         \
                       const Dims &, const Dims &) const final;
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 private:
@@ -49,7 +49,7 @@ private:
                        const std::string &, const size_t, const Dims &,        \
                        const Dims &, const Dims &)>                            \
         m_Function##L;
-    ADIOS2_FOREACH_TYPE_2ARGS(declare_type)
+    ADIOS2_FOREACH_STDTYPE_2ARGS(declare_type)
 #undef declare_type
 };
 

--- a/source/adios2/toolkit/format/bp3/BP3Base.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Base.cpp
@@ -882,7 +882,7 @@ std::string BP3Base::GetBPSubStreamName(const std::string &name,
     BP3Base::SetBP3Operations<T>(                                              \
         const std::vector<core::VariableBase::Operation> &) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp3/BP3Base.h
+++ b/source/adios2/toolkit/format/bp3/BP3Base.h
@@ -629,7 +629,7 @@ private:
     BP3Base::SetBP3Operations<T>(                                              \
         const std::vector<core::VariableBase::Operation> &) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Deserializer.cpp
@@ -485,7 +485,7 @@ BP3Deserializer::PerformGetsVariablesSubFileInfo(core::IO &io)
         subFileInfoPair.second =                                               \
             GetSubFileInfo(*io.InquireVariable<T>(variableName));              \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
     return m_DeferredVariablesMap;
@@ -513,7 +513,7 @@ void BP3Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
                                          m_IsRowMajor, m_ReverseDimensions);   \
         }                                                                      \
     }
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 }
 
@@ -534,7 +534,7 @@ void BP3Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
     template void BP3Deserializer::GetValueFromMetadata(                       \
         core::Variable<T> &variable, T *) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 #define declare_template_instantiation(T)                                      \
@@ -569,7 +569,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
         core::Variable<T> &, typename core::Variable<T>::Info &,               \
         const helper::SubStreamBoxInfo &, const bool, const size_t);
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace formata

--- a/source/adios2/toolkit/format/bp3/BP3Deserializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Deserializer.h
@@ -232,7 +232,7 @@ private:
     extern template void BP3Deserializer::GetValueFromMetadata(                \
         core::Variable<T> &variable, T *) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 #define declare_template_instantiation(T)                                      \
@@ -268,7 +268,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
         core::Variable<T> &, typename core::Variable<T>::Info &,               \
         const helper::SubStreamBoxInfo &, const bool, const size_t);
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -350,8 +350,8 @@ void BP3Serializer::UpdateOffsetsInMetadata()
 
             case (type_byte):
             {
-                UpdateIndexOffsetsCharacteristics<char>(currentPosition,
-                                                        type_byte, buffer);
+                UpdateIndexOffsetsCharacteristics<signed char>(
+                    currentPosition, type_byte, buffer);
                 break;
             }
 
@@ -1137,8 +1137,9 @@ void BP3Serializer::MergeSerializeIndices(
 
         case (type_byte):
         {
-            const auto characteristics = ReadElementIndexCharacteristics<char>(
-                buffer, position, type_byte, true);
+            const auto characteristics =
+                ReadElementIndexCharacteristics<signed char>(buffer, position,
+                                                             type_byte, true);
             count = characteristics.EntryCount;
             length = characteristics.EntryLength;
             timeStep = characteristics.Statistics.Step;

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -503,7 +503,7 @@ void BP3Serializer::PutAttributes(core::IO &io)
         PutAttributeInData(attribute, stats);                                  \
         PutAttributeInIndex(attribute, stats);                                 \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
         ++memberID;
@@ -1652,7 +1652,7 @@ size_t BP3Serializer::GetAttributesSizeInData(core::IO &io) const noexcept
         const core::Attribute<T> &attribute = *io.InquireAttribute<T>(name);   \
         attributesSizeInData += GetAttributeSizeInData<T>(attribute);          \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 
@@ -1671,7 +1671,7 @@ size_t BP3Serializer::GetAttributesSizeInData(core::IO &io) const noexcept
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
         const bool) noexcept;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 //------------------------------------------------------------------------------

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.h
@@ -428,7 +428,7 @@ private:
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
         const bool) noexcept;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp3/operation/BP3Operation.cpp
+++ b/source/adios2/toolkit/format/bp3/operation/BP3Operation.cpp
@@ -40,7 +40,7 @@ namespace format
     {                                                                          \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp3/operation/BP3Operation.h
+++ b/source/adios2/toolkit/format/bp3/operation/BP3Operation.h
@@ -49,7 +49,7 @@ public:
         const typename core::Variable<T>::Operation &operation,                \
         std::vector<char> &buffer) const noexcept;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /**

--- a/source/adios2/toolkit/format/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Base.cpp
@@ -949,7 +949,7 @@ std::string BP4Base::GetBPSubStreamName(const std::string &name,
     BP4Base::SetBP4Operations<T>(                                              \
         const std::vector<core::VariableBase::Operation> &) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp4/BP4Base.h
@@ -656,7 +656,7 @@ private:
     BP4Base::SetBP4Operations<T>(                                              \
         const std::vector<core::VariableBase::Operation> &) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Deserializer.cpp
@@ -884,7 +884,7 @@ BP4Deserializer::PerformGetsVariablesSubFileInfo(core::IO &io)
         subFileInfoPair.second =                                               \
             GetSubFileInfo(*io.InquireVariable<T>(variableName));              \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
     return m_DeferredVariablesMap;
@@ -912,7 +912,7 @@ void BP4Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
                                          m_IsRowMajor, m_ReverseDimensions);   \
         }                                                                      \
     }
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 }
 
@@ -933,7 +933,7 @@ void BP4Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
     template void BP4Deserializer::GetValueFromMetadata(                       \
         core::Variable<T> &variable, T *) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 #define declare_template_instantiation(T)                                      \
@@ -964,7 +964,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
         core::Variable<T> &, typename core::Variable<T>::Info &,               \
         const helper::SubStreamBoxInfo &, const bool, const size_t);
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp4/BP4Deserializer.h
@@ -247,7 +247,7 @@ private:
     extern template void BP4Deserializer::GetValueFromMetadata(                \
         core::Variable<T> &variable, T *) const;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 #define declare_template_instantiation(T)                                      \
@@ -279,7 +279,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
         core::Variable<T> &, typename core::Variable<T>::Info &,               \
         const helper::SubStreamBoxInfo &, const bool, const size_t);
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
@@ -402,8 +402,8 @@ void BP4Serializer::UpdateOffsetsInMetadata()
 
             case (type_byte):
             {
-                UpdateIndexOffsetsCharacteristics<char>(currentPosition,
-                                                        type_byte, buffer);
+                UpdateIndexOffsetsCharacteristics<signed char>(
+                    currentPosition, type_byte, buffer);
                 break;
             }
 
@@ -1234,8 +1234,9 @@ void BP4Serializer::MergeSerializeIndicesPerStep(
 
         case (type_byte):
         {
-            const auto characteristics = ReadElementIndexCharacteristics<char>(
-                buffer, position, type_byte, true);
+            const auto characteristics =
+                ReadElementIndexCharacteristics<signed char>(buffer, position,
+                                                             type_byte, true);
             count = characteristics.EntryCount;
             length = characteristics.EntryLength;
             timeStep = characteristics.Statistics.Step;
@@ -1679,8 +1680,9 @@ void BP4Serializer::MergeSerializeIndices(
 
         case (type_byte):
         {
-            const auto characteristics = ReadElementIndexCharacteristics<char>(
-                buffer, position, type_byte, true);
+            const auto characteristics =
+                ReadElementIndexCharacteristics<signed char>(buffer, position,
+                                                             type_byte, true);
             count = characteristics.EntryCount;
             length = characteristics.EntryLength;
             timeStep = characteristics.Statistics.Step;

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
@@ -555,7 +555,7 @@ void BP4Serializer::PutAttributes(core::IO &io)
         PutAttributeInData(attribute, stats);                                  \
         PutAttributeInIndex(attribute, stats);                                 \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
         ++memberID;
@@ -2177,7 +2177,7 @@ size_t BP4Serializer::GetAttributesSizeInData(core::IO &io) const noexcept
         const core::Attribute<T> &attribute = *io.InquireAttribute<T>(name);   \
         attributesSizeInData += GetAttributeSizeInData<T>(attribute);          \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 
@@ -2196,7 +2196,7 @@ size_t BP4Serializer::GetAttributesSizeInData(core::IO &io) const noexcept
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
         const bool) noexcept;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 //------------------------------------------------------------------------------

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.h
@@ -468,7 +468,7 @@ private:
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
         const bool) noexcept;
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp4/operation/BP4Operation.cpp
+++ b/source/adios2/toolkit/format/bp4/operation/BP4Operation.cpp
@@ -40,7 +40,7 @@ namespace format
     {                                                                          \
     }
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp4/operation/BP4Operation.h
+++ b/source/adios2/toolkit/format/bp4/operation/BP4Operation.h
@@ -49,7 +49,7 @@ public:
         const typename core::Variable<T>::Operation &operation,                \
         std::vector<char> &buffer) const noexcept;
 
-    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
     /**

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -204,7 +204,7 @@ void DataManSerializer::PutAttributes(core::IO &io, const int rank)
         core::Attribute<T> &attribute = *io.InquireAttribute<T>(name);         \
         PutAttribute(attribute, rank);                                         \
     }
-            ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)
+            ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
 #undef declare_type
         }
     }
@@ -446,7 +446,7 @@ void DataManSerializer::GetAttributes(core::IO &io)
             }                                                                  \
         }                                                                      \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
 }
@@ -614,7 +614,7 @@ DataManSerializer::GenerateReply(const std::vector<char> &request, size_t &step)
                ovlpStart, ovlpCount, ovlpStart, ovlpCount, var.doid, step,     \
                var.rank, var.address, Params(), replyLocalBuffer, replyMetaJ); \
     }
-                    ADIOS2_FOREACH_TYPE_1ARG(declare_type)
+                    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
                     std::vector<char> metapack = SerializeJson(*replyMetaJ);

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -457,7 +457,7 @@ void HDF5Common::CreateVar(core::IO &io, hid_t datasetId,
     }
     else if (H5Tequal(H5T_NATIVE_CHAR, h5Type))
     {
-        AddVar<char>(io, name, datasetId, ts);
+        AddVar<TypeInfo<char>::IOType>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_UCHAR, h5Type))
     {
@@ -491,19 +491,19 @@ void HDF5Common::CreateVar(core::IO &io, hid_t datasetId,
     }
     else if (H5Tequal(H5T_NATIVE_LONG, h5Type))
     {
-        AddVar<long>(io, name, datasetId, ts);
+        AddVar<TypeInfo<long>::IOType>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_ULONG, h5Type))
     {
-        AddVar<unsigned long>(io, name, datasetId, ts);
+        AddVar<TypeInfo<unsigned long>::IOType>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_LLONG, h5Type))
     {
-        AddVar<long long>(io, name, datasetId, ts);
+        AddVar<TypeInfo<long long>::IOType>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_ULLONG, h5Type))
     {
-        AddVar<unsigned long long>(io, name, datasetId, ts);
+        AddVar<TypeInfo<unsigned long long>::IOType>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_FLOAT, h5Type))
     {
@@ -893,17 +893,18 @@ void HDF5Common::AddNonStringAttribute(core::IO &io,
                                        hid_t attrId, hid_t h5Type,
                                        hsize_t arraySize)
 {
+    using IOType = typename TypeInfo<T>::IOType;
     if (arraySize == 0)
     { // SCALAR
-        T val;
+        IOType val;
         H5Aread(attrId, h5Type, &val);
-        io.DefineAttribute<T>(attrName, val);
+        io.DefineAttribute(attrName, val);
     }
     else
     {
-        T val[arraySize];
+        IOType val[arraySize];
         H5Aread(attrId, h5Type, val);
-        io.DefineAttribute<T>(attrName, val, arraySize);
+        io.DefineAttribute(attrName, val, arraySize);
     }
 }
 
@@ -1216,7 +1217,7 @@ void HDF5Common::WriteAttrFromIO(core::IO &io)
         core::Attribute<T> *adiosAttr = io.InquireAttribute<T>(attrName);      \
         WriteNonStringAttr(io, adiosAttr, parentID, list.back().c_str());      \
     }
-        ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }
 
@@ -1347,7 +1348,7 @@ void HDF5Common::StaticGetAdiosStepString(std::string &stepName, int ts)
 #define declare_template_instantiation(T)                                      \
     template void HDF5Common::Write(core::Variable<T> &, const T *);
 
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace interop

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -216,7 +216,7 @@ private:
 #define declare_template_instantiation(T)                                      \
     extern template void HDF5Common::Write(core::Variable<T> &variable,        \
                                            const T *value);
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace interop

--- a/source/utils/adios_reorganize/Reorganize.cpp
+++ b/source/utils/adios_reorganize/Reorganize.cpp
@@ -431,7 +431,7 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
     {                                                                          \
         variable = io.InquireVariable<T>(variablePair.first);                  \
     }
-        ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
         varinfo[varidx].v = variable;
@@ -549,7 +549,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
                            reinterpret_cast<T *>(varinfo[varidx].readbuf));    \
         }                                                                      \
     }
-            ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+            ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
         }
     }
@@ -589,7 +589,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
                            reinterpret_cast<T *>(varinfo[varidx].readbuf));    \
         }                                                                      \
     }
-            ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+            ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
         }
     }

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -621,7 +621,7 @@ int doList_vars(core::Engine *fp, core::IO *io)
         core::Attribute<T> *a = io->InquireAttribute<T>(name);                 \
         retval = printAttributeValue(fp, io, a);                               \
     }
-                    ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(
+                    ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(
                         declare_template_instantiation)
 #undef declare_template_instantiation
                     fprintf(outf, "\n");
@@ -644,7 +644,7 @@ int doList_vars(core::Engine *fp, core::IO *io)
         core::Variable<T> *v = io->InquireVariable<T>(name);                   \
         retval = printVariableInfo(fp, io, v);                                 \
     }
-                ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+                ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
             }
         }


### PR DESCRIPTION
Now that both the C and CXX11 interface interact with core only via stdint-based types, the rest of adios2 really only needs to support those types.

Essentially, that's already the case: Integer variables created through the interfaces will be of one of the 8 stdint types (or whatever primitive type they alias). Integer variables read from a file (or other mans) will be one of the 8 stdint types. So the support for other variable types (essentially, char, long, unsigned long) is there but not ever used, at least it shouldn't be unless there are bugs.

This set of patches does touch a lot of code at the heart of adios, but it's also fairly straightforward changes -- for the most part it's ADIOS2_FOREACH_..._TYPE_1ARG to .._STDTYPE_1ARG.

There is one change in particular which could use a second look:
* I removed `adiostypestringToMatlabClass` from the matlab interface, because it appears to be unused, and it uses hardcoded strings for the types (which would break if eventually going to use "uint8_t" etc.)

Note that while this ends up being almost a global search and replace of _TYPE_1ARG to _STDTYPE_1ARG, it doesn't actually touch all uses, and is done step-by-step which would help if thing broke and one needs to figure out where. (Though I'm pretty sure there's no major breakage.)

Eventually, it'd certainly be possible to change over the remaining uses in the cxx11 interface into their own macro and just rename _STDTYPE_ back to _TYPE_.

Overall, it's "216 additions and 533 deletions", so it actually makes code shorter in some cases (mostly where I use macro generated code).
