### PR TITLE
mpi_comm_dup from the beginning

### DIFF
--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -47,13 +47,17 @@ namespace core
 
 ADIOS::ADIOS(const std::string configFile, MPI_Comm mpiComm,
              const bool debugMode, const std::string hostLanguage)
-: m_MPIComm(mpiComm), m_ConfigFile(configFile), m_DebugMode(debugMode),
-  m_HostLanguage(hostLanguage)
+: m_ConfigFile(configFile), m_DebugMode(debugMode), m_HostLanguage(hostLanguage)
 {
-    if (m_DebugMode)
+    if (m_DebugMode && mpiComm == MPI_COMM_NULL)
     {
-        CheckMPI();
+        throw std::ios_base::failure(
+            "ERROR: MPI communicator is MPI_COMM_NULL, "
+            " in call to ADIOS constructor\n");
     }
+
+    MPI_Comm_dup(mpiComm, &m_MPIComm);
+
     if (!configFile.empty())
     {
         if (configFile.substr(configFile.size() - 3) == "xml")
@@ -286,15 +290,6 @@ bool ADIOS::RemoveIO(const std::string name)
 void ADIOS::RemoveAllIOs() noexcept { m_IOs.clear(); }
 
 // PRIVATE FUNCTIONS
-void ADIOS::CheckMPI() const
-{
-    if (m_MPIComm == MPI_COMM_NULL)
-    {
-        throw std::ios_base::failure("ERROR: MPI communicator is MPI_COMM_NULL,"
-                                     " in call to ADIOS constructor\n");
-    }
-}
-
 void ADIOS::CheckOperator(const std::string name) const
 {
     if (m_DebugMode)

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -99,8 +99,8 @@ ADIOS::ADIOS(const bool debugMode, const std::string hostLanguage)
 ADIOS::~ADIOS()
 {
     int flag;
-    MPI_Initialized(&flag);
-    if (flag && m_NeedMPICommFree)
+    MPI_Finalized(&flag);
+    if (!flag && m_NeedMPICommFree)
     {
         MPI_Comm_free(&m_MPIComm);
     }

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -94,7 +94,7 @@ public:
      */
     ADIOS(const ADIOS &adios) = delete;
 
-    ~ADIOS() = default;
+    ~ADIOS();
 
     /**
      * Declares a new IO class object and returns a reference to that object.
@@ -184,6 +184,8 @@ public:
     void RemoveAllIOs() noexcept;
 
 private:
+    bool m_NeedMPICommFree;
+
     /** XML File to be read containing configuration information */
     const std::string m_ConfigFile;
 

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -201,9 +201,6 @@ private:
     /** operators created with DefineOperator */
     std::map<std::string, std::shared_ptr<Operator>> m_Operators;
 
-    /** throws exception if m_MPIComm = MPI_COMM_NULL */
-    void CheckMPI() const;
-
     void CheckOperator(const std::string name) const;
 
     void XMLInit(const std::string &configFileXML);

--- a/source/adios2/helper/mpidummy.cpp
+++ b/source/adios2/helper/mpidummy.cpp
@@ -54,6 +54,12 @@ int MPI_Initialized(int *flag)
     return MPI_SUCCESS;
 }
 
+int MPI_Finalized(int *flag)
+{
+    *flag = 0;
+    return MPI_SUCCESS;
+}
+
 int MPI_Comm_split(MPI_Comm /*comm*/, int /*color*/, int /*key*/,
                    MPI_Comm * /*comm_out*/)
 {

--- a/source/adios2/helper/mpidummy.h
+++ b/source/adios2/helper/mpidummy.h
@@ -85,6 +85,7 @@ using MPI_Op = int;
 int MPI_Init(int *argc, char ***argv);
 int MPI_Finalize();
 int MPI_Initialized(int *flag);
+int MPI_Finalized(int *flag);
 
 int MPI_Barrier(MPI_Comm comm);
 int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,

--- a/testing/adios2/interface/CMakeLists.txt
+++ b/testing/adios2/interface/CMakeLists.txt
@@ -3,6 +3,9 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
+add_executable(TestADIOSInterface TestADIOSInterface.cpp)
+target_link_libraries(TestADIOSInterface adios2 gtest)
+
 add_executable(TestADIOSInterfaceWrite TestADIOSInterfaceWrite.cpp)
 target_link_libraries(TestADIOSInterfaceWrite adios2 gtest)
 
@@ -13,6 +16,7 @@ add_executable(TestADIOSDefineAttribute TestADIOSDefineAttribute.cpp)
 target_link_libraries(TestADIOSDefineAttribute adios2 gtest)
 
 if(ADIOS2_HAVE_MPI)
+  target_link_libraries(TestADIOSInterface MPI::MPI_C)
   target_link_libraries(TestADIOSInterfaceWrite MPI::MPI_C)
   target_link_libraries(TestADIOSDefineVariable MPI::MPI_C)
   target_link_libraries(TestADIOSDefineAttribute MPI::MPI_C)
@@ -20,6 +24,7 @@ if(ADIOS2_HAVE_MPI)
   set(extra_test_args EXEC_WRAPPER ${MPIEXEC_COMMAND})
 endif()
 
+gtest_add_tests(TARGET TestADIOSInterface ${extra_test_args})
 gtest_add_tests(TARGET TestADIOSInterfaceWrite ${extra_test_args})
 gtest_add_tests(TARGET TestADIOSDefineVariable ${extra_test_args})
 gtest_add_tests(TARGET TestADIOSDefineAttribute ${extra_test_args})

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -1,0 +1,40 @@
+#include <cstdint>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#ifdef ADIOS2_HAVE_MPI
+
+TEST(ADIOSInterface, MPICommRemoved)
+{
+    MPI_Comm myComm;
+    MPI_Comm_dup(MPI_COMM_WORLD, &myComm);
+    adios2::ADIOS adios(myComm);
+    adios2::IO io = adios.DeclareIO("TestIO");
+    MPI_Comm_free(&myComm);
+
+    adios2::Engine engine = io.Open("test.bp", adios2::Mode::Write);
+}
+
+#endif
+
+int main(int argc, char **argv)
+{
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+    result = RUN_ALL_TESTS();
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}


### PR DESCRIPTION
Also came from an unrelated discussion. ADIOS2 MPI_Comm_dup()s its communicators, but potentially too late to protect from the user doing stupid things.

The first commit adds a test that triggers it. The 2nd commit is the simple fix.
