### PR TITLE
more testing of IO/Engine functionality and a fix for the Fortran bindings

### DIFF
--- a/bindings/C/c/adios2_c_engine.cpp
+++ b/bindings/C/c/adios2_c_engine.cpp
@@ -12,6 +12,7 @@
 
 #include "adios2/core/Engine.h"
 #include "adios2/helper/adiosFunctions.h" //GetType<T>
+#include "adios2_c_internal.h"
 
 namespace
 {
@@ -87,6 +88,28 @@ adios2_step_status ToStepStatus(const adios2::StepStatus statusCpp,
     return status;
 }
 } // end anonymous namespace
+
+adios2_error adios2_engine_name(char *name, size_t *size,
+                                const adios2_engine *engine)
+{
+    try
+    {
+        adios2::helper::CheckForNullptr(
+            engine, "for const adios2_engine, in call to adios2_engine_name");
+        adios2::helper::CheckForNullptr(
+            size, "for size_t* size, in call to adios2_engine_name");
+
+        const adios2::core::Engine *engineCpp =
+            reinterpret_cast<const adios2::core::Engine *>(engine);
+
+        return String2CAPI(engineCpp->m_Name, name, size);
+    }
+    catch (...)
+    {
+        return static_cast<adios2_error>(
+            adios2::helper::ExceptionToError("adios2_engine_name"));
+    }
+}
 
 adios2_error adios2_begin_step(adios2_engine *engine,
                                const adios2_step_mode mode,

--- a/bindings/C/c/adios2_c_engine.h
+++ b/bindings/C/c/adios2_c_engine.h
@@ -18,6 +18,21 @@ extern "C" {
 #endif
 
 /**
+ * Return engine name string and length without '\0\ character
+ * For safe use, call this function first with NULL name parameter
+ * to get the size, then preallocate the buffer (with room for '\0'
+ * if desired), then call the function again with the buffer.
+ * Then '\0' terminate it if desired.
+ * @param name output, string without trailing '\0', NULL or preallocated
+ * buffer
+ * @param size output, engine_type size without '\0'
+ * @param engine handler
+ * @return adios2_error 0: success, see enum adios2_error for errors
+ */
+adios2_error adios2_engine_name(char *name, size_t *size,
+                                const adios2_engine *engine);
+
+/**
  * @brief Begin a logical adios2 step stream
  * @param engine handler
  * @param mode see enum adios2_step_mode in adios2_c_types.h for options,

--- a/bindings/Fortran/modules/adios2_attribute_mod.f90
+++ b/bindings/Fortran/modules/adios2_attribute_mod.f90
@@ -22,10 +22,10 @@ module adios2_attribute_mod
         !local
         integer :: length
 
-        call adios2_attribute_name_length_f2c(length, attribute%f2c, ierr)
-
         if (allocated(name)) deallocate (name)
-        if (length > 0) then
+
+        call adios2_attribute_name_length_f2c(length, attribute%f2c, ierr)
+        if (ierr == 0) then
             allocate (character(length) :: name)
             call adios2_attribute_name_f2c(name, attribute%f2c, ierr)
         end if

--- a/bindings/Fortran/modules/adios2_io_mod.f90
+++ b/bindings/Fortran/modules/adios2_io_mod.f90
@@ -25,10 +25,10 @@ contains
         !local
         integer :: length
 
-        call adios2_io_engine_type_length_f2c(length, io%f2c, ierr)
-
         if (allocated(type)) deallocate (type)
-        if (length > 0) then
+
+        call adios2_io_engine_type_length_f2c(length, io%f2c, ierr)
+        if (ierr == 0) then
             allocate (character(length) :: type)
             call adios2_io_engine_type_f2c(type, io%f2c, ierr)
         end if

--- a/bindings/Fortran/modules/adios2_operator_mod.f90
+++ b/bindings/Fortran/modules/adios2_operator_mod.f90
@@ -22,10 +22,10 @@ contains
         !local
         integer :: length
 
-        call adios2_operator_type_length_f2c(length, op%f2c, ierr)
-
         if (allocated(type)) deallocate (type)
-        if (length > 0) then
+
+        call adios2_operator_type_length_f2c(length, op%f2c, ierr)
+        if (ierr == 0) then
             allocate (character(length) :: type)
             call adios2_operator_type_f2c(type, op%f2c, ierr)
         end if

--- a/bindings/Fortran/modules/adios2_variable_mod.f90
+++ b/bindings/Fortran/modules/adios2_variable_mod.f90
@@ -22,10 +22,10 @@ contains
         !local
         integer :: length
 
-        call adios2_variable_name_length_f2c(length, variable%f2c, ierr)
-
         if (allocated(name)) deallocate (name)
-        if (length > 0) then
+
+        call adios2_variable_name_length_f2c(length, variable%f2c, ierr)
+        if (ierr == 0) then
             allocate (character(length) :: name)
             call adios2_variable_name_f2c(name, variable%f2c, ierr)
         end if

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -360,6 +360,28 @@ TEST_F(ADIOS2_C_API_IO, Engine)
                                   // changes the engine_type string?
 }
 
+TEST_F(ADIOS2_C_API_IO, EngineDefault)
+{
+    int ierr;
+
+    ierr = adios2_set_engine(ioH, "");
+    EXPECT_EQ(ierr, 0);
+
+    std::string engine_type = testing::adios2_engine_type_as_string(ioH);
+    EXPECT_EQ(engine_type, "");
+
+    /*adios2_engine *engineH =*/adios2_open(ioH, "ctypes.bp",
+                                            adios2_mode_write);
+
+    // FIXME, I'd like to check that the engine type itself is correct, but
+    // there's no API to get it
+    // FIXME, I'd like to check the engine's name, but there's no API to get it
+
+    engine_type = testing::adios2_engine_type_as_string(ioH);
+    EXPECT_EQ(engine_type, "bp"); // FIXME? Is it expected that adios2_open
+                                  // changes the engine_type string?
+}
+
 TEST_F(ADIOS2_C_API_IO, ReturnedStrings)
 {
     // create some objects

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -336,6 +336,22 @@ std::string adios2_engine_type_as_string(adios2_io *ioH)
 
     return type;
 }
+
+std::string adios2_engine_name_as_string(adios2_engine *engineH)
+{
+    int ierr;
+    size_t engine_name_size;
+    ierr = adios2_engine_name(NULL, &engine_name_size, engineH);
+    EXPECT_EQ(ierr, 0);
+    char *engine_name = (char *)malloc(engine_name_size + 1);
+    ierr = adios2_engine_name(engine_name, &engine_name_size, engineH);
+    EXPECT_EQ(ierr, 0);
+    engine_name[engine_name_size] = '\0';
+    std::string name(engine_name);
+    free(engine_name);
+
+    return name;
+}
 }
 
 TEST_F(ADIOS2_C_API_IO, Engine)
