### PR TITLE
WIP: Python fixes

### DIFF
--- a/bindings/Python/py11IO.h
+++ b/bindings/Python/py11IO.h
@@ -87,7 +87,8 @@ public:
     Engine Open(const std::string &name, const int openMode);
 
 #ifdef ADIOS2_HAVE_MPI
-    Engine Open(const std::string &name, const Mode mode, MPI_Comm comm);
+    Engine Open(const std::string &name, const int openMode,
+                pybind11::object &comm);
 #endif
 
     void FlushAll();

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -366,6 +366,10 @@ PYBIND11_MODULE(adios2, m)
         .def("Open", (adios2::py11::Engine (adios2::py11::IO::*)(
                          const std::string &, const int)) &
                          adios2::py11::IO::Open)
+        .def("Open",
+             (adios2::py11::Engine (adios2::py11::IO::*)(
+                 const std::string &, const int, pybind11::object &comm)) &
+                 adios2::py11::IO::Open)
         .def("AvailableVariables", &adios2::py11::IO::AvailableVariables)
         .def("AvailableAttributes", &adios2::py11::IO::AvailableAttributes)
         .def("FlushAll", &adios2::py11::IO::FlushAll)

--- a/examples/hello/bpReader/helloBPReaderHeatMap2D.py
+++ b/examples/hello/bpReader/helloBPReaderHeatMap2D.py
@@ -41,9 +41,8 @@ for i in range(0, Nx):
 adios = adios2.ADIOS(comm)
 ioWrite = adios.DeclareIO("ioWriter")
 
-varTemperature = ioWrite.DefineVariable("temperature2D", shape,
-                                        start, count, adios2.ConstantDims,
-                                        temperatures)
+varTemperature = ioWrite.DefineVariable("temperature2D", temperatures, shape,
+                                        start, count, adios2.ConstantDims)
 
 obpStream = ioWrite.Open('HeatMap2D_py.bp', adios2.Mode.Write)
 obpStream.Put(varTemperature, temperatures)

--- a/testing/adios2/bindings/python/CMakeLists.txt
+++ b/testing/adios2/bindings/python/CMakeLists.txt
@@ -17,6 +17,8 @@ if(ADIOS2_HAVE_MPI)
                     SCRIPT TestBPWriteTypesHighLevelAPI.py)
     python_add_test(NAME PythonBPReadMultisteps ${test_parameters} 
                     SCRIPT TestBPReadMultisteps.py)
+    python_add_test(NAME PythonBPWriteRead2D ${test_parameters} 
+                    SCRIPT TestBPWriteRead2D.py)
     if (ADIOS2_HAVE_HDF5)
         python_add_test(NAME PythonBPWriteReadHighLevelAPI_HDF5 
                         SCRIPT TestBPWriteTypesHighLevelAPI_HDF5.py)

--- a/testing/adios2/bindings/python/TestBPWriteRead2D.py
+++ b/testing/adios2/bindings/python/TestBPWriteRead2D.py
@@ -27,14 +27,11 @@ count = [Nx, Ny]
 start = [rank * Nx, 0]
 shape = [size * Nx, Ny]
 
-temperatures = np.empty(count, dtype=np.int)
+temperatures = np.zeros(count, dtype=np.int)
 
 for i in range(0, Nx):
-    iGlobal = start[0] + i
-
     for j in range(0, Ny):
-        value = iGlobal * shape[1] + j
-        temperatures[i, j] = value
+        temperatures[i, j] = (start[0] + i) * shape[1] + (j + start[1])
 
 # print(temperatures)
 # ADIOS2 read
@@ -64,7 +61,7 @@ if rank == 0:
     ibpStream.Get(var_inTemperature, inTemperatures, adios2.Mode.Sync)
     ibpStream.Close()
 
