### PR TITLE
[COMMENTS?] Fix RemoveVariable/Attribute to really remove the Variable/Attribute

### DIFF
--- a/source/adios2/ADIOSTypes.h
+++ b/source/adios2/ADIOSTypes.h
@@ -137,6 +137,10 @@ using std::uint64_t;
 using cfloat = std::complex<float>;
 using cdouble = std::complex<double>;
 
+// Compound is never actually defined, it's just used to template with, in
+// particular Variable<Compound>.
+class Compound;
+
 // Limit, using uint64_t to make it portable
 constexpr uint64_t MaxU64 = std::numeric_limits<uint64_t>::max();
 constexpr size_t MaxSizeT = std::numeric_limits<size_t>::max();

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -131,8 +131,10 @@ IO &ADIOS::DeclareIO(const std::string name)
         }
     }
 
-    auto ioPair = m_IOs.emplace(
-        name, IO(*this, name, m_MPIComm, false, m_HostLanguage, m_DebugMode));
+    auto ioPair =
+        m_IOs.emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                      std::forward_as_tuple(*this, name, m_MPIComm, false,
+                                            m_HostLanguage, m_DebugMode));
     IO &io = ioPair.first->second;
     io.SetDeclared();
     return io;

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -208,7 +208,7 @@ bool IO::RemoveAttribute(const std::string &name) noexcept
 #define declare_type(T)                                                        \
     else if (type == helper::GetType<T>())                                     \
     {                                                                          \
-        auto attributeMap = GetAttributeMap<T>();                              \
+        auto &attributeMap = GetAttributeMap<T>();                             \
         attributeMap.erase(index);                                             \
         isRemoved = true;                                                      \
     }

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -159,13 +159,13 @@ bool IO::RemoveVariable(const std::string &name) noexcept
 
         if (type == "compound")
         {
-            auto variableMap = m_Compound;
+            auto &variableMap = m_Compound;
             variableMap.erase(index);
         }
 #define declare_type(T)                                                        \
     else if (type == helper::GetType<T>())                                     \
     {                                                                          \
-        auto variableMap = GetVariableMap<T>();                                \
+        auto &variableMap = GetVariableMap<T>();                               \
         variableMap.erase(index);                                              \
         isRemoved = true;                                                      \
     }

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -56,9 +56,14 @@ public:
     const Value &at(Index key) const { return m_Map.at(key); }
 
     template <class... Args>
