### PR TITLE
Assorted clean up and small fixes

### DIFF
--- a/bindings/C/c/adios2_c_attribute.cpp
+++ b/bindings/C/c/adios2_c_attribute.cpp
@@ -38,7 +38,7 @@ adios2_error adios2_attribute_name(char *name, size_t *size,
     }
 }
 
-adios2_error adios2_attribute_type(adios2_type *type,
+adios2_error adios2_attribute_type(adios2_type *c_type,
                                    const adios2_attribute *attribute)
 {
     try
@@ -48,19 +48,19 @@ adios2_error adios2_attribute_type(adios2_type *type,
         const adios2::core::AttributeBase *attributeBase =
             reinterpret_cast<const adios2::core::AttributeBase *>(attribute);
 
-        auto type_s = attributeBase->m_Type;
-        if (type_s == adios2::helper::GetType<std::string>())
+        std::string type = attributeBase->m_Type;
+        if (type == adios2::helper::GetType<std::string>())
         {
-            *type = adios2_type_string;
+            *c_type = adios2_type_string;
         }
 #define make_case(T)                                                           \
-    else if (type_s == adios2::helper::GetType<MapAdios2Type<T>::Type>())      \
+    else if (type == adios2::helper::GetType<MapAdios2Type<T>::Type>())        \
     {                                                                          \
-        *type = T;                                                             \
+        *c_type = T;                                                           \
     }
         ADIOS2_FOREACH_C_ATTRIBUTE_TYPE_1ARG(make_case)
 #undef make_case
-        else { *type = adios2_type_unknown; }
+        else { *c_type = adios2_type_unknown; }
         return adios2_error_none;
     }
     catch (...)

--- a/bindings/C/c/adios2_c_attribute.cpp
+++ b/bindings/C/c/adios2_c_attribute.cpp
@@ -152,7 +152,7 @@ adios2_error adios2_attribute_data(void *data, size_t *size,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             const adios2::core::Attribute<std::string> *attributeCpp =
                 dynamic_cast<const adios2::core::Attribute<std::string> *>(

--- a/bindings/C/c/adios2_c_engine.cpp
+++ b/bindings/C/c/adios2_c_engine.cpp
@@ -154,7 +154,7 @@ adios2_error adios2_put(adios2_engine *engine, adios2_variable *variable,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             const std::string dataStr(reinterpret_cast<const char *>(data));
             adios2::core::Engine &engineCpp =
@@ -215,7 +215,7 @@ adios2_error adios2_put_by_name(adios2_engine *engine,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             const std::string dataStr(reinterpret_cast<const char *>(data));
             engineCpp.Put(variable_name, dataStr);
@@ -274,7 +274,7 @@ adios2_error adios2_get(adios2_engine *engine, adios2_variable *variable,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             adios2::core::Engine &engineCpp =
                 *reinterpret_cast<adios2::core::Engine *>(engine);
@@ -331,7 +331,7 @@ adios2_error adios2_get_by_name(adios2_engine *engine,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             std::string dataStr;
             engineCpp.Get(variable_name, dataStr);

--- a/bindings/C/c/adios2_c_internal.h
+++ b/bindings/C/c/adios2_c_internal.h
@@ -3,7 +3,8 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * adios2_c_internal.h
+ * adios2_c_internal.h: helper functionality for use within the C bindings,
+ *                      but not part of the public interface
  *
  *  Created on: Feb 9, 2019
  *      Author: Kai Germaschewski <kai.germaschewski@unh.edu>

--- a/bindings/C/c/adios2_c_variable.cpp
+++ b/bindings/C/c/adios2_c_variable.cpp
@@ -206,7 +206,7 @@ adios2_error adios2_variable_name(char *name, size_t *size,
     }
 }
 
-adios2_error adios2_variable_type(adios2_type *type,
+adios2_error adios2_variable_type(adios2_type *c_type,
                                   const adios2_variable *variable)
 {
     try
@@ -218,19 +218,19 @@ adios2_error adios2_variable_type(adios2_type *type,
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
 
-        const std::string typeCpp = variableBase->m_Type;
-        if (typeCpp == adios2::helper::GetType<std::string>())
+        std::string type = variableBase->m_Type;
+        if (type == adios2::helper::GetType<std::string>())
         {
-            *type = adios2_type_string;
+            *c_type = adios2_type_string;
         }
 #define make_case(T)                                                           \
-    else if (typeCpp == adios2::helper::GetType<MapAdios2Type<T>::Type>())     \
+    else if (type == adios2::helper::GetType<MapAdios2Type<T>::Type>())        \
     {                                                                          \
-        *type = T;                                                             \
+        *c_type = T;                                                           \
     }
         ADIOS2_FOREACH_C_TYPE_1ARG(make_case)
 #undef make_case
-        else { *type = adios2_type_unknown; }
+        else { *c_type = adios2_type_unknown; }
         return adios2_error_none;
     }
     catch (...)

--- a/bindings/CXX11/adios2.h
+++ b/bindings/CXX11/adios2.h
@@ -12,7 +12,6 @@
 #define ADIOS2_BINDINGS_CXX11_H_
 
 #include "adios2/ADIOSConfig.h"
-#include "adios2/ADIOSMacros.h"
 #include "adios2/ADIOSTypes.h"
 
 #include "cxx11/ADIOS.h"

--- a/bindings/CXX11/cxx11/ADIOS.h
+++ b/bindings/CXX11/cxx11/ADIOS.h
@@ -22,7 +22,6 @@
 #include <mpi.h>
 #endif
 
-#include "adios2/ADIOSMacros.h"
 #include "adios2/ADIOSTypes.h"
 
 namespace adios2

--- a/bindings/CXX11/cxx11/Attribute.cpp
+++ b/bindings/CXX11/cxx11/Attribute.cpp
@@ -9,8 +9,8 @@
  */
 
 #include "Attribute.h"
+#include "Types.h"
 
-#include "adios2/ADIOSMacros.h"
 #include "adios2/core/Attribute.h"
 #include "adios2/helper/adiosFunctions.h"
 

--- a/bindings/CXX11/cxx11/Engine.h
+++ b/bindings/CXX11/cxx11/Engine.h
@@ -11,9 +11,9 @@
 #ifndef ADIOS2_BINDINGS_CXX11_CXX11_ENGINE_H_
 #define ADIOS2_BINDINGS_CXX11_CXX11_ENGINE_H_
 
+#include "Types.h"
 #include "Variable.h"
 
-#include "adios2/ADIOSMacros.h"
 #include "adios2/ADIOSTypes.h"
 
 namespace adios2

--- a/bindings/CXX11/cxx11/IO.h
+++ b/bindings/CXX11/cxx11/IO.h
@@ -20,7 +20,6 @@
 #include <mpi.h>
 #endif
 
-#include "adios2/ADIOSMacros.h"
 #include "adios2/ADIOSTypes.h"
 
 namespace adios2

--- a/bindings/CXX11/cxx11/Operator.h
+++ b/bindings/CXX11/cxx11/Operator.h
@@ -11,7 +11,6 @@
 #ifndef ADIOS2_BINDINGS_CXX11_CXX11_OPERATOR_H_
 #define ADIOS2_BINDINGS_CXX11_CXX11_OPERATOR_H_
 
-#include "adios2/ADIOSMacros.h"
 #include "adios2/ADIOSTypes.h"
 
 namespace adios2

--- a/bindings/CXX11/cxx11/Types.h
+++ b/bindings/CXX11/cxx11/Types.h
@@ -16,6 +16,41 @@
 
 #include <vector>
 
+/**
+ * The ADIOS_FOREACH_TYPE_1ARG macros are similar to the _STDTYPE macros used in
+ * core,
+ * but use primitive C++ types rather than stdint based types. Only for use in
+ * the CXX11 bindings.
+ */
+#define ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)                    \
+    MACRO(char)                                                                \
+    MACRO(signed char)                                                         \
+    MACRO(unsigned char)                                                       \
+    MACRO(short)                                                               \
+    MACRO(unsigned short)                                                      \
+    MACRO(int)                                                                 \
+    MACRO(unsigned int)                                                        \
+    MACRO(long int)                                                            \
+    MACRO(unsigned long int)                                                   \
+    MACRO(long long int)                                                       \
+    MACRO(unsigned long long int)                                              \
+    MACRO(float)                                                               \
+    MACRO(double)                                                              \
+    MACRO(long double)
+
+#define ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(MACRO)                              \
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)                        \
+    MACRO(std::complex<float>)                                                 \
+    MACRO(std::complex<double>)
+
+#define ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(MACRO)                              \
+    MACRO(std::string)                                                         \
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)
+
+#define ADIOS2_FOREACH_TYPE_1ARG(MACRO)                                        \
+    MACRO(std::string)                                                         \
+    ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(MACRO)
+
 namespace adios2
 {
 

--- a/bindings/CXX11/cxx11/Variable.cpp
+++ b/bindings/CXX11/cxx11/Variable.cpp
@@ -8,9 +8,9 @@
  *      Author: William F Godoy godoywf@ornl.gov
  */
 #include "Variable.h"
+#include "Types.h"
 #include "Variable.tcc"
 
-#include "adios2/ADIOSMacros.h"
 #include "adios2/core/Variable.h"
 #include "adios2/helper/adiosFunctions.h" //CheckNullptr
 

--- a/bindings/CXX11/cxx11/fstream/ADIOS2fstream.h
+++ b/bindings/CXX11/cxx11/fstream/ADIOS2fstream.h
@@ -11,15 +11,15 @@
 #ifndef ADIOS2_BINDINGS_CXX11_CXX11_FSTREAM_ADIOS2FSTREAM_H_
 #define ADIOS2_BINDINGS_CXX11_CXX11_FSTREAM_ADIOS2FSTREAM_H_
 
-#include <memory> //std::shared_ptr
+#include "../Types.h"
 
 #include "adios2/ADIOSConfig.h"
 
+#include <memory> //std::shared_ptr
 #ifdef ADIOS2_HAVE_MPI
 #include <mpi.h>
 #endif
 
-#include "adios2/ADIOSMacros.h"
 #include "adios2/ADIOSTypes.h"
 
 namespace adios2

--- a/bindings/Python/py11Attribute.cpp
+++ b/bindings/Python/py11Attribute.cpp
@@ -46,7 +46,7 @@ std::vector<std::string> Attribute::DataString()
 
     std::vector<std::string> data;
 
-    if (type == "string")
+    if (type == helper::GetType<std::string>())
     {
         const core::Attribute<std::string> *attribute =
             dynamic_cast<core::Attribute<std::string> *>(m_Attribute);

--- a/bindings/Python/py11File.cpp
+++ b/bindings/Python/py11File.cpp
@@ -180,7 +180,7 @@ pybind11::array File::Read(const std::string &name)
 {
     const std::string type = m_Stream->m_IO->InquireVariableType(name);
 
-    if (type == "string")
+    if (type == helper::GetType<std::string>())
     {
         const std::string value = m_Stream->Read<std::string>(name).front();
         pybind11::array pyArray(pybind11::dtype::of<char>(),

--- a/examples/hello/datamanReader/DataManCallbackReceiver.cpp
+++ b/examples/hello/datamanReader/DataManCallbackReceiver.cpp
@@ -53,7 +53,7 @@ void UserCallBack(void *data, const std::string &doid, const std::string &var,
     std::cout << "Data : " << std::endl;
 
 #define declare_type(T)                                                        \
-    if (type == adios2::helper::GetType<T>())                                  \
+    if (type == adios2::GetType<T>())                                          \
     {                                                                          \
         for (size_t i = 0; i < dumpsize; ++i)                                  \
         {                                                                      \

--- a/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
+++ b/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <adios2.h>
+#include <adios2/ADIOSMacros.h>
 
 #ifdef ADIOS2_HAVE_MPI
 #include <mpi.h>

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -57,40 +57,6 @@
     MACRO(std::string)                                                         \
     ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)
 
-/**
- * The ADIOS_FOREACH_TYPE_1ARG macro is similar, but uses primitive C++ types
- * rather than stdint based types. Should only be used in CXX11 bindings, not in
- * the core.
- */
-#define ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)                    \
-    MACRO(char)                                                                \
-    MACRO(signed char)                                                         \
-    MACRO(unsigned char)                                                       \
-    MACRO(short)                                                               \
-    MACRO(unsigned short)                                                      \
-    MACRO(int)                                                                 \
-    MACRO(unsigned int)                                                        \
-    MACRO(long int)                                                            \
-    MACRO(unsigned long int)                                                   \
-    MACRO(long long int)                                                       \
-    MACRO(unsigned long long int)                                              \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(long double)
-
-#define ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(MACRO)                              \
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)                        \
-    MACRO(std::complex<float>)                                                 \
-    MACRO(std::complex<double>)
-
-#define ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(MACRO)                              \
-    MACRO(std::string)                                                         \
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)
-
-#define ADIOS2_FOREACH_TYPE_1ARG(MACRO)                                        \
-    MACRO(std::string)                                                         \
-    ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(MACRO)
-
 #define ADIOS2_FOREACH_COMPLEX_PRIMITIVE_TYPE_1ARG(MACRO)                      \
     MACRO(float)                                                               \
     MACRO(double)                                                              \

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -89,21 +89,6 @@
     MACRO(signed char)                                                         \
     MACRO(unsigned char)
 
-#define ADIOS2_FOREACH_NUMERIC_TYPE_1ARG(MACRO)                                \
-    MACRO(short)                                                               \
-    MACRO(unsigned short)                                                      \
-    MACRO(int)                                                                 \
-    MACRO(unsigned int)                                                        \
-    MACRO(long int)                                                            \
-    MACRO(long long int)                                                       \
-    MACRO(unsigned long int)                                                   \
-    MACRO(unsigned long long int)                                              \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(long double)                                                         \
-    MACRO(std::complex<float>)                                                 \
-    MACRO(std::complex<double>)
-
 #define ADIOS2_FOREACH_ZFP_TYPE_1ARG(MACRO)                                    \
     MACRO(int32_t)                                                             \
     MACRO(int64_t)                                                             \
@@ -144,19 +129,6 @@
     MACRO(long int)                                                            \
     MACRO(unsigned long int)                                                   \
     MACRO(long long int)                                                       \
-    MACRO(unsigned long long int)                                              \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(long double)
-
-#define ADIOS2_FOREACH_NUMERIC_ATTRIBUTE_TYPE_1ARG(MACRO)                      \
-    MACRO(short)                                                               \
-    MACRO(unsigned short)                                                      \
-    MACRO(int)                                                                 \
-    MACRO(unsigned int)                                                        \
-    MACRO(long int)                                                            \
-    MACRO(long long int)                                                       \
-    MACRO(unsigned long int)                                                   \
     MACRO(unsigned long long int)                                              \
     MACRO(float)                                                               \
     MACRO(double)                                                              \

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -220,12 +220,4 @@
     MACRO(std::complex<float>, cfloat)                                         \
     MACRO(std::complex<double>, cdouble)
 
-#define ADIOS2_FOREACH_COMPLEX_TYPE_2ARGS(MACRO)                               \
-    MACRO(std::complex<float>, CFloat)                                         \
-    MACRO(std::complex<double>, CDouble)
-
-#define ADIOS2_FOREACH_LAUNCH_MODE(MACRO)                                      \
-    MACRO(Sync)                                                                \
-    MACRO(Deferred)
-
 #endif /* ADIOS2_ADIOSMACROS_H */

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -57,25 +57,6 @@
     MACRO(std::string)                                                         \
     ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)
 
-#define ADIOS2_FOREACH_TYPE_1ARG(MACRO)                                        \
-    MACRO(std::string)                                                         \
-    MACRO(char)                                                                \
-    MACRO(signed char)                                                         \
-    MACRO(unsigned char)                                                       \
-    MACRO(short)                                                               \
-    MACRO(unsigned short)                                                      \
-    MACRO(int)                                                                 \
-    MACRO(unsigned int)                                                        \
-    MACRO(long int)                                                            \
-    MACRO(long long int)                                                       \
-    MACRO(unsigned long int)                                                   \
-    MACRO(unsigned long long int)                                              \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(long double)                                                         \
-    MACRO(std::complex<float>)                                                 \
-    MACRO(std::complex<double>)
-
 #define ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(MACRO)                              \
     MACRO(char)                                                                \
     MACRO(signed char)                                                         \
@@ -93,6 +74,10 @@
     MACRO(long double)                                                         \
     MACRO(std::complex<float>)                                                 \
     MACRO(std::complex<double>)
+
+#define ADIOS2_FOREACH_TYPE_1ARG(MACRO)                                        \
+    MACRO(std::string)                                                         \
+    ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(MACRO)
 
 #define ADIOS2_FOREACH_COMPLEX_PRIMITIVE_TYPE_1ARG(MACRO)                      \
     MACRO(float)                                                               \

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -17,7 +17,7 @@
 
 /**
  <pre>
- The ADIOS_FOREACH_TYPE_1ARG macro assumes the given argument is a macro which
+ The ADIOS_FOREACH_STTYPE_1ARG macro assumes the given argument is a macro which
  takes a single argument that is a type and then inserts the given MACRO for
  each of the known primitive types
 
@@ -27,7 +27,7 @@
    template<typename T> int foo() { // some implementation of foo  }
 
    #define instantiate_foo(T) template int foo<T>();
-   ADIOS_FOREACH_TYPE_1ARG(instantiate_foo)
+   ADIOS_FOREACH_STDTYPE_1ARG(instantiate_foo)
    #undef instantiate_foo
  </pre>
 */
@@ -57,7 +57,12 @@
     MACRO(std::string)                                                         \
     ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)
 
-#define ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(MACRO)                              \
+/**
+ * The ADIOS_FOREACH_TYPE_1ARG macro is similar, but uses primitive C++ types
+ * rather than stdint based types. Should only be used in CXX11 bindings, not in
+ * the core.
+ */
+#define ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)                    \
     MACRO(char)                                                                \
     MACRO(signed char)                                                         \
     MACRO(unsigned char)                                                       \
@@ -66,14 +71,21 @@
     MACRO(int)                                                                 \
     MACRO(unsigned int)                                                        \
     MACRO(long int)                                                            \
-    MACRO(long long int)                                                       \
     MACRO(unsigned long int)                                                   \
+    MACRO(long long int)                                                       \
     MACRO(unsigned long long int)                                              \
     MACRO(float)                                                               \
     MACRO(double)                                                              \
-    MACRO(long double)                                                         \
+    MACRO(long double)
+
+#define ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(MACRO)                              \
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)                        \
     MACRO(std::complex<float>)                                                 \
     MACRO(std::complex<double>)
+
+#define ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(MACRO)                              \
+    MACRO(std::string)                                                         \
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)
 
 #define ADIOS2_FOREACH_TYPE_1ARG(MACRO)                                        \
     MACRO(std::string)                                                         \
@@ -100,39 +112,6 @@
     MACRO(double)
 
 #define ADIOS2_FOREACH_MGARD_TYPE_1ARG(MACRO) MACRO(double)
-
-#define ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(MACRO)                              \
-    MACRO(std::string)                                                         \
-    MACRO(char)                                                                \
-    MACRO(signed char)                                                         \
-    MACRO(unsigned char)                                                       \
-    MACRO(short)                                                               \
-    MACRO(unsigned short)                                                      \
-    MACRO(int)                                                                 \
-    MACRO(unsigned int)                                                        \
-    MACRO(long int)                                                            \
-    MACRO(unsigned long int)                                                   \
-    MACRO(long long int)                                                       \
-    MACRO(unsigned long long int)                                              \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(long double)
-
-#define ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)                    \
-    MACRO(char)                                                                \
-    MACRO(signed char)                                                         \
-    MACRO(unsigned char)                                                       \
-    MACRO(short)                                                               \
-    MACRO(unsigned short)                                                      \
-    MACRO(int)                                                                 \
-    MACRO(unsigned int)                                                        \
-    MACRO(long int)                                                            \
-    MACRO(unsigned long int)                                                   \
-    MACRO(long long int)                                                       \
-    MACRO(unsigned long long int)                                              \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(long double)
 
 /**
  <pre>

--- a/source/adios2/ADIOSTypes.inl
+++ b/source/adios2/ADIOSTypes.inl
@@ -3,8 +3,7 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * ADIOSTypes.h : public header that contains "using/typedef" alias, defaults
- * and parameters options as enum classes
+ * ADIOSTypes.inl : inline implementatios for ADIOSTypes.h
  *
  *  Created on: Feb 20, 2019
  *      Author: Kai Germaschewski <kai.germaschewski@unh.edu>

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -197,7 +197,7 @@ bool IO::RemoveAttribute(const std::string &name) noexcept
     // attribute exists
     if (itAttribute != m_Attributes.end())
     {
-        // first remove the Variable object
+        // first remove the Attribute object
         const std::string type(itAttribute->second.first);
         const unsigned int index(itAttribute->second.second);
 

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -91,7 +91,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
             {
                 return;
             }
-            else if (Type == "string")
+            else if (Type == helper::GetType<std::string>())
             {
                 Reader->m_IO.DefineAttribute<std::string>(attrName,
                                                           *(char **)data);

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -84,7 +84,7 @@ void SstWriter::FFSMarshalAttributes()
         if (type == "unknown")
         {
         }
-        else if (type == "string")
+        else if (type == helper::GetType<std::string>())
         {
             core::Attribute<std::string> &attribute =
                 *m_IO.InquireAttribute<std::string>(name);

--- a/source/adios2/helper/adiosType.h
+++ b/source/adios2/helper/adiosType.h
@@ -104,19 +104,6 @@ template <class T>
 std::string GetType() noexcept;
 
 /**
- * Check in types set if "type" is one of the aliases for a certain type,
- * (e.g. if type = integer is an accepted alias for "int", returning true)
- * @param type input to be compared with an alias
- * @param aliases set containing aliases to a certain type, typically
- * Support::DatatypesAliases from Support.h
- * @return true: is an alias, false: is not
- */
-template <class T>
-bool IsTypeAlias(
-    const std::string type,
-    const std::map<std::string, std::set<std::string>> &aliases) noexcept;
-
-/**
  * Converts a vector of dimensions to a CSV string
  * @param dims vector of dimensions
  * @return comma separate value (CSV)

--- a/source/adios2/helper/adiosType.inl
+++ b/source/adios2/helper/adiosType.inl
@@ -96,25 +96,6 @@ inline std::string GetType<std::complex<double>>() noexcept
     return "double complex";
 }
 
-template <class T>
-bool IsTypeAlias(
-    const std::string type,
-    const std::map<std::string, std::set<std::string>> &aliases) noexcept
-{
-    if (type == GetType<T>()) // is key itself
-    {
-        return true;
-    }
-
-    bool isAlias = false;
-    if (aliases.at(GetType<T>()).count(type) == 1)
-    {
-        isAlias = true;
-    }
-
-    return isAlias;
-}
-
 template <class T, class U>
 std::vector<U> NewVectorType(const std::vector<T> &in)
 {

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -1154,7 +1154,7 @@ void HDF5Common::WriteAttrFromIO(core::IO &io)
         {
             // not supported
         }
-        else if (attrType == "string")
+        else if (attrType == helper::GetType<std::string>())
         {
             // WriteStringAttr(io, attrName, parentID);
             core::Attribute<std::string> *adiosAttr =


### PR DESCRIPTION
Here's a bunch of little things I've had lie around for a while now. These are mostly independent from reach other, so pieces could be dropped if needed.

It's mostly some cleanup following from the stdint type changes. Maybe the most noteworthy change is moving the `ADIOS2_FOREACH_*_TYPE_1ARG` macros into the CXX11 bindings, as all of the rest of
the code now uses he `_STDTYPE_` macros, so having the `_TYPE_` macro out of the way should prevent any confusion.