### PR TITLE
pass strings safely to Fortran bindings

### DIFF
--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -35,6 +35,7 @@ set(MODULES
      ${CMAKE_CURRENT_SOURCE_DIR}/modules/adios2_variable_mod.f90
      ${CMAKE_CURRENT_SOURCE_DIR}/modules/adios2_variable_min_mod.f90
      ${CMAKE_CURRENT_SOURCE_DIR}/modules/adios2_variable_max_mod.f90
+     ${CMAKE_CURRENT_SOURCE_DIR}/modules/adios2_operator_mod.f90
 )
 
 add_library(adios2_f ${MODULES} ${F2C})

--- a/bindings/Fortran/f2c/adios2_f2c_attribute.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_attribute.cpp
@@ -17,6 +17,29 @@
 extern "C" {
 #endif
 
+void FC_GLOBAL(adios2_attribute_name_f2c,
+               ADIOS2_ATTRIBUTE_NAME_F2C)(char *name,
+                                          const adios2_attribute **attribute,
+                                          int *ierr)
+{
+    size_t sizeC;
+    *ierr = static_cast<int>(adios2_attribute_name(name, &sizeC, *attribute));
+}
+
+void FC_GLOBAL(adios2_attribute_name_length_f2c,
+               ADIOS2_ATTRIBUTE_NAME_LENGTH_F2C)(
+    int *size, const adios2_attribute **attribute, int *ierr)
+{
+    *size = -1;
+    size_t sizeC;
+    *ierr =
+        static_cast<int>(adios2_attribute_name(nullptr, &sizeC, *attribute));
+    if (*ierr == static_cast<int>(adios2_error_none))
+    {
+        *size = static_cast<int>(sizeC);
+    }
+}
+
 void FC_GLOBAL(adios2_attribute_is_value_f2c, ADIOS2_ATTRIBUTE_IS_VALUE_F2C)(
     int *is_value, const adios2_attribute **attribute, int *ierr)
 {

--- a/bindings/Fortran/f2c/adios2_f2c_io.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_io.cpp
@@ -332,13 +332,21 @@ void FC_GLOBAL(adios2_lock_definitions_f2c,
 }
 
 void FC_GLOBAL(adios2_io_engine_type_f2c,
-               ADIOS2_IO_ENGINE_TYPE_F2C)(const adios2_io **io,
-                                          char engine_type[32], int *size,
+               ADIOS2_IO_ENGINE_TYPE_F2C)(char *type, const adios2_io **io,
                                           int *ierr)
+{
+    size_t sizeC;
+    *ierr = static_cast<int>(adios2_engine_type(type, &sizeC, *io));
+}
+
+void FC_GLOBAL(adios2_io_engine_type_length_f2c,
+               ADIOS2_io_ENGINE_TYPE_LENGTH_F2C)(int *size,
+                                                 const adios2_io **io,
+                                                 int *ierr)
 {
     *size = -1;
     size_t sizeC;
-    *ierr = static_cast<int>(adios2_engine_type(engine_type, &sizeC, *io));
+    *ierr = static_cast<int>(adios2_engine_type(nullptr, &sizeC, *io));
     if (*ierr == static_cast<int>(adios2_error_none))
     {
         *size = static_cast<int>(sizeC);

--- a/bindings/Fortran/f2c/adios2_f2c_operator.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_operator.cpp
@@ -15,12 +15,21 @@ extern "C" {
 #endif
 
 void FC_GLOBAL(adios2_operator_type_f2c,
-               ADIOS2_OPERATOR_TYPE_F2C)(const adios2_operator **op,
-                                         char type[1024], int *size, int *ierr)
+               ADIOS2_OPERATOR_TYPE_F2C)(char *type,
+                                         const adios2_operator **op,
+                                         int *ierr)
+{
+    size_t sizeC;
+    *ierr = static_cast<int>(adios2_operator_type(type, &sizeC, *op));
+}
+
+void FC_GLOBAL(adios2_operator_type_length_f2c,
+               ADIOS2_OPERATOR_TYPE_LENGTH_F2C)(
+    int *size, const adios2_operator **op, int *ierr)
 {
     *size = -1;
     size_t sizeC;
-    *ierr = static_cast<int>(adios2_operator_type(type, &sizeC, *op));
+    *ierr = static_cast<int>(adios2_operator_type(nullptr, &sizeC, *op));
     if (*ierr == static_cast<int>(adios2_error_none))
     {
         *size = static_cast<int>(sizeC);

--- a/bindings/Fortran/f2c/adios2_f2c_operator.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_operator.cpp
@@ -15,8 +15,7 @@ extern "C" {
 #endif
 
 void FC_GLOBAL(adios2_operator_type_f2c,
-               ADIOS2_OPERATOR_TYPE_F2C)(char *type,
-                                         const adios2_operator **op,
+               ADIOS2_OPERATOR_TYPE_F2C)(char *type, const adios2_operator **op,
                                          int *ierr)
 {
     size_t sizeC;
@@ -24,8 +23,9 @@ void FC_GLOBAL(adios2_operator_type_f2c,
 }
 
 void FC_GLOBAL(adios2_operator_type_length_f2c,
-               ADIOS2_OPERATOR_TYPE_LENGTH_F2C)(
-    int *size, const adios2_operator **op, int *ierr)
+               ADIOS2_OPERATOR_TYPE_LENGTH_F2C)(int *size,
+                                                const adios2_operator **op,
+                                                int *ierr)
 {
     *size = -1;
     size_t sizeC;

--- a/bindings/Fortran/f2c/adios2_f2c_variable.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_variable.cpp
@@ -17,13 +17,21 @@ extern "C" {
 #endif
 
 void FC_GLOBAL(adios2_variable_name_f2c,
-               ADIOS2_VARIABLE_NAME_F2C)(char name[4096], int *size,
+               ADIOS2_VARIABLE_NAME_F2C)(char *name,
                                          const adios2_variable **variable,
                                          int *ierr)
 {
-    *size = -1;
     size_t sizeC;
     *ierr = static_cast<int>(adios2_variable_name(name, &sizeC, *variable));
+}
+
+void FC_GLOBAL(adios2_variable_name_length_f2c,
+               ADIOS2_VARIABLE_NAME_LENGTH_F2C)(
+    int *size, const adios2_variable **variable, int *ierr)
+{
+    *size = -1;
+    size_t sizeC;
+    *ierr = static_cast<int>(adios2_variable_name(nullptr, &sizeC, *variable));
     if (*ierr == static_cast<int>(adios2_error_none))
     {
         *size = static_cast<int>(sizeC);

--- a/bindings/Fortran/modules/adios2_adios_mod.f90
+++ b/bindings/Fortran/modules/adios2_adios_mod.f90
@@ -78,7 +78,6 @@ contains
         character*(*), intent(in)  :: op_name
         integer, intent(out) :: ierr
         !local
-        character(len=1024) :: c_type
         integer :: length
 
         call adios2_inquire_operator_f2c(op%f2c, adios%f2c, &
@@ -87,8 +86,11 @@ contains
         if(ierr == adios2_found) then
             op%valid = .true.
             op%name = op_name
-            call adios2_operator_type_f2c(op%f2c, c_type, length, ierr)
-            op%type = TRIM(ADJUSTL(c_type))
+
+            call adios2_operator_type_length_f2c(length, op%f2c, ierr)
+            if (length > 64) stop 'adios2_inquire_operator: operator_type too long!'
+            call adios2_operator_type_f2c(op%type, op%f2c, ierr)
+            op%type = op%type(1:length)
         else
             op%valid = .false.
             op%name = ''

--- a/bindings/Fortran/modules/adios2_adios_mod.f90
+++ b/bindings/Fortran/modules/adios2_adios_mod.f90
@@ -26,8 +26,10 @@ contains
                                    TRIM(ADJUSTL(io_name))//char(0), ierr)
         if( ierr == 0 ) then
             io%valid = .true.
-            call adios2_io_engine_type_f2c(io%f2c, io%engine_type, length, ierr)
-            io%engine_type = trim(io%engine_type(1:length))
+            call adios2_io_engine_type_length_f2c(length, io%f2c, ierr)
+            if (length > 15) stop 'adios2_declare_io: engine_type too long!'
+            call adios2_io_engine_type_f2c(io%engine_type, io%f2c, ierr)
+            io%engine_type = io%engine_type(1:length)
         end if
 
     end subroutine
@@ -44,8 +46,10 @@ contains
                               TRIM(ADJUSTL(io_name))//char(0), ierr)
         if( ierr == 0 ) then
             io%valid = .true.
-            call adios2_io_engine_type_f2c(io%f2c, io%engine_type, length, ierr)
-            io%engine_type = trim(io%engine_type(1:length))
+            call adios2_io_engine_type_length_f2c(length, io%f2c, ierr)
+            if (length > 15) stop 'adios2_at_io: engine_type too long!'
+            call adios2_io_engine_type_f2c(io%engine_type, io%f2c, ierr)
+            io%engine_type = io%engine_type(1:length)
         end if
 
     end subroutine

--- a/bindings/Fortran/modules/adios2_attribute_mod.f90
+++ b/bindings/Fortran/modules/adios2_attribute_mod.f90
@@ -14,6 +14,24 @@ module adios2_attribute_mod
 
     contains
 
+    subroutine adios2_attribute_name(name, attribute, ierr)
+        character(len=:), allocatable, intent(out) :: name
+        type(adios2_attribute), intent(in) :: attribute
+        integer, intent(out) :: ierr
+
+        !local
+        integer :: length
+
+        call adios2_attribute_name_length_f2c(length, attribute%f2c, ierr)
+
+        if (allocated(name)) deallocate (name)
+        if (length > 0) then
+            allocate (character(length) :: name)
+            call adios2_attribute_name_f2c(name, attribute%f2c, ierr)
+        end if
+
+    end subroutine
+
     subroutine adios2_attribute_check_type(attribute, adios2_type, hint, ierr)
         type(adios2_attribute), intent(in):: attribute
         integer, intent(in):: adios2_type

--- a/bindings/Fortran/modules/adios2_functions_mod.f90
+++ b/bindings/Fortran/modules/adios2_functions_mod.f90
@@ -25,19 +25,6 @@ contains
 
     end function
 
-    subroutine adios2_StringC2F(c_string, length, f_string)
-        character*(*), intent(in) :: c_string
-        integer, intent(in) :: length
-        character(len=:), allocatable, intent(out) :: f_string
-
-        if (allocated(f_string)) deallocate (f_string)
-        if (length > 0) then
-            allocate (character(length) :: f_string)
-            f_string = c_string(1:length)
-        end if
-
-    end subroutine
-
     subroutine adios2_TypeC2F(c_type, f_type)
         integer, intent(in) :: c_type
         integer, intent(out) :: f_type

--- a/bindings/Fortran/modules/adios2_io_mod.f90
+++ b/bindings/Fortran/modules/adios2_io_mod.f90
@@ -17,6 +17,24 @@ module adios2_io_mod
 
 contains
 
+    subroutine adios2_io_engine_type(type, io, ierr)
+        character(len=:), allocatable, intent(out) :: type
+        type(adios2_io), intent(in) :: io
+        integer, intent(out) :: ierr
+
+        !local
+        integer :: length
+
+        call adios2_io_engine_type_length_f2c(length, io%f2c, ierr)
+
+        if (allocated(type)) deallocate (type)
+        if (length > 0) then
+            allocate (character(length) :: type)
+            call adios2_io_engine_type_f2c(type, io%f2c, ierr)
+        end if
+
+    end subroutine
+
     subroutine adios2_set_engine(io, engine_type, ierr)
         type(adios2_io), intent(inout) :: io
         character*(*), intent(in) :: engine_type

--- a/bindings/Fortran/modules/adios2_operator_mod.f90
+++ b/bindings/Fortran/modules/adios2_operator_mod.f90
@@ -1,0 +1,35 @@
+!
+! Distributed under the OSI-approved Apache License, Version 2.0.  See
+!  accompanying file Copyright.txt for details.
+!
+!  adios2_operator_mod.f90 : ADIOS2 Fortran bindings for Operator class
+!
+!   Created on: Feb 6, 2019
+!       Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+!
+
+module adios2_operator_mod
+    use adios2_parameters_mod
+    implicit none
+
+contains
+
+    subroutine adios2_operator_type(type, op, ierr)
+        character(len=:), allocatable, intent(out) :: type
+        type(adios2_operator), intent(in) :: op
+        integer, intent(out) :: ierr
+
+        !local
+        integer :: length
+
+        call adios2_operator_type_length_f2c(length, op%f2c, ierr)
+
+        if (allocated(type)) deallocate (type)
+        if (length > 0) then
+            allocate (character(length) :: type)
+            call adios2_operator_type_f2c(type, op%f2c, ierr)
+        end if
+
+    end subroutine
+
+end module

--- a/bindings/Fortran/modules/adios2_variable_mod.f90
+++ b/bindings/Fortran/modules/adios2_variable_mod.f90
@@ -20,11 +20,15 @@ contains
         integer, intent(out) :: ierr
 
         !local
-        character(len=4096) :: c_name
         integer :: length
 
-        call adios2_variable_name_f2c(c_name, length, variable%f2c, ierr)
-        call adios2_StringC2F(c_name, length, name)
+        call adios2_variable_name_length_f2c(length, variable%f2c, ierr)
+
+        if (allocated(name)) deallocate (name)
+        if (length > 0) then
+            allocate (character(length) :: name)
+            call adios2_variable_name_f2c(name, variable%f2c, ierr)
+        end if
 
     end subroutine
 

--- a/testing/adios2/bindings/fortran/TestBPWriteReadAttributes.f90
+++ b/testing/adios2/bindings/fortran/TestBPWriteReadAttributes.f90
@@ -10,6 +10,7 @@ program TestBPWriteAttributes
     type(adios2_attribute), dimension(14) :: attributes, attributes_in
 
     integer :: ierr, i
+    character(len=:), allocatable :: attrName
     character(len=23):: iString_value
     integer(kind=1):: i8_value
     integer(kind=2):: i16_value
@@ -88,6 +89,11 @@ program TestBPWriteAttributes
     do i=1,14
         if( attributes(i)%valid .eqv. .false. ) stop 'Invalid adios2_define_attribute'
     end do
+     
+    ! Testing adios2_attribute_name for just one case
+    call adios2_attribute_name(attrName, attributes(1), ierr)
+    if (attrName /= 'att_String') stop 'Invalid adios2_attribute_name'
+    deallocate(attrName)
 
     call adios2_open(bpWriter, ioWrite, "fattr_types.bp", adios2_mode_write, &
                      ierr)

--- a/testing/adios2/bindings/fortran/TestBPWriteTypes.f90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypes.f90
@@ -12,6 +12,7 @@
      type(adios2_variable), dimension(13) :: variables
      type(adios2_engine) :: bpWriter, bpReader
      character(len=15) :: inString
+     character(len=:), allocatable :: varName
 
      ! read handlers
      integer :: ndims
@@ -110,6 +111,15 @@
      do i=1,13
         if( variables(i)%valid .eqv. .false. ) stop 'Invalid adios2_define_variable'
      end do
+
+     ! Testing adios2_variable_name for just two cases
+     call adios2_variable_name(varName, variables(1), ierr)
+     if (varName /= 'var_I8') stop 'Invalid adios2_variable_name'
+
+     call adios2_variable_name(varName, variables(2), ierr)
+     if (varName /= 'var_I16') stop 'Invalid adios2_variable_name'
+
+     deallocate(varName)
 
      ! Open myVector_f.bp in write mode, this launches an engine
      if( ioWrite%valid .eqv. .false. ) stop 'Invalid adios2_io'

--- a/testing/adios2/bindings/fortran/TestBPWriteTypes.f90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypes.f90
@@ -13,6 +13,7 @@
      type(adios2_engine) :: bpWriter, bpReader
      character(len=15) :: inString
      character(len=:), allocatable :: varName
+     character(len=:), allocatable :: engineType
 
      ! read handlers
      integer :: ndims
@@ -133,6 +134,11 @@
      if( TRIM(bpWriter%type) /= 'bpfile') then
         write(*,*) 'Engine Type ', TRIM(bpWriter%type)
         stop 'Invalid adios2_engine name'
+     end if
+     call adios2_io_engine_type(engineType, ioWrite, ierr)
+     if( engineType /= 'bp') then ! FIXME, different from the above!
+        write(*,*) 'Engine Type ', engineType
+        stop 'Invalid type from adios2_engine_type'
      end if
 
      if( bpWriter%mode /= adios2_mode_write) stop 'Invalid adios2_engine mode'


### PR DESCRIPTION
This PR demonstrates how strings can now be safely passed through to the Fortran API. (Though the implementation is not exactly pretty. But it's that's at least not visible on the interface side.)

#### Background

There are right now 6 function in the C API that "return" strings (ie, copy them into preallocated buffers).
* `adios2_variable_name`
* `adios2_attribute_name`
* `adios2_engine_type`
* `adios2_operator_type`
* `adios2_variable_type_string`
* `adios2_attribute_type_string`

Only the very first one is actually interfaced into Fortran right now, but wasn't tested. 
For the next 3, part of the Fortran API implementation exist, but it is not complete.
For the final 2, there is no trace of them in the Fortran API binding.

[Off-topic here, but I think the last 2 functions should be deleted from the C API. They're not used anywhere, and duplicate functionality which is already there (`adios2_{variable,attribute}_type` returning the adios2_type enum, which is otherwise used throughout the C API.) The only possible value of this functions would be for debugging, but they're really too cumbersome to use to produce quick human readable output.]

#### Changes

This PR does
* not change any APIs
* avoids the fixed size buffer used in interfacing `adios_variable_type`, and avoids one copy. (One copy remain, copying the string into the Fortran `character` string.) It is safe for any size string.
* adds a test for `adios_variable_type` used from Fortran.

I can do the same thing for the other 3 functions, which are currently missing from the Fortran API, if people agree with this approach.

The implementation is not pretty, because two calls have to be made into C to (1) get the string length; then the buffer is allocated and (2) the string is copied. (For what it's worth: Yes, I had two use two C functions to support this interface, but it's internal. Even if the C API had a separate `_length` function, I'd still need those two wrappers, anyway.)

One way to avoid having two layers of glue code (one on the Fortran side, one on the C side) in the Fortran bindings in general would be to use `ISO_C_BINDING`. I believe it's available since Fortran2003. It would simplify the code, though otherwise not really make a difference. BTW, that one provides `C_NULLPTR` or something like that.