@@ -348,12 +364,12 @@ TEST_F(ADIOS2_C_API_IO, Engine)
     std::string engine_type = testing::adios2_engine_type_as_string(ioH);
     EXPECT_EQ(engine_type, "bpfile");
 
-    /*adios2_engine *engineH =*/adios2_open(ioH, "ctypes.bp",
-                                            adios2_mode_write);
+    adios2_engine *engineH = adios2_open(ioH, "ctypes.bp", adios2_mode_write);
 
     // FIXME, I'd like to check that the engine type itself is correct, but
     // there's no API to get it
-    // FIXME, I'd like to check the engine's name, but there's no API to get it
+    std::string engine_name = testing::adios2_engine_name_as_string(engineH);
+    EXPECT_EQ(engine_name, "ctypes.bp");
 
     engine_type = testing::adios2_engine_type_as_string(ioH);
     EXPECT_EQ(engine_type, "bp"); // FIXME? Is it expected that adios2_open
@@ -370,12 +386,12 @@ TEST_F(ADIOS2_C_API_IO, EngineDefault)
     std::string engine_type = testing::adios2_engine_type_as_string(ioH);
     EXPECT_EQ(engine_type, "");
 
-    /*adios2_engine *engineH =*/adios2_open(ioH, "ctypes.bp",
-                                            adios2_mode_write);
+    adios2_engine *engineH = adios2_open(ioH, "ctypes.bp", adios2_mode_write);
 
     // FIXME, I'd like to check that the engine type itself is correct, but
     // there's no API to get it
-    // FIXME, I'd like to check the engine's name, but there's no API to get it
+    std::string engine_name = testing::adios2_engine_name_as_string(engineH);
+    EXPECT_EQ(engine_name, "ctypes.bp");
 
     engine_type = testing::adios2_engine_type_as_string(ioH);
     EXPECT_EQ(engine_type, "bp"); // FIXME? Is it expected that adios2_open

--- a/testing/adios2/bindings/fortran/CMakeLists.txt
+++ b/testing/adios2/bindings/fortran/CMakeLists.txt
@@ -12,6 +12,9 @@ add_executable(TestRemove_f $<TARGET_OBJECTS:SmallTestData_f>)
 target_link_libraries(TestRemove_f adios2_f)
 
 if(ADIOS2_HAVE_MPI)
+  add_executable(TestAdios2BindingsFortranIO_f TestAdios2BindingsFortranIO.f90)
+  target_link_libraries(TestAdios2BindingsFortranIO_f adios2_f MPI::MPI_Fortran)
+
   target_sources(TestBPWriteReadTypes_f PRIVATE TestBPWriteTypes.f90)
   target_link_libraries(TestBPWriteReadTypes_f MPI::MPI_Fortran)
   
@@ -83,6 +86,10 @@ if(ADIOS2_HAVE_MPI)
     ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
   )
   
+  add_test(NAME TestAdios2BindingsFortranIO_f
+    COMMAND ${test_parameters} $<TARGET_FILE:TestAdios2BindingsFortranIO_f>
+  )
+
   add_test(NAME BPWriteReadAttributes_f
     COMMAND ${test_parameters} $<TARGET_FILE:TestBPWriteReadAttributes_f>
   )

