### PR TITLE
More stdint-type updates

### DIFF
--- a/source/adios2/toolkit/format/bp3/BP3Base.h
+++ b/source/adios2/toolkit/format/bp3/BP3Base.h
@@ -360,6 +360,12 @@ protected:
     };
 
     /**
+     * Maps C++ type to DataTypes enum
+     */
+    template <typename T>
+    struct TypeTraits;
+
+    /**
      * Characteristic ID in variable metadata
      */
     enum CharacteristicID
@@ -537,14 +543,6 @@ protected:
     /** Sets if IO is node-local so each rank creates its own IO directory and
      * stream */
     void InitParameterNodeLocal(const std::string value);
-
-    /**
-     * Returns data type index from enum Datatypes
-     * @param variable input variable
-     * @return data type
-     */
-    template <class T>
-    int8_t GetDataType() const noexcept;
 
     std::vector<uint8_t>
     GetTransportIDs(const std::vector<std::string> &transportsTypes) const

--- a/source/adios2/toolkit/format/bp3/BP3Base.h
+++ b/source/adios2/toolkit/format/bp3/BP3Base.h
@@ -635,4 +635,6 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 } // end namespace format
 } // end namespace adios2
 
+#include "BP3Base.inl"
+
 #endif /* ADIOS2_TOOLKIT_FORMAT_BP3_BP3BASE_H_ */

--- a/source/adios2/toolkit/format/bp3/BP3Base.inl
+++ b/source/adios2/toolkit/format/bp3/BP3Base.inl
@@ -23,30 +23,30 @@ namespace format
 
 // PROTECTED
 
-#define make_GetDataType(data_type, TYPE)                                      \
+#define make_TypeTraits(data_type, TYPE)                                       \
     template <>                                                                \
-    inline int8_t BP3Base::GetDataType<TYPE>() const noexcept                  \
+    struct BP3Base::TypeTraits<TYPE>                                           \
     {                                                                          \
-        const int8_t type = static_cast<int8_t>(data_type);                    \
-        return type;                                                           \
-    }
+        static const DataTypes type_enum = DataTypes::data_type;               \
+    };
 
 /* clang-format off */
-make_GetDataType(type_string, std::string)
-make_GetDataType(type_byte, int8_t)
-make_GetDataType(type_short, int16_t)
-make_GetDataType(type_integer, int32_t)
-make_GetDataType(type_long, int64_t)
-make_GetDataType(type_unsigned_byte, uint8_t)
-make_GetDataType(type_unsigned_short, uint16_t)
-make_GetDataType(type_unsigned_integer, uint32_t)
-make_GetDataType(type_unsigned_long, uint64_t)
-make_GetDataType(type_real, float)
-make_GetDataType(type_double, double)
-make_GetDataType(type_long_double, long double)
-make_GetDataType(type_complex, cfloat)
-make_GetDataType(type_double_complex, cdouble)
+make_TypeTraits(type_string, std::string)
+make_TypeTraits(type_byte, int8_t)
+make_TypeTraits(type_short, int16_t)
+make_TypeTraits(type_integer, int32_t)
+make_TypeTraits(type_long, int64_t)
+make_TypeTraits(type_unsigned_byte, uint8_t)
+make_TypeTraits(type_unsigned_short, uint16_t)
+make_TypeTraits(type_unsigned_integer, uint32_t)
+make_TypeTraits(type_unsigned_long, uint64_t)
+make_TypeTraits(type_real, float)
+make_TypeTraits(type_double, double)
+make_TypeTraits(type_long_double, long double)
+make_TypeTraits(type_complex, cfloat)
+make_TypeTraits(type_double_complex, cdouble)
 /* clang-format on */
+#undef make_TypeTraits
 
 } // end namespace format
 } // end namespace adios2

--- a/source/adios2/toolkit/format/bp3/BP3Base.inl
+++ b/source/adios2/toolkit/format/bp3/BP3Base.inl
@@ -1,0 +1,54 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * BP3Base.inl
+ *
+ *  Created on: Feb 13, 2019
+ *      Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+ */
+
+#ifndef ADIOS2_TOOLKIT_FORMAT_BP3_BP3BASE_INL_
+#define ADIOS2_TOOLKIT_FORMAT_BP3_BP3BASE_INL_
+#ifndef ADIOS2_TOOLKIT_FORMAT_BP3_BP3BASE_H_
+#error "Inline file should only be included from its header, never on its own"
+#endif
+
+#include "BP3Base.h"
+
+namespace adios2
+{
+namespace format
+{
+
+// PROTECTED
+
+#define make_GetDataType(data_type, TYPE)                                      \
+    template <>                                                                \
+    inline int8_t BP3Base::GetDataType<TYPE>() const noexcept                  \
+    {                                                                          \
+        const int8_t type = static_cast<int8_t>(data_type);                    \
+        return type;                                                           \
+    }
+
+/* clang-format off */
+make_GetDataType(type_string, std::string)
+make_GetDataType(type_byte, int8_t)
+make_GetDataType(type_short, int16_t)
+make_GetDataType(type_integer, int32_t)
+make_GetDataType(type_long, int64_t)
+make_GetDataType(type_unsigned_byte, uint8_t)
+make_GetDataType(type_unsigned_short, uint16_t)
+make_GetDataType(type_unsigned_integer, uint32_t)
+make_GetDataType(type_unsigned_long, uint64_t)
+make_GetDataType(type_real, float)
+make_GetDataType(type_double, double)
+make_GetDataType(type_long_double, long double)
+make_GetDataType(type_complex, cfloat)
+make_GetDataType(type_double_complex, cdouble)
+/* clang-format on */
+
+} // end namespace format
+} // end namespace adios2
+
+#endif /* ADIOS2_TOOLKIT_FORMAT_BP3_BP3BASE_INL_ */

--- a/source/adios2/toolkit/format/bp3/BP3Base.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Base.tcc
@@ -24,31 +24,6 @@ namespace format
 
 // PROTECTED
 
