### PR TITLE
fix bugs exposed by address sanitizer

### DIFF
--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -644,11 +644,7 @@ void HDF5Common::ReadStringScalarDataset(hid_t dataSetId, std::string &result)
     char *val = (char *)(calloc(typesize, sizeof(char)));
     hid_t ret2 = H5Dread(dataSetId, h5Type, H5S_ALL, H5S_ALL, H5P_DEFAULT, val);
 
-    /*if (std::is_same<T, std::string> :: value)  { // double check
-      ((std::string*)values) ->assign(val);
-    }
-    */
-    result.assign(val);
+    result.assign(val, typesize);
     free(val);
 
     H5Tclose(h5Type);
@@ -754,7 +750,7 @@ void HDF5Common::ReadADIOSName(hid_t dsetID, std::string &adiosName)
     H5Tclose(attrType);
     H5Aclose(attrID);
 
-    adiosName.assign(val);
+    adiosName.assign(val, typeSize);
     free(val);
 }
 

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -206,7 +206,7 @@ int process_unused_args(adios2sys::CommandLineArguments &arg)
     arg.GetUnusedArguments(&nuargs, &uargs);
 
     std::vector<char *> retry_args;
-    retry_args.push_back(new char[4]);
+    retry_args.push_back(new char[4]{});
 
     // first arg is argv[0], so skip that
     for (int i = 1; i < nuargs; i++)

--- a/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
+++ b/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
@@ -411,7 +411,7 @@ void HDF5NativeReader::ReadString(const std::string varName,
     char *val = (char *)(calloc(typesize, sizeof(char)));
     hid_t ret2 = H5Dread(dataSetId, h5Type, H5S_ALL, H5S_ALL, H5P_DEFAULT, val);
 
-    result.assign(val);
+    result.assign(val, typesize);
     free(val);
 
     H5Dclose(dataSetId);


### PR DESCRIPTION
In an unrelated PR, I had to use clang's address sanitize, and when running the test suite, a whole bunch of other tests then failed. Fortunately, there were actually relatively few bugs underlying the many failures.
I'd consider adding an address sanitizer to the list of automated builds/checks -- looks like you already have some ubsan, so should be similar.

All of these triggered in the existing test suite, and are shown to be gone by the existing test suites, so new tests are added.