### PR TITLE
fix helloBPWriter Python example

### DIFF
--- a/examples/hello/bpWriter/helloBPWriter.py
+++ b/examples/hello/bpWriter/helloBPWriter.py
@@ -23,7 +23,7 @@ adios = adios2.ADIOS(comm, adios2.DebugON)
 
 # ADIOS IO
 bpIO = adios.DeclareIO("BPFile_N2N")
-bpIO.SetEngine('BPFileWriter')
+bpIO.SetEngine('bp3')
 # bpIO.SetParameters( {"Threads" : "2", "ProfileUnits" : "Microseconds",
 # "InitialBufferSize" : "17Kb"} )
 bpIOParams = {}
@@ -36,7 +36,7 @@ fileID = bpIO.AddTransport('File', {'Library': 'fstream'})
 
 # ADIOS Variable name, shape, start, offset, constant dims
 ioArray = bpIO.DefineVariable(
-    "bpArray", [size * Nx], [rank * Nx], [Nx], adios2.ConstantDims, myArray)
+    "bpArray", myArray, [size * Nx], [rank * Nx], [Nx], adios2.ConstantDims)
 
 # ADIOS Engine
 bpFileWriter = bpIO.Open("npArray.bp", adios2.Mode.Write)

--- a/examples/hello/bpWriter/helloBPWriter_nompi.py
+++ b/examples/hello/bpWriter/helloBPWriter_nompi.py
@@ -21,7 +21,7 @@ bpIO = adios.DeclareIO("BPFile_N2N")
 
 # ADIOS Variable name, shape, start, offset, constant dims
 ioArray = bpIO.DefineVariable(
-    "bpArray", [], [], [Nx], adios2.ConstantDims, myArray)
+    "bpArray", myArray, [], [], [Nx], adios2.ConstantDims)
 
 # ADIOS Engine
 bpFileWriter = bpIO.Open("npArray.bp", adios2.Mode.Write)


### PR DESCRIPTION
This addresses the immediate problem in #1233, but not the fact that
even with wrong arguments, the python interface shouldn't crash
completely.