-#define make_GetDataType(data_type, TYPE)\
-template <>\
-int8_t BP3Base::GetDataType<TYPE>() const noexcept\
-{\
-    const int8_t type = static_cast<int8_t>(data_type);\
-    return type;\
-}
-
-/* clang-format off */
-make_GetDataType(type_string, std::string)
-make_GetDataType(type_byte, int8_t)
-make_GetDataType(type_short, int16_t)
-make_GetDataType(type_integer, int32_t)
-make_GetDataType(type_long, int64_t)
-make_GetDataType(type_unsigned_byte, uint8_t)
-make_GetDataType(type_unsigned_short, uint16_t)
-make_GetDataType(type_unsigned_integer, uint32_t)
-make_GetDataType(type_unsigned_long, uint64_t)
-make_GetDataType(type_real, float)
-make_GetDataType(type_double, double)
-make_GetDataType(type_long_double, long double)
-make_GetDataType(type_complex, cfloat)
-make_GetDataType(type_double_complex, cdouble)
-/* clang-format on */
-
 template <class T>
 BP3Base::Characteristics<T> BP3Base::ReadElementIndexCharacteristics(
     const std::vector<char> &buffer, size_t &position, const DataTypes dataType,

--- a/source/adios2/toolkit/format/bp3/BP3Base.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Base.tcc
@@ -23,103 +23,31 @@ namespace format
 {
 
 // PROTECTED
-template <>
-int8_t BP3Base::GetDataType<std::string>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_string);
-    return type;
+
+#define make_GetDataType(data_type, TYPE)\
+template <>\
+int8_t BP3Base::GetDataType<TYPE>() const noexcept\
+{\
+    const int8_t type = static_cast<int8_t>(data_type);\
+    return type;\
 }
 
-template <>
-int8_t BP3Base::GetDataType<int8_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_byte);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<int16_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_short);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<int32_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_integer);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<int64_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_long);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<uint8_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_unsigned_byte);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<uint16_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_unsigned_short);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<uint32_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_unsigned_integer);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<uint64_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_unsigned_long);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<float>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_real);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<double>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_double);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<long double>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_long_double);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<cfloat>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_complex);
-    return type;
-}
-
-template <>
-int8_t BP3Base::GetDataType<cdouble>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_double_complex);
-    return type;
-}
+/* clang-format off */
+make_GetDataType(type_string, std::string)
+make_GetDataType(type_byte, int8_t)
+make_GetDataType(type_short, int16_t)
+make_GetDataType(type_integer, int32_t)
+make_GetDataType(type_long, int64_t)
+make_GetDataType(type_unsigned_byte, uint8_t)
+make_GetDataType(type_unsigned_short, uint16_t)
+make_GetDataType(type_unsigned_integer, uint32_t)
+make_GetDataType(type_unsigned_long, uint64_t)
+make_GetDataType(type_real, float)
+make_GetDataType(type_double, double)
+make_GetDataType(type_long_double, long double)
+make_GetDataType(type_complex, cfloat)
+make_GetDataType(type_double_complex, cdouble)
+/* clang-format on */
 
 template <class T>
 BP3Base::Characteristics<T> BP3Base::ReadElementIndexCharacteristics(

--- a/source/adios2/toolkit/format/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Deserializer.cpp
@@ -173,96 +173,14 @@ void BP3Deserializer::ParseVariablesIndex(const BufferSTL &bufferSTL,
         switch (header.DataType)
         {
 
-        case (type_string):
-        {
-            DefineVariableInEngineIO<std::string>(header, engine, buffer,
-                                                  position);
-            break;
-        }
-
-        case (type_byte):
-        {
-            DefineVariableInEngineIO<int8_t>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_short):
-        {
-            DefineVariableInEngineIO<int16_t>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_integer):
-        {
-            DefineVariableInEngineIO<int32_t>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_long):
-        {
-            DefineVariableInEngineIO<int64_t>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_byte):
-        {
-            DefineVariableInEngineIO<uint8_t>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_short):
-        {
-            DefineVariableInEngineIO<uint16_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_unsigned_integer):
-        {
-            DefineVariableInEngineIO<uint32_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_unsigned_long):
-        {
-            DefineVariableInEngineIO<uint64_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_real):
-        {
-            DefineVariableInEngineIO<float>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_double):
-        {
-            DefineVariableInEngineIO<double>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_long_double):
-        {
-            DefineVariableInEngineIO<long double>(header, engine, buffer,
-                                                  position);
-            break;
-        }
-
-        case (type_complex):
-        {
-            DefineVariableInEngineIO<std::complex<float>>(header, engine,
-                                                          buffer, position);
-            break;
-        }
-
-        case (type_double_complex):
-        {
-            DefineVariableInEngineIO<std::complex<double>>(header, engine,
-                                                           buffer, position);
-            break;
-        }
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        DefineVariableInEngineIO<T>(header, engine, buffer, position);         \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_STDTYPE_1ARG(make_case)
+#undef make_case
 
         } // end switch
     };
@@ -348,90 +266,17 @@ void BP3Deserializer::ParseAttributesIndex(const BufferSTL &bufferSTL,
         switch (header.DataType)
         {
 
-        case (type_string):
-        {
-            DefineAttributeInEngineIO<std::string>(header, engine, buffer,
-                                                   position);
-            break;
-        }
-
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        DefineAttributeInEngineIO<T>(header, engine, buffer, position);        \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(make_case)
+#undef make_case
         case (type_string_array):
         {
             DefineAttributeInEngineIO<std::string>(header, engine, buffer,
-                                                   position);
-            break;
-        }
-
-        case (type_byte):
-        {
-            DefineAttributeInEngineIO<int8_t>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_short):
-        {
-            DefineAttributeInEngineIO<int16_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_integer):
-        {
-            DefineAttributeInEngineIO<int32_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_long):
-        {
-            DefineAttributeInEngineIO<int64_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_unsigned_byte):
-        {
-            DefineAttributeInEngineIO<uint8_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_unsigned_short):
-        {
-            DefineAttributeInEngineIO<uint16_t>(header, engine, buffer,
-                                                position);
-            break;
-        }
-
-        case (type_unsigned_integer):
-        {
-            DefineAttributeInEngineIO<uint32_t>(header, engine, buffer,
-                                                position);
-            break;
-        }
-
-        case (type_unsigned_long):
-        {
-            DefineAttributeInEngineIO<uint64_t>(header, engine, buffer,
-                                                position);
-            break;
-        }
-
-        case (type_real):
-        {
-            DefineAttributeInEngineIO<float>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_double):
-        {
-            DefineAttributeInEngineIO<double>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_long_double):
-        {
-            DefineAttributeInEngineIO<long double>(header, engine, buffer,
                                                    position);
             break;
         }

--- a/source/adios2/toolkit/format/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Deserializer.tcc
@@ -40,9 +40,9 @@ void BP3Deserializer::GetSyncVariableDataFromStream(core::Variable<T> &variable,
     size_t position = itStep->second.front();
 
     const Characteristics<T> characteristics =
-        ReadElementIndexCharacteristics<T>(
-            buffer, position, static_cast<DataTypes>(GetDataType<T>()), false,
-            m_Minifooter.IsLittleEndian);
+        ReadElementIndexCharacteristics<T>(buffer, position,
+                                           TypeTraits<T>::type_enum, false,
+                                           m_Minifooter.IsLittleEndian);
 
     const size_t payloadOffset = characteristics.Statistics.PayloadOffset;
     variable.m_Data = reinterpret_cast<T *>(&buffer[payloadOffset]);
@@ -165,9 +165,9 @@ void BP3Deserializer::SetVariableBlockInfo(
         size_t position = blockIndexOffset;
 
         const Characteristics<T> blockCharacteristics =
-            ReadElementIndexCharacteristics<T>(
-                buffer, position, static_cast<DataTypes>(GetDataType<T>()),
-                false, m_Minifooter.IsLittleEndian);
+            ReadElementIndexCharacteristics<T>(buffer, position,
+                                               TypeTraits<T>::type_enum, false,
+                                               m_Minifooter.IsLittleEndian);
         // check if they intersect
         helper::SubStreamBoxInfo subStreamInfo;
 
@@ -283,9 +283,9 @@ void BP3Deserializer::SetVariableBlockInfo(
         size_t position = blockIndexOffset;
 
         const Characteristics<T> blockCharacteristics =
-            ReadElementIndexCharacteristics<T>(
-                buffer, position, static_cast<DataTypes>(GetDataType<T>()),
-                false, m_Minifooter.IsLittleEndian);
+            ReadElementIndexCharacteristics<T>(buffer, position,
+                                               TypeTraits<T>::type_enum, false,
+                                               m_Minifooter.IsLittleEndian);
 
         // check if they intersect
         helper::SubStreamBoxInfo subStreamInfo;
@@ -984,8 +984,7 @@ BP3Deserializer::GetSubFileInfo(const core::Variable<T> &variable) const
         {
             const Characteristics<T> blockCharacteristics =
                 ReadElementIndexCharacteristics<T>(
-                    buffer, blockPosition,
-                    static_cast<DataTypes>(GetDataType<T>()), false,
+                    buffer, blockPosition, TypeTraits<T>::type_enum, false,
                     m_Minifooter.IsLittleEndian);
 
             // check if they intersect
@@ -1041,10 +1040,9 @@ std::vector<typename core::Variable<T>::Info> BP3Deserializer::BlocksInfoCommon(
         size_t position = blockIndexOffset;
 
         const Characteristics<T> blockCharacteristics =
-            ReadElementIndexCharacteristics<T>(
-                m_Metadata.m_Buffer, position,
-                static_cast<DataTypes>(GetDataType<T>()), false,
-                m_Minifooter.IsLittleEndian);
+            ReadElementIndexCharacteristics<T>(m_Metadata.m_Buffer, position,
+                                               TypeTraits<T>::type_enum, false,
+                                               m_Minifooter.IsLittleEndian);
 
         typename core::Variable<T>::Info blockInfo;
         blockInfo.Shape = blockCharacteristics.Shape;

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -943,8 +943,7 @@ BP3Serializer::AggregateCollectiveMetadataIndices(MPI_Comm comm,
 
     auto lf_SortMergeIndices = [&](
         const std::unordered_map<std::string, std::vector<SerialElementIndex>>
-            &deserializedIndices)
-    {
+            &deserializedIndices) {
         auto &position = bufferSTL.m_Position;
         auto &buffer = bufferSTL.m_Buffer;
 
@@ -1082,8 +1081,7 @@ void BP3Serializer::MergeSerializeIndices(
     };
 
     auto lf_MergeRankSerial = [&](
-        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL)
-    {
+        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL) {
         auto &bufferOut = bufferSTL.m_Buffer;
         auto &positionOut = bufferSTL.m_Position;
 

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -348,81 +348,16 @@ void BP3Serializer::UpdateOffsetsInMetadata()
                 break;
             }
 
-            case (type_byte):
-            {
-                UpdateIndexOffsetsCharacteristics<int8_t>(currentPosition,
-                                                          type_byte, buffer);
-                break;
-            }
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        UpdateIndexOffsetsCharacteristics<T>(                                  \
+            currentPosition, TypeTraits<T>::type_enum, buffer);                \
+        break;                                                                 \
+    }
 
-            case (type_short):
-            {
-                UpdateIndexOffsetsCharacteristics<int16_t>(currentPosition,
-                                                           type_short, buffer);
-                break;
-            }
-
-            case (type_integer):
-            {
-                UpdateIndexOffsetsCharacteristics<int32_t>(
-                    currentPosition, type_integer, buffer);
-                break;
-            }
-
-            case (type_long):
-            {
-                UpdateIndexOffsetsCharacteristics<int64_t>(currentPosition,
-                                                           type_long, buffer);
-
-                break;
-            }
-
-            case (type_unsigned_byte):
-            {
-                UpdateIndexOffsetsCharacteristics<uint8_t>(
-                    currentPosition, type_unsigned_byte, buffer);
-
-                break;
-            }
-
-            case (type_unsigned_short):
-            {
-                UpdateIndexOffsetsCharacteristics<uint16_t>(
-                    currentPosition, type_unsigned_short, buffer);
-
-                break;
-            }
-
-            case (type_unsigned_integer):
-            {
-                UpdateIndexOffsetsCharacteristics<uint32_t>(
-                    currentPosition, type_unsigned_integer, buffer);
-
-                break;
-            }
-
-            case (type_unsigned_long):
-            {
-                UpdateIndexOffsetsCharacteristics<uint64_t>(
-                    currentPosition, type_unsigned_long, buffer);
-
-                break;
-            }
-
-            case (type_real):
-            {
-                UpdateIndexOffsetsCharacteristics<float>(currentPosition,
-                                                         type_real, buffer);
-                break;
-            }
-
-            case (type_double):
-            {
-                UpdateIndexOffsetsCharacteristics<double>(currentPosition,
-                                                          type_double, buffer);
-
-                break;
-            }
+                ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(make_case)
+#undef make_case
 
             default:
                 // TODO: complex, long double
@@ -1008,7 +943,8 @@ BP3Serializer::AggregateCollectiveMetadataIndices(MPI_Comm comm,
 
     auto lf_SortMergeIndices = [&](
         const std::unordered_map<std::string, std::vector<SerialElementIndex>>
-            &deserializedIndices) {
+            &deserializedIndices)
+    {
         auto &position = bufferSTL.m_Position;
         auto &buffer = bufferSTL.m_Buffer;
 
@@ -1113,149 +1049,24 @@ void BP3Serializer::MergeSerializeIndices(
         switch (dataTypeEnum)
         {
 
-        case (type_string):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<std::string>(buffer, position,
-                                                             type_string, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        const auto characteristics = ReadElementIndexCharacteristics<T>(       \
+            buffer, position, TypeTraits<T>::type_enum, true);                 \
+        count = characteristics.EntryCount;                                    \
+        length = characteristics.EntryLength;                                  \
+        timeStep = characteristics.Statistics.Step;                            \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_STDTYPE_1ARG(make_case)
+#undef make_case
 
         case (type_string_array):
         {
             const auto characteristics =
                 ReadElementIndexCharacteristics<std::string>(
                     buffer, position, type_string_array, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_byte):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int8_t>(buffer, position,
-                                                        type_byte, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_short):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int16_t>(buffer, position,
-                                                         type_short, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_integer):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int32_t>(buffer, position,
-                                                         type_integer, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_long):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int64_t>(buffer, position,
-                                                         type_long, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_byte):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<uint8_t>(
-                    buffer, position, type_unsigned_byte, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_short):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<uint16_t>(
-                    buffer, position, type_unsigned_short, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_integer):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<uint32_t>(
-                    buffer, position, type_unsigned_integer, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_long):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<uint64_t>(
-                buffer, position, type_unsigned_long, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_real):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<float>(
-                buffer, position, type_real, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_double):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<double>(
-                buffer, position, type_double, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_complex):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<double>(
-                buffer, position, type_complex, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_double_complex):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<double>(
-                buffer, position, type_double_complex, true);
             count = characteristics.EntryCount;
             length = characteristics.EntryLength;
             timeStep = characteristics.Statistics.Step;
@@ -1271,7 +1082,8 @@ void BP3Serializer::MergeSerializeIndices(
     };
 
     auto lf_MergeRankSerial = [&](
-        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL) {
+        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL)
+    {
         auto &bufferOut = bufferSTL.m_Buffer;
         auto &positionOut = bufferSTL.m_Position;
 

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
@@ -133,7 +133,7 @@ BP3Serializer::PutAttributeInData(const core::Attribute<std::string> &attribute,
     auto &position = m_Data.m_Position;
     auto &absolutePosition = m_Data.m_AbsolutePosition;
 
-    uint8_t dataType = GetDataType<std::string>();
+    uint8_t dataType = TypeTraits<std::string>::type_enum;
     if (!attribute.m_IsSingleValue)
     {
         dataType = type_string_array;
@@ -184,7 +184,7 @@ void BP3Serializer::PutAttributeInData(const core::Attribute<T> &attribute,
     auto &position = m_Data.m_Position;
     auto &absolutePosition = m_Data.m_AbsolutePosition;
 
-    uint8_t dataType = GetDataType<T>();
+    uint8_t dataType = TypeTraits<T>::type_enum;
     helper::CopyToBuffer(buffer, position, &dataType);
 
     // here record payload offset
@@ -276,7 +276,7 @@ void BP3Serializer::PutAttributeInIndex(const core::Attribute<T> &attribute,
     PutNameRecord(attribute.m_Name, buffer);
     buffer.insert(buffer.end(), 2, '\0'); // skip path
 
-    uint8_t dataType = GetDataType<T>(); // dataType
+    uint8_t dataType = TypeTraits<T>::type_enum; // dataType
 
     if (dataType == type_string && !attribute.m_IsSingleValue)
     {
@@ -411,7 +411,7 @@ void BP3Serializer::PutVariableMetadataInData(
     PutNameRecord(variable.m_Name, buffer, position);
     position += 2; // skip path
 
-    const uint8_t dataType = GetDataType<T>();
+    const uint8_t dataType = TypeTraits<T>::type_enum;
     helper::CopyToBuffer(buffer, position, &dataType);
 
     constexpr char no = 'n'; // isDimension
@@ -462,7 +462,7 @@ inline void BP3Serializer::PutVariableMetadataInData(
     PutNameRecord(variable.m_Name, buffer, position);
     position += 2; // skip path
 
-    const uint8_t dataType = GetDataType<std::string>();
+    const uint8_t dataType = TypeTraits<std::string>::type_enum;
     helper::CopyToBuffer(buffer, position, &dataType);
 
     constexpr char no = 'n'; // is dimension is deprecated
@@ -507,7 +507,7 @@ void BP3Serializer::PutVariableMetadataInIndex(
         PutNameRecord(variable.m_Name, buffer);
         buffer.insert(buffer.end(), 2, '\0'); // skip path
 
-        const uint8_t dataType = GetDataType<T>();
+        const uint8_t dataType = TypeTraits<T>::type_enum;
         helper::InsertToBuffer(buffer, &dataType);
 
         // Characteristics Sets Count in Metadata
@@ -979,7 +979,7 @@ void BP3Serializer::PutCharacteristicOperation(
     helper::InsertToBuffer(buffer, type.c_str(), type.size());
 
     // pre-transform type
-    const uint8_t dataType = GetDataType<T>();
+    const uint8_t dataType = TypeTraits<T>::type_enum;
     helper::InsertToBuffer(buffer, &dataType);
     // pre-transform dimensions
     const uint8_t dimensions = static_cast<uint8_t>(blockInfo.Count.size());

--- a/source/adios2/toolkit/format/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp4/BP4Base.h
@@ -387,6 +387,12 @@ protected:
     };
 
     /**
+     * Maps C++ type to DataTypes enum
+     */
+    template <typename T>
+    struct TypeTraits;
+
+    /**
      * Characteristic ID in variable metadata
      */
     enum CharacteristicID
@@ -564,14 +570,6 @@ protected:
     /** Sets if IO is node-local so each rank creates its own IO directory and
      * stream */
     void InitParameterNodeLocal(const std::string value);
-
-    /**
-     * Returns data type index from enum Datatypes
-     * @param variable input variable
-     * @return data type
-     */
-    template <class T>
-    int8_t GetDataType() const noexcept;
 
     std::vector<uint8_t>
     GetTransportIDs(const std::vector<std::string> &transportsTypes) const

--- a/source/adios2/toolkit/format/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp4/BP4Base.h
@@ -662,4 +662,6 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 } // end namespace format
 } // end namespace adios2
 
+#include "BP4Base.inl"
+
 #endif /* ADIOS2_TOOLKIT_FORMAT_BP4_BP4BASE_H_ */

--- a/source/adios2/toolkit/format/bp4/BP4Base.inl
+++ b/source/adios2/toolkit/format/bp4/BP4Base.inl
@@ -1,0 +1,55 @@
+
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * BP4Base.inl
+ *
+ *  Created on: Feb 13, 2019
+ *      Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+ */
+
+#ifndef ADIOS2_TOOLKIT_FORMAT_BP4_BP4BASE_INL_
+#define ADIOS2_TOOLKIT_FORMAT_BP4_BP4BASE_INL_
+#ifndef ADIOS2_TOOLKIT_FORMAT_BP4_BP4BASE_H_
+#error "Inline file should only be included from its header, never on its own"
+#endif
+
+#include "BP4Base.h"
+
+namespace adios2
+{
+namespace format
+{
+
+// PROTECTED
+
+#define make_GetDataType(data_type, TYPE)                                      \
+    template <>                                                                \
+    inline int8_t BP4Base::GetDataType<TYPE>() const noexcept                  \
+    {                                                                          \
+        const int8_t type = static_cast<int8_t>(data_type);                    \
+        return type;                                                           \
+    }
+
+/* clang-format off */
+make_GetDataType(type_string, std::string)
+make_GetDataType(type_byte, int8_t)
+make_GetDataType(type_short, int16_t)
+make_GetDataType(type_integer, int32_t)
+make_GetDataType(type_long, int64_t)
+make_GetDataType(type_unsigned_byte, uint8_t)
+make_GetDataType(type_unsigned_short, uint16_t)
+make_GetDataType(type_unsigned_integer, uint32_t)
+make_GetDataType(type_unsigned_long, uint64_t)
+make_GetDataType(type_real, float)
+make_GetDataType(type_double, double)
+make_GetDataType(type_long_double, long double)
+make_GetDataType(type_complex, cfloat)
+make_GetDataType(type_double_complex, cdouble)
+/* clang-format on */
+
+} // end namespace format
+} // end namespace adios2
+
+#endif /* ADIOS2_TOOLKIT_FORMAT_BP4_BP4BASE_INL_ */

--- a/source/adios2/toolkit/format/bp4/BP4Base.inl
+++ b/source/adios2/toolkit/format/bp4/BP4Base.inl
@@ -24,30 +24,30 @@ namespace format
 
 // PROTECTED
 
-#define make_GetDataType(data_type, TYPE)                                      \
+#define make_TypeTraits(data_type, TYPE)                                       \
     template <>                                                                \
-    inline int8_t BP4Base::GetDataType<TYPE>() const noexcept                  \
+    struct BP4Base::TypeTraits<TYPE>                                           \
     {                                                                          \
-        const int8_t type = static_cast<int8_t>(data_type);                    \
-        return type;                                                           \
-    }
+        static const DataTypes type_enum = DataTypes::data_type;               \
+    };
 
 /* clang-format off */
-make_GetDataType(type_string, std::string)
-make_GetDataType(type_byte, int8_t)
-make_GetDataType(type_short, int16_t)
-make_GetDataType(type_integer, int32_t)
-make_GetDataType(type_long, int64_t)
-make_GetDataType(type_unsigned_byte, uint8_t)
-make_GetDataType(type_unsigned_short, uint16_t)
-make_GetDataType(type_unsigned_integer, uint32_t)
-make_GetDataType(type_unsigned_long, uint64_t)
-make_GetDataType(type_real, float)
-make_GetDataType(type_double, double)
-make_GetDataType(type_long_double, long double)
-make_GetDataType(type_complex, cfloat)
-make_GetDataType(type_double_complex, cdouble)
+make_TypeTraits(type_string, std::string)
+make_TypeTraits(type_byte, int8_t)
+make_TypeTraits(type_short, int16_t)
+make_TypeTraits(type_integer, int32_t)
+make_TypeTraits(type_long, int64_t)
+make_TypeTraits(type_unsigned_byte, uint8_t)
+make_TypeTraits(type_unsigned_short, uint16_t)
+make_TypeTraits(type_unsigned_integer, uint32_t)
+make_TypeTraits(type_unsigned_long, uint64_t)
+make_TypeTraits(type_real, float)
+make_TypeTraits(type_double, double)
+make_TypeTraits(type_long_double, long double)
+make_TypeTraits(type_complex, cfloat)
+make_TypeTraits(type_double_complex, cdouble)
 /* clang-format on */
+#undef make_TypeTraits
 
 } // end namespace format
 } // end namespace adios2

--- a/source/adios2/toolkit/format/bp4/BP4Base.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Base.tcc
@@ -23,108 +23,37 @@ namespace format
 {
 
 // PROTECTED
-template <>
-int8_t BP4Base::GetDataType<std::string>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_string);
-    return type;
-}
 
-template <>
-int8_t BP4Base::GetDataType<int8_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_byte);
-    return type;
-}
+#define make_GetDataType(data_type, TYPE)                                      \
+    template <>                                                                \
+    int8_t BP4Base::GetDataType<TYPE>() const noexcept                         \
+    {                                                                          \
+        const int8_t type = static_cast<int8_t>(data_type);                    \
+        return type;                                                           \
+    }
 
-template <>
-int8_t BP4Base::GetDataType<int16_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_short);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<int32_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_integer);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<int64_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_long);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<uint8_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_unsigned_byte);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<uint16_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_unsigned_short);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<uint32_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_unsigned_integer);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<uint64_t>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_unsigned_long);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<float>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_real);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<double>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_double);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<long double>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_long_double);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<cfloat>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_complex);
-    return type;
-}
-
-template <>
-int8_t BP4Base::GetDataType<cdouble>() const noexcept
-{
-    const int8_t type = static_cast<int8_t>(type_double_complex);
-    return type;
-}
+/* clang-format off */
+make_GetDataType(type_string, std::string)
+make_GetDataType(type_byte, int8_t)
+make_GetDataType(type_short, int16_t)
+make_GetDataType(type_integer, int32_t)
+make_GetDataType(type_long, int64_t)
+make_GetDataType(type_unsigned_byte, uint8_t)
+make_GetDataType(type_unsigned_short, uint16_t)
+make_GetDataType(type_unsigned_integer, uint32_t)
+make_GetDataType(type_unsigned_long, uint64_t)
+make_GetDataType(type_real, float)
+make_GetDataType(type_double, double)
+make_GetDataType(type_long_double, long double)
+make_GetDataType(type_complex, cfloat)
+make_GetDataType(type_double_complex, cdouble)
+/* clang-format on */
 
 template <class T>
 BP4Base::Characteristics<T> BP4Base::ReadElementIndexCharacteristics(
-    const std::vector<char> &buffer, size_t &position, const DataTypes dataType,
-    const bool untilTimeStep, const bool isLittleEndian) const
+    const std::vector<char> &buffer, size_t &position,
+    const DataTypes dataType, const bool untilTimeStep,
+    const bool isLittleEndian) const
 {
     Characteristics<T> characteristics;
     characteristics.EntryCount =

--- a/source/adios2/toolkit/format/bp4/BP4Base.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Base.tcc
@@ -24,36 +24,10 @@ namespace format
 
 // PROTECTED
 
-#define make_GetDataType(data_type, TYPE)                                      \
-    template <>                                                                \
-    int8_t BP4Base::GetDataType<TYPE>() const noexcept                         \
-    {                                                                          \
-        const int8_t type = static_cast<int8_t>(data_type);                    \
-        return type;                                                           \
-    }
-
-/* clang-format off */
-make_GetDataType(type_string, std::string)
-make_GetDataType(type_byte, int8_t)
-make_GetDataType(type_short, int16_t)
-make_GetDataType(type_integer, int32_t)
-make_GetDataType(type_long, int64_t)
-make_GetDataType(type_unsigned_byte, uint8_t)
-make_GetDataType(type_unsigned_short, uint16_t)
-make_GetDataType(type_unsigned_integer, uint32_t)
-make_GetDataType(type_unsigned_long, uint64_t)
-make_GetDataType(type_real, float)
-make_GetDataType(type_double, double)
-make_GetDataType(type_long_double, long double)
-make_GetDataType(type_complex, cfloat)
-make_GetDataType(type_double_complex, cdouble)
-/* clang-format on */
-
 template <class T>
 BP4Base::Characteristics<T> BP4Base::ReadElementIndexCharacteristics(
-    const std::vector<char> &buffer, size_t &position,
-    const DataTypes dataType, const bool untilTimeStep,
-    const bool isLittleEndian) const
+    const std::vector<char> &buffer, size_t &position, const DataTypes dataType,
+    const bool untilTimeStep, const bool isLittleEndian) const
 {
     Characteristics<T> characteristics;
     characteristics.EntryCount =

--- a/source/adios2/toolkit/format/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Deserializer.cpp
@@ -288,103 +288,15 @@ void BP4Deserializer::ParseVariablesIndexPerStep(const BufferSTL &bufferSTL,
         switch (header.DataType)
         {
 
-        case (type_string):
-        {
-            DefineVariableInEngineIOPerStep<std::string>(header, engine, buffer,
-                                                         position, step);
-            break;
-        }
-
-        case (type_byte):
-        {
-            DefineVariableInEngineIOPerStep<int8_t>(header, engine, buffer,
-                                                    position, step);
-            break;
-        }
-
-        case (type_short):
-        {
-            DefineVariableInEngineIOPerStep<int16_t>(header, engine, buffer,
-                                                     position, step);
-            break;
-        }
-
-        case (type_integer):
-        {
-            DefineVariableInEngineIOPerStep<int32_t>(header, engine, buffer,
-                                                     position, step);
-            break;
-        }
-
-        case (type_long):
-        {
-            DefineVariableInEngineIOPerStep<int64_t>(header, engine, buffer,
-                                                     position, step);
-            break;
-        }
-
-        case (type_unsigned_byte):
-        {
-            DefineVariableInEngineIOPerStep<uint8_t>(header, engine, buffer,
-                                                     position, step);
-            break;
-        }
-
-        case (type_unsigned_short):
-        {
-            DefineVariableInEngineIOPerStep<uint16_t>(header, engine, buffer,
-                                                      position, step);
-            break;
-        }
-
-        case (type_unsigned_integer):
-        {
-            DefineVariableInEngineIOPerStep<uint32_t>(header, engine, buffer,
-                                                      position, step);
-            break;
-        }
-
-        case (type_unsigned_long):
-        {
-            DefineVariableInEngineIOPerStep<uint64_t>(header, engine, buffer,
-                                                      position, step);
-            break;
-        }
-
-        case (type_real):
-        {
-            DefineVariableInEngineIOPerStep<float>(header, engine, buffer,
-                                                   position, step);
-            break;
-        }
-
-        case (type_double):
-        {
-            DefineVariableInEngineIOPerStep<double>(header, engine, buffer,
-                                                    position, step);
-            break;
-        }
-
-        case (type_long_double):
-        {
-            DefineVariableInEngineIOPerStep<long double>(header, engine, buffer,
-                                                         position, step);
-            break;
-        }
-
-        case (type_complex):
-        {
-            DefineVariableInEngineIOPerStep<std::complex<float>>(
-                header, engine, buffer, position, step);
-            break;
-        }
-
-        case (type_double_complex):
-        {
-            DefineVariableInEngineIOPerStep<std::complex<double>>(
-                header, engine, buffer, position, step);
-            break;
-        }
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        DefineVariableInEngineIOPerStep<T>(header, engine, buffer, position,   \
+                                           step);                              \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_STDTYPE_1ARG(make_case)
+#undef make_case
 
         } // end switch
     };
@@ -469,91 +381,14 @@ void BP4Deserializer::ParseVariablesIndexPerStep(const BufferSTL &bufferSTL,
         switch (header.DataType)
         {
 
-        case (type_string):
-        {
-            DefineVariableInIO<std::string>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_byte):
-        {
-            DefineVariableInIO<int8_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_short):
-        {
-            DefineVariableInIO<int16_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_integer):
-        {
-            DefineVariableInIO<int32_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_long):
-        {
-            DefineVariableInIO<int64_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_byte):
-        {
-            DefineVariableInIO<uint8_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_short):
-        {
-            DefineVariableInIO<uint16_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_integer):
-        {
-            DefineVariableInIO<uint32_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_long):
-        {
-            DefineVariableInIO<uint64_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_real):
-        {
-            DefineVariableInIO<float>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_double):
-        {
-            DefineVariableInIO<double>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_long_double):
-        {
-            DefineVariableInIO<long double>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_complex):
-        {
-            DefineVariableInIO<std::complex<float>>(header, io, buffer,
-                                                    position);
-            break;
-        }
-
-        case (type_double_complex):
-        {
-            DefineVariableInIO<std::complex<double>>(header, io, buffer,
-                                                     position);
-            break;
-        }
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        DefineVariableInIO<T>(header, io, buffer, position);
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(make_case)
+#undef make_case
 
         } // end switch
     };
@@ -637,90 +472,17 @@ void BP4Deserializer::ParseAttributesIndexPerStep(const BufferSTL &bufferSTL,
         switch (header.DataType)
         {
 
-        case (type_string):
-        {
-            DefineAttributeInEngineIO<std::string>(header, engine, buffer,
-                                                   position);
-            break;
-        }
-
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        DefineAttributeInEngineIO<T>(header, engine, buffer, position);        \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(make_case)
+#undef make_case
         case (type_string_array):
         {
             DefineAttributeInEngineIO<std::string>(header, engine, buffer,
-                                                   position);
-            break;
-        }
-
-        case (type_byte):
-        {
-            DefineAttributeInEngineIO<int8_t>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_short):
-        {
-            DefineAttributeInEngineIO<int16_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_integer):
-        {
-            DefineAttributeInEngineIO<int32_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_long):
-        {
-            DefineAttributeInEngineIO<int64_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_unsigned_byte):
-        {
-            DefineAttributeInEngineIO<uint8_t>(header, engine, buffer,
-                                               position);
-            break;
-        }
-
-        case (type_unsigned_short):
-        {
-            DefineAttributeInEngineIO<uint16_t>(header, engine, buffer,
-                                                position);
-            break;
-        }
-
-        case (type_unsigned_integer):
-        {
-            DefineAttributeInEngineIO<uint32_t>(header, engine, buffer,
-                                                position);
-            break;
-        }
-
-        case (type_unsigned_long):
-        {
-            DefineAttributeInEngineIO<uint64_t>(header, engine, buffer,
-                                                position);
-            break;
-        }
-
-        case (type_real):
-        {
-            DefineAttributeInEngineIO<float>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_double):
-        {
-            DefineAttributeInEngineIO<double>(header, engine, buffer, position);
-            break;
-        }
-
-        case (type_long_double):
-        {
-            DefineAttributeInEngineIO<long double>(header, engine, buffer,
                                                    position);
             break;
         }
@@ -762,81 +524,18 @@ void BP4Deserializer::ParseAttributesIndexPerStep(const BufferSTL &bufferSTL,
         switch (header.DataType)
         {
 
-        case (type_string):
-        {
-            DefineAttributeInIO<std::string>(header, io, buffer, position);
-            break;
-        }
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        DefineAttributeInIO<T>(header, io, buffer, position);                  \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(make_case)
+#undef make_case
 
         case (type_string_array):
         {
             DefineAttributeInIO<std::string>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_byte):
-        {
-            DefineAttributeInIO<int8_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_short):
-        {
-            DefineAttributeInIO<int16_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_integer):
-        {
-            DefineAttributeInIO<int32_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_long):
-        {
-            DefineAttributeInIO<int64_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_byte):
-        {
-            DefineAttributeInIO<uint8_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_short):
-        {
-            DefineAttributeInIO<uint16_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_integer):
-        {
-            DefineAttributeInIO<uint32_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_unsigned_long):
-        {
-            DefineAttributeInIO<uint64_t>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_real):
-        {
-            DefineAttributeInIO<float>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_double):
-        {
-            DefineAttributeInIO<double>(header, io, buffer, position);
-            break;
-        }
-
-        case (type_long_double):
-        {
-            DefineAttributeInIO<long double>(header, io, buffer, position);
             break;
         }
 

--- a/source/adios2/toolkit/format/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Deserializer.tcc
@@ -41,9 +41,9 @@ void BP4Deserializer::GetSyncVariableDataFromStream(core::Variable<T> &variable,
     size_t position = itStep->second.front();
 
     const Characteristics<T> characteristics =
-        ReadElementIndexCharacteristics<T>(
-            buffer, position, static_cast<DataTypes>(GetDataType<T>()), false,
-            m_Minifooter.IsLittleEndian);
+        ReadElementIndexCharacteristics<T>(buffer, position,
+                                           TypeTraits<T>::type_enum, false,
+                                           m_Minifooter.IsLittleEndian);
 
     const size_t payloadOffset = characteristics.Statistics.PayloadOffset;
     variable.m_Data = reinterpret_cast<T *>(&buffer[payloadOffset]);
@@ -166,9 +166,9 @@ void BP4Deserializer::SetVariableBlockInfo(
         size_t position = blockIndexOffset;
 
         const Characteristics<T> blockCharacteristics =
-            ReadElementIndexCharacteristics<T>(
-                buffer, position, static_cast<DataTypes>(GetDataType<T>()),
-                false, m_Minifooter.IsLittleEndian);
+            ReadElementIndexCharacteristics<T>(buffer, position,
+                                               TypeTraits<T>::type_enum, false,
+                                               m_Minifooter.IsLittleEndian);
         // check if they intersect
         helper::SubStreamBoxInfo subStreamInfo;
 
@@ -284,9 +284,9 @@ void BP4Deserializer::SetVariableBlockInfo(
         size_t position = blockIndexOffset;
 
         const Characteristics<T> blockCharacteristics =
-            ReadElementIndexCharacteristics<T>(
-                buffer, position, static_cast<DataTypes>(GetDataType<T>()),
-                false, m_Minifooter.IsLittleEndian);
+            ReadElementIndexCharacteristics<T>(buffer, position,
+                                               TypeTraits<T>::type_enum, false,
+                                               m_Minifooter.IsLittleEndian);
 
         // check if they intersect
         helper::SubStreamBoxInfo subStreamInfo;
@@ -1080,8 +1080,7 @@ BP4Deserializer::GetSubFileInfo(const core::Variable<T> &variable) const
         {
             const Characteristics<T> blockCharacteristics =
                 ReadElementIndexCharacteristics<T>(
-                    buffer, blockPosition,
-                    static_cast<DataTypes>(GetDataType<T>()), false,
+                    buffer, blockPosition, TypeTraits<T>::type_enum, false,
                     m_Minifooter.IsLittleEndian);
 
             // check if they intersect
@@ -1135,10 +1134,9 @@ std::vector<typename core::Variable<T>::Info> BP4Deserializer::BlocksInfoCommon(
         size_t position = blockIndexOffset;
 
         const Characteristics<T> blockCharacteristics =
-            ReadElementIndexCharacteristics<T>(
-                m_Metadata.m_Buffer, position,
-                static_cast<DataTypes>(GetDataType<T>()), false,
-                m_Minifooter.IsLittleEndian);
+            ReadElementIndexCharacteristics<T>(m_Metadata.m_Buffer, position,
+                                               TypeTraits<T>::type_enum, false,
+                                               m_Minifooter.IsLittleEndian);
 
         typename core::Variable<T>::Info blockInfo;
         blockInfo.Shape = blockCharacteristics.Shape;

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
@@ -1178,8 +1178,7 @@ void BP4Serializer::MergeSerializeIndicesPerStep(
     };
 
     auto lf_MergeRankSerial = [&](
-        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL)
-    {
+        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL) {
         auto &bufferOut = bufferSTL.m_Buffer;
         auto &positionOut = bufferSTL.m_Position;
 
@@ -1502,8 +1501,7 @@ void BP4Serializer::MergeSerializeIndices(
     };
 
     auto lf_MergeRankSerial = [&](
-        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL)
-    {
+        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL) {
         auto &bufferOut = bufferSTL.m_Buffer;
         auto &positionOut = bufferSTL.m_Position;
 

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
@@ -400,81 +400,15 @@ void BP4Serializer::UpdateOffsetsInMetadata()
                 break;
             }
 
-            case (type_byte):
-            {
-                UpdateIndexOffsetsCharacteristics<int8_t>(currentPosition,
-                                                          type_byte, buffer);
-                break;
-            }
-
-            case (type_short):
-            {
-                UpdateIndexOffsetsCharacteristics<int16_t>(currentPosition,
-                                                           type_short, buffer);
-                break;
-            }
-
-            case (type_integer):
-            {
-                UpdateIndexOffsetsCharacteristics<int32_t>(
-                    currentPosition, type_integer, buffer);
-                break;
-            }
-
-            case (type_long):
-            {
-                UpdateIndexOffsetsCharacteristics<int64_t>(currentPosition,
-                                                           type_long, buffer);
-
-                break;
-            }
-
-            case (type_unsigned_byte):
-            {
-                UpdateIndexOffsetsCharacteristics<uint8_t>(
-                    currentPosition, type_unsigned_byte, buffer);
-
-                break;
-            }
-
-            case (type_unsigned_short):
-            {
-                UpdateIndexOffsetsCharacteristics<uint16_t>(
-                    currentPosition, type_unsigned_short, buffer);
-
-                break;
-            }
-
-            case (type_unsigned_integer):
-            {
-                UpdateIndexOffsetsCharacteristics<uint32_t>(
-                    currentPosition, type_unsigned_integer, buffer);
-
-                break;
-            }
-
-            case (type_unsigned_long):
-            {
-                UpdateIndexOffsetsCharacteristics<uint64_t>(
-                    currentPosition, type_unsigned_long, buffer);
-
-                break;
-            }
-
-            case (type_real):
-            {
-                UpdateIndexOffsetsCharacteristics<float>(currentPosition,
-                                                         type_real, buffer);
-                break;
-            }
-
-            case (type_double):
-            {
-                UpdateIndexOffsetsCharacteristics<double>(currentPosition,
-                                                          type_double, buffer);
-
-                break;
-            }
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        UpdateIndexOffsetsCharacteristics<T>(                                  \
+            currentPosition, TypeTraits<T>::type_enum, buffer);                \
+        break;                                                                 \
+    }
+                ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(make_case)
+#undef make_case
 
             default:
                 // TODO: complex, long double
@@ -1193,7 +1127,7 @@ BP4Serializer::DeserializeIndicesPerRankThreads(
     return deserialized;
 }
 
-/* Merge and serialize all the indeices at each step */
+/* Merge and serialize all the indices at each step */
 void BP4Serializer::MergeSerializeIndicesPerStep(
     const std::unordered_map<std::string, std::vector<SerialElementIndex>>
         &nameRankIndices,
@@ -1210,149 +1144,24 @@ void BP4Serializer::MergeSerializeIndicesPerStep(
         switch (dataTypeEnum)
         {
 
-        case (type_string):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<std::string>(buffer, position,
-                                                             type_string, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        const auto characteristics = ReadElementIndexCharacteristics<T>(       \
+            buffer, position, TypeTraits<T>::type_enum, true);                 \
+        count = characteristics.EntryCount;                                    \
+        length = characteristics.EntryLength;                                  \
+        timeStep = characteristics.Statistics.Step;                            \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_STDTYPE_1ARG(make_case)
+#undef make_case
 
         case (type_string_array):
         {
             const auto characteristics =
                 ReadElementIndexCharacteristics<std::string>(
                     buffer, position, type_string_array, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_byte):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int8_t>(buffer, position,
-                                                        type_byte, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_short):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int16_t>(buffer, position,
-                                                         type_short, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_integer):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int32_t>(buffer, position,
-                                                         type_integer, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_long):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int64_t>(buffer, position,
-                                                         type_long, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_byte):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<uint8_t>(
-                    buffer, position, type_unsigned_byte, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_short):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<uint16_t>(
-                    buffer, position, type_unsigned_short, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_integer):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<uint32_t>(
-                    buffer, position, type_unsigned_integer, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_long):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<uint64_t>(
-                buffer, position, type_unsigned_long, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_real):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<float>(
-                buffer, position, type_real, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_double):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<double>(
-                buffer, position, type_double, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_complex):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<double>(
-                buffer, position, type_complex, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_double_complex):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<double>(
-                buffer, position, type_double_complex, true);
             count = characteristics.EntryCount;
             length = characteristics.EntryLength;
             timeStep = characteristics.Statistics.Step;
@@ -1369,7 +1178,8 @@ void BP4Serializer::MergeSerializeIndicesPerStep(
     };
 
     auto lf_MergeRankSerial = [&](
-        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL) {
+        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL)
+    {
         auto &bufferOut = bufferSTL.m_Buffer;
         auto &positionOut = bufferSTL.m_Position;
 
@@ -1658,129 +1468,24 @@ void BP4Serializer::MergeSerializeIndices(
         switch (dataTypeEnum)
         {
 
-        case (type_string):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<std::string>(buffer, position,
-                                                             type_string, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
+#define make_case(T)                                                           \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
+        const auto characteristics = ReadElementIndexCharacteristics<T>(       \
+            buffer, position, TypeTraits<T>::type_enum, true);                 \
+        count = characteristics.EntryCount;                                    \
+        length = characteristics.EntryLength;                                  \
+        timeStep = characteristics.Statistics.Step;                            \
+        break;                                                                 \
+    }
+            ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(make_case)
+#undef make_case
 
         case (type_string_array):
         {
             const auto characteristics =
                 ReadElementIndexCharacteristics<std::string>(
                     buffer, position, type_string_array, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_byte):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int8_t>(buffer, position,
-                                                        type_byte, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_short):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int16_t>(buffer, position,
-                                                         type_short, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_integer):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int32_t>(buffer, position,
-                                                         type_integer, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_long):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<int64_t>(buffer, position,
-                                                         type_long, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_byte):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<uint8_t>(
-                    buffer, position, type_unsigned_byte, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_short):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<uint16_t>(
-                    buffer, position, type_unsigned_short, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_integer):
-        {
-            const auto characteristics =
-                ReadElementIndexCharacteristics<uint32_t>(
-                    buffer, position, type_unsigned_integer, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_unsigned_long):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<uint64_t>(
-                buffer, position, type_unsigned_long, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_real):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<float>(
-                buffer, position, type_real, true);
-            count = characteristics.EntryCount;
-            length = characteristics.EntryLength;
-            timeStep = characteristics.Statistics.Step;
-            break;
-        }
-
-        case (type_double):
-        {
-            auto characteristics = ReadElementIndexCharacteristics<double>(
-                buffer, position, type_double, true);
             count = characteristics.EntryCount;
             length = characteristics.EntryLength;
             timeStep = characteristics.Statistics.Step;
@@ -1797,7 +1502,8 @@ void BP4Serializer::MergeSerializeIndices(
     };
 
     auto lf_MergeRankSerial = [&](
-        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL) {
+        const std::vector<SerialElementIndex> &indices, BufferSTL &bufferSTL)
+    {
         auto &bufferOut = bufferSTL.m_Buffer;
         auto &positionOut = bufferSTL.m_Position;
 

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
@@ -136,7 +136,7 @@ BP4Serializer::PutAttributeInData(const core::Attribute<std::string> &attribute,
     auto &position = m_Data.m_Position;
     auto &absolutePosition = m_Data.m_AbsolutePosition;
 
-    uint8_t dataType = GetDataType<std::string>();
+    uint8_t dataType = TypeTraits<std::string>::type_enum;
     if (!attribute.m_IsSingleValue)
     {
         dataType = type_string_array;
@@ -187,7 +187,7 @@ void BP4Serializer::PutAttributeInData(const core::Attribute<T> &attribute,
     auto &position = m_Data.m_Position;
     auto &absolutePosition = m_Data.m_AbsolutePosition;
 
-    uint8_t dataType = GetDataType<T>();
+    uint8_t dataType = TypeTraits<T>::type_enum;
     helper::CopyToBuffer(buffer, position, &dataType);
 
     // here record payload offset
@@ -281,7 +281,7 @@ void BP4Serializer::PutAttributeInIndex(const core::Attribute<T> &attribute,
     PutNameRecord(attribute.m_Name, buffer);
     buffer.insert(buffer.end(), 2, '\0'); // skip path
 
-    uint8_t dataType = GetDataType<T>(); // dataType
+    uint8_t dataType = TypeTraits<T>::type_enum; // dataType
 
     if (dataType == type_string && !attribute.m_IsSingleValue)
     {
@@ -416,7 +416,7 @@ void BP4Serializer::PutVariableMetadataInData(
     PutNameRecord(variable.m_Name, buffer, position);
     position += 2; // skip path
 
-    const uint8_t dataType = GetDataType<T>();
+    const uint8_t dataType = TypeTraits<T>::type_enum;
     helper::CopyToBuffer(buffer, position, &dataType);
 
     constexpr char no = 'n'; // isDimension
@@ -467,7 +467,7 @@ inline void BP4Serializer::PutVariableMetadataInData(
     PutNameRecord(variable.m_Name, buffer, position);
     position += 2; // skip path
 
-    const uint8_t dataType = GetDataType<std::string>();
+    const uint8_t dataType = TypeTraits<std::string>::type_enum;
     helper::CopyToBuffer(buffer, position, &dataType);
 
     constexpr char no = 'n'; // is dimension is deprecated
@@ -512,7 +512,7 @@ void BP4Serializer::PutVariableMetadataInIndex(
         PutNameRecord(variable.m_Name, buffer);
         buffer.insert(buffer.end(), 2, '\0'); // skip path
 
-        const uint8_t dataType = GetDataType<T>();
+        const uint8_t dataType = TypeTraits<T>::type_enum;
         helper::InsertToBuffer(buffer, &dataType);
 
         // Characteristics Sets Count in Metadata
@@ -984,7 +984,7 @@ void BP4Serializer::PutCharacteristicOperation(
     helper::InsertToBuffer(buffer, type.c_str(), type.size());
 
     // pre-transform type
-    const uint8_t dataType = GetDataType<T>();
+    const uint8_t dataType = TypeTraits<T>::type_enum;
     helper::InsertToBuffer(buffer, &dataType);
     // pre-transform dimensions
     const uint8_t dimensions = static_cast<uint8_t>(blockInfo.Count.size());

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -451,59 +451,37 @@ void HDF5Common::CreateVar(core::IO &io, hid_t datasetId,
         return;
     }
 
-    if (H5Tequal(H5T_NATIVE_SCHAR, h5Type))
+    if (H5Tequal(H5T_NATIVE_INT8, h5Type))
     {
         AddVar<signed char>(io, name, datasetId, ts);
     }
-    else if (H5Tequal(H5T_NATIVE_CHAR, h5Type))
-    {
-        AddVar<TypeInfo<char>::IOType>(io, name, datasetId, ts);
-    }
-    else if (H5Tequal(H5T_NATIVE_UCHAR, h5Type))
+    else if (H5Tequal(H5T_NATIVE_UINT8, h5Type))
     {
         AddVar<unsigned char>(io, name, datasetId, ts);
     }
-    else if (H5Tequal(H5T_NATIVE_SHORT, h5Type))
+    else if (H5Tequal(H5T_NATIVE_INT16, h5Type))
     {
         AddVar<short>(io, name, datasetId, ts);
     }
-    else if (H5Tequal(H5T_NATIVE_USHORT, h5Type))
+    else if (H5Tequal(H5T_NATIVE_UINT16, h5Type))
     {
         AddVar<unsigned short>(io, name, datasetId, ts);
     }
-    else if (H5Tequal(H5T_NATIVE_INT, h5Type))
+    else if (H5Tequal(H5T_NATIVE_INT32, h5Type))
     {
         AddVar<int>(io, name, datasetId, ts);
     }
-    else if (H5Tequal(H5T_NATIVE_UINT, h5Type))
+    else if (H5Tequal(H5T_NATIVE_UINT32, h5Type))
     {
         AddVar<unsigned int>(io, name, datasetId, ts);
     }
-    else if (H5Tequal(H5T_STD_I64LE, h5Type))
+    else if (H5Tequal(H5T_NATIVE_INT64, h5Type))
     {
-        /*
-         */
         AddVar<int64_t>(io, name, datasetId, ts);
     }
-    else if (H5Tequal(H5T_STD_U64LE, h5Type))
+    else if (H5Tequal(H5T_NATIVE_UINT64, h5Type))
     {
         AddVar<uint64_t>(io, name, datasetId, ts);
-    }
-    else if (H5Tequal(H5T_NATIVE_LONG, h5Type))
-    {
-        AddVar<TypeInfo<long>::IOType>(io, name, datasetId, ts);
-    }
-    else if (H5Tequal(H5T_NATIVE_ULONG, h5Type))
-    {
-        AddVar<TypeInfo<unsigned long>::IOType>(io, name, datasetId, ts);
-    }
-    else if (H5Tequal(H5T_NATIVE_LLONG, h5Type))
-    {
-        AddVar<TypeInfo<long long>::IOType>(io, name, datasetId, ts);
-    }
-    else if (H5Tequal(H5T_NATIVE_ULLONG, h5Type))
-    {
-        AddVar<TypeInfo<unsigned long long>::IOType>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_FLOAT, h5Type))
     {
@@ -926,63 +904,41 @@ void HDF5Common::ReadInNonStringAttr(core::IO &io, const std::string &attrName,
     if (ndims == 1)
         hid_t ret = H5Sget_simple_extent_dims(sid, dims, NULL);
 
-    if (H5Tequal(H5T_NATIVE_SCHAR, h5Type))
+    if (H5Tequal(H5T_NATIVE_INT8, h5Type))
     {
         AddNonStringAttribute<signed char>(io, attrName, attrId, h5Type,
                                            dims[0]);
     }
-    else if (H5Tequal(H5T_NATIVE_CHAR, h5Type))
-    {
-        AddNonStringAttribute<char>(io, attrName, attrId, h5Type, dims[0]);
-    }
-    else if (H5Tequal(H5T_NATIVE_UCHAR, h5Type))
+    else if (H5Tequal(H5T_NATIVE_UINT8, h5Type))
     {
         AddNonStringAttribute<unsigned char>(io, attrName, attrId, h5Type,
                                              dims[0]);
     }
-    else if (H5Tequal(H5T_NATIVE_SHORT, h5Type))
+    else if (H5Tequal(H5T_NATIVE_INT16, h5Type))
     {
         AddNonStringAttribute<short>(io, attrName, attrId, h5Type, dims[0]);
     }
-    else if (H5Tequal(H5T_NATIVE_USHORT, h5Type))
+    else if (H5Tequal(H5T_NATIVE_UINT16, h5Type))
     {
         AddNonStringAttribute<unsigned short>(io, attrName, attrId, h5Type,
                                               dims[0]);
     }
-    else if (H5Tequal(H5T_NATIVE_INT, h5Type))
+    else if (H5Tequal(H5T_NATIVE_INT32, h5Type))
     {
         AddNonStringAttribute<int>(io, attrName, attrId, h5Type, dims[0]);
     }
-    else if (H5Tequal(H5T_NATIVE_UINT, h5Type))
+    else if (H5Tequal(H5T_NATIVE_UINT32, h5Type))
     {
         AddNonStringAttribute<unsigned int>(io, attrName, attrId, h5Type,
                                             dims[0]);
     }
-    else if (H5Tequal(H5T_STD_I64LE, h5Type))
+    else if (H5Tequal(H5T_NATIVE_INT64, h5Type))
     {
         AddNonStringAttribute<int64_t>(io, attrName, attrId, h5Type, dims[0]);
     }
-    else if (H5Tequal(H5T_STD_U64LE, h5Type))
+    else if (H5Tequal(H5T_NATIVE_UINT64, h5Type))
     {
         AddNonStringAttribute<uint64_t>(io, attrName, attrId, h5Type, dims[0]);
-    }
-    else if (H5Tequal(H5T_NATIVE_LONG, h5Type))
-    {
-        AddNonStringAttribute<long>(io, attrName, attrId, h5Type, dims[0]);
-    }
-    else if (H5Tequal(H5T_NATIVE_ULONG, h5Type))
-    {
-        AddNonStringAttribute<unsigned long>(io, attrName, attrId, h5Type,
-                                             dims[0]);
-    }
-    else if (H5Tequal(H5T_NATIVE_LLONG, h5Type))
-    {
-        AddNonStringAttribute<long long>(io, attrName, attrId, h5Type, dims[0]);
-    }
-    else if (H5Tequal(H5T_NATIVE_ULLONG, h5Type))
-    {
-        AddNonStringAttribute<unsigned long long>(io, attrName, attrId, h5Type,
-                                                  dims[0]);
     }
     else if (H5Tequal(H5T_NATIVE_FLOAT, h5Type))
     {

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -453,27 +453,27 @@ void HDF5Common::CreateVar(core::IO &io, hid_t datasetId,
 
     if (H5Tequal(H5T_NATIVE_INT8, h5Type))
     {
-        AddVar<signed char>(io, name, datasetId, ts);
+        AddVar<int8_t>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_UINT8, h5Type))
     {
-        AddVar<unsigned char>(io, name, datasetId, ts);
+        AddVar<uint8_t>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_INT16, h5Type))
     {
-        AddVar<short>(io, name, datasetId, ts);
+        AddVar<int16_t>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_UINT16, h5Type))
     {
-        AddVar<unsigned short>(io, name, datasetId, ts);
+        AddVar<uint16_t>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_INT32, h5Type))
     {
-        AddVar<int>(io, name, datasetId, ts);
+        AddVar<int32_t>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_UINT32, h5Type))
     {
-        AddVar<unsigned int>(io, name, datasetId, ts);
+        AddVar<uint32_t>(io, name, datasetId, ts);
     }
     else if (H5Tequal(H5T_NATIVE_INT64, h5Type))
     {
@@ -906,31 +906,27 @@ void HDF5Common::ReadInNonStringAttr(core::IO &io, const std::string &attrName,
 
     if (H5Tequal(H5T_NATIVE_INT8, h5Type))
     {
-        AddNonStringAttribute<signed char>(io, attrName, attrId, h5Type,
-                                           dims[0]);
+        AddNonStringAttribute<int8_t>(io, attrName, attrId, h5Type, dims[0]);
     }
     else if (H5Tequal(H5T_NATIVE_UINT8, h5Type))
     {
-        AddNonStringAttribute<unsigned char>(io, attrName, attrId, h5Type,
-                                             dims[0]);
+        AddNonStringAttribute<uint8_t>(io, attrName, attrId, h5Type, dims[0]);
     }
     else if (H5Tequal(H5T_NATIVE_INT16, h5Type))
     {
-        AddNonStringAttribute<short>(io, attrName, attrId, h5Type, dims[0]);
+        AddNonStringAttribute<int16_t>(io, attrName, attrId, h5Type, dims[0]);
     }
     else if (H5Tequal(H5T_NATIVE_UINT16, h5Type))
     {
-        AddNonStringAttribute<unsigned short>(io, attrName, attrId, h5Type,
-                                              dims[0]);
+        AddNonStringAttribute<uint16_t>(io, attrName, attrId, h5Type, dims[0]);
     }
     else if (H5Tequal(H5T_NATIVE_INT32, h5Type))
     {
-        AddNonStringAttribute<int>(io, attrName, attrId, h5Type, dims[0]);
+        AddNonStringAttribute<int32_t>(io, attrName, attrId, h5Type, dims[0]);
     }
     else if (H5Tequal(H5T_NATIVE_UINT32, h5Type))
     {
-        AddNonStringAttribute<unsigned int>(io, attrName, attrId, h5Type,
-                                            dims[0]);
+        AddNonStringAttribute<uint32_t>(io, attrName, attrId, h5Type, dims[0]);
     }
     else if (H5Tequal(H5T_NATIVE_INT64, h5Type))
     {

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
@@ -240,44 +240,44 @@ hid_t HDF5Common::GetHDF5Type<std::string>()
 }
 
 template <>
-hid_t HDF5Common::GetHDF5Type<signed char>()
+hid_t HDF5Common::GetHDF5Type<int8_t>()
 {
     return H5T_NATIVE_INT8;
 }
 
 template <>
-hid_t HDF5Common::GetHDF5Type<unsigned char>()
+hid_t HDF5Common::GetHDF5Type<uint8_t>()
 {
     return H5T_NATIVE_UINT8;
 }
 
 template <>
-hid_t HDF5Common::GetHDF5Type<short>()
+hid_t HDF5Common::GetHDF5Type<int16_t>()
 {
     return H5T_NATIVE_INT16;
 }
 template <>
-hid_t HDF5Common::GetHDF5Type<unsigned short>()
+hid_t HDF5Common::GetHDF5Type<uint16_t>()
 {
     return H5T_NATIVE_UINT16;
 }
 template <>
-hid_t HDF5Common::GetHDF5Type<int>()
+hid_t HDF5Common::GetHDF5Type<int32_t>()
 {
     return H5T_NATIVE_INT32;
 }
 template <>
-hid_t HDF5Common::GetHDF5Type<unsigned int>()
+hid_t HDF5Common::GetHDF5Type<uint32_t>()
 {
     return H5T_NATIVE_UINT32;
 }
 template <>
-hid_t HDF5Common::GetHDF5Type<long long int>()
+hid_t HDF5Common::GetHDF5Type<int64_t>()
 {
     return H5T_NATIVE_INT64;
 }
 template <>
-hid_t HDF5Common::GetHDF5Type<unsigned long long int>()
+hid_t HDF5Common::GetHDF5Type<uint64_t>()
 {
     return H5T_NATIVE_UINT64;
 }

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
@@ -242,44 +242,44 @@ hid_t HDF5Common::GetHDF5Type<std::string>()
 template <>
 hid_t HDF5Common::GetHDF5Type<signed char>()
 {
-    return H5T_NATIVE_SCHAR;
+    return H5T_NATIVE_INT8;
 }
 
 template <>
 hid_t HDF5Common::GetHDF5Type<unsigned char>()
 {
-    return H5T_NATIVE_UCHAR;
+    return H5T_NATIVE_UINT8;
 }
 
 template <>
 hid_t HDF5Common::GetHDF5Type<short>()
 {
-    return H5T_NATIVE_SHORT;
+    return H5T_NATIVE_INT16;
 }
 template <>
 hid_t HDF5Common::GetHDF5Type<unsigned short>()
 {
-    return H5T_NATIVE_USHORT;
+    return H5T_NATIVE_UINT16;
 }
 template <>
 hid_t HDF5Common::GetHDF5Type<int>()
 {
-    return H5T_NATIVE_INT;
+    return H5T_NATIVE_INT32;
 }
 template <>
 hid_t HDF5Common::GetHDF5Type<unsigned int>()
 {
-    return H5T_NATIVE_UINT;
+    return H5T_NATIVE_UINT32;
 }
 template <>
 hid_t HDF5Common::GetHDF5Type<long long int>()
 {
-    return H5T_NATIVE_LLONG;
+    return H5T_NATIVE_INT64;
 }
 template <>
 hid_t HDF5Common::GetHDF5Type<unsigned long long int>()
 {
-    return H5T_NATIVE_ULLONG;
+    return H5T_NATIVE_UINT64;
 }
 template <>
 hid_t HDF5Common::GetHDF5Type<float>()

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
@@ -252,12 +252,6 @@ hid_t HDF5Common::GetHDF5Type<unsigned char>()
 }
 
 template <>
-hid_t HDF5Common::GetHDF5Type<char>()
-{
-    return H5T_NATIVE_CHAR;
-}
-
-template <>
 hid_t HDF5Common::GetHDF5Type<short>()
 {
     return H5T_NATIVE_SHORT;
@@ -276,16 +270,6 @@ template <>
 hid_t HDF5Common::GetHDF5Type<unsigned int>()
 {
     return H5T_NATIVE_UINT;
-}
-template <>
-hid_t HDF5Common::GetHDF5Type<long int>()
-{
-    return H5T_NATIVE_LONG;
-}
-template <>
-hid_t HDF5Common::GetHDF5Type<unsigned long int>()
-{
-    return H5T_NATIVE_ULONG;
 }
 template <>
 hid_t HDF5Common::GetHDF5Type<long long int>()


### PR DESCRIPTION
I'm continuing my quest to explicitly use only stdint-based types in core and below.

This series updates format/bp3, format/bp4 and interop/hdf5 correspondingly, while also avoiding
a good amount of repetitiveness by using ADIOS2_FOREACH_....

diffstat speaks for itself: `16 files changed, 321 insertions(+), 1412 deletions(-)`  ;)