### PR TITLE
Fixes #1253 (master broken with Endian_Reverse)

### DIFF
--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -38,7 +38,7 @@ void CopyPayloadStride(const char *src, const size_t payloadStride, char *dest,
         CopyEndianReverse<T>(src, payloadStride, reinterpret_cast<T *>(dest)); \
     }
 
-        ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_type)
+        ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
 #undef declare_type
     }
     else
@@ -285,6 +285,11 @@ void CopyPayload(char *dest, const Dims &destStart, const Dims &destCount,
                         srcMemCount, endianReverse, destType);
     }
 }
+
+#ifdef ADIOS2_HAVE_ENDIAN_REVERSE
+template void CopyEndianReverse(const char *src, const size_t payloadStride,
+                                char *dest);
+#endif
 
 } // end namespace helper
 } // end namespace adios2


### PR DESCRIPTION
CopyPayloadStride was using ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG, which
includes non-stdint types like char, for which GetType<> isn't
specialized anymore.

Fixing that to use ADIOS2_FOREACH_PRIMITIVE_STDTYPE then kinda exposes
another bug, ie., ~~some functions in adiosMemory.inl aren't actually
declared inline and relied on being instantiated through their use
in CopyPayloadStride~~. I added an explicit instantiation for
CopyEndianReverse which makes everything work for me, but that's not
really a clean fix.