-    #print('Incoming temperature map\n', inTemperatures)
+    # print('Incoming temperature map\n', inTemperatures)
     expected = np.array([[22, 23, 24, 25],
                          [32, 33, 34, 35],
                          [42, 43, 44, 45],

--- a/testing/adios2/bindings/python/TestBPWriteRead2D.py
+++ b/testing/adios2/bindings/python/TestBPWriteRead2D.py
@@ -11,7 +11,7 @@
 #
 
 from mpi4py import MPI
-import numpy
+import numpy as np
 import adios2
 
 # MPI
@@ -27,7 +27,7 @@ count = [Nx, Ny]
 start = [rank * Nx, 0]
 shape = [size * Nx, Ny]
 
-temperatures = numpy.empty(count, dtype=numpy.int)
+temperatures = np.empty(count, dtype=np.int)
 
 for i in range(0, Nx):
     iGlobal = start[0] + i
@@ -60,13 +60,13 @@ if rank == 0:
     readSize = [4, 4]
 
     var_inTemperature.SetSelection([readOffset, readSize])
-    inTemperatures = numpy.zeros(readSize, dtype=numpy.int)
+    inTemperatures = np.zeros(readSize, dtype=np.int)
     ibpStream.Get(var_inTemperature, inTemperatures, adios2.Mode.Sync)
     ibpStream.Close()
 
     #print('Incoming temperature map\n', inTemperatures)
-    expected = numpy.array([[22, 23, 24, 25],
-                            [32, 33, 34, 35],
-                            [42, 43, 44, 45],
-                            [52, 53, 54, 55]], numpy.int)
-    assert numpy.array_equal(inTemperatures, expected)
+    expected = np.array([[22, 23, 24, 25],
+                         [32, 33, 34, 35],
+                         [42, 43, 44, 45],
+                         [52, 53, 54, 55]], np.int)
+    assert np.array_equal(inTemperatures, expected)

--- a/testing/adios2/bindings/python/TestBPWriteRead2D.py
+++ b/testing/adios2/bindings/python/TestBPWriteRead2D.py
@@ -1,0 +1,77 @@
+#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#
+# TestBPWriteRead2D.py
+#
+#
+#  Created on: Mar 3rd, 2019
+#      Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+#              William F Godoy godoywf@ornl.gov
+#
+
+from mpi4py import MPI
+import numpy
+import adios2
+
+# MPI
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+# User data
+Nx = 10
+Ny = 10
+
+count = [Nx, Ny]
+start = [rank * Nx, 0]
+shape = [size * Nx, Ny]
+
+temperatures = numpy.zeros(Nx * Ny, dtype=numpy.int)
+
+for i in range(0, Nx):
+    iGlobal = start[0] + i
+
+    for j in range(0, Ny):
+        value = iGlobal * shape[1] + j
+        temperatures[i * Nx + j] = value
+        print(str(i) + "," + str(j) + " " + str(value))
+
+
+# ADIOS portion
+adios = adios2.ADIOS(comm)
+ioWrite = adios.DeclareIO("ioWriter")
+
+varTemperature = ioWrite.DefineVariable("temperature2D", temperatures, shape,
+                                        start, count, adios2.ConstantDims)
+
+obpStream = ioWrite.Open('HeatMap2D_py.bp', adios2.Mode.Write)
+obpStream.Put(varTemperature, temperatures)
+obpStream.Close()
+
+
+if rank == 0:
+    ioRead = adios.DeclareIO("ioReader")
+
+    ibpStream = ioRead.Open('HeatMap2D_py.bp', adios2.Mode.Read, MPI.COMM_SELF)
+
+    var_inTemperature = ioRead.InquireVariable("temperature2D")
+
+    if var_inTemperature is not None:
+        var_inTemperature.SetSelection([[2, 2], [4, 4]])
+
+        inSize = var_inTemperature.SelectionSize()
+        print('Incoming size ' + str(inSize))
+        inTemperatures = numpy.zeros(inSize, dtype=numpy.int)
+
+        ibpStream.Get(var_inTemperature, inTemperatures, adios2.Mode.Sync)
+
+        print('Incoming temperature map')
+
+        for i in range(0, inTemperatures.size):
+            print(str(inTemperatures[i]) + ' ')
+
+            if (i + 1) % 4 == 0:
+                print()
+
+    ibpStream.Close()

--- a/testing/adios2/bindings/python/TestBPWriteRead2D.py
+++ b/testing/adios2/bindings/python/TestBPWriteRead2D.py
@@ -34,10 +34,10 @@ for i in range(0, Nx):
 
     for j in range(0, Ny):
         value = iGlobal * shape[1] + j
-        temperatures[i,j] = value
+        temperatures[i, j] = value
 
-print(temperatures)
-# ADIOS portion
+# print(temperatures)
+# ADIOS2 read
 adios = adios2.ADIOS(comm)
 ioWrite = adios.DeclareIO("ioWriter")
 
@@ -50,20 +50,23 @@ obpStream.Close()
 
 
 if rank == 0:
+    # ADIOS2 read
     ioRead = adios.DeclareIO("ioReader")
-
     ibpStream = ioRead.Open('HeatMap2D_py.bp', adios2.Mode.Read, MPI.COMM_SELF)
-
     var_inTemperature = ioRead.InquireVariable("temperature2D")
 
-    if var_inTemperature is not None:
-        readOffset = [2, 2]
-        readSize = [4, 4]
+    assert var_inTemperature is not None
+    readOffset = [2, 2]
+    readSize = [4, 4]
 
-        var_inTemperature.SetSelection([readOffset, readSize])
-        inTemperatures = numpy.zeros(readSize, dtype=numpy.int)
-        ibpStream.Get(var_inTemperature, inTemperatures, adios2.Mode.Sync)
-
-        print('Incoming temperature map\n', inTemperatures)
-
+    var_inTemperature.SetSelection([readOffset, readSize])
+    inTemperatures = numpy.zeros(readSize, dtype=numpy.int)
+    ibpStream.Get(var_inTemperature, inTemperatures, adios2.Mode.Sync)
     ibpStream.Close()
+
+    #print('Incoming temperature map\n', inTemperatures)
+    expected = numpy.array([[22, 23, 24, 25],
+                            [32, 33, 34, 35],
+                            [42, 43, 44, 45],
+                            [52, 53, 54, 55]], numpy.int)
+    assert numpy.array_equal(inTemperatures, expected)

--- a/testing/adios2/bindings/python/TestBPWriteRead2D.py
+++ b/testing/adios2/bindings/python/TestBPWriteRead2D.py
@@ -27,17 +27,16 @@ count = [Nx, Ny]
 start = [rank * Nx, 0]
 shape = [size * Nx, Ny]
 
-temperatures = numpy.zeros(Nx * Ny, dtype=numpy.int)
+temperatures = numpy.empty(count, dtype=numpy.int)
 
 for i in range(0, Nx):
     iGlobal = start[0] + i
 
     for j in range(0, Ny):
         value = iGlobal * shape[1] + j
-        temperatures[i * Nx + j] = value
-        print(str(i) + "," + str(j) + " " + str(value))
+        temperatures[i,j] = value
 
-
+print(temperatures)
 # ADIOS portion
 adios = adios2.ADIOS(comm)
 ioWrite = adios.DeclareIO("ioWriter")
@@ -58,20 +57,13 @@ if rank == 0:
     var_inTemperature = ioRead.InquireVariable("temperature2D")
 
     if var_inTemperature is not None:
-        var_inTemperature.SetSelection([[2, 2], [4, 4]])
+        readOffset = [2, 2]
+        readSize = [4, 4]
 
-        inSize = var_inTemperature.SelectionSize()
-        print('Incoming size ' + str(inSize))
-        inTemperatures = numpy.zeros(inSize, dtype=numpy.int)
-
+        var_inTemperature.SetSelection([readOffset, readSize])
+        inTemperatures = numpy.zeros(readSize, dtype=numpy.int)
         ibpStream.Get(var_inTemperature, inTemperatures, adios2.Mode.Sync)
 
-        print('Incoming temperature map')
-
-        for i in range(0, inTemperatures.size):
-            print(str(inTemperatures[i]) + ' ')
-
-            if (i + 1) % 4 == 0:
-                print()
+        print('Incoming temperature map\n', inTemperatures)
 
     ibpStream.Close()


### PR DESCRIPTION
This fixes the issues from #1246.
* fix arg order in helloBPReaderHeatMap2D.py
* fix the `IO::Open(..., MPI_Comm)` to actually use the passed comm (it was just using the comm from m_IO)
* add that function to the interface and correctly translate the communicator

I don't think this is the prettiest possible way of doing things, but it works for now (for me, anyway)