### PR TITLE
Cleanup2

### DIFF
--- a/source/adios2/ADIOSTypes.h
+++ b/source/adios2/ADIOSTypes.h
@@ -192,91 +192,15 @@ using Steps = size_t;
 template <class T>
 using Box = std::pair<T, T>;
 
-// Get a fixed width integer type from a size specification
-template <size_t Bytes, bool Signed>
-struct FixedWidthInt;
-
-template <>
-struct FixedWidthInt<1, true>
-{
-    using Type = std::int8_t;
-};
-template <>
-struct FixedWidthInt<2, true>
-{
-    using Type = std::int16_t;
-};
-template <>
-struct FixedWidthInt<4, true>
-{
-    using Type = std::int32_t;
-};
-template <>
-struct FixedWidthInt<8, true>
-{
-    using Type = std::int64_t;
-};
-template <>
-struct FixedWidthInt<1, false>
-{
-    using Type = std::uint8_t;
-};
-template <>
-struct FixedWidthInt<2, false>
-{
-    using Type = std::uint16_t;
-};
-template <>
-struct FixedWidthInt<4, false>
-{
-    using Type = std::uint32_t;
-};
-template <>
-struct FixedWidthInt<8, false>
-{
-    using Type = std::uint64_t;
-};
-
-// Some core type information that may be useful at compile time
+/**
+ * TypeInfo
+ * used to map from primitive types to stdint-based types
+ */
 template <typename T, typename Enable = void>
-struct TypeInfo
-{
-    using IOType = T;
-    using ValueType = T;
-};
-
-template <typename T>
-struct TypeInfo<T, typename std::enable_if<std::is_integral<T>::value>::type>
-{
-    using IOType =
-        typename FixedWidthInt<sizeof(T), std::is_signed<T>::value>::Type;
-    using ValueType = T;
-};
-
-template <typename T>
-struct TypeInfo<T,
-                typename std::enable_if<std::is_floating_point<T>::value>::type>
-{
-    using IOType = T;
-    using ValueType = T;
-};
-
-template <typename T>
-struct TypeInfo<T, typename std::enable_if<std::is_same<
-                       T, std::complex<typename T::value_type>>::value>::type>
-{
-    using IOType = T;
-    using ValueType = typename T::value_type;
-};
-
-template <typename T>
-struct TypeInfo<
-    T, typename std::enable_if<std::is_same<T, std::string>::value>::type>
-{
-    using IOType = T;
-    using ValueType = T;
-};
+struct TypeInfo;
 
 } // end namespace adios2
+
+#include "ADIOSTypes.inl"
 
 #endif /* ADIOS2_ADIOSTYPES_H_ */

--- a/source/adios2/ADIOSTypes.inl
+++ b/source/adios2/ADIOSTypes.inl
@@ -1,0 +1,117 @@
+
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * ADIOSTypes.h : public header that contains "using/typedef" alias, defaults
+ * and parameters options as enum classes
+ *
+ *  Created on: Feb 20, 2019
+ *      Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+ *              Chuck Atkins chuck.atkins@kitware.com
+ *              Norbert Podhorszki pnorbert@ornl.gov
+ *              William F Godoy godoywf@ornl.gov
+ */
+
+#ifndef ADIOS2_ADIOSTYPES_INL_
+#define ADIOS2_ADIOSTYPES_INL_
+#ifndef ADIOS2_ADIOSTYPES_H_
+#error "Inline file should only be included from its header, never on its own"
+#endif
+
+namespace adios2
+{
+
+namespace
+{
+
+// Get a fixed width integer type from a size specification
+template <size_t Bytes, bool Signed>
+struct FixedWidthInt;
+
+template <>
+struct FixedWidthInt<1, true>
+{
+    using Type = std::int8_t;
+};
+template <>
+struct FixedWidthInt<2, true>
+{
+    using Type = std::int16_t;
+};
+template <>
+struct FixedWidthInt<4, true>
+{
+    using Type = std::int32_t;
+};
+template <>
+struct FixedWidthInt<8, true>
+{
+    using Type = std::int64_t;
+};
+template <>
+struct FixedWidthInt<1, false>
+{
+    using Type = std::uint8_t;
+};
+template <>
+struct FixedWidthInt<2, false>
+{
+    using Type = std::uint16_t;
+};
+template <>
+struct FixedWidthInt<4, false>
+{
+    using Type = std::uint32_t;
+};
+template <>
+struct FixedWidthInt<8, false>
+{
+    using Type = std::uint64_t;
+};
+
+} // namespace
+
+// Some core type information that may be useful at compile time
+template <typename T, typename Enable>
+struct TypeInfo
+{
+    using IOType = T;
+    using ValueType = T;
+};
+
+template <typename T>
+struct TypeInfo<T, typename std::enable_if<std::is_integral<T>::value>::type>
+{
+    using IOType =
+        typename FixedWidthInt<sizeof(T), std::is_signed<T>::value>::Type;
+    using ValueType = T;
+};
+
+template <typename T>
+struct TypeInfo<T,
+                typename std::enable_if<std::is_floating_point<T>::value>::type>
+{
+    using IOType = T;
+    using ValueType = T;
+};
+
+template <typename T>
+struct TypeInfo<T, typename std::enable_if<std::is_same<
+                       T, std::complex<typename T::value_type>>::value>::type>
+{
+    using IOType = T;
+    using ValueType = typename T::value_type;
+};
+
+template <typename T>
+struct TypeInfo<
+    T, typename std::enable_if<std::is_same<T, std::string>::value>::type>
+{
+    using IOType = T;
+    using ValueType = T;
+};
+
+} // end namespace adios2
+
+#endif /* ADIOS2_ADIOSTYPES_INL_ */

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -227,7 +227,7 @@ set_target_properties(adios2 PROPERTIES
   SOVERSION ${ADIOS2_VERSION_MAJOR}
 )
 
-install(FILES ADIOSMacros.h ADIOSTypes.h ADIOSMPICommOnly.h
+install(FILES ADIOSMacros.h ADIOSTypes.h ADIOSTypes.inl ADIOSMPICommOnly.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/adios2
 )
 

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -871,16 +871,15 @@ void HDF5Common::AddNonStringAttribute(core::IO &io,
                                        hid_t attrId, hid_t h5Type,
                                        hsize_t arraySize)
 {
-    using IOType = typename TypeInfo<T>::IOType;
     if (arraySize == 0)
     { // SCALAR
-        IOType val;
+        T val;
         H5Aread(attrId, h5Type, &val);
         io.DefineAttribute(attrName, val);
     }
     else
     {
-        IOType val[arraySize];
+        T val[arraySize];
         H5Aread(attrId, h5Type, val);
         io.DefineAttribute(attrName, val, arraySize);
     }


### PR DESCRIPTION
So hopefully, this is one is actually non-controversial

* Move the implementation of `struct TypeInfo` into ADIOSTypes.inl, following the standard practices for the project. It also puts `struct FixedWidthInt` into an anonymous namespace, which arguably doesn't do much. I can undo that part if you prefer.
* Fixed (eliminated) the last use of the primitive - stdint mapping within the core of adios, which is already using all stdint-based types, so that one piece of mapping already is an identity map that can be removed.
