### PR TITLE
tell codacy / bandit to accept assert in python

### DIFF
--- a/bandit.yml
+++ b/bandit.yml
@@ -1,0 +1,2 @@
+# tell codacy / bandit to accept assert in python
+skips: ['B101']


### PR DESCRIPTION
This is subject to the outcome of the discussion in #1248 -- me being curious to see whether this actually works to make the otherwise failing `master` branch pass checks.