### PR TITLE
Python cleanup

### DIFF
--- a/bindings/Python/py11ADIOS.cpp
+++ b/bindings/Python/py11ADIOS.cpp
@@ -18,14 +18,14 @@ namespace py11
 {
 
 #ifdef ADIOS2_HAVE_MPI
-ADIOS::ADIOS(const std::string &configFile, MPI_Comm mpiComm,
+ADIOS::ADIOS(const std::string &configFile, MPI4PY_Comm mpiComm,
              const bool debugMode)
 : m_ADIOS(std::make_shared<adios2::core::ADIOS>(configFile, mpiComm, debugMode,
                                                 "Python"))
 {
 }
 
-ADIOS::ADIOS(MPI_Comm mpiComm, const bool debugMode)
+ADIOS::ADIOS(MPI4PY_Comm mpiComm, const bool debugMode)
 : ADIOS("", mpiComm, debugMode)
 {
 }

--- a/bindings/Python/py11ADIOS.h
+++ b/bindings/Python/py11ADIOS.h
@@ -30,9 +30,9 @@ class ADIOS
 
 public:
 #ifdef ADIOS2_HAVE_MPI
-    ADIOS(const std::string &configFile, MPI_Comm comm,
+    ADIOS(const std::string &configFile, MPI4PY_Comm comm,
           const bool debugMode = true);
-    ADIOS(MPI_Comm comm, const bool debugMode = true);
+    ADIOS(MPI4PY_Comm comm, const bool debugMode = true);
 #else
     ADIOS(const std::string &configFile, const bool debugMode = true);
     ADIOS(const bool debugMode);

--- a/bindings/Python/py11IO.cpp
+++ b/bindings/Python/py11IO.cpp
@@ -247,20 +247,12 @@ Engine IO::Open(const std::string &name, const int mode)
 }
 
 #ifdef ADIOS2_HAVE_MPI
-Engine IO::Open(const std::string &name, const int mode, pybind11::object &comm)
+Engine IO::Open(const std::string &name, const int mode, MPI4PY_Comm comm)
 {
-    if (import_mpi4py() < 0)
-    {
-        throw std::runtime_error("ERROR: could not import mpi4py "
-                                 "communicator\n");
-    }
-
     helper::CheckForNullptr(m_IO,
                             "for engine " + name + ", in call to IO::Open");
 
-    MPI_Comm *mpiCommPtr = PyMPIComm_Get(comm.ptr());
-    return Engine(
-        &m_IO->Open(name, static_cast<adios2::Mode>(mode), *mpiCommPtr));
+    return Engine(&m_IO->Open(name, static_cast<adios2::Mode>(mode), comm));
 }
 #endif
 

--- a/bindings/Python/py11IO.h
+++ b/bindings/Python/py11IO.h
@@ -18,6 +18,7 @@
 #include "py11Attribute.h"
 #include "py11Engine.h"
 #include "py11Variable.h"
+#include "py11types.h"
 
 namespace adios2
 {
@@ -87,8 +88,7 @@ public:
     Engine Open(const std::string &name, const int openMode);
 
 #ifdef ADIOS2_HAVE_MPI
-    Engine Open(const std::string &name, const int openMode,
-                pybind11::object &comm);
+    Engine Open(const std::string &name, const int openMode, MPI4PY_Comm comm);
 #endif
 
     void FlushAll();

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -72,85 +72,31 @@ public:
 #ifdef ADIOS2_HAVE_MPI
 
 adios2::py11::ADIOS ADIOSInitConfig(const std::string &configFile,
-                                    pybind11::object &comm,
+                                    const adios2::py11::MPI4PY_Comm comm,
                                     const bool debugMode)
 {
-    MPI_Comm *mpiCommPtr = PyMPIComm_Get(comm.ptr());
-
-    if (import_mpi4py() < 0)
-    {
-        throw std::runtime_error("ERROR: could not import mpi4py "
-                                 "communicator, in call to ADIOS "
-                                 "constructor\n");
-    }
-
-    if (mpiCommPtr == nullptr)
-    {
-        throw std::runtime_error("ERROR: mpi4py communicator is null, in call "
-                                 "to ADIOS constructor\n");
-    }
-    return adios2::py11::ADIOS(configFile, *mpiCommPtr, debugMode);
+    return adios2::py11::ADIOS(configFile, comm, debugMode);
 }
 
-adios2::py11::ADIOS ADIOSInit(pybind11::object &comm, const bool debugMode)
+adios2::py11::ADIOS ADIOSInit(adios2::py11::MPI4PY_Comm comm,
+                              const bool debugMode)
 {
-    MPI_Comm *mpiCommPtr = PyMPIComm_Get(comm.ptr());
-
-    if (import_mpi4py() < 0)
-    {
-        throw std::runtime_error("ERROR: could not import mpi4py "
-                                 "communicator, in call to ADIOS "
-                                 "constructor\n");
-    }
-
-    if (mpiCommPtr == nullptr)
-    {
-        throw std::runtime_error("ERROR: mpi4py communicator is null, in call "
-                                 "to ADIOS constructor\n");
-    }
-    return adios2::py11::ADIOS(*mpiCommPtr, debugMode);
+    return adios2::py11::ADIOS(comm, debugMode);
 }
 
 adios2::py11::File Open(const std::string &name, const std::string mode,
-                        pybind11::object &comm, const std::string enginetype)
+                        adios2::py11::MPI4PY_Comm comm,
+                        const std::string enginetype)
 {
-    MPI_Comm *mpiCommPtr = PyMPIComm_Get(comm.ptr());
-
-    if (import_mpi4py() < 0)
-    {
-        throw std::runtime_error("ERROR: could not import mpi4py "
-                                 "communicator, in call to ADIOS "
-                                 "constructor\n");
-    }
-
-    if (mpiCommPtr == nullptr)
-    {
-        throw std::runtime_error("ERROR: mpi4py communicator is null, in call "
-                                 "to ADIOS constructor\n");
-    }
-    return adios2::py11::File(name, mode, *mpiCommPtr, enginetype);
+    return adios2::py11::File(name, mode, comm, enginetype);
 }
 
 adios2::py11::File OpenConfig(const std::string &name, const std::string mode,
-                              pybind11::object &comm,
+                              adios2::py11::MPI4PY_Comm comm,
                               const std::string &configfile,
                               const std::string ioinconfigfile)
 {
-    MPI_Comm *mpiCommPtr = PyMPIComm_Get(comm.ptr());
-
-    if (import_mpi4py() < 0)
-    {
-        throw std::runtime_error("ERROR: could not import mpi4py "
-                                 "communicator, in call to open\n");
-    }
-
-    if (mpiCommPtr == nullptr)
-    {
-        throw std::runtime_error("ERROR: mpi4py communicator is null, in call "
-                                 "to ADIOS constructor\n");
-    }
-    return adios2::py11::File(name, mode, *mpiCommPtr, configfile,
-                              ioinconfigfile);
+    return adios2::py11::File(name, mode, comm, configfile, ioinconfigfile);
 }
 
 #else
@@ -220,12 +166,12 @@ PYBIND11_MODULE(adios2, m)
 #ifdef ADIOS2_HAVE_MPI
     m.def("ADIOS", &ADIOSInit,
           "adios2 module starting point, creates an ADIOS class object",
-          pybind11::arg("object"), pybind11::arg("debugMode") = true);
+          pybind11::arg("comm"), pybind11::arg("debugMode") = true);
 
     m.def("ADIOS", &ADIOSInitConfig, "adios2 module starting point, creates an "
                                      "ADIOS class object including a runtime "
                                      "config file",
-          pybind11::arg("configFile") = "", pybind11::arg("object"),
+          pybind11::arg("configFile") = "", pybind11::arg("comm"),
           pybind11::arg("debugMode") = true);
 
     m.def("open", &Open, pybind11::arg("name"), pybind11::arg("mode"),

--- a/bindings/Python/py11types.h
+++ b/bindings/Python/py11types.h
@@ -11,12 +11,30 @@
 #ifndef ADIOS2_BINDINGS_PYTHON_PY11TYPES_H_
 #define ADIOS2_BINDINGS_PYTHON_PY11TYPES_H_
 
-#include <string>
+#include <adios2.h>
 
 namespace adios2
 {
 namespace py11
 {
+
+#ifdef ADIOS2_HAVE_MPI
+
+/**
+ * MPI4PY_Comm provides automatic conversion of Python mpi4py communicators to
+ * the C++ MPI4PY_Comm type, which in itself implicitly converts to a MPI_Comm.
+ *
+ * The actual work is done by the caster in py11glue.cpp
+ */
+struct MPI4PY_Comm
+{
+    MPI_Comm comm;
+
+    // allow implicit conversion to MPI_Comm
+    operator MPI_Comm() { return comm; }
+};
+
+#endif
 
 #define ADIOS2_FOREACH_PYTHON_TYPE_1ARG(MACRO)                                 \
     ADIOS2_FOREACH_STDTYPE_1ARG(MACRO)


### PR DESCRIPTION
Since I'm at it, let's dump on more PR here. This one is on top of #1247, so shouldn't be considered before that one has been worked out.

This PR adds a pybind11 caster to make passing MPI4PY communicators much simpler. It also converts
`ADIOS` back into an actual Python object, rather than a fake-constructor that returns a `py11_ADIOS` object.