### PR TITLE
use GetType<std::string> consistently

### DIFF
--- a/bindings/C/c/adios2_c_attribute.cpp
+++ b/bindings/C/c/adios2_c_attribute.cpp
@@ -152,7 +152,7 @@ adios2_error adios2_attribute_data(void *data, size_t *size,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             const adios2::core::Attribute<std::string> *attributeCpp =
                 dynamic_cast<const adios2::core::Attribute<std::string> *>(

--- a/bindings/C/c/adios2_c_engine.cpp
+++ b/bindings/C/c/adios2_c_engine.cpp
@@ -154,7 +154,7 @@ adios2_error adios2_put(adios2_engine *engine, adios2_variable *variable,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             const std::string dataStr(reinterpret_cast<const char *>(data));
             adios2::core::Engine &engineCpp =
@@ -215,7 +215,7 @@ adios2_error adios2_put_by_name(adios2_engine *engine,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             const std::string dataStr(reinterpret_cast<const char *>(data));
             engineCpp.Put(variable_name, dataStr);
@@ -274,7 +274,7 @@ adios2_error adios2_get(adios2_engine *engine, adios2_variable *variable,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             adios2::core::Engine &engineCpp =
                 *reinterpret_cast<adios2::core::Engine *>(engine);
@@ -331,7 +331,7 @@ adios2_error adios2_get_by_name(adios2_engine *engine,
         {
             // not supported
         }
-        else if (type == "string")
+        else if (type == adios2::helper::GetType<std::string>())
         {
             std::string dataStr;
             engineCpp.Get(variable_name, dataStr);

--- a/bindings/Python/py11Attribute.cpp
+++ b/bindings/Python/py11Attribute.cpp
@@ -46,7 +46,7 @@ std::vector<std::string> Attribute::DataString()
 
     std::vector<std::string> data;
 
-    if (type == "string")
+    if (type == helper::GetType<std::string>())
     {
         const core::Attribute<std::string> *attribute =
             dynamic_cast<core::Attribute<std::string> *>(m_Attribute);

--- a/bindings/Python/py11File.cpp
+++ b/bindings/Python/py11File.cpp
@@ -180,7 +180,7 @@ pybind11::array File::Read(const std::string &name)
 {
     const std::string type = m_Stream->m_IO->InquireVariableType(name);
 
-    if (type == "string")
+    if (type == helper::GetType<std::string>())
     {
         const std::string value = m_Stream->Read<std::string>(name).front();
         pybind11::array pyArray(pybind11::dtype::of<char>(),

--- a/examples/hello/datamanReader/DataManCallbackReceiver.cpp
+++ b/examples/hello/datamanReader/DataManCallbackReceiver.cpp
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "adios2/ADIOSMacros.h"
-#include "adios2/helper/adiosFunctions.h"
 #include <adios2.h>
 
 // matches Signature2 in ADIOS2
@@ -53,7 +52,7 @@ void UserCallBack(void *data, const std::string &doid, const std::string &var,
     std::cout << "Data : " << std::endl;
 
 #define declare_type(T)                                                        \
-    if (type == adios2::helper::GetType<T>())                                  \
+    if (type == adios2::GetType<T>())                                          \
     {                                                                          \
         for (size_t i = 0; i < dumpsize; ++i)                                  \
         {                                                                      \

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -91,7 +91,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
             {
                 return;
             }
-            else if (Type == "string")
+            else if (Type == helper::GetType<std::string>())
             {
                 Reader->m_IO.DefineAttribute<std::string>(attrName,
                                                           *(char **)data);

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -84,7 +84,7 @@ void SstWriter::FFSMarshalAttributes()
         if (type == "unknown")
         {
         }
-        else if (type == "string")
+        else if (type == helper::GetType<std::string>())
         {
             core::Attribute<std::string> &attribute =
                 *m_IO.InquireAttribute<std::string>(name);

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -1154,7 +1154,7 @@ void HDF5Common::WriteAttrFromIO(core::IO &io)
         {
             // not supported
         }
-        else if (attrType == "string")
+        else if (attrType == helper::GetType<std::string>())
         {
             // WriteStringAttr(io, attrName, parentID);
             core::Attribute<std::string> *adiosAttr =


### PR DESCRIPTION
Sometimes we use `GetType<std::string>`, sometimes just `"string"`. The code generally uses `GetType<T>()` instead of hardcoded strings for the other types, so this patch consistently does the same for strings.

Also fixes one external use from `helper::GetType` to `GetType`.