-    std::pair<iterator, bool> emplace(Args &&... args)
+    iterator emplace(Args &&... args)
     {
-        return m_Map.emplace(std::forward<Args>(args)...);
+        auto status = m_Map.emplace(std::forward<Args>(args)...);
+        if (!status.second)
+        {
+            throw std::runtime_error("emplace failed in VariableMap::emplace");
+        }
+        return status.first;
     }
 
 private:

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -44,11 +44,22 @@ class VariableMap
 {
 public:
     using Index = unsigned int;
-    using Map = std::map<Index, Variable<T>>;
+    using Value = Variable<T>;
+    using Map = std::map<Index, Value>;
+    using iterator = typename Map::iterator;
 
-    Map &GetMap() noexcept { return m_Map; }
     void erase(Index key) { m_Map.erase(key); }
     void clear() noexcept { m_Map.clear(); }
+    size_t size() const noexcept { return m_Map.size(); }
+
+    Value &at(Index key) { return m_Map.at(key); }
+    const Value &at(Index key) const { return m_Map.at(key); }
+
+    template <class... Args>
+    std::pair<iterator, bool> emplace(Args &&... args)
+    {
+        return m_Map.emplace(std::forward<Args>(args)...);
+    }
 
 private:
     Map m_Map;
@@ -460,7 +471,7 @@ private:
     /** Gets the internal reference to a variable map for type T
      *  This function is specialized in IO.tcc */
     template <class T>
-    std::map<unsigned int, Variable<T>> &GetVariableMap() noexcept;
+    VariableMap<T> &GetVariableMap() noexcept;
 
     /**
      * Map holding attribute identifiers

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -39,6 +39,21 @@ namespace core
 using DataMap =
     std::unordered_map<std::string, std::pair<std::string, unsigned int>>;
 
+template <class T>
+class VariableMap
+{
+public:
+    using Index = unsigned int;
+    using Map = std::map<Index, Variable<T>>;
+
+    Map &GetMap() noexcept { return m_Map; }
+    void erase(Index key) { m_Map.erase(key); }
+    void clear() noexcept { m_Map.clear(); }
+
+private:
+    Map m_Map;
+};
+
 // forward declaration needed as IO is passed to Engine derived
 // classes
 class Engine;
@@ -436,11 +451,11 @@ private:
     DataMap m_Variables;
 
     /** Variable containers based on fixed-size type */
-#define declare_map(T, NAME) std::map<unsigned int, Variable<T>> m_##NAME;
+#define declare_map(T, NAME) VariableMap<T> m_##NAME;
     ADIOS2_FOREACH_STDTYPE_2ARGS(declare_map)
 #undef declare_map
 
-    std::map<unsigned int, VariableCompound> m_Compound;
+    VariableMap<Compound> m_Compound;
 
     /** Gets the internal reference to a variable map for type T
      *  This function is specialized in IO.tcc */

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -56,8 +56,9 @@ public:
     const Value &at(Index key) const { return m_Map.at(key); }
 
     template <class... Args>
-    iterator emplace(Index key, Args &&... args)
+    iterator emplace(Args &&... args)
     {
+        Index key = static_cast<Index>(m_Map.size());
         auto status = m_Map.emplace(key, std::forward<Args>(args)...);
         if (!status.second)
         {

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -48,6 +48,13 @@ public:
     using Map = std::map<Index, Value>;
     using iterator = typename Map::iterator;
 
+    EntityMap() = default;
+    // copy ctor / assignment would work fine, but they're deleted to prevent
+    // buggy /
+    // inefficient code
+    EntityMap(const EntityMap &) = delete;
+    EntityMap &operator=(const EntityMap &) = delete;
+
     void erase(Index key) { m_Map.erase(key); }
     void clear() noexcept { m_Map.clear(); }
 

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -39,12 +39,12 @@ namespace core
 using DataMap =
     std::unordered_map<std::string, std::pair<std::string, unsigned int>>;
 
-template <class T>
-class VariableMap
+template <template <class> class Entity, class T>
+class EntityMap
 {
 public:
     using Index = unsigned int;
-    using Value = Variable<T>;
+    using Value = Entity<T>;
     using Map = std::map<Index, Value>;
     using iterator = typename Map::iterator;
 
@@ -60,7 +60,7 @@ public:
         auto status = m_Map.emplace(m_Index++, std::forward<Args>(args)...);
         if (!status.second)
         {
-            throw std::runtime_error("emplace failed in VariableMap::emplace");
+            throw std::runtime_error("emplace failed in EntityMap::emplace");
         }
         return status.first;
     }
@@ -69,6 +69,9 @@ private:
     Map m_Map;
     Index m_Index = 0;
 };
+
+template <class T>
+using VariableMap = EntityMap<Variable, T>;
 
 // forward declaration needed as IO is passed to Engine derived
 // classes

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -57,8 +57,7 @@ public:
     template <class... Args>
     iterator emplace(Args &&... args)
     {
-        Index key = static_cast<Index>(m_Map.size());
-        auto status = m_Map.emplace(key, std::forward<Args>(args)...);
+        auto status = m_Map.emplace(m_Index++, std::forward<Args>(args)...);
         if (!status.second)
         {
             throw std::runtime_error("emplace failed in VariableMap::emplace");
@@ -68,6 +67,7 @@ public:
 
 private:
     Map m_Map;
+    Index m_Index = 0;
 };
 
 // forward declaration needed as IO is passed to Engine derived

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -56,9 +56,9 @@ public:
     const Value &at(Index key) const { return m_Map.at(key); }
 
     template <class... Args>
-    iterator emplace(Args &&... args)
+    iterator emplace(Index key, Args &&... args)
     {
-        auto status = m_Map.emplace(std::forward<Args>(args)...);
+        auto status = m_Map.emplace(key, std::forward<Args>(args)...);
         if (!status.second)
         {
             throw std::runtime_error("emplace failed in VariableMap::emplace");

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -50,7 +50,6 @@ public:
 
     void erase(Index key) { m_Map.erase(key); }
     void clear() noexcept { m_Map.clear(); }
-    size_t size() const noexcept { return m_Map.size(); }
 
     Value &at(Index key) { return m_Map.at(key); }
     const Value &at(Index key) const { return m_Map.at(key); }

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -73,6 +73,9 @@ private:
 template <class T>
 using VariableMap = EntityMap<Variable, T>;
 
+template <class T>
+using AttributeMap = EntityMap<Attribute, T>;
+
 // forward declaration needed as IO is passed to Engine derived
 // classes
 class Engine;
@@ -492,12 +495,12 @@ private:
      */
     DataMap m_Attributes;
 
-#define declare_map(T, NAME) std::map<unsigned int, Attribute<T>> m_##NAME##A;
+#define declare_map(T, NAME) AttributeMap<T> m_##NAME##A;
     ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(declare_map)
 #undef declare_map
 
     template <class T>
-    std::map<unsigned int, Attribute<T>> &GetAttributeMap() noexcept;
+    AttributeMap<T> &GetAttributeMap() noexcept;
 
     std::map<std::string, std::shared_ptr<Engine>> m_Engines;
 

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -195,7 +195,7 @@ Attribute<T> *IO::InquireAttribute(const std::string &name,
     template <>                                                                \
     std::map<unsigned int, Variable<T>> &IO::GetVariableMap() noexcept         \
     {                                                                          \
-        return m_##NAME;                                                       \
+        return m_##NAME.GetMap();                                              \
     }
 ADIOS2_FOREACH_STDTYPE_2ARGS(make_GetVariableMap)
 #undef make_GetVariableMap

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -45,15 +45,12 @@ Variable<T> &IO::DefineVariable(const std::string &name, const Dims &shape,
 
     auto &variableMap = GetVariableMap<T>();
     const unsigned int size = static_cast<unsigned int>(variableMap.size());
-    auto itVariablePair =
+    auto itVariable =
         variableMap.emplace(size, Variable<T>(name, shape, start, count,
                                               constantDims, m_DebugMode));
-    bool emplaceSucceeded = itVariablePair.second;
-    if (!emplaceSucceeded)
-        throw std::runtime_error("emplace failed in IO::DefineVariable");
     m_Variables.emplace(name, std::make_pair(helper::GetType<T>(), size));
 
-    Variable<T> &variable = itVariablePair.first->second;
+    Variable<T> &variable = itVariable->second;
 
     // check IO placeholder for variable operations
     auto itOperations = m_VarOpsPlaceholder.find(name);

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -44,13 +44,12 @@ Variable<T> &IO::DefineVariable(const std::string &name, const Dims &shape,
     }
 
     auto &variableMap = GetVariableMap<T>();
-    const unsigned int size = static_cast<unsigned int>(variableMap.size());
-    auto itVariable =
-        variableMap.emplace(size, Variable<T>(name, shape, start, count,
-                                              constantDims, m_DebugMode));
-    m_Variables.emplace(name, std::make_pair(helper::GetType<T>(), size));
-
+    auto itVariable = variableMap.emplace(
+        Variable<T>(name, shape, start, count, constantDims, m_DebugMode));
+    typename VariableMap<T>::Index index = itVariable->first;
     Variable<T> &variable = itVariable->second;
+
+    m_Variables.emplace(name, std::make_pair(helper::GetType<T>(), index));
 
     // check IO placeholder for variable operations
     auto itOperations = m_VarOpsPlaceholder.find(name);

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -48,6 +48,9 @@ Variable<T> &IO::DefineVariable(const std::string &name, const Dims &shape,
     auto itVariablePair =
         variableMap.emplace(size, Variable<T>(name, shape, start, count,
                                               constantDims, m_DebugMode));
+    bool emplaceSucceeded = itVariablePair.second;
+    if (!emplaceSucceeded)
+        throw std::runtime_error("emplace failed in IO::DefineVariable");
     m_Variables.emplace(name, std::make_pair(helper::GetType<T>(), size));
 
     Variable<T> &variable = itVariablePair.first->second;

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -116,14 +116,14 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T &value,
     }
 
     auto &attributeMap = GetAttributeMap<T>();
-    const unsigned int size = static_cast<unsigned int>(attributeMap.size());
+    auto itAttribute = attributeMap.emplace(Attribute<T>(globalName, value));
+    typename AttributeMap<T>::Index index = itAttribute->first;
+    Attribute<T> &attribute = itAttribute->second;
 
-    auto itAttributePair =
-        attributeMap.emplace(size, Attribute<T>(globalName, value));
     m_Attributes.emplace(globalName,
-                         std::make_pair(helper::GetType<T>(), size));
+                         std::make_pair(helper::GetType<T>(), index));
 
-    return itAttributePair.first->second;
+    return attribute;
 }
 
 template <class T>
@@ -152,14 +152,15 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T *array,
     }
 
     auto &attributeMap = GetAttributeMap<T>();
-    const unsigned int size = static_cast<unsigned int>(attributeMap.size());
+    auto itAttribute =
+        attributeMap.emplace(Attribute<T>(globalName, array, elements));
+    typename AttributeMap<T>::Index index = itAttribute->first;
+    Attribute<T> &attribute = itAttribute->second;
 
-    auto itAttributePair =
-        attributeMap.emplace(size, Attribute<T>(globalName, array, elements));
     m_Attributes.emplace(globalName,
-                         std::make_pair(helper::GetType<T>(), size));
+                         std::make_pair(helper::GetType<T>(), index));
 
-    return itAttributePair.first->second;
+    return attribute;
 }
 
 template <class T>
@@ -199,7 +200,7 @@ ADIOS2_FOREACH_STDTYPE_2ARGS(make_GetVariableMap)
 // GetAttributeMap
 #define make_GetAttributeMap(T, NAME)                                          \
     template <>                                                                \
-    std::map<unsigned int, Attribute<T>> &IO::GetAttributeMap() noexcept       \
+    AttributeMap<T> &IO::GetAttributeMap() noexcept                            \
     {                                                                          \
         return m_##NAME##A;                                                    \
     }

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -193,9 +193,9 @@ Attribute<T> *IO::InquireAttribute(const std::string &name,
 // GetVariableMap
 #define make_GetVariableMap(T, NAME)                                           \
     template <>                                                                \
-    std::map<unsigned int, Variable<T>> &IO::GetVariableMap() noexcept         \
+    VariableMap<T> &IO::GetVariableMap() noexcept                              \
     {                                                                          \
-        return m_##NAME.GetMap();                                              \
+        return m_##NAME;                                                       \
     }
 ADIOS2_FOREACH_STDTYPE_2ARGS(make_GetVariableMap)
 #undef make_GetVariableMap

--- a/source/adios2/core/VariableCompound.cpp
+++ b/source/adios2/core/VariableCompound.cpp
@@ -18,19 +18,18 @@ namespace adios2
 namespace core
 {
 
-VariableCompound::VariableCompound(const std::string &name,
-                                   const size_t structSize, const Dims &shape,
-                                   const Dims &start, const Dims &count,
-                                   const bool constantDims,
-                                   const bool debugMode)
-: VariableBase(name, "compound", structSize, shape, start, count, constantDims,
-               debugMode)
+Variable<Compound>::Variable(const std::string &name, const size_t structSize,
+                             const Dims &shape, const Dims &start,
+                             const Dims &count, const bool constantDims,
+                             const bool debugMode)
+: VariableBase(name, "compound", structSize, shape, start, count,
+               constantDims, debugMode)
 {
 }
 
 #define declare_template_instantiation(T)                                      \
-    template void VariableCompound::InsertMember<T>(const std::string &,       \
-                                                    const size_t);
+    template void Variable<Compound>::InsertMember<T>(const std::string &,     \
+                                                      const size_t);
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 

--- a/source/adios2/core/VariableCompound.h
+++ b/source/adios2/core/VariableCompound.h
@@ -11,7 +11,9 @@
 #ifndef ADIOS2_CORE_VARIABLECOMPOUND_H_
 #define ADIOS2_CORE_VARIABLECOMPOUND_H_
 
-#include "VariableBase.h"
+// FIXME, VariableCompound is now also an alias for Variable<Compound>, so
+// arguably this should be all merged into Variable.{h,tcc,cpp}
+#include "Variable.h"
 
 #include "adios2/ADIOSMacros.h"
 
@@ -24,7 +26,8 @@ namespace core
  * @param Base (parent) class for template derived (child) class CVariable.
  * Required to put CVariable objects in STL containers.
  */
-class VariableCompound : public VariableBase
+template <>
+class Variable<Compound> : public VariableBase
 {
 
 public:
@@ -41,11 +44,12 @@ public:
     /** vector of primitve element types defining compound struct */
     std::vector<Element> m_Elements;
 
-    VariableCompound(const std::string &name, const size_t structSize,
-                     const Dims &shape, const Dims &start, const Dims &count,
-                     const bool constantDims, const bool debugMode);
+    Variable();
+    Variable(const std::string &name, const size_t structSize,
+             const Dims &shape, const Dims &start, const Dims &count,
+             const bool constantDims, const bool debugMode);
 
-    ~VariableCompound() = default;
+    ~Variable() = default;
 
     /**
      * Inserts an Element into the compound struct definition
@@ -58,10 +62,12 @@ public:
 
 // Explicit declaration of the public template methods
 #define declare_template_instantiation(T)                                      \
-    extern template void VariableCompound::InsertMember<T>(                    \
+    extern template void Variable<Compound>::InsertMember<T>(                  \
         const std::string &, const size_t);
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
+
+using VariableCompound = Variable<Compound>;
 
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/core/VariableCompound.tcc
+++ b/source/adios2/core/VariableCompound.tcc
@@ -21,8 +21,8 @@ namespace core
 {
 
 template <class T>
-void VariableCompound::InsertMember(const std::string &name,
-                                    const size_t offset)
+void Variable<Compound>::InsertMember(const std::string &name,
+                                      const size_t offset)
 {
     m_Elements.push_back(Element{name, helper::GetType<T>(), offset});
 }

--- a/source/adios2/helper/adiosXML.cpp
+++ b/source/adios2/helper/adiosXML.cpp
@@ -292,10 +292,10 @@ void ParseConfigXML(
             helper::XMLAttribute("name", io, adios.m_DebugMode, hint);
 
         // Build the IO object
-        auto itCurrentIO =
-            ios.emplace(ioName.value(),
-                        core::IO(adios, ioName.value(), adios.m_MPIComm, true,
-                                 adios.m_HostLanguage, adios.m_DebugMode));
+        auto itCurrentIO = ios.emplace(
+            std::piecewise_construct, std::forward_as_tuple(ioName.value()),
+            std::forward_as_tuple(adios, ioName.value(), adios.m_MPIComm, true,
+                                  adios.m_HostLanguage, adios.m_DebugMode));
         core::IO &currentIO = itCurrentIO.first->second;
 
         // must be unique per io

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -51,6 +51,18 @@ public:
     adios2::IO io;
 };
 
+TEST_F(ADIOS2_CXX11_API_IO, RemoveVariable)
+{
+    using T = int;
+
+    auto var1 = io.DefineVariable<T>("var1");
+    auto var2 = io.DefineVariable<T>("var2");
+    io.RemoveVariable("var1");
+    auto var3 = io.DefineVariable<T>("var3");
+    EXPECT_EQ(var2.Name(), "var2");
+    EXPECT_EQ(var3.Name(), "var3");
+}
+
 TEST_F(ADIOS2_CXX11_API_IO, Engine)
 {
     io.SetEngine("bpfile");


### PR DESCRIPTION
This PR fixes #1193, see there for some background.

This PR fixes the issue by keeping a monotonically increasing counter for the index into the variable map, so no two variables can have the same index (unless the counter wraps around, which for an `unsigned int` takes a long time -- but it could be changed to `uint64_t` if one were to worry about it.) Since we now have to keep a counter together with the map, and those are macro generated member variables for each type, I made a custom type for it, `EntityMap`, which is essentially a wrapper around `std::map` that keeps track of the last index used.

It should be noted that while I believe this PR is bug-free, applying it may expose other bugs. Since the existing (buggy) code doesn't actually remove Variables/Attributes, handles remain valid, and so access after remove causes no troubles. Now that objects actually get freed, you better don't access them afterwards.

The PR in its current shape doesn't quite follow the style guide, the extra `class EntityMap` is defined in `core/IO.h` and uses inline definitions. I can easily clean that up, though, if the PR is otherwise acceptable. It includes a test that first works (because the bug is masked by not actually removing variables), then fails after that has been fixed, and finally passes again when using the monotonic and hence unique index.