### PR TITLE
Enable reading adios1 files with statistics_cnt

### DIFF
--- a/source/adios2/toolkit/format/bp3/BP3Base.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Base.tcc
@@ -431,9 +431,9 @@ inline void BP3Base::ParseCharacteristics(const std::vector<char> &buffer,
                 }
                 case (statistic_cnt):
                 {
-                    throw std::invalid_argument(
-                        "ERROR: ADIOS2 default BP3 engine doesn't support "
-                        "count statistics\n");
+                    characteristics.Statistics.BitCount =
+                        helper::ReadValue<uint32_t>(buffer, position,
+                                                    isLittleEndian);
                 }
 
                 } // switch

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -2886,7 +2886,16 @@ int main(int argc, char *argv[])
 #ifdef ADIOS2_HAVE_MPI
     MPI_Init(&argc, &argv);
 #endif
-    int retval = adios2::utils::bplsMain(argc, argv);
+    int retval = 1;
+    try
+    {
+        retval = adios2::utils::bplsMain(argc, argv);
+    }
+    catch (std::exception &e)
+    {
+        std::cout << "\nbpls caught an exception\n";
+        std::cout << e.what() << std::endl;
+    }
 #ifdef ADIOS2_HAVE_MPI
     MPI_Finalize();
 #endif


### PR DESCRIPTION
enable reading statistic_cnt from adios1 generated files
bpls to catch exceptions
tested outside CI with external file