### PR TITLE
add some tests for C/CXX11 bindings for IO/Engine

### DIFF
--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -19,25 +19,29 @@
 
 #include "SmallTestData_c.h"
 
-class BPWriteTypesCC : public ::testing::Test
+class ADIOS2_C_API : public ::testing::Test
 {
 public:
-    BPWriteTypesCC() = default;
-};
+    ADIOS2_C_API()
+    {
+#ifdef ADIOS2_HAVE_MPI
+        adiosH = adios2_init(MPI_COMM_WORLD, adios2_debug_mode_on);
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &size);
+#else
+        adiosH = adios2_init(adios2_debug_mode_on);
+#endif
+    }
 
-TEST_F(BPWriteTypesCC, ADIOS2BPWriteTypes)
-{
+    ~ADIOS2_C_API() { adios2_finalize(adiosH); }
+
+    adios2_adios *adiosH;
     int rank = 0;
     int size = 1;
+};
 
-#ifdef ADIOS2_HAVE_MPI
-    adios2_adios *adiosH = adios2_init(MPI_COMM_WORLD, adios2_debug_mode_on);
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
-#else
-    adios2_adios *adiosH = adios2_init(adios2_debug_mode_on);
-#endif
-
+TEST_F(ADIOS2_C_API, ADIOS2BPWriteTypes)
+{
     // write
     {
         // IO
@@ -300,11 +304,9 @@ TEST_F(BPWriteTypesCC, ADIOS2BPWriteTypes)
 
         delete[] dataArray;
     }
-    // deallocate adiosH
-    adios2_finalize(adiosH);
 }
 
-TEST(ADIOS2_C_API, ReturnedStrings)
+TEST_F(ADIOS2_C_API, ReturnedStrings)
 {
 #ifdef ADIOS2_HAVE_MPI
     adios2_adios *adiosH = adios2_init(MPI_COMM_WORLD, adios2_debug_mode_on);

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -306,18 +306,17 @@ TEST_F(ADIOS2_C_API, ADIOS2BPWriteTypes)
     }
 }
 
