### PR TITLE
A little bit of clean up

### DIFF
--- a/bindings/C/c/adios2_c_io.cpp
+++ b/bindings/C/c/adios2_c_io.cpp
@@ -247,7 +247,7 @@ adios2_error adios2_inquire_all_variables(adios2_variable ***variables,
         for (auto &name : names)
         {
             auto it = dataMap.find(name);
-            const std::string type(it->second.first);
+            const std::string type(it->second.m_Type);
             adios2::core::VariableBase *variable = nullptr;
 
             if (type == "compound")
@@ -444,7 +444,7 @@ adios2_attribute *adios2_inquire_attribute(adios2_io *io, const char *name)
             return attribute;
         }
 
-        const std::string type(itAttribute->second.first);
+        const std::string type(itAttribute->second.m_Type);
         adios2::core::AttributeBase *attributeCpp = nullptr;
 
         if (type == "compound")
@@ -505,7 +505,7 @@ adios2_error adios2_inquire_all_attributes(adios2_attribute ***attributes,
         for (auto &name : names)
         {
             auto it = dataMap.find(name);
-            const std::string type(it->second.first);
+            const std::string type(it->second.m_Type);
             adios2::core::AttributeBase *attribute = nullptr;
 
             if (type == "compound")

--- a/source/adios2/ADIOSTypes.h
+++ b/source/adios2/ADIOSTypes.h
@@ -192,91 +192,15 @@ using Steps = size_t;
 template <class T>
 using Box = std::pair<T, T>;
 
-// Get a fixed width integer type from a size specification
-template <size_t Bytes, bool Signed>
-struct FixedWidthInt;
-
-template <>
-struct FixedWidthInt<1, true>
-{
-    using Type = std::int8_t;
-};
-template <>
-struct FixedWidthInt<2, true>
-{
-    using Type = std::int16_t;
-};
-template <>
-struct FixedWidthInt<4, true>
-{
-    using Type = std::int32_t;
-};
-template <>
-struct FixedWidthInt<8, true>
-{
-    using Type = std::int64_t;
-};
-template <>
-struct FixedWidthInt<1, false>
-{
-    using Type = std::uint8_t;
-};
-template <>
-struct FixedWidthInt<2, false>
-{
-    using Type = std::uint16_t;
-};
-template <>
-struct FixedWidthInt<4, false>
-{
-    using Type = std::uint32_t;
-};
-template <>
-struct FixedWidthInt<8, false>
-{
-    using Type = std::uint64_t;
-};
-
-// Some core type information that may be useful at compile time
+/**
+ * TypeInfo
+ * used to map from primitive types to stdint-based types
+ */
 template <typename T, typename Enable = void>
-struct TypeInfo
-{
-    using IOType = T;
-    using ValueType = T;
-};
-
-template <typename T>
-struct TypeInfo<T, typename std::enable_if<std::is_integral<T>::value>::type>
-{
-    using IOType =
-        typename FixedWidthInt<sizeof(T), std::is_signed<T>::value>::Type;
-    using ValueType = T;
-};
-
-template <typename T>
-struct TypeInfo<T,
-                typename std::enable_if<std::is_floating_point<T>::value>::type>
-{
-    using IOType = T;
-    using ValueType = T;
-};
-
-template <typename T>
-struct TypeInfo<T, typename std::enable_if<std::is_same<
-                       T, std::complex<typename T::value_type>>::value>::type>
-{
-    using IOType = T;
-    using ValueType = typename T::value_type;
-};
-
-template <typename T>
-struct TypeInfo<
-    T, typename std::enable_if<std::is_same<T, std::string>::value>::type>
-{
-    using IOType = T;
-    using ValueType = T;
-};
+struct TypeInfo;
 
 } // end namespace adios2
+
+#include "ADIOSTypes.inl"
 
 #endif /* ADIOS2_ADIOSTYPES_H_ */

--- a/source/adios2/ADIOSTypes.inl
+++ b/source/adios2/ADIOSTypes.inl
@@ -1,0 +1,117 @@
+
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * ADIOSTypes.h : public header that contains "using/typedef" alias, defaults
+ * and parameters options as enum classes
+ *
+ *  Created on: Feb 20, 2019
+ *      Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+ *              Chuck Atkins chuck.atkins@kitware.com
+ *              Norbert Podhorszki pnorbert@ornl.gov
+ *              William F Godoy godoywf@ornl.gov
+ */
+
+#ifndef ADIOS2_ADIOSTYPES_INL_
+#define ADIOS2_ADIOSTYPES_INL_
+#ifndef ADIOS2_ADIOSTYPES_H_
+#error "Inline file should only be included from its header, never on its own"
+#endif
+
+namespace adios2
+{
+
+namespace
+{
+
+// Get a fixed width integer type from a size specification
+template <size_t Bytes, bool Signed>
+struct FixedWidthInt;
+
+template <>
+struct FixedWidthInt<1, true>
+{
+    using Type = std::int8_t;
+};
+template <>
+struct FixedWidthInt<2, true>
+{
+    using Type = std::int16_t;
+};
+template <>
+struct FixedWidthInt<4, true>
+{
+    using Type = std::int32_t;
+};
+template <>
+struct FixedWidthInt<8, true>
+{
+    using Type = std::int64_t;
+};
+template <>
+struct FixedWidthInt<1, false>
+{
+    using Type = std::uint8_t;
+};
+template <>
+struct FixedWidthInt<2, false>
+{
+    using Type = std::uint16_t;
+};
+template <>
+struct FixedWidthInt<4, false>
+{
+    using Type = std::uint32_t;
+};
+template <>
+struct FixedWidthInt<8, false>
+{
+    using Type = std::uint64_t;
+};
+
+} // namespace
+
+// Some core type information that may be useful at compile time
+template <typename T, typename Enable>
+struct TypeInfo
+{
+    using IOType = T;
+    using ValueType = T;
+};
+
+template <typename T>
+struct TypeInfo<T, typename std::enable_if<std::is_integral<T>::value>::type>
+{
+    using IOType =
+        typename FixedWidthInt<sizeof(T), std::is_signed<T>::value>::Type;
+    using ValueType = T;
+};
+
+template <typename T>
+struct TypeInfo<T,
+                typename std::enable_if<std::is_floating_point<T>::value>::type>
+{
+    using IOType = T;
+    using ValueType = T;
+};
+
+template <typename T>
+struct TypeInfo<T, typename std::enable_if<std::is_same<
+                       T, std::complex<typename T::value_type>>::value>::type>
+{
+    using IOType = T;
+    using ValueType = typename T::value_type;
+};
+
+template <typename T>
+struct TypeInfo<
+    T, typename std::enable_if<std::is_same<T, std::string>::value>::type>
+{
+    using IOType = T;
+    using ValueType = T;
+};
+
+} // end namespace adios2
+
+#endif /* ADIOS2_ADIOSTYPES_INL_ */

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -227,7 +227,7 @@ set_target_properties(adios2 PROPERTIES
   SOVERSION ${ADIOS2_VERSION_MAJOR}
 )
 
-install(FILES ADIOSMacros.h ADIOSTypes.h ADIOSMPICommOnly.h
+install(FILES ADIOSMacros.h ADIOSTypes.h ADIOSTypes.inl ADIOSMPICommOnly.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/adios2
 )
 

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -154,8 +154,8 @@ bool IO::RemoveVariable(const std::string &name) noexcept
     if (itVariable != m_Variables.end())
     {
         // first remove the Variable object
-        const std::string type(itVariable->second.first);
-        const unsigned int index(itVariable->second.second);
+        const std::string type(itVariable->second.m_Type);
+        const unsigned int index(itVariable->second.m_Index);
 
         if (type == "compound")
         {
@@ -198,8 +198,8 @@ bool IO::RemoveAttribute(const std::string &name) noexcept
     if (itAttribute != m_Attributes.end())
     {
         // first remove the Variable object
-        const std::string type(itAttribute->second.first);
-        const unsigned int index(itAttribute->second.second);
+        const std::string type(itAttribute->second.m_Type);
+        const unsigned int index(itAttribute->second.m_Index);
 
         if (type.empty())
         {
@@ -304,7 +304,7 @@ IO::GetAvailableAttributes(const std::string &variableName,
             }
         }
 
-        const std::string type(attributePair.second.first);
+        const std::string type(attributePair.second.m_Type);
         attributesInfo[name]["Type"] = type;
 
         if (type == "compound")
@@ -343,7 +343,7 @@ std::string IO::InquireVariableType(const std::string &name) const noexcept
         return std::string();
     }
 
-    const std::string type = itVariable->second.first;
+    const std::string type = itVariable->second.m_Type;
 
     if (m_ReadStreaming)
     {
@@ -355,7 +355,7 @@ std::string IO::InquireVariableType(const std::string &name) const noexcept
     {                                                                          \
         const Variable<T> &variable =                                          \
             const_cast<IO *>(this)->GetVariableMap<T>().at(                    \
-                itVariable->second.second);                                    \
+                itVariable->second.m_Index);                                   \
         if (!variable.IsValidStep(m_EngineStep + 1))                           \
         {                                                                      \
             return std::string();                                              \
@@ -381,7 +381,7 @@ std::string IO::InquireAttributeType(const std::string &name,
         return std::string();
     }
 
-    return itAttribute->second.first;
+    return itAttribute->second.m_Type;
 }
 
 size_t IO::AddOperation(Operator &op, const Params &parameters) noexcept
@@ -675,7 +675,7 @@ int IO::GetMapIndex(const std::string &name, const DataMap &dataMap) const
     {
         return -1;
     }
-    return itName->second.second;
+    return itName->second.m_Index;
 }
 
 void IO::CheckAttributeCommon(const std::string &name) const

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -35,9 +35,10 @@ namespace adios2
 namespace core
 {
 
+using DataMapEntry = std::pair<std::string, unsigned int>;
+
 /** used for Variables and Attributes, name, type, type-index */
-using DataMap =
-    std::unordered_map<std::string, std::pair<std::string, unsigned int>>;
+using DataMap = std::unordered_map<std::string, DataMapEntry>;
 
 // forward declaration needed as IO is passed to Engine derived
 // classes

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -35,7 +35,11 @@ namespace adios2
 namespace core
 {
 
-using DataMapEntry = std::pair<std::string, unsigned int>;
+struct DataMapEntry
+{
+    std::string m_Type;
+    unsigned int m_Index;
+};
 
 /** used for Variables and Attributes, name, type, type-index */
 using DataMap = std::unordered_map<std::string, DataMapEntry>;
@@ -276,8 +280,8 @@ public:
      * @return
      * <pre>
      * key: unique variable name,
-     * value: pair.first = string type
-     *        pair.second = order in the type bucket
+     * value: DataMapEntry entry: entry.m_Type = string type
+     *                            entry.m_Index = order in the type bucket
      * </pre>
      */
     const DataMap &GetVariablesDataMap() const noexcept;
@@ -287,8 +291,8 @@ public:
      * @return
      * <pre>
      * key: unique attribute name,
-     * value: pair.first = string type
-     *        pair.second = order in the type bucket
+     * value: DataMapEntry entry: entry.m_Type = string type
+     *                            entry.m_Index = order in the type bucket
      * </pre>
      */
     const DataMap &GetAttributesDataMap() const noexcept;
@@ -430,8 +434,9 @@ private:
      * Map holding variable identifiers
      * <pre>
      * key: unique variable name,
-     * value: pair.first = type as string GetType<T> from adiosTemplates.h
-     *        pair.second = index in fixed size map (e.g. m_Int8, m_Double)
+     * value: DataMapEntry entry
+     *        entry.m_Type = type as string GetType<T> from adiosTemplates.h
+     *        entry.m_Index = index in fixed size map (e.g. m_Int8, m_Double)
      * </pre>
      */
     DataMap m_Variables;
@@ -452,9 +457,9 @@ private:
      * Map holding attribute identifiers
      * <pre>
      * key: unique attribute name,
-     * value: pair.first = type as string GetType<T> from
-     *                     helper/adiosTemplates.h
-     *        pair.second = index in fixed size map (e.g. m_Int8, m_Double)
+     * value: DataMapEntry entry
+     *        entry.m_Type = type as string GetType<T> from adiosTemplates.h
+     *        entry.m_Index = index in fixed size map (e.g. m_Int8, m_Double)
      * </pre>
      */
     DataMap m_Attributes;

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -48,7 +48,7 @@ Variable<T> &IO::DefineVariable(const std::string &name, const Dims &shape,
     auto itVariablePair =
         variableMap.emplace(size, Variable<T>(name, shape, start, count,
                                               constantDims, m_DebugMode));
-    m_Variables.emplace(name, std::make_pair(helper::GetType<T>(), size));
+    m_Variables.emplace(name, DataMapEntry{helper::GetType<T>(), size});
 
     Variable<T> &variable = itVariablePair.first->second;
 
@@ -121,8 +121,7 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T &value,
 
     auto itAttributePair =
         attributeMap.emplace(size, Attribute<T>(globalName, value));
-    m_Attributes.emplace(globalName,
-                         std::make_pair(helper::GetType<T>(), size));
+    m_Attributes.emplace(globalName, DataMapEntry{helper::GetType<T>(), size});
 
     return itAttributePair.first->second;
 }
@@ -157,8 +156,7 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T *array,
 
     auto itAttributePair =
         attributeMap.emplace(size, Attribute<T>(globalName, array, elements));
-    m_Attributes.emplace(globalName,
-                         std::make_pair(helper::GetType<T>(), size));
+    m_Attributes.emplace(globalName, DataMapEntry{helper::GetType<T>(), size});
 
     return itAttributePair.first->second;
 }

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -77,12 +77,12 @@ Variable<T> *IO::InquireVariable(const std::string &name) noexcept
         return nullptr;
     }
 
-    if (itVariable->second.first != helper::GetType<T>())
+    if (itVariable->second.m_Type != helper::GetType<T>())
     {
         return nullptr;
     }
 
-    Variable<T> *variable = &GetVariableMap<T>().at(itVariable->second.second);
+    Variable<T> *variable = &GetVariableMap<T>().at(itVariable->second.m_Index);
     if (m_ReadStreaming)
     {
         if (!variable->IsValidStep(m_EngineStep + 1))
@@ -175,12 +175,12 @@ Attribute<T> *IO::InquireAttribute(const std::string &name,
         return nullptr;
     }
 
-    if (itAttribute->second.first != helper::GetType<T>())
+    if (itAttribute->second.m_Type != helper::GetType<T>())
     {
         return nullptr;
     }
 
-    return &GetAttributeMap<T>().at(itAttribute->second.second);
+    return &GetAttributeMap<T>().at(itAttribute->second.m_Index);
 }
 
 // PRIVATE

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -76,7 +76,7 @@ void SstWriter::FFSMarshalAttributes()
     for (const auto &attributePair : attributesDataMap)
     {
         const std::string name(attributePair.first);
-        const std::string type(attributePair.second.first);
+        const std::string type(attributePair.second.m_Type);
 
         if (type == "unknown")
         {

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -413,7 +413,7 @@ void BP3Serializer::PutAttributes(core::IO &io)
     for (const auto &attributePair : attributesDataMap)
     {
         const std::string name(attributePair.first);
-        const std::string type(attributePair.second.first);
+        const std::string type(attributePair.second.m_Type);
 
         // each attribute is only written to output once
         // so filter out the ones already written
@@ -1444,7 +1444,7 @@ size_t BP3Serializer::GetAttributesSizeInData(core::IO &io) const noexcept
 
     for (const auto &attribute : attributes)
     {
-        const std::string type = attribute.second.first;
+        const std::string type = attribute.second.m_Type;
 
         // each attribute is only written to output once
         // so filter out the ones already written

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
@@ -464,7 +464,7 @@ void BP4Serializer::PutAttributes(core::IO &io)
     for (const auto &attributePair : attributesDataMap)
     {
         const std::string name(attributePair.first);
-        const std::string type(attributePair.second.first);
+        const std::string type(attributePair.second.m_Type);
 
         // each attribute is only written to output once
         // so filter out the ones already written
@@ -1865,7 +1865,7 @@ size_t BP4Serializer::GetAttributesSizeInData(core::IO &io) const noexcept
 
     for (const auto &attribute : attributes)
     {
-        const std::string type = attribute.second.first;
+        const std::string type = attribute.second.m_Type;
 
         // each attribute is only written to output once
         // so filter out the ones already written

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -199,7 +199,7 @@ void DataManSerializer::PutAttributes(core::IO &io, const int rank)
         for (const auto &attributePair : attributesDataMap)
         {
             const std::string name(attributePair.first);
-            const std::string type(attributePair.second.first);
+            const std::string type(attributePair.second.m_Type);
             if (type == "unknown")
             {
             }

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -871,16 +871,15 @@ void HDF5Common::AddNonStringAttribute(core::IO &io,
                                        hid_t attrId, hid_t h5Type,
                                        hsize_t arraySize)
 {
-    using IOType = typename TypeInfo<T>::IOType;
     if (arraySize == 0)
     { // SCALAR
-        IOType val;
+        T val;
         H5Aread(attrId, h5Type, &val);
         io.DefineAttribute(attrName, val);
     }
     else
     {
-        IOType val[arraySize];
+        T val[arraySize];
         H5Aread(attrId, h5Type, val);
         io.DefineAttribute(attrName, val, arraySize);
     }

--- a/source/utils/adios_reorganize/Reorganize.cpp
+++ b/source/utils/adios_reorganize/Reorganize.cpp
@@ -418,7 +418,7 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
     for (const auto &variablePair : variables)
     {
         const std::string &name(variablePair.first);
-        const std::string &type(variablePair.second.first);
+        const std::string &type(variablePair.second.m_Type);
         core::VariableBase *variable = nullptr;
         print0("Get info on variable ", varidx, ": ", name);
 
@@ -526,7 +526,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
             // read variable subset
             std::cout << "rank " << rank << ": Read variable " << name
                       << std::endl;
-            const std::string &type = variables.at(name).first;
+            const std::string &type = variables.at(name).m_Type;
             if (type == "compound")
             {
                 // not supported
@@ -567,7 +567,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
             // Write variable subset
             std::cout << "rank " << rank << ": Write variable " << name
                       << std::endl;
-            const std::string &type = variables.at(name).first;
+            const std::string &type = variables.at(name).m_Type;
             if (type == "compound")
             {
                 // not supported

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -642,7 +642,7 @@ int doList_vars(core::Engine *fp, core::IO *io)
     {
         for (const auto &vpair : variables)
         {
-            Entry e(true, vpair.second.first, vpair.second.second);
+            Entry e(true, vpair.second.m_Type, vpair.second.m_Index);
             entries.emplace(vpair.first, e);
         }
     }
@@ -650,7 +650,7 @@ int doList_vars(core::Engine *fp, core::IO *io)
     {
         for (const auto &apair : attributes)
         {
-            Entry e(false, apair.second.first, apair.second.second);
+            Entry e(false, apair.second.m_Type, apair.second.m_Index);
             entries.emplace(apair.first, e);
         }
     }


### PR DESCRIPTION
This one is hopefully not so controversial:
* Use `DataMapEntry` instead of std::pair to make the code more readable.
* do a bit of header cleanup
* remove one left over IOType mapping bit which is not necessary anymoe