### PR TITLE
rename adios2_engine_type -> adios2_io_engine_type

### DIFF
--- a/bindings/C/c/adios2_c_io.cpp
+++ b/bindings/C/c/adios2_c_io.cpp
@@ -693,8 +693,8 @@ adios2_error adios2_flush_all_engines(adios2_io *io)
     }
 }
 
-adios2_error adios2_engine_type(char *engine_type, size_t *size,
-                                const adios2_io *io)
+adios2_error adios2_io_engine_type(char *engine_type, size_t *size,
+                                   const adios2_io *io)
 {
     try
     {
@@ -711,7 +711,7 @@ adios2_error adios2_engine_type(char *engine_type, size_t *size,
     catch (...)
     {
         return static_cast<adios2_error>(
-            adios2::helper::ExceptionToError("adios2_engine_type"));
+            adios2::helper::ExceptionToError("adios2_io_engine_type"));
     }
 }
 
@@ -727,7 +727,7 @@ adios2_error adios2_lock_definitions(adios2_io *io)
     catch (...)
     {
         return static_cast<adios2_error>(
-            adios2::helper::ExceptionToError("adios2_engine_type"));
+            adios2::helper::ExceptionToError("adios2_lock_definitions"));
     }
 }
 

--- a/bindings/C/c/adios2_c_io.h
+++ b/bindings/C/c/adios2_c_io.h
@@ -291,8 +291,8 @@ adios2_error adios2_flush_all_engines(adios2_io *io);
  * @param io handler
  * @return adios2_error 0: success, see enum adios2_error for errors
  */
-adios2_error adios2_engine_type(char *engine_type, size_t *size,
-                                const adios2_io *io);
+adios2_error adios2_io_engine_type(char *engine_type, size_t *size,
+                                   const adios2_io *io);
 
 /**
  * Promise that no more definitions or changes to defined variables will

--- a/bindings/Fortran/f2c/adios2_f2c_io.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_io.cpp
@@ -338,7 +338,7 @@ void FC_GLOBAL(adios2_io_engine_type_f2c,
 {
     *size = -1;
     size_t sizeC;
-    *ierr = static_cast<int>(adios2_engine_type(engine_type, &sizeC, *io));
+    *ierr = static_cast<int>(adios2_io_engine_type(engine_type, &sizeC, *io));
     if (*ierr == static_cast<int>(adios2_error_none))
     {
         *size = static_cast<int>(sizeC);

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -336,9 +336,9 @@ TEST(ADIOS2_C_API, ReturnedStrings)
 
         // now test the APIs that return strings
         size_t engine_type_size;
-        adios2_engine_type(NULL, &engine_type_size, ioH);
+        adios2_io_engine_type(NULL, &engine_type_size, ioH);
         char *engine_type = (char *)malloc(engine_type_size + 1);
-        adios2_engine_type(engine_type, &engine_type_size, ioH);
+        adios2_io_engine_type(engine_type, &engine_type_size, ioH);
         engine_type[engine_type_size] = '\0';
 
         size_t var_name_size;


### PR DESCRIPTION
This is an API change (in the C bindings), but I believe `adios2_engine_type` right now is exclusively used by the Fortran bindings and one test (that I had added), so it's very unlikely that any external user is affected.

Its Fortran (f2c) version is already named that way, and it makes more sense,
since the function actually takes an adios2_io, not an adios2_engine.
This will allow to later add a adios2_engine_type function to the C
bindings that actually takes an adios2_engine (if needed). (The CXX11
interface already has Engine::Type(), which does not have an equivalent
 in the C or Fortran bindings).

I also changed the argument order to take the adios2_io first,
since most other adios2_io binding functions do so.