-TEST_F(ADIOS2_C_API, ReturnedStrings)
+class ADIOS2_C_API_IO : public ADIOS2_C_API
 {
-#ifdef ADIOS2_HAVE_MPI
-    adios2_adios *adiosH = adios2_init(MPI_COMM_WORLD, adios2_debug_mode_on);
-#else
-    adios2_adios *adiosH = adios2_init(adios2_debug_mode_on);
-#endif
+public:
+    ADIOS2_C_API_IO() { ioH = adios2_declare_io(adiosH, "C_API_TestIO"); }
 
+    adios2_io *ioH;
+};
+
+TEST_F(ADIOS2_C_API_IO, ReturnedStrings)
+{
     {
-        // IO
-        adios2_io *ioH = adios2_declare_io(adiosH, "C_API_TestIO");
-
         // create some objects
         adios2_set_engine(ioH, "BP3");
 

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -314,6 +314,30 @@ public:
     adios2_io *ioH;
 };
 
+TEST_F(ADIOS2_C_API_IO, Engine)
+{
+    int ierr;
+
+    ierr = adios2_set_engine(ioH, "bpfile");
+    EXPECT_EQ(ierr, 0);
+
+    size_t engine_type_size;
+    ierr = adios2_engine_type(NULL, &engine_type_size, ioH);
+    EXPECT_EQ(ierr, 0);
+    char *engine_type = (char *)malloc(engine_type_size + 1);
+    ierr = adios2_engine_type(engine_type, &engine_type_size, ioH);
+    EXPECT_EQ(ierr, 0);
+    engine_type[engine_type_size] = '\0';
+
+    EXPECT_EQ(std::string(engine_type), "bpfile");
+    free(engine_type);
+
+    adios2_engine *engineH = adios2_open(ioH, "ctypes.bp", adios2_mode_write);
+
+    // FIXME, I'd like to check that the engine type is correct, but there's no
+    // API for it
+}
+
 TEST_F(ADIOS2_C_API_IO, ReturnedStrings)
 {
     // create some objects

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -316,68 +316,68 @@ public:
 
 TEST_F(ADIOS2_C_API_IO, ReturnedStrings)
 {
-    {
-        // create some objects
-        adios2_set_engine(ioH, "BP3");
+    // create some objects
+    adios2_set_engine(ioH, "BP3");
 
-        size_t shape[1] = {2};
-        size_t start[1] = {0};
-        size_t count[1] = {2};
-        adios2_variable *var =
-            adios2_define_variable(ioH, "varI8", adios2_type_int8_t, 1, shape,
-                                   start, count, adios2_constant_dims_true);
+    size_t shape[1] = {2};
+    size_t start[1] = {0};
+    size_t count[1] = {2};
+    adios2_variable *var =
+        adios2_define_variable(ioH, "varI8", adios2_type_int8_t, 1, shape,
+                               start, count, adios2_constant_dims_true);
 
-        int32_t value = 99;
-        adios2_attribute *attr = adios2_define_attribute(
-            ioH, "intAttr", adios2_type_int32_t, &value);
-
-#ifdef ADIOS2_HAVE_BZIP2
-        adios2_operator *op = adios2_define_operator(adiosH, "testOp", "bzip2");
-#endif
-
-        // now test the APIs that return strings
-        size_t engine_type_size;
-        adios2_engine_type(NULL, &engine_type_size, ioH);
-        char *engine_type = (char *)malloc(engine_type_size + 1);
-        adios2_engine_type(engine_type, &engine_type_size, ioH);
-        engine_type[engine_type_size] = '\0';
-
-        size_t var_name_size;
-        adios2_variable_name(NULL, &var_name_size, var);
-        char *var_name = (char *)malloc(var_name_size + 1);
-        adios2_variable_name(var_name, &var_name_size, var);
-        var_name[var_name_size] = '\0';
-
-        size_t attr_name_size;
-        adios2_attribute_name(NULL, &attr_name_size, attr);
-        char *attr_name = (char *)malloc(attr_name_size + 1);
-        adios2_attribute_name(attr_name, &attr_name_size, attr);
-        attr_name[attr_name_size] = '\0';
+    int32_t value = 99;
+    adios2_attribute *attr =
+        adios2_define_attribute(ioH, "intAttr", adios2_type_int32_t, &value);
 
 #ifdef ADIOS2_HAVE_BZIP2
-        size_t op_type_size;
-        adios2_operator_type(NULL, &op_type_size, op);
-        char *op_type = (char *)malloc(op_type_size + 1);
-        adios2_operator_type(op_type, &op_type_size, op);
-        op_type[op_type_size] = '\0';
+    adios2_operator *op = adios2_define_operator(adiosH, "testOp", "bzip2");
 #endif
 
-        adios2_remove_all_ios(adiosH);
+    // now test the APIs that return strings
+    size_t engine_type_size;
+    adios2_engine_type(NULL, &engine_type_size, ioH);
+    char *engine_type = (char *)malloc(engine_type_size + 1);
+    adios2_engine_type(engine_type, &engine_type_size, ioH);
+    engine_type[engine_type_size] = '\0';
 
-        EXPECT_EQ(std::string(engine_type), "BP3");
-        EXPECT_EQ(std::string(var_name), "varI8");
-        EXPECT_EQ(std::string(attr_name), "intAttr");
+    size_t var_name_size;
+    adios2_variable_name(NULL, &var_name_size, var);
+    char *var_name = (char *)malloc(var_name_size + 1);
+    adios2_variable_name(var_name, &var_name_size, var);
+    var_name[var_name_size] = '\0';
+
+    size_t attr_name_size;
+    adios2_attribute_name(NULL, &attr_name_size, attr);
+    char *attr_name = (char *)malloc(attr_name_size + 1);
+    adios2_attribute_name(attr_name, &attr_name_size, attr);
+    attr_name[attr_name_size] = '\0';
+
 #ifdef ADIOS2_HAVE_BZIP2
-        EXPECT_EQ(std::string(op_type), "bzip2");
+    size_t op_type_size;
+    adios2_operator_type(NULL, &op_type_size, op);
+    char *op_type = (char *)malloc(op_type_size + 1);
+    adios2_operator_type(op_type, &op_type_size, op);
+    op_type[op_type_size] = '\0';
 #endif
 
-        free(engine_type);
-        free(var_name);
-        free(attr_name);
+    // remove all IOs here to specifically check that the strings
+    // are still accessible (which is kinda obvious)
+    adios2_remove_all_ios(adiosH);
+
+    EXPECT_EQ(std::string(engine_type), "BP3");
+    EXPECT_EQ(std::string(var_name), "varI8");
+    EXPECT_EQ(std::string(attr_name), "intAttr");
 #ifdef ADIOS2_HAVE_BZIP2
-        free(op_type);
+    EXPECT_EQ(std::string(op_type), "bzip2");
 #endif
-    }
+
+    free(engine_type);
+    free(var_name);
+    free(attr_name);
+#ifdef ADIOS2_HAVE_BZIP2
+    free(op_type);
+#endif
 }
 
 //******************************************************************************

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -350,8 +350,13 @@ TEST_F(ADIOS2_C_API_IO, Engine)
 
     adios2_engine *engineH = adios2_open(ioH, "ctypes.bp", adios2_mode_write);
 
-    // FIXME, I'd like to check that the engine type is correct, but there's no
-    // API for it
+    // FIXME, I'd like to check that the engine type itself is correct, but
+    // there's no API to get it
+    // FIXME, I'd like to check the engine's name, but there's no API to get it
+
+    engine_type = testing::adios2_engine_type_as_string(ioH);
+    EXPECT_EQ(engine_type, "bp"); // FIXME? Is it expected that adios2_open
+                                  // changes the engine_type string?
 }
 
 TEST_F(ADIOS2_C_API_IO, ReturnedStrings)

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -348,7 +348,8 @@ TEST_F(ADIOS2_C_API_IO, Engine)
     std::string engine_type = testing::adios2_engine_type_as_string(ioH);
     EXPECT_EQ(engine_type, "bpfile");
 
-    adios2_engine *engineH = adios2_open(ioH, "ctypes.bp", adios2_mode_write);
+    /*adios2_engine *engineH =*/adios2_open(ioH, "ctypes.bp",
+                                            adios2_mode_write);
 
     // FIXME, I'd like to check that the engine type itself is correct, but
     // there's no API to get it

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -22,6 +22,48 @@ TEST(ADIOSInterface, MPICommRemoved)
 
 #endif
 
+class ADIOS2_CXX11_API : public ::testing::Test
+{
+public:
+    ADIOS2_CXX11_API()
+#ifdef ADIOS2_HAVE_MPI
+    : ad(MPI_COMM_WORLD, adios2::DebugON)
+#else
+    : ad(adios2::DebugON)
+#endif
+    {
+#ifdef ADIOS2_HAVE_MPI
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &size);
+#endif
+    }
+
+    adios2::ADIOS ad;
+    int rank = 0;
+    int size = 1;
+};
+
+class ADIOS2_CXX11_API_IO : public ADIOS2_CXX11_API
+{
+public:
+    ADIOS2_CXX11_API_IO() : io(ad.DeclareIO("CXX11_API_TestIO")) {}
+
+    adios2::IO io;
+};
+
+TEST_F(ADIOS2_CXX11_API_IO, Engine)
+{
+    io.SetEngine("bpfile");
+    EXPECT_EQ(io.EngineType(), "bpfile");
+
+    adios2::Engine engine = io.Open("types.bp", adios2::Mode::Write);
+    EXPECT_EQ(engine.Name(), "types.bp");
+    EXPECT_EQ(engine.Type(), "BP3");
+
+    EXPECT_EQ(io.EngineType(), "bp"); // FIXME? Is it expected that adios2_open
+                                      // changes the engine_type string?
+}
+
 int main(int argc, char **argv)
 {
 #ifdef ADIOS2_HAVE_MPI


### PR DESCRIPTION
This tests IO::Open, Engine::Name, Engine::Type, IO::EngineType, using both CXX11 and C bindings.

The C bindings tests are somewhat incomplete, as two CXX11 functions are missing, so I left those out.

In the last two commits (so they can be dropped if needed), I added CXX11 and C API functions for `core::IO::GetEngine`, which allows to get a handle to an existing Engine by name. There's no chance anything gets broken because these are additions, but there is of course a valid question as to whether those are needed. I'm generally not much of a fan for recovering handles by name where one could have just saved the handle, but ADIOS2 generally allows to replace the name for a handle in many places, I suppose a a convenience in particular for people using the Fortran interface. If this gets merged, I'd follow up with a Fortran binding for GetEngine, which is really the main purpose of it all.

FWIW, the XGC code's interface with ADIOS2 (which I don't understand too well yet), maintains its own list of adios2_engines, parallel to the one that's kept in core::IO which arguably is a bit of a hassle.