--- a/testing/adios2/bindings/fortran/TestAdios2BindingsFortranIO.f90
+++ b/testing/adios2/bindings/fortran/TestAdios2BindingsFortranIO.f90
@@ -1,0 +1,117 @@
+
+! ======================================================================
+module testing_adios
+! ======================================================================
+  use adios2
+  use mpi
+  implicit none
+
+  type(adios2_adios) :: adios
+
+contains
+  ! ------------------------------------------------------------
+  subroutine testing_adios_init()
+  ! ------------------------------------------------------------
+
+    integer :: ierr
+    
+    call adios2_init(adios, MPI_COMM_WORLD, adios2_debug_mode_on, ierr)
+    
+  end subroutine testing_adios_init
+
+  ! ------------------------------------------------------------
+  subroutine testing_adios_finalize()
+  ! ------------------------------------------------------------
+
+    integer :: ierr
+    
+    call adios2_finalize(adios, ierr)
+
+  end subroutine testing_adios_finalize
+
+end module testing_adios
+
+! ======================================================================
+module testing_adios_io
+! ======================================================================
+  use testing_adios
+  use adios2
+  implicit none
+
+  type(adios2_io) :: io
+
+contains
+  ! ------------------------------------------------------------
+  subroutine testing_adios_io_init()
+  ! ------------------------------------------------------------
+
+    integer :: ierr
+
+    call testing_adios_init()
+    call adios2_declare_io(io, adios, "TestIo", ierr)
+
+  end subroutine testing_adios_io_init
+
+  ! ------------------------------------------------------------
+  subroutine testing_adios_io_finalize()
+  ! ------------------------------------------------------------
+
+    integer :: ierr
+    logical :: result
+
+    ! FIXME, shouldn't we be able to do this by handle?
+    call adios2_remove_io(result, adios, "TestIo", ierr)
+    if ((ierr /= 0) .or. (result .neqv. .true.)) stop "FAIL: adios2_remove_io"
+    call testing_adios_finalize()
+
+  end subroutine testing_adios_io_finalize
+
+end module testing_adios_io
+
+! ======================================================================
+
+! ------------------------------------------------------------
+subroutine testing_adios_io_engine()
+! ------------------------------------------------------------
+  use testing_adios_io
+  implicit none
+
+  integer :: ierr
+  type(adios2_engine) :: engine
+
+  character(len=:), allocatable :: engine_type
+
+  call MPI_Init(ierr)
+  call testing_adios_io_init()
+
+  ! Engine related functionality
+  call adios2_set_engine(io, "bpfile", ierr)
+
+  call adios2_io_engine_type(engine_type, io, ierr)
+  if (engine_type /= "bpfile") stop "FAIL adios2_io_engine_type"
+  deallocate(engine_type)
+
+  call adios2_open(engine, io, "ftypes.bp", adios2_mode_write, ierr)
+
+  if (engine%type /= "bpfile") stop "FAIL engine%type"
+  ! // FIXME, I'd like to check that the engine type itself is correct, but
+  ! // there's no (function-style) API to get it
+  ! // FIXME, I'd like to check the engine's name, but there's no API to get it
+
+  call adios2_io_engine_type(engine_type, io, ierr)
+  if (engine_type /= "bp") stop "FAIL adios2_io_engine_type"
+  deallocate(engine_type)
+
+  call testing_adios_io_finalize()
+  call MPI_Finalize(ierr)
+
+end subroutine testing_adios_io_engine
+
+! ======================================================================
+program main
+! ======================================================================
+  implicit none
+
+  call testing_adios_io_engine()
+
+end program main

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -64,6 +64,19 @@ TEST_F(ADIOS2_CXX11_API_IO, Engine)
                                       // changes the engine_type string?
 }
 
+TEST_F(ADIOS2_CXX11_API_IO, EngineDefault)
+{
+    io.SetEngine("");
+    EXPECT_EQ(io.EngineType(), "");
+
+    adios2::Engine engine = io.Open("types.bp", adios2::Mode::Write);
+    EXPECT_EQ(engine.Name(), "types.bp");
+    EXPECT_EQ(engine.Type(), "BP3");
+
+    EXPECT_EQ(io.EngineType(), "bp"); // FIXME? Is it expected that adios2_open
+                                      // changes the engine_type string?
+}
+
 int main(int argc, char **argv)
 {
 #ifdef ADIOS2_HAVE_MPI


### PR DESCRIPTION
This still covers only a small piece of Engine-related IO functionality, though it was enough to find a bug in the Fortran bindings: When returning strings of 0 length from C to Fortran, the old code
would leave the Fortran string in deallocated state, which leads to a crash when checking its content. Fortunately, Fortran allows for 0-size allocated arrays/strings, so the fix is to return just that.

This PR also adds `adios2_engine_name()` to the C and Fortran APIs, as the same functionality exists in the CXX11 API.