### PR TITLE
adios2::Variable<T>::Span to access internal BP3 buffer memory 

### DIFF
--- a/bindings/C/c/adios2_c_engine.cpp
+++ b/bindings/C/c/adios2_c_engine.cpp
@@ -173,6 +173,10 @@ adios2_error adios2_put(adios2_engine *engine, adios2_variable *variable,
             reinterpret_cast<adios2::core::VariableBase *>(variable);
         const std::string type(variableBase->m_Type);
 
+        const adios2::Mode modeCpp = adios2_ToMode(
+            mode, "only adios2_mode_deferred or adios2_mode_sync are valid, "
+                  "in call to adios2_put");
+
         if (type == "compound")
         {
             // not supported
@@ -185,17 +189,13 @@ adios2_error adios2_put(adios2_engine *engine, adios2_variable *variable,
 
             engineCpp.Put(*dynamic_cast<adios2::core::Variable<std::string> *>(
                               variableBase),
-                          dataStr);
+                          dataStr, modeCpp);
         }
 #define declare_template_instantiation(T)                                      \
     else if (type == adios2::helper::GetType<T>())                             \
     {                                                                          \
         adios2::core::Engine &engineCpp =                                      \
             *reinterpret_cast<adios2::core::Engine *>(engine);                 \
-                                                                               \
-        const adios2::Mode modeCpp = adios2_ToMode(                            \
-            mode, "only adios2_mode_deferred or adios2_mode_sync are valid, "  \
-                  "in call to adios2_put");                                    \
                                                                                \
         engineCpp.Put(                                                         \
             *dynamic_cast<adios2::core::Variable<T> *>(variableBase),          \
@@ -241,7 +241,7 @@ adios2_error adios2_put_by_name(adios2_engine *engine,
         else if (type == adios2::helper::GetType<std::string>())
         {
             const std::string dataStr(reinterpret_cast<const char *>(data));
-            engineCpp.Put(variable_name, dataStr);
+            engineCpp.Put(variable_name, dataStr, modeCpp);
         }
 #define declare_template_instantiation(T)                                      \
     else if (type == adios2::helper::GetType<T>())                             \

--- a/bindings/CXX11/cxx11/Engine.cpp
+++ b/bindings/CXX11/cxx11/Engine.cpp
@@ -92,7 +92,7 @@ Engine::Engine(core::Engine *engine) : m_Engine(engine) {}
 
 #define declare_template_instantiation(T)                                      \
                                                                                \
-    template typename Variable<T>::Span Engine::Put(Variable<T> variable);
+    template typename Variable<T>::Span Engine::Put(Variable<T>, const size_t);
 
 ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/bindings/CXX11/cxx11/Engine.cpp
+++ b/bindings/CXX11/cxx11/Engine.cpp
@@ -91,6 +91,13 @@ void Engine::Close(const int transportIndex)
 Engine::Engine(core::Engine *engine) : m_Engine(engine) {}
 
 #define declare_template_instantiation(T)                                      \
+                                                                               \
+    template typename Variable<T>::Span Engine::Put(Variable<T> variable);
+
+ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+
+#define declare_template_instantiation(T)                                      \
     template void Engine::Put<T>(Variable<T>, const T *, const Mode);          \
     template void Engine::Put<T>(const std::string &, const T *, const Mode);  \
     template void Engine::Put<T>(Variable<T>, const T &, const Mode);          \

--- a/bindings/CXX11/cxx11/Engine.h
+++ b/bindings/CXX11/cxx11/Engine.h
@@ -85,6 +85,18 @@ public:
     size_t CurrentStep() const;
 
     /**
+     * Put signature that provides access to the internal engine buffer for a
+     * pre-allocated variable. Returns a fixed size Span (based on C++20
+     * std::span) so applications can populate data value after this Put.
+     * Requires a call to PerformPuts, EndStep, or Close to extract the Min/Max
+     * bounds.
+     * @param variable input variable
+     * @return span to variable data in engine internal buffer
+     */
+    template <class T>
+    typename Variable<T>::Span Put(Variable<T> variable);
+
+    /**
      * Put data associated with a Variable in the Engine
      * @param variable contains variable metadata information
      * @param data user data to be associated with a variable
@@ -361,6 +373,14 @@ private:
 };
 
 #define declare_template_instantiation(T)                                      \
+                                                                               \
+    extern template typename Variable<T>::Span Engine::Put(                    \
+        Variable<T> variable);
+
+ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+
+#define declare_template_instantiation(T)                                      \
     extern template void Engine::Put<T>(Variable<T>, const T *, const Mode);   \
     extern template void Engine::Put<T>(const std::string &, const T *,        \
                                         const Mode);                           \
@@ -387,7 +407,10 @@ private:
     Engine::AllStepsBlocksInfo(const Variable<T> variable) const;              \
                                                                                \
     extern template std::vector<typename Variable<T>::Info>                    \
-    Engine::BlocksInfo(const Variable<T> variable, const size_t step) const;
+    Engine::BlocksInfo(const Variable<T> variable, const size_t step) const;   \
+                                                                               \
+    extern template typename Variable<T>::Span Engine::Put(                    \
+        const Variable<T> variable);
 
 ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/bindings/CXX11/cxx11/Engine.h
+++ b/bindings/CXX11/cxx11/Engine.h
@@ -91,10 +91,12 @@ public:
      * Requires a call to PerformPuts, EndStep, or Close to extract the Min/Max
      * bounds.
      * @param variable input variable
+     * @param bufferID (default = 0) optional, if engine has multiple buffers
      * @return span to variable data in engine internal buffer
      */
     template <class T>
-    typename Variable<T>::Span Put(Variable<T> variable);
+    typename Variable<T>::Span Put(Variable<T> variable,
+                                   const size_t bufferID = 0);
 
     /**
      * Put data associated with a Variable in the Engine
@@ -374,8 +376,8 @@ private:
 
 #define declare_template_instantiation(T)                                      \
                                                                                \
-    extern template typename Variable<T>::Span Engine::Put(                    \
-        Variable<T> variable);
+    extern template typename Variable<T>::Span Engine::Put(Variable<T>,        \
+                                                           const size_t);
 
 ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
@@ -407,10 +409,7 @@ ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
     Engine::AllStepsBlocksInfo(const Variable<T> variable) const;              \
                                                                                \
     extern template std::vector<typename Variable<T>::Info>                    \
-    Engine::BlocksInfo(const Variable<T> variable, const size_t step) const;   \
-                                                                               \
-    extern template typename Variable<T>::Span Engine::Put(                    \
-        const Variable<T> variable);
+    Engine::BlocksInfo(const Variable<T> variable, const size_t step) const;
 
 ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/bindings/CXX11/cxx11/Engine.tcc
+++ b/bindings/CXX11/cxx11/Engine.tcc
@@ -59,7 +59,8 @@ ToBlocksInfo(const std::vector<typename core::Variable<
 } // end empty namespace
 
 template <class T>
-typename Variable<T>::Span Engine::Put(Variable<T> variable)
+typename Variable<T>::Span Engine::Put(Variable<T> variable,
+                                       const size_t bufferID)
 {
     adios2::helper::CheckForNullptr(m_Engine,
                                     "for Engine in call to Engine::Array");
@@ -68,7 +69,7 @@ typename Variable<T>::Span Engine::Put(Variable<T> variable)
 
     typename Variable<T>::Span::CoreSpan *coreSpan =
         reinterpret_cast<typename Variable<T>::Span::CoreSpan *>(
-            &m_Engine->Put(*variable.m_Variable));
+            &m_Engine->Put(*variable.m_Variable, bufferID));
 
     return typename Variable<T>::Span(coreSpan);
 }

--- a/bindings/CXX11/cxx11/Engine.tcc
+++ b/bindings/CXX11/cxx11/Engine.tcc
@@ -20,6 +20,8 @@
 namespace adios2
 {
 
+namespace
+{
 template <class T>
 static std::vector<typename Variable<T>::Info>
 ToBlocksInfo(const std::vector<typename core::Variable<
@@ -53,6 +55,22 @@ ToBlocksInfo(const std::vector<typename core::Variable<
     }
 
     return blocksInfo;
+}
+} // end empty namespace
+
+template <class T>
+typename Variable<T>::Span Engine::Put(Variable<T> variable)
+{
+    adios2::helper::CheckForNullptr(m_Engine,
+                                    "for Engine in call to Engine::Array");
+    adios2::helper::CheckForNullptr(variable.m_Variable,
+                                    "for variable in call to Engine::Array");
+
+    typename Variable<T>::Span::CoreSpan *coreSpan =
+        reinterpret_cast<typename Variable<T>::Span::CoreSpan *>(
+            &m_Engine->Put(*variable.m_Variable));
+
+    return typename Variable<T>::Span(coreSpan);
 }
 
 template <class T>

--- a/bindings/CXX11/cxx11/Engine.tcc
+++ b/bindings/CXX11/cxx11/Engine.tcc
@@ -95,23 +95,24 @@ void Engine::Put(const std::string &variableName, const T *data,
 }
 
 template <class T>
-void Engine::Put(Variable<T> variable, const T &datum, const Mode /*launch*/)
+void Engine::Put(Variable<T> variable, const T &datum, const Mode launch)
 {
     using IOType = typename TypeInfo<T>::IOType;
     adios2::helper::CheckForNullptr(m_Engine, "in call to Engine::Put");
     adios2::helper::CheckForNullptr(variable.m_Variable,
                                     "for variable in call to Engine::Put");
-    m_Engine->Put(*variable.m_Variable,
-                  reinterpret_cast<const IOType &>(datum));
+    m_Engine->Put(*variable.m_Variable, reinterpret_cast<const IOType &>(datum),
+                  launch);
 }
 
 template <class T>
 void Engine::Put(const std::string &variableName, const T &datum,
-                 const Mode /*launch*/)
+                 const Mode launch)
 {
     using IOType = typename TypeInfo<T>::IOType;
     adios2::helper::CheckForNullptr(m_Engine, "in call to Engine::Put");
-    m_Engine->Put(variableName, reinterpret_cast<const IOType &>(datum));
+    m_Engine->Put(variableName, reinterpret_cast<const IOType &>(datum),
+                  launch);
 }
 
 template <class T>

--- a/bindings/CXX11/cxx11/Variable.cpp
+++ b/bindings/CXX11/cxx11/Variable.cpp
@@ -224,4 +224,66 @@ namespace adios2
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
 
+#define declare_type(T)                                                        \
+                                                                               \
+    template <>                                                                \
+    Variable<T>::Span::Span(CoreSpan *coreSpan) : m_Span(coreSpan)             \
+    {                                                                          \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    size_t Variable<T>::Span::Size() const noexcept                            \
+    {                                                                          \
+        const core::Variable<IOType>::Span *coreSpan =                         \
+            reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
+        return coreSpan->Size();                                               \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    T *Variable<T>::Span::Data() const noexcept                                \
+    {                                                                          \
+        const core::Variable<IOType>::Span *coreSpan =                         \
+            reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
+        return reinterpret_cast<T *>(coreSpan->Data());                        \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    T &Variable<T>::Span::At(const size_t position)                            \
+    {                                                                          \
+        core::Variable<IOType>::Span *coreSpan =                               \
+            reinterpret_cast<core::Variable<IOType>::Span *>(m_Span);          \
+        IOType &data = coreSpan->At(position);                                 \
+        return reinterpret_cast<T &>(data);                                    \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    const T &Variable<T>::Span::At(const size_t position) const                \
+    {                                                                          \
+        const core::Variable<IOType>::Span *coreSpan =                         \
+            reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
+        const IOType &data = coreSpan->At(position);                           \
+        return reinterpret_cast<const T &>(data);                              \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    T &Variable<T>::Span::operator[](const size_t position)                    \
+    {                                                                          \
+        core::Variable<IOType>::Span *coreSpan =                               \
+            reinterpret_cast<core::Variable<IOType>::Span *>(m_Span);          \
+        IOType &data = coreSpan->Access(position);                             \
+        return reinterpret_cast<T &>(data);                                    \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    const T &Variable<T>::Span::operator[](const size_t position) const        \
+    {                                                                          \
+        const core::Variable<IOType>::Span *coreSpan =                         \
+            reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
+        const IOType &data = coreSpan->Access(position);                       \
+        return reinterpret_cast<const T &>(data);                              \
+    }
+
+ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_type)
+#undef declare_type
+
 } // end namespace adios2

--- a/bindings/CXX11/cxx11/Variable.cpp
+++ b/bindings/CXX11/cxx11/Variable.cpp
@@ -232,7 +232,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
     }                                                                          \
                                                                                \
     template <>                                                                \
-    size_t Variable<T>::Span::Size() const noexcept                            \
+    size_t Variable<T>::Span::size() const noexcept                            \
     {                                                                          \
         const core::Variable<IOType>::Span *coreSpan =                         \
             reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
@@ -240,7 +240,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
     }                                                                          \
                                                                                \
     template <>                                                                \
-    T *Variable<T>::Span::Data() const noexcept                                \
+    T *Variable<T>::Span::data() const noexcept                                \
     {                                                                          \
         const core::Variable<IOType>::Span *coreSpan =                         \
             reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
@@ -248,7 +248,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
     }                                                                          \
                                                                                \
     template <>                                                                \
-    T &Variable<T>::Span::At(const size_t position)                            \
+    T &Variable<T>::Span::at(const size_t position)                            \
     {                                                                          \
         core::Variable<IOType>::Span *coreSpan =                               \
             reinterpret_cast<core::Variable<IOType>::Span *>(m_Span);          \
@@ -257,7 +257,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
     }                                                                          \
                                                                                \
     template <>                                                                \
-    const T &Variable<T>::Span::At(const size_t position) const                \
+    const T &Variable<T>::Span::at(const size_t position) const                \
     {                                                                          \
         const core::Variable<IOType>::Span *coreSpan =                         \
             reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \

--- a/bindings/CXX11/cxx11/Variable.h
+++ b/bindings/CXX11/cxx11/Variable.h
@@ -243,7 +243,7 @@ public:
         IOType Max = IOType();   ///< block Max, if IsValue is false
         IOType Value = IOType(); ///< block Value, if IsValue is true
         bool IsValue = false;    ///< true: value, false: array
-        size_t BlockID = -1;     ///< block ID for block selections
+        size_t BlockID = 0;      ///< block ID for block selections
         size_t Step = 0;
         const T *Data() const;
 
@@ -264,6 +264,35 @@ public:
      * step
      */
     std::vector<std::vector<typename Variable<T>::Info>> AllStepsBlocksInfo();
+
+    class Span
+    {
+    public:
+        Span() = delete;
+        Span(const Span &) = delete;
+        Span(Span &&) = default;
+        ~Span() = default;
+
+        Span &operator=(const Span &) = delete;
+        Span &operator=(Span &&) = default;
+
+        size_t Size() const noexcept;
+        T *Data() const noexcept;
+
+        T &At(const size_t position);
+        const T &At(const size_t position) const;
+
+        T &operator[](const size_t position);
+        const T &operator[](const size_t position) const;
+
+        // engine allowed to set m_Span
+        friend class Engine;
+
+    private:
+        class CoreSpan;
+        Span(CoreSpan *span);
+        CoreSpan *m_Span = nullptr;
+    };
 
 private:
     Variable<T>(core::Variable<IOType> *variable);

--- a/bindings/CXX11/cxx11/Variable.h
+++ b/bindings/CXX11/cxx11/Variable.h
@@ -276,17 +276,20 @@ public:
         Span &operator=(const Span &) = delete;
         Span &operator=(Span &&) = default;
 
-        size_t Size() const noexcept;
-        T *Data() const noexcept;
+        size_t size() const noexcept;
+        T *data() const noexcept;
 
-        T &At(const size_t position);
-        const T &At(const size_t position) const;
+        T &at(const size_t position);
+        const T &at(const size_t position) const;
 
         T &operator[](const size_t position);
         const T &operator[](const size_t position) const;
 
         // engine allowed to set m_Span
         friend class Engine;
+
+        ADIOS2_CLASS_iterator;
+        ADIOS2_iterators_functions(data(), size());
 
     private:
         class CoreSpan;

--- a/bindings/Python/py11Engine.cpp
+++ b/bindings/Python/py11Engine.cpp
@@ -92,7 +92,7 @@ void Engine::Put(Variable variable, const std::string &string)
 
     m_Engine->Put(
         *dynamic_cast<core::Variable<std::string> *>(variable.m_VariableBase),
-        string);
+        string, adios2::Mode::Sync);
 }
 
 void Engine::PerformPuts()

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -244,4 +244,47 @@
     MACRO(Sync)                                                                \
     MACRO(Deferred)
 
+/**
+ * Custom iterators from:
+ * https://gist.github.com/jeetsukumaran/307264#file-custom_iterator-cpp-L26
+ */
+#define ADIOS2_CLASS_iterator                                                  \
+    class iterator                                                             \
+    {                                                                          \
+    public:                                                                    \
+        typedef iterator self_type;                                            \
+        typedef T value_type;                                                  \
+        typedef T &reference;                                                  \
+        typedef T *pointer;                                                    \
+        typedef std::forward_iterator_tag iterator_category;                   \
+        typedef int difference_type;                                           \
+        iterator(pointer ptr) : ptr_(ptr) {}                                   \
+        self_type operator++()                                                 \
+        {                                                                      \
+            self_type i = *this;                                               \
+            ptr_++;                                                            \
+            return i;                                                          \
+        }                                                                      \
+        self_type operator++(int junk)                                         \
+        {                                                                      \
+            ptr_++;                                                            \
+            return *this;                                                      \
+        }                                                                      \
+        reference operator*() { return *ptr_; }                                \
+        pointer operator->() { return ptr_; }                                  \
+        bool operator==(const self_type &rhs) { return ptr_ == rhs.ptr_; }     \
+        bool operator!=(const self_type &rhs) { return ptr_ != rhs.ptr_; }     \
+    private:                                                                   \
+        pointer ptr_;                                                          \
+    };
+
+#define ADIOS2_iterators_functions(DATA_FUNCTION, SIZE_FUNCTION)               \
+    iterator begin() noexcept { return iterator(DATA_FUNCTION); }              \
+    iterator end() noexcept                                                    \
+    {                                                                          \
+        return iterator(DATA_FUNCTION + SIZE_FUNCTION);                        \
+    }                                                                          \
+    iterator rbegin() noexcept { return --end(); }                             \
+    iterator rend() noexcept { return --begin(); }
+
 #endif /* ADIOS2_ADIOSMACROS_H */

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -6,6 +6,7 @@
  *
  * Created on: March 23, 2017
  *     Author: Chuck Atkins chuck.atkins@kitware.com
+ *             William F Godoy godoywf@ornl.gov
  */
 
 #ifndef ADIOS2_ADIOSMACROS_H
@@ -187,7 +188,7 @@
  type, and since the method is virtual then it cannot be a template.
  For example:
 
-   #define declare_foo(T,L) virtual const T& foo ## L (std::string bar);
+   #define declare_foo(T,L) virtual const T& foo_## L (std::string bar);
    ADIOS2_FOREACH_STDTYPE_2ARGS(declare_foo)
    #undef declare_foo
 
@@ -214,6 +215,21 @@
     MACRO(float, float)                                                        \
     MACRO(double, double)                                                      \
     MACRO(long double, ldouble)
+
+#define ADIOS2_FOREACH_PRIMITVE_STDTYPE_2ARGS(MACRO)                           \
+    MACRO(int8_t, int8)                                                        \
+    MACRO(uint8_t, uint8)                                                      \
+    MACRO(int16_t, int16)                                                      \
+    MACRO(uint16_t, uint16)                                                    \
+    MACRO(int32_t, int32)                                                      \
+    MACRO(uint32_t, uint32)                                                    \
+    MACRO(int64_t, int64)                                                      \
+    MACRO(uint64_t, uint64)                                                    \
+    MACRO(float, float)                                                        \
+    MACRO(double, double)                                                      \
+    MACRO(long double, ldouble)                                                \
+    MACRO(std::complex<float>, cfloat)                                         \
+    MACRO(std::complex<double>, cdouble)
 
 #define ADIOS2_FOREACH_STDTYPE_2ARGS(MACRO)                                    \
     ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)                              \

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -178,8 +178,8 @@ void Engine::CheckOpenModes(const std::set<Mode> &modes,
     template void Engine::Put<T>(Variable<T> &, const T *, const Mode);        \
     template void Engine::Put<T>(const std::string &, const T *, const Mode);  \
                                                                                \
-    template void Engine::Put<T>(Variable<T> &, const T &);                    \
-    template void Engine::Put<T>(const std::string &, const T &);              \
+    template void Engine::Put<T>(Variable<T> &, const T &, const Mode);        \
+    template void Engine::Put<T>(const std::string &, const T &, const Mode);  \
                                                                                \
     template void Engine::Get<T>(Variable<T> &, T *, const Mode);              \
     template void Engine::Get<T>(const std::string &, T *, const Mode);        \

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -85,7 +85,8 @@ void Engine::InitTransports() {}
 
 // DoPut*
 #define declare_type(T)                                                        \
-    void Engine::DoPut(Variable<T> &, typename Variable<T>::Span &)            \
+    void Engine::DoPut(Variable<T> &, typename Variable<T>::Span &,            \
+                       const size_t)                                           \
     {                                                                          \
         ThrowUp("DoPut");                                                      \
     }
@@ -211,7 +212,8 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 #define declare_template_instantiation(T)                                      \
-    template typename Variable<T>::Span &Engine::Put(Variable<T> &);
+    template typename Variable<T>::Span &Engine::Put(Variable<T> &,            \
+                                                     const size_t);
 
 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -85,6 +85,15 @@ void Engine::InitTransports() {}
 
 // DoPut*
 #define declare_type(T)                                                        \
+    void Engine::DoPut(Variable<T> &, typename Variable<T>::Span &)            \
+    {                                                                          \
+        ThrowUp("DoPut");                                                      \
+    }
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+#define declare_type(T)                                                        \
     void Engine::DoPutSync(Variable<T> &, const T *) { ThrowUp("DoPutSync"); } \
     void Engine::DoPutDeferred(Variable<T> &, const T *)                       \
     {                                                                          \
@@ -131,6 +140,17 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
     }
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+#define declare_type(T, L)                                                     \
+    T *Engine::DoBufferData_##L(const size_t payloadPosition,                  \
+                                const size_t bufferID) noexcept                \
+    {                                                                          \
+        T *data = nullptr;                                                     \
+        return data;                                                           \
+    }
+
+ADIOS2_FOREACH_PRIMITVE_STDTYPE_2ARGS(declare_type)
 #undef declare_type
 
 // PRIVATE
@@ -188,6 +208,12 @@ void Engine::CheckOpenModes(const std::set<Mode> &modes,
         const Variable<T> &, const size_t) const;
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+
+#define declare_template_instantiation(T)                                      \
+    template typename Variable<T>::Span &Engine::Put(Variable<T> &);
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace core

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -169,7 +169,7 @@ public:
      * @param datum contains user defined single value
      */
     template <class T>
-    void Put(Variable<T> &variable, const T &datum);
+    void Put(Variable<T> &variable, const T &datum, const Mode launch);
 
     /**
      * @brief Put version for single value datum using variable name. Throws
@@ -192,7 +192,8 @@ public:
      * </pre>
      */
     template <class T>
-    void Put(const std::string &variableName, const T &datum);
+    void Put(const std::string &variableName, const T &datum,
+             const Mode launch);
 
     /**
      * @brief Get associates an existing variable selections and populates data
@@ -538,8 +539,9 @@ private:
     extern template void Engine::Put<T>(const std::string &, const T *,        \
                                         const Mode);                           \
                                                                                \
-    extern template void Engine::Put<T>(Variable<T> &, const T &);             \
-    extern template void Engine::Put<T>(const std::string &, const T &);       \
+    extern template void Engine::Put<T>(Variable<T> &, const T &, const Mode); \
+    extern template void Engine::Put<T>(const std::string &, const T &,        \
+                                        const Mode);                           \
                                                                                \
     extern template void Engine::Get<T>(Variable<T> &, T *, const Mode);       \
     extern template void Engine::Get<T>(const std::string &, T *, const Mode); \

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -110,7 +110,8 @@ public:
      * application
      */
     template <class T>
-    typename Variable<T>::Span &Put(Variable<T> &variable);
+    typename Variable<T>::Span &Put(Variable<T> &variable,
+                                    const size_t bufferID = 0);
 
     /**
      * @brief Put associates variable and data into adios2 in Engine Write mode.
@@ -450,7 +451,9 @@ protected:
 
 // Put
 #define declare_type(T)                                                        \
-    virtual void DoPut(Variable<T> &variable, typename Variable<T>::Span &span);
+    virtual void DoPut(Variable<T> &variable,                                  \
+                       typename Variable<T>::Span &span,                       \
+                       const size_t blockID);
 
     ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
 #undef declare_type
@@ -571,7 +574,8 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 #define declare_template_instantiation(T)                                      \
-    extern template typename Variable<T>::Span &Engine::Put(Variable<T> &);
+    extern template typename Variable<T>::Span &Engine::Put(Variable<T> &,     \
+                                                            const size_t);
 
 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/source/adios2/core/Engine.tcc
+++ b/source/adios2/core/Engine.tcc
@@ -76,16 +76,19 @@ void Engine::Put(const std::string &variableName, const T *data,
 }
 
 template <class T>
-void Engine::Put(Variable<T> &variable, const T &datum)
+void Engine::Put(Variable<T> &variable, const T &datum, const Mode /*launch*/)
 {
     const T datumLocal = datum;
     Put(variable, &datumLocal, Mode::Sync);
 }
 
 template <class T>
-void Engine::Put(const std::string &variableName, const T &datum)
+void Engine::Put(const std::string &variableName, const T &datum,
+                 const Mode /*launch*/)
 {
-    Put(FindVariable<T>(variableName, "in call to Put"), datum);
+    const T datumLocal = datum;
+    Put(FindVariable<T>(variableName, "in call to Put"), &datumLocal,
+        Mode::Sync);
 }
 
 // Get

--- a/source/adios2/core/Engine.tcc
+++ b/source/adios2/core/Engine.tcc
@@ -23,7 +23,8 @@ namespace core
 {
 
 template <class T>
-typename Variable<T>::Span &Engine::Put(Variable<T> &variable)
+typename Variable<T>::Span &Engine::Put(Variable<T> &variable,
+                                        const size_t bufferID)
 {
     if (m_DebugMode)
     {
@@ -35,7 +36,7 @@ typename Variable<T>::Span &Engine::Put(Variable<T> &variable)
     auto itSpan = variable.m_BlocksSpan.emplace(
         variable.m_BlocksInfo.size(),
         typename Variable<T>::Span(*this, variable.TotalSize()));
-    DoPut(variable, itSpan.first->second);
+    DoPut(variable, itSpan.first->second, bufferID);
     return itSpan.first->second;
 }
 

--- a/source/adios2/core/Variable.cpp
+++ b/source/adios2/core/Variable.cpp
@@ -112,5 +112,56 @@ namespace core
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
+#define declare_type(T)                                                        \
+                                                                               \
+    template <>                                                                \
+    Variable<T>::Span::Span(Engine &engine, const size_t size)                 \
+    : m_Engine(engine), m_Size(size)                                           \
+    {                                                                          \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    size_t Variable<T>::Span::Size() const noexcept                            \
+    {                                                                          \
+        return m_Size;                                                         \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    T *Variable<T>::Span::Data() const noexcept                                \
+    {                                                                          \
+        return m_Engine.BufferData<T>(m_PayloadPosition);                      \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    T &Variable<T>::Span::At(const size_t position)                            \
+    {                                                                          \
+        T &data = DoAt(position);                                              \
+        return data;                                                           \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    const T &Variable<T>::Span::At(const size_t position) const                \
+    {                                                                          \
+        const T &data = DoAt(position);                                        \
+        return data;                                                           \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    T &Variable<T>::Span::Access(const size_t position)                        \
+    {                                                                          \
+        T &data = DoAccess(position);                                          \
+        return data;                                                           \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    const T &Variable<T>::Span::Access(const size_t position) const            \
+    {                                                                          \
+        const T &data = DoAccess(position);                                    \
+        return data;                                                           \
+    }
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -80,6 +80,40 @@ public:
     /** use for multiblock info */
     std::vector<Info> m_BlocksInfo;
 
+    class Span
+    {
+    public:
+        std::pair<size_t, size_t> m_MinMaxDataPositions;
+        std::pair<size_t, size_t> m_MinMaxMetadataPositions;
+        size_t m_PayloadPosition = 0;
+
+        Span(Engine &engine, const size_t size);
+        ~Span() = default;
+
+        size_t Size() const noexcept;
+        T *Data() const noexcept;
+
+        T &At(const size_t position);
+        const T &At(const size_t position) const;
+
+        T &Access(const size_t position);
+        const T &Access(const size_t position) const;
+
+    private:
+        Engine &m_Engine;
+        size_t m_Size = 0;
+
+        T &DoAt(const size_t position);
+        const T &DoAt(const size_t position) const;
+
+        T &DoAccess(const size_t position);
+        const T &DoAccess(const size_t position) const;
+    };
+
+    /** Needs a map to preserve iterator as it resizes and the key to match the
+     * m_BlocksInfo index */
+    std::map<size_t, Span> m_BlocksSpan;
+
     Variable<T>(const std::string &name, const Dims &shape, const Dims &start,
                 const Dims &count, const bool constantShape,
                 const bool debugMode);

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -223,6 +223,49 @@ void Variable<T>::CheckRandomAccess(const size_t step,
     }
 }
 
+// Variable<T>::Span functions
+template <class T>
+T &Variable<T>::Span::DoAt(const size_t position)
+{
+    if (position > m_Size)
+    {
+        throw std::invalid_argument(
+            "ERROR: position " + std::to_string(position) +
+            " is out of bounds for span of size " + std::to_string(m_Size) +
+            " , in call to T& Variable<T>::Span::At\n");
+    }
+
+    return DoAccess(position);
+}
+
+template <class T>
+const T &Variable<T>::Span::DoAt(const size_t position) const
+{
+    if (position > m_Size)
+    {
+        throw std::invalid_argument(
+            "ERROR: position " + std::to_string(position) +
+            " is out of bounds for span of size " + std::to_string(m_Size) +
+            " , in call to const T& Variable<T>::Span::At\n");
+    }
+
+    return DoAccess(position);
+}
+
+template <class T>
+T &Variable<T>::Span::DoAccess(const size_t position)
+{
+    T &data = *m_Engine.BufferData<T>(m_PayloadPosition + position);
+    return data;
+}
+
+template <class T>
+const T &Variable<T>::Span::DoAccess(const size_t position) const
+{
+    const T &data = *m_Engine.BufferData<T>(m_PayloadPosition + position);
+    return data;
+}
+
 } // end namespace core
 } // end namespace adios2
 

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -255,14 +255,15 @@ const T &Variable<T>::Span::DoAt(const size_t position) const
 template <class T>
 T &Variable<T>::Span::DoAccess(const size_t position)
 {
-    T &data = *m_Engine.BufferData<T>(m_PayloadPosition + position);
+    T &data = *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));
     return data;
 }
 
 template <class T>
 const T &Variable<T>::Span::DoAccess(const size_t position) const
 {
-    const T &data = *m_Engine.BufferData<T>(m_PayloadPosition + position);
+    const T &data =
+        *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));
     return data;
 }
 

--- a/source/adios2/engine/bp3/BP3Reader.h
+++ b/source/adios2/engine/bp3/BP3Reader.h
@@ -37,7 +37,7 @@ public:
     BP3Reader(IO &io, const std::string &name, const Mode mode,
               MPI_Comm mpiComm);
 
-    virtual ~BP3Reader() = default;
+    ~BP3Reader() = default;
 
     StepStatus BeginStep(StepMode mode = StepMode::NextAvailable,
                          const float timeoutSeconds = -1.0) final;

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -70,15 +70,9 @@ void BP3Writer::PerformPuts()
     {                                                                          \
         Variable<T> &variable = FindVariable<T>(                               \
             variableName, "in call to PerformPuts, EndStep or Close");         \
-                                                                               \
-        for (const auto &blockInfo : variable.m_BlocksInfo)                    \
-        {                                                                      \
-            PutSyncCommon(variable, blockInfo);                                \
-        }                                                                      \
-        variable.m_BlocksInfo.clear();                                         \
+        PerformPutCommon(variable);                                            \
     }
-
-        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }
     m_BP3Serializer.m_DeferredVariables.clear();

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -124,9 +124,10 @@ void BP3Writer::Init()
 
 #define declare_type(T)                                                        \
     void BP3Writer::DoPut(Variable<T> &variable,                               \
-                          typename Variable<T>::Span &span)                    \
+                          typename Variable<T>::Span &span,                    \
+                          const size_t bufferID)                               \
     {                                                                          \
-        return PutCommon(variable, span);                                      \
+        return PutCommon(variable, span, bufferID);                            \
     }
 
 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)

--- a/source/adios2/engine/bp3/BP3Writer.h
+++ b/source/adios2/engine/bp3/BP3Writer.h
@@ -121,6 +121,9 @@ private:
     template <class T>
     T *BufferDataCommon(const size_t payloadOffset,
                         const size_t bufferID) noexcept;
+
+    template <class T>
+    void PerformPutCommon(Variable<T> &variable);
 };
 
 } // end namespace engine

--- a/source/adios2/engine/bp3/BP3Writer.h
+++ b/source/adios2/engine/bp3/BP3Writer.h
@@ -65,7 +65,8 @@ private:
     void InitBPBuffer();
 
 #define declare_type(T)                                                        \
-    void DoPut(Variable<T> &variable, typename Variable<T>::Span &span) final;
+    void DoPut(Variable<T> &variable, typename Variable<T>::Span &span,        \
+               const size_t bufferID) final;
 
     ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
 #undef declare_type
@@ -78,7 +79,8 @@ private:
 #undef declare_type
 
     template <class T>
-    void PutCommon(Variable<T> &variable, typename Variable<T>::Span &span);
+    void PutCommon(Variable<T> &variable, typename Variable<T>::Span &span,
+                   const size_t bufferID);
 
     template <class T>
     void PutSyncCommon(Variable<T> &variable,

--- a/source/adios2/engine/bp3/BP3Writer.h
+++ b/source/adios2/engine/bp3/BP3Writer.h
@@ -36,7 +36,7 @@ public:
     BP3Writer(IO &io, const std::string &name, const Mode mode,
               MPI_Comm mpiComm);
 
-    ~BP3Writer();
+    ~BP3Writer() = default;
 
     StepStatus BeginStep(StepMode mode,
                          const float timeoutSeconds = -1.0) final;
@@ -65,17 +65,21 @@ private:
     void InitBPBuffer();
 
 #define declare_type(T)                                                        \
+    void DoPut(Variable<T> &variable, typename Variable<T>::Span &span) final;
+
+    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+#define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &, const T *) final;                            \
     void DoPutDeferred(Variable<T> &, const T *) final;
 
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
-    /**
-     * Common function for primitive PutSync, puts variables in buffer
-     * @param variable
-     * @param values
-     */
+    template <class T>
+    void PutCommon(Variable<T> &variable, typename Variable<T>::Span &span);
+
     template <class T>
     void PutSyncCommon(Variable<T> &variable,
                        const typename Variable<T>::Info &blockInfo);
@@ -104,6 +108,17 @@ private:
      * @param transportIndex
      */
     void AggregateWriteData(const bool isFinal, const int transportIndex = -1);
+
+#define declare_type(T, L)                                                     \
+    T *DoBufferData_##L(const size_t payloadPosition,                          \
+                        const size_t bufferID = 0) noexcept final;
+
+    ADIOS2_FOREACH_PRIMITVE_STDTYPE_2ARGS(declare_type)
+#undef declare_type
+
+    template <class T>
+    T *BufferDataCommon(const size_t payloadOffset,
+                        const size_t bufferID) noexcept;
 };
 
 } // end namespace engine

--- a/source/adios2/engine/bp3/BP3Writer.tcc
+++ b/source/adios2/engine/bp3/BP3Writer.tcc
@@ -21,7 +21,8 @@ namespace engine
 
 template <class T>
 void BP3Writer::PutCommon(Variable<T> &variable,
-                          typename Variable<T>::Span &span)
+                          typename Variable<T>::Span &span,
+                          const size_t /*bufferID*/)
 {
     // TODO fill payload size and span members
 }

--- a/source/adios2/engine/bp3/BP3Writer.tcc
+++ b/source/adios2/engine/bp3/BP3Writer.tcc
@@ -52,10 +52,10 @@ void BP3Writer::PutCommon(Variable<T> &variable,
 
     // WRITE INDEX to data buffer and metadata structure (in memory)//
     const bool sourceRowMajor = helper::IsRowMajor(m_IO.m_HostLanguage);
-    m_BP3Serializer.PutVariableMetadata(variable, blockInfo, span,
-                                        sourceRowMajor);
-    m_BP3Serializer.PutVariablePayload(variable, blockInfo, span,
-                                       sourceRowMajor);
+    m_BP3Serializer.PutVariableMetadata(variable, blockInfo, sourceRowMajor,
+                                        &span);
+    m_BP3Serializer.PutVariablePayload(variable, blockInfo, sourceRowMajor,
+                                       &span);
 
     // TODO fill payload size and span members
 }

--- a/source/adios2/engine/bp3/BP3Writer.tcc
+++ b/source/adios2/engine/bp3/BP3Writer.tcc
@@ -120,10 +120,8 @@ template <class T>
 T *BP3Writer::BufferDataCommon(const size_t payloadPosition,
                                const size_t /*bufferID*/) noexcept
 {
-    //    T *data = reinterpret_cast<T *>(m_BP3Serializer.m_Data.m_Buffer.data()
-    //    +
-    //                                    payloadPosition);
-    T *data = nullptr;
+    T *data = reinterpret_cast<T *>(m_BP3Serializer.m_Data.m_Buffer.data() +
+                                    payloadPosition);
     return data;
 }
 

--- a/source/adios2/engine/bp3/BP3Writer.tcc
+++ b/source/adios2/engine/bp3/BP3Writer.tcc
@@ -20,6 +20,13 @@ namespace engine
 {
 
 template <class T>
+void BP3Writer::PutCommon(Variable<T> &variable,
+                          typename Variable<T>::Span &span)
+{
+    // TODO fill payload size and span members
+}
+
+template <class T>
 void BP3Writer::PutSyncCommon(Variable<T> &variable,
                               const typename Variable<T>::Info &blockInfo)
 {
@@ -73,6 +80,17 @@ void BP3Writer::PutDeferredCommon(Variable<T> &variable, const T *data)
         4 *
             m_BP3Serializer.GetBPIndexSizeInData(variable.m_Name,
                                                  blockInfo.Count));
+}
+
+template <class T>
+T *BP3Writer::BufferDataCommon(const size_t payloadPosition,
+                               const size_t /*bufferID*/) noexcept
+{
+    //    T *data = reinterpret_cast<T *>(m_BP3Serializer.m_Data.m_Buffer.data()
+    //    +
+    //                                    payloadPosition);
+    T *data = nullptr;
+    return data;
 }
 
 } // end namespace engine

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -1482,8 +1482,17 @@ size_t BP3Serializer::GetAttributesSizeInData(core::IO &io) const noexcept
     return attributesSizeInData;
 }
 
-//------------------------------------------------------------------------------
-// Explicit instantiation of only public templates
+void BP3Serializer::SetDataOffset(uint64_t &offset) noexcept
+{
+    if (m_Aggregator.m_IsActive && !m_Aggregator.m_IsConsumer)
+    {
+        offset = static_cast<uint64_t>(m_Data.m_Position);
+    }
+    else
+    {
+        offset = static_cast<uint64_t>(m_Data.m_AbsolutePosition);
+    }
+}
 
 #define declare_template_instantiation(T)                                      \
     template void BP3Serializer::PutVariablePayload(                           \
@@ -1497,7 +1506,17 @@ size_t BP3Serializer::GetAttributesSizeInData(core::IO &io) const noexcept
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
-//------------------------------------------------------------------------------
+#define declare_template_instantiation(T)                                      \
+    template void BP3Serializer::PutVariablePayload(                           \
+        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
+        typename core::Variable<T>::Span &, const bool) noexcept;              \
+                                                                               \
+    template void BP3Serializer::PutVariableMetadata(                          \
+        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
+        typename core::Variable<T>::Span &, const bool) noexcept;
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
 
 } // end namespace format
 } // end namespace adios2

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -1495,27 +1495,15 @@ void BP3Serializer::SetDataOffset(uint64_t &offset) noexcept
 }
 
 #define declare_template_instantiation(T)                                      \
-    template void BP3Serializer::PutVariablePayload(                           \
-        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        const bool) noexcept;                                                  \
-                                                                               \
     template void BP3Serializer::PutVariableMetadata(                          \
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        const bool) noexcept;
+        const bool, typename core::Variable<T>::Span *) noexcept;              \
+                                                                               \
+    template void BP3Serializer::PutVariablePayload(                           \
+        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
+        const bool, typename core::Variable<T>::Span *) noexcept;
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
-
-#define declare_template_instantiation(T)                                      \
-    template void BP3Serializer::PutVariablePayload(                           \
-        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        typename core::Variable<T>::Span &, const bool) noexcept;              \
-                                                                               \
-    template void BP3Serializer::PutVariableMetadata(                          \
-        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        typename core::Variable<T>::Span &, const bool) noexcept;
-
-ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -1506,5 +1506,13 @@ void BP3Serializer::SetDataOffset(uint64_t &offset) noexcept
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
+#define declare_template_instantiation(T)                                      \
+    template void BP3Serializer::PutSpanMetadata(                              \
+        const core::Variable<T> &,                                             \
+        const typename core::Variable<T>::Span &) noexcept;
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+
 } // end namespace format
 } // end namespace adios2

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.h
@@ -51,30 +51,22 @@ public:
      * @param variable
      */
     template <class T>
-    void PutVariableMetadata(const core::Variable<T> &variable,
-                             const typename core::Variable<T>::Info &blockInfo,
-                             const bool sourceRowMajor = true) noexcept;
-
-    template <class T>
-    void PutVariableMetadata(const core::Variable<T> &variable,
-                             const typename core::Variable<T>::Info &blockInfo,
-                             typename core::Variable<T>::Span &span,
-                             const bool sourceRowMajor = true) noexcept;
+    void PutVariableMetadata(
+        const core::Variable<T> &variable,
+        const typename core::Variable<T>::Info &blockInfo,
+        const bool sourceRowMajor = true,
+        typename core::Variable<T>::Span *span = nullptr) noexcept;
 
     /**
      * Put in buffer variable payload. Expensive part.
      * @param variable payload input from m_PutValues
      */
     template <class T>
-    void PutVariablePayload(const core::Variable<T> &variable,
-                            const typename core::Variable<T>::Info &blockInfo,
-                            const bool sourceRowMajor = true) noexcept;
-
-    template <class T>
-    void PutVariablePayload(const core::Variable<T> &variable,
-                            const typename core::Variable<T>::Info &blockInfo,
-                            typename core::Variable<T>::Span &span,
-                            const bool sourceRowMajor = true) noexcept;
+    void PutVariablePayload(
+        const core::Variable<T> &variable,
+        const typename core::Variable<T>::Info &blockInfo,
+        const bool sourceRowMajor = true,
+        typename core::Variable<T>::Span *span = nullptr) noexcept;
 
     /**
      *  Serializes data buffer and close current process group
@@ -251,7 +243,7 @@ private:
         const core::Variable<T> &variable,
         const typename core::Variable<T>::Info &blockInfo,
         const Stats<T> &stats, const bool isNew, SerialElementIndex &index,
-        typename core::Variable<T>::Span *span = nullptr) noexcept;
+        typename core::Variable<T>::Span *span) noexcept;
 
     template <class T>
     void PutVariableCharacteristics(
@@ -435,27 +427,15 @@ private:
 };
 
 #define declare_template_instantiation(T)                                      \
-    extern template void BP3Serializer::PutVariablePayload(                    \
-        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        const bool) noexcept;                                                  \
-                                                                               \
     extern template void BP3Serializer::PutVariableMetadata(                   \
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        const bool) noexcept;
+        const bool, typename core::Variable<T>::Span *) noexcept;              \
+                                                                               \
+    extern template void BP3Serializer::PutVariablePayload(                    \
+        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
+        const bool, typename core::Variable<T>::Span *) noexcept;
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
-
-#define declare_template_instantiation(T)                                      \
-    extern template void BP3Serializer::PutVariablePayload(                    \
-        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        typename core::Variable<T>::Span &, const bool) noexcept;              \
-                                                                               \
-    extern template void BP3Serializer::PutVariableMetadata(                   \
-        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        typename core::Variable<T>::Span &, const bool) noexcept;
-
-ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.h
@@ -48,7 +48,6 @@ public:
 
     /**
      * Put in buffer metadata for a given variable
-     * @param variable
      */
     template <class T>
     void PutVariableMetadata(
@@ -67,6 +66,10 @@ public:
         const typename core::Variable<T>::Info &blockInfo,
         const bool sourceRowMajor = true,
         typename core::Variable<T>::Span *span = nullptr) noexcept;
+
+    template <class T>
+    void PutSpanMetadata(const core::Variable<T> &variable,
+                         const typename core::Variable<T>::Span &span) noexcept;
 
     /**
      *  Serializes data buffer and close current process group
@@ -436,6 +439,14 @@ private:
         const bool, typename core::Variable<T>::Span *) noexcept;
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+
+#define declare_template_instantiation(T)                                      \
+    extern template void BP3Serializer::PutSpanMetadata(                       \
+        const core::Variable<T> &,                                             \
+        const typename core::Variable<T>::Span &) noexcept;
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.h
@@ -55,6 +55,12 @@ public:
                              const typename core::Variable<T>::Info &blockInfo,
                              const bool sourceRowMajor = true) noexcept;
 
+    template <class T>
+    void PutVariableMetadata(const core::Variable<T> &variable,
+                             const typename core::Variable<T>::Info &blockInfo,
+                             typename core::Variable<T>::Span &span,
+                             const bool sourceRowMajor = true) noexcept;
+
     /**
      * Put in buffer variable payload. Expensive part.
      * @param variable payload input from m_PutValues
@@ -62,6 +68,12 @@ public:
     template <class T>
     void PutVariablePayload(const core::Variable<T> &variable,
                             const typename core::Variable<T>::Info &blockInfo,
+                            const bool sourceRowMajor = true) noexcept;
+
+    template <class T>
+    void PutVariablePayload(const core::Variable<T> &variable,
+                            const typename core::Variable<T>::Info &blockInfo,
+                            typename core::Variable<T>::Span &span,
                             const bool sourceRowMajor = true) noexcept;
 
     /**
@@ -238,14 +250,15 @@ private:
     void PutVariableMetadataInIndex(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::Info &blockInfo,
-        const Stats<T> &stats, const bool isNew,
-        SerialElementIndex &index) noexcept;
+        const Stats<T> &stats, const bool isNew, SerialElementIndex &index,
+        typename core::Variable<T>::Span *span = nullptr) noexcept;
 
     template <class T>
     void PutVariableCharacteristics(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::Info &blockInfo,
-        const Stats<T> &stats, std::vector<char> &buffer) noexcept;
+        const Stats<T> &stats, std::vector<char> &buffer,
+        typename core::Variable<T>::Span *span) noexcept;
 
     template <class T>
     void PutVariableCharacteristics(
@@ -402,6 +415,8 @@ private:
 
     size_t GetAttributesSizeInData(core::IO &io) const noexcept;
 
+    void SetDataOffset(uint64_t &offset) noexcept;
+
     template <class T>
     size_t GetAttributeSizeInData(const core::Attribute<T> &attribute) const
         noexcept;
@@ -429,6 +444,18 @@ private:
         const bool) noexcept;
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+
+#define declare_template_instantiation(T)                                      \
+    extern template void BP3Serializer::PutVariablePayload(                    \
+        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
+        typename core::Variable<T>::Span &, const bool) noexcept;              \
+                                                                               \
+    extern template void BP3Serializer::PutVariableMetadata(                   \
+        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
+        typename core::Variable<T>::Span &, const bool) noexcept;
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
@@ -687,7 +687,7 @@ void BP3Serializer::PutVariableCharacteristics(
 
     if (blockInfo.Data != nullptr || span != nullptr)
     {
-        if (m_StatsLevel == 0)
+        if (m_StatsLevel == 0 && span != nullptr)
         {
             span->m_MinMaxMetadataPositions.first = buffer.size() + 1;
             span->m_MinMaxMetadataPositions.second =

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
@@ -817,7 +817,6 @@ void BP3Serializer::PutPayloadInBuffer(
     ProfilerStart("memcpy");
     if (!blockInfo.MemoryStart.empty())
     {
-        // TODO make it a BP3Serializer function
         helper::CopyMemory(
             reinterpret_cast<T *>(m_Data.m_Buffer.data() + m_Data.m_Position),
             blockInfo.Start, blockInfo.Count, sourceRowMajor, blockInfo.Data,

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
@@ -62,6 +62,15 @@ inline void BP3Serializer::PutVariablePayload(
     const bool sourceRowMajor, typename core::Variable<T>::Span *span) noexcept
 {
     ProfilerStart("buffering");
+
+    if (span != nullptr)
+    {
+        const size_t blockSize = helper::GetTotalSize(blockInfo.Count);
+        m_Data.m_Position += blockSize * sizeof(T);
+        m_Data.m_AbsolutePosition += blockSize * sizeof(T);
+        return;
+    }
+
     if (blockInfo.Operations.empty())
     {
         PutPayloadInBuffer(variable, blockInfo, sourceRowMajor);

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -70,6 +70,9 @@ target_link_libraries(TestBPChangingShape adios2 gtest)
 add_executable(TestBPWriteReadBlockInfo TestBPWriteReadBlockInfo.cpp)
 target_link_libraries(TestBPWriteReadBlockInfo adios2 gtest)
 
+add_executable(TestBPWriteReadVariableSpan TestBPWriteReadVariableSpan.cpp)
+target_link_libraries(TestBPWriteReadVariableSpan adios2 gtest)
+
 if(ADIOS2_HAVE_MPI)
 
   target_link_libraries(TestBPWriteReadADIOS2 MPI::MPI_C)
@@ -90,6 +93,7 @@ if(ADIOS2_HAVE_MPI)
   target_link_libraries(TestBPWriteReadLocalVariablesSel MPI::MPI_C)
   target_link_libraries(TestBPChangingShape MPI::MPI_C)
   target_link_libraries(TestBPWriteReadBlockInfo MPI::MPI_C)
+  target_link_libraries(TestBPWriteReadVariableSpan MPI::MPI_C)
   
   add_executable(TestBPWriteAggregateRead TestBPWriteAggregateRead.cpp)
   target_link_libraries(TestBPWriteAggregateRead
@@ -138,4 +142,6 @@ gtest_add_tests(TARGET TestBPWriteReadLocalVariables ${extra_test_args} WORKING_
 gtest_add_tests(TARGET TestBPWriteReadLocalVariablesSel ${extra_test_args} WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4" TEST_SUFFIX _BP4)
 gtest_add_tests(TARGET TestBPChangingShape ${extra_test_args} WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4" TEST_SUFFIX _BP4)
 
-gtest_add_tests(TARGET TestBPWriteReadBlockInfo ${extra_test_args})
+# BP3 only for now
+gtest_add_tests(TARGET TestBPWriteReadBlockInfo ${extra_test_args} WORKING_DIRECTORY ${BP3_DIR})
+gtest_add_tests(TARGET TestBPWriteReadVariableSpan ${extra_test_args} WORKING_DIRECTORY ${BP3_DIR})

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -1,0 +1,976 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#include "../SmallTestData.h"
+
+std::string engineName; // comes from command line
+
+class BPWriteReadSpan : public ::testing::Test
+{
+public:
+    BPWriteReadSpan() = default;
+
+    SmallTestData m_TestData;
+};
+
+TEST_F(BPWriteReadSpan, BPWriteRead1D8)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("BPWriteReadSpan1D8.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 8;
+
+    // Number of steps
+    const size_t NSteps = 5;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using BP
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        //        if (!engineName.empty())
+        //        {
+        //            io.SetEngine(engineName);
+        //        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize)};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
+        const adios2::Dims count{Nx};
+
+        auto var_String = io.DefineVariable<std::string>("iString");
+        auto var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_i16 = io.DefineVariable<int16_t>("i16", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_i32 = io.DefineVariable<int32_t>("i32", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_i64 = io.DefineVariable<int64_t>("i64", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_u8 = io.DefineVariable<uint8_t>("u8", shape, start, count,
+                                                 adios2::ConstantDims);
+        auto var_u16 = io.DefineVariable<uint16_t>("u16", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_u32 = io.DefineVariable<uint32_t>("u32", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_u64 = io.DefineVariable<uint64_t>("u64", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+        auto var_cr32 = io.DefineVariable<std::complex<float>>(
+            "cr32", shape, start, count, adios2::ConstantDims);
+        auto var_cr64 = io.DefineVariable<std::complex<double>>(
+            "cr64", shape, start, count, adios2::ConstantDims);
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            EXPECT_EQ(bpWriter.CurrentStep(), step);
+
+            bpWriter.BeginStep();
+            bpWriter.Put<std::string>("iString", currentTestData.S1);
+
+            adios2::Variable<int8_t>::Span i8Span = bpWriter.Put(var_i8);
+            adios2::Variable<int16_t>::Span i16Span = bpWriter.Put(var_i16);
+            adios2::Variable<int32_t>::Span i32Span = bpWriter.Put(var_i32);
+            adios2::Variable<int64_t>::Span i64Span = bpWriter.Put(var_i64);
+            adios2::Variable<uint8_t>::Span u8Span = bpWriter.Put(var_u8);
+            adios2::Variable<uint16_t>::Span u16Span = bpWriter.Put(var_u16);
+            adios2::Variable<uint32_t>::Span u32Span = bpWriter.Put(var_u32);
+            adios2::Variable<uint64_t>::Span u64Span = bpWriter.Put(var_u64);
+            adios2::Variable<float>::Span r32Span = bpWriter.Put(var_r32);
+            adios2::Variable<double>::Span r64Span = bpWriter.Put(var_r64);
+            adios2::Variable<std::complex<float>>::Span cr32Span =
+                bpWriter.Put(var_cr32);
+            adios2::Variable<std::complex<double>>::Span cr64Span =
+                bpWriter.Put(var_cr64);
+
+            // Testing Data()
+            int8_t *i8_data = i8Span.Data();
+            EXPECT_EQ(i8_data, nullptr);
+
+            //            std::copy(currentTestData.I8.begin(),
+            //                      currentTestData.I8.begin() + Nx,
+            //                      i8Span.Data());
+            //            std::copy(currentTestData.I16.begin(),
+            //                      currentTestData.I16.begin() + Nx,
+            //                      i16Span.Data());
+            //            std::copy(currentTestData.I32.begin(),
+            //                      currentTestData.I32.begin() + Nx,
+            //                      i32Span.Data());
+            //            std::copy(currentTestData.I64.begin(),
+            //                      currentTestData.I64.begin() + Nx,
+            //                      i64Span.Data());
+            //            // Testing operator[] and At
+            //            for (auto i = 0; i < Nx; ++i)
+            //            {
+            //                u8Span[i] = currentTestData.U8[i];
+            //                u16Span[i] = currentTestData.U16[i];
+            //                u32Span[i] = currentTestData.U32[i];
+            //                u64Span[i] = currentTestData.U64[i];
+            //
+            //                r32Span.At(i) = currentTestData.R32[i];
+            //                r64Span.At(i) = currentTestData.R64[i];
+            //                cr32Span.At(i) = currentTestData.CR32[i];
+            //                cr64Span.At(i) = currentTestData.CR64[i];
+            //            }
+
+            // here get update min/max for spans
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    if (false)
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        //        if (!engineName.empty())
+        //        {
+        //            io.SetEngine(engineName);
+        //        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        std::string IString;
+        std::array<int8_t, Nx> I8;
+        std::array<int16_t, Nx> I16;
+        std::array<int32_t, Nx> I32;
+        std::array<int64_t, Nx> I64;
+        std::array<uint8_t, Nx> U8;
+        std::array<uint16_t, Nx> U16;
+        std::array<uint32_t, Nx> U32;
+        std::array<uint64_t, Nx> U64;
+        std::array<float, Nx> R32;
+        std::array<double, Nx> R64;
+        std::array<std::complex<float>, Nx> CR32;
+        std::array<std::complex<double>, Nx> CR64;
+
+        const adios2::Dims start{mpiRank * Nx};
+        const adios2::Dims count{Nx};
+
+        const adios2::Box<adios2::Dims> sel(start, count);
+
+        size_t t = 0;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            const size_t currentStep = bpReader.CurrentStep();
+            EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(currentStep), mpiRank, mpiSize);
+
+            auto var_iString = io.InquireVariable<std::string>("iString");
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            auto var_r32 = io.InquireVariable<float>("r32");
+            auto var_r64 = io.InquireVariable<double>("r64");
+            auto var_cr32 = io.InquireVariable<std::complex<float>>("cr32");
+            auto var_cr64 = io.InquireVariable<std::complex<double>>("cr64");
+
+            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8.Steps(), NSteps);
+            ASSERT_EQ(var_i8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16.Steps(), NSteps);
+            ASSERT_EQ(var_i16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32.Steps(), NSteps);
+            ASSERT_EQ(var_i32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64.Steps(), NSteps);
+            ASSERT_EQ(var_i64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8.Steps(), NSteps);
+            ASSERT_EQ(var_u8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16.Steps(), NSteps);
+            ASSERT_EQ(var_u16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32.Steps(), NSteps);
+            ASSERT_EQ(var_u32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64.Steps(), NSteps);
+            ASSERT_EQ(var_u64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Steps(), NSteps);
+            ASSERT_EQ(var_r32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Steps(), NSteps);
+            ASSERT_EQ(var_r64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_cr32.Steps(), NSteps);
+            ASSERT_EQ(var_cr32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_cr64.Steps(), NSteps);
+            ASSERT_EQ(var_cr64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+            var_cr32.SetSelection(sel);
+            var_cr64.SetSelection(sel);
+
+            bpReader.Get(var_iString, IString);
+            bpReader.Get(var_i8, I8.data());
+            bpReader.Get(var_i16, I16.data());
+            bpReader.Get(var_i32, I32.data());
+            bpReader.Get(var_i64, I64.data());
+            bpReader.Get(var_u8, U8.data());
+            bpReader.Get(var_u16, U16.data());
+            bpReader.Get(var_u32, U32.data());
+            bpReader.Get(var_u64, U64.data());
+            bpReader.Get(var_r32, R32.data());
+            bpReader.Get(var_r64, R64.data());
+            bpReader.Get(var_cr32, CR32.data());
+            bpReader.Get(var_cr64, CR64.data());
+            bpReader.EndStep();
+
+            EXPECT_EQ(IString, currentTestData.S1);
+
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+                EXPECT_EQ(CR32[i], currentTestData.CR32[i]) << msg;
+                EXPECT_EQ(CR64[i], currentTestData.CR64[i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
+{
+    // Each process would write a 2x4 array and all processes would
+    // form a 2D 2 * (numberOfProcess*Nx) matrix where Nx is 4 here
+    const std::string fname("BPWriteReadSpan2D2x4Test.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 4;
+
+    // Number of rows
+    const std::size_t Ny = 2;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using ADIOS2
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        // Declare 2D variables (Ny * (NumOfProcesses * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
+        {
+            const adios2::Dims shape{Ny, static_cast<size_t>(Nx * mpiSize)};
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
+            const adios2::Dims count{Ny, Nx};
+
+            io.DefineVariable<int8_t>("i8", shape, start, count,
+                                      adios2::ConstantDims);
+            io.DefineVariable<int16_t>("i16", shape, start, count,
+                                       adios2::ConstantDims);
+            io.DefineVariable<int32_t>("i32", shape, start, count,
+                                       adios2::ConstantDims);
+            io.DefineVariable<int64_t>("i64", shape, start, count,
+                                       adios2::ConstantDims);
+
+            io.DefineVariable<uint8_t>("u8", shape, start, count,
+                                       adios2::ConstantDims);
+
+            io.DefineVariable<uint16_t>("u16", shape, start, count,
+                                        adios2::ConstantDims);
+            io.DefineVariable<uint32_t>("u32", shape, start, count,
+                                        adios2::ConstantDims);
+            io.DefineVariable<uint64_t>("u64", shape, start, count,
+                                        adios2::ConstantDims);
+
+            io.DefineVariable<float>("r32", shape, start, count,
+                                     adios2::ConstantDims);
+            io.DefineVariable<double>("r64", shape, start, count,
+                                      adios2::ConstantDims);
+        }
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+        io.AddTransport("file");
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            EXPECT_EQ(bpWriter.CurrentStep(), step);
+
+            bpWriter.BeginStep();
+            bpWriter.Put<int8_t>("i8", currentTestData.I8.data());
+            bpWriter.Put<int16_t>("i16", currentTestData.I16.data());
+            bpWriter.Put<int32_t>("i32", currentTestData.I32.data());
+            bpWriter.Put<int64_t>("i64", currentTestData.I64.data());
+            bpWriter.Put<uint8_t>("u8", currentTestData.U8.data());
+            bpWriter.Put<uint16_t>("u16", currentTestData.U16.data());
+            bpWriter.Put<uint32_t>("u32", currentTestData.U32.data());
+            bpWriter.Put<uint64_t>("u64", currentTestData.U64.data());
+            bpWriter.Put<float>("r32", currentTestData.R32.data());
+            bpWriter.Put<double>("r64", currentTestData.R64.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        size_t t = 0;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            EXPECT_TRUE(var_i8);
+            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8.Steps(), NSteps);
+            ASSERT_EQ(var_i8.Shape()[0], Ny);
+            ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            EXPECT_TRUE(var_i16);
+            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16.Steps(), NSteps);
+            ASSERT_EQ(var_i16.Shape()[0], Ny);
+            ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            EXPECT_TRUE(var_i32);
+            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32.Steps(), NSteps);
+            ASSERT_EQ(var_i32.Shape()[0], Ny);
+            ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            EXPECT_TRUE(var_i64);
+            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64.Steps(), NSteps);
+            ASSERT_EQ(var_i64.Shape()[0], Ny);
+            ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            EXPECT_TRUE(var_u8);
+            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8.Steps(), NSteps);
+            ASSERT_EQ(var_u8.Shape()[0], Ny);
+            ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            EXPECT_TRUE(var_u16);
+            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16.Steps(), NSteps);
+            ASSERT_EQ(var_u16.Shape()[0], Ny);
+            ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            EXPECT_TRUE(var_u32);
+            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32.Steps(), NSteps);
+            ASSERT_EQ(var_u32.Shape()[0], Ny);
+            ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            EXPECT_TRUE(var_u64);
+            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64.Steps(), NSteps);
+            ASSERT_EQ(var_u64.Shape()[0], Ny);
+            ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Steps(), NSteps);
+            ASSERT_EQ(var_r32.Shape()[0], Ny);
+            ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(var_r64);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Steps(), NSteps);
+            ASSERT_EQ(var_r64.Shape()[0], Ny);
+            ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            std::array<int8_t, Nx * Ny> I8;
+            std::array<int16_t, Nx * Ny> I16;
+            std::array<int32_t, Nx * Ny> I32;
+            std::array<int64_t, Nx * Ny> I64;
+            std::array<uint8_t, Nx * Ny> U8;
+            std::array<uint16_t, Nx * Ny> U16;
+            std::array<uint32_t, Nx * Ny> U32;
+            std::array<uint64_t, Nx * Ny> U64;
+            std::array<float, Nx * Ny> R32;
+            std::array<double, Nx * Ny> R64;
+
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
+            const adios2::Dims count{Ny, Nx};
+
+            const adios2::Box<adios2::Dims> sel(start, count);
+
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
+            const size_t currentStep = bpReader.CurrentStep();
+            EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(currentStep), mpiRank, mpiSize);
+
+            bpReader.Get(var_i8, I8.data());
+            bpReader.Get(var_i16, I16.data());
+            bpReader.Get(var_i32, I32.data());
+            bpReader.Get(var_i64, I64.data());
+
+            bpReader.Get(var_u8, U8.data());
+            bpReader.Get(var_u16, U16.data());
+            bpReader.Get(var_u32, U32.data());
+            bpReader.Get(var_u64, U64.data());
+
+            bpReader.Get(var_r32, R32.data());
+            bpReader.Get(var_r64, R64.data());
+
+            bpReader.PerformGets();
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx * Ny; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+            }
+            ++t;
+        }
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D4x2)
+{
+    // Each process would write a 4x2 array and all processes would
+    // form a 2D 4 * (NumberOfProcess * Nx) matrix where Nx is 2 here
+    const std::string fname("BPWriteReadSpan2D4x2Test.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 2;
+    // Number of cols
+    const std::size_t Ny = 4;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using ADIOS2
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        // Declare 2D variables (4 * (NumberOfProcess * Nx))
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
+        {
+            adios2::Dims shape{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(mpiSize * Nx)};
+            adios2::Dims start{static_cast<unsigned int>(0),
+                               static_cast<unsigned int>(mpiRank * Nx)};
+            adios2::Dims count{static_cast<unsigned int>(Ny),
+                               static_cast<unsigned int>(Nx)};
+
+            io.DefineVariable<int8_t>("i8", shape, start, count,
+                                      adios2::ConstantDims);
+            io.DefineVariable<int16_t>("i16", shape, start, count,
+                                       adios2::ConstantDims);
+            io.DefineVariable<int32_t>("i32", shape, start, count,
+                                       adios2::ConstantDims);
+            io.DefineVariable<int64_t>("i64", shape, start, count,
+                                       adios2::ConstantDims);
+
+            io.DefineVariable<uint8_t>("u8", shape, start, count,
+                                       adios2::ConstantDims);
+
+            io.DefineVariable<uint16_t>("u16", shape, start, count,
+                                        adios2::ConstantDims);
+            io.DefineVariable<uint32_t>("u32", shape, start, count,
+                                        adios2::ConstantDims);
+            io.DefineVariable<uint64_t>("u64", shape, start, count,
+                                        adios2::ConstantDims);
+
+            io.DefineVariable<float>("r32", shape, start, count,
+                                     adios2::ConstantDims);
+            io.DefineVariable<double>("r64", shape, start, count,
+                                      adios2::ConstantDims);
+        }
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        io.AddTransport("file");
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            EXPECT_EQ(bpWriter.CurrentStep(), step);
+
+            bpWriter.BeginStep();
+            bpWriter.Put<int8_t>("i8", currentTestData.I8.data());
+            bpWriter.Put<int16_t>("i16", currentTestData.I16.data());
+            bpWriter.Put<int32_t>("i32", currentTestData.I32.data());
+            bpWriter.Put<int64_t>("i64", currentTestData.I64.data());
+            bpWriter.Put<uint8_t>("u8", currentTestData.U8.data());
+            bpWriter.Put<uint16_t>("u16", currentTestData.U16.data());
+            bpWriter.Put<uint32_t>("u32", currentTestData.U32.data());
+            bpWriter.Put<uint64_t>("u64", currentTestData.U64.data());
+            bpWriter.Put<float>("r32", currentTestData.R32.data());
+            bpWriter.Put<double>("r64", currentTestData.R64.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        size_t t = 0;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            EXPECT_TRUE(var_i8);
+            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8.Steps(), NSteps);
+            ASSERT_EQ(var_i8.Shape()[0], Ny);
+            ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            EXPECT_TRUE(var_i16);
+            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16.Steps(), NSteps);
+            ASSERT_EQ(var_i16.Shape()[0], Ny);
+            ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            EXPECT_TRUE(var_i32);
+            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32.Steps(), NSteps);
+            ASSERT_EQ(var_i32.Shape()[0], Ny);
+            ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            EXPECT_TRUE(var_i64);
+            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64.Steps(), NSteps);
+            ASSERT_EQ(var_i64.Shape()[0], Ny);
+            ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            EXPECT_TRUE(var_u8);
+            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8.Steps(), NSteps);
+            ASSERT_EQ(var_u8.Shape()[0], Ny);
+            ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            EXPECT_TRUE(var_u16);
+            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16.Steps(), NSteps);
+            ASSERT_EQ(var_u16.Shape()[0], Ny);
+            ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            EXPECT_TRUE(var_u32);
+            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32.Steps(), NSteps);
+            ASSERT_EQ(var_u32.Shape()[0], Ny);
+            ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            EXPECT_TRUE(var_u64);
+            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64.Steps(), NSteps);
+            ASSERT_EQ(var_u64.Shape()[0], Ny);
+            ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Steps(), NSteps);
+            ASSERT_EQ(var_r32.Shape()[0], Ny);
+            ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(var_r64);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Steps(), NSteps);
+            ASSERT_EQ(var_r64.Shape()[0], Ny);
+            ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            // If the size of the array is smaller than the data
+            // the result is weird... double and uint64_t would get
+            // completely garbage data
+            std::array<int8_t, Nx * Ny> I8;
+            std::array<int16_t, Nx * Ny> I16;
+            std::array<int32_t, Nx * Ny> I32;
+            std::array<int64_t, Nx * Ny> I64;
+            std::array<uint8_t, Nx * Ny> U8;
+            std::array<uint16_t, Nx * Ny> U16;
+            std::array<uint32_t, Nx * Ny> U32;
+            std::array<uint64_t, Nx * Ny> U64;
+            std::array<float, Nx * Ny> R32;
+            std::array<double, Nx * Ny> R64;
+
+            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
+            const adios2::Dims count{Ny, Nx};
+
+            const adios2::Box<adios2::Dims> sel(start, count);
+
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
+            const size_t currentStep = bpReader.CurrentStep();
+            EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(currentStep), mpiRank, mpiSize);
+
+            bpReader.Get(var_i8, I8.data());
+            bpReader.Get(var_i16, I16.data());
+            bpReader.Get(var_i32, I32.data());
+            bpReader.Get(var_i64, I64.data());
+
+            bpReader.Get(var_u8, U8.data());
+            bpReader.Get(var_u16, U16.data());
+            bpReader.Get(var_u32, U32.data());
+            bpReader.Get(var_u64, U64.data());
+
+            bpReader.Get(var_r32, R32.data());
+            bpReader.Get(var_r64, R64.data());
+
+            bpReader.PerformGets();
+
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx * Ny; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+            }
+            ++t;
+        }
+        EXPECT_EQ(t, NSteps);
+        bpReader.Close();
+    }
+}
+
+TEST_F(BPWriteReadSpan, DISABLED_ReaderWriterDefineVariable)
+{
+    const std::string fnameFloat("BPReaderWriterDefineVariable_float.bp");
+    const std::string fname("BPReaderWriterDefineVariable_all.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 2;
+    // Number of cols
+    const std::size_t Ny = 4;
+
+    // Number of steps
+    const std::size_t NSteps = 3;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using ADIOS2
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+
+    const adios2::Dims shape{Ny, static_cast<size_t>(Nx * mpiSize)};
+    const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
+    const adios2::Dims count{Ny, Nx};
+    // simple writer to generate content
+    {
+        adios2::IO io = adios.DeclareIO("Writer");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+
+        io.DefineVariable<float>("r32", shape, start, count,
+                                 adios2::ConstantDims);
+
+        adios2::Engine bpWriter = io.Open(fnameFloat, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", currentTestData.R32.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Barrier(MPI_COMM_WORLD);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("ReaderWriter");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+
+        adios2::Engine reader = io.Open(fnameFloat, adios2::Mode::Read);
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            reader.BeginStep();
+            adios2::Variable<float> varR32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(varR32);
+            reader.EndStep();
+
+            if (step == 0)
+            {
+                adios2::Variable<double> varR64 = io.DefineVariable<double>(
+                    "r64", shape, start, count, adios2::ConstantDims);
+                EXPECT_TRUE(varR64);
+            }
+
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+            writer.BeginStep();
+            writer.Put<float>("r32", currentTestData.R32.data());
+            writer.Put<double>("r64", currentTestData.R64.data());
+            writer.EndStep();
+        }
+
+        writer.Close();
+        reader.Close();
+    }
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Barrier(MPI_COMM_WORLD);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("Reader");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        adios2::Engine reader = io.Open(fname, adios2::Mode::Read);
+        while (reader.BeginStep() == adios2::StepStatus::OK)
+        {
+            adios2::Variable<float> varR32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(varR32);
+            adios2::Variable<double> varR64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(varR32);
+            reader.EndStep();
+        }
+        reader.Close();
+    }
+}
+
+int main(int argc, char **argv)
+{
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+    result = RUN_ALL_TESTS();
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -116,13 +116,13 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
 
             // Testing Data()
             std::copy(currentTestData.I8.begin(),
-                      currentTestData.I8.begin() + Nx, i8Span.Data());
+                      currentTestData.I8.begin() + Nx, i8Span.begin());
             std::copy(currentTestData.I16.begin(),
-                      currentTestData.I16.begin() + Nx, i16Span.Data());
+                      currentTestData.I16.begin() + Nx, i16Span.begin());
             std::copy(currentTestData.I32.begin(),
-                      currentTestData.I32.begin() + Nx, i32Span.Data());
+                      currentTestData.I32.begin() + Nx, i32Span.data());
             std::copy(currentTestData.I64.begin(),
-                      currentTestData.I64.begin() + Nx, i64Span.Data());
+                      currentTestData.I64.begin() + Nx, i64Span.data());
             // Testing operator[] and At
             for (auto i = 0; i < Nx; ++i)
             {
@@ -131,10 +131,10 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
                 u32Span[i] = currentTestData.U32[i];
                 u64Span[i] = currentTestData.U64[i];
 
-                r32Span.At(i) = currentTestData.R32[i];
-                r64Span.At(i) = currentTestData.R64[i];
-                cr32Span.At(i) = currentTestData.CR32[i];
-                cr64Span.At(i) = currentTestData.CR64[i];
+                r32Span.at(i) = currentTestData.R32[i];
+                r64Span.at(i) = currentTestData.R64[i];
+                cr32Span.at(i) = currentTestData.CR32[i];
+                cr64Span.at(i) = currentTestData.CR64[i];
             }
 
             // TODO: update min/max for spans
@@ -144,7 +144,6 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
         bpWriter.Close();
     }
 
-    if (false)
     {
         adios2::IO io = adios.DeclareIO("ReadIO");
 
@@ -272,6 +271,7 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
             bpReader.Get(var_r64, R64.data());
             bpReader.Get(var_cr32, CR32.data());
             bpReader.Get(var_cr64, CR64.data());
+
             bpReader.EndStep();
 
             EXPECT_EQ(IString, currentTestData.S1);
@@ -295,6 +295,7 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
                 EXPECT_EQ(CR32[i], currentTestData.CR32[i]) << msg;
                 EXPECT_EQ(CR64[i], currentTestData.CR64[i]) << msg;
             }
+
             ++t;
         }
 
@@ -304,11 +305,11 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
     }
 }
 
-TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
+TEST_F(BPWriteReadSpan, BPWriteRead2D2x4)
 {
     // Each process would write a 2x4 array and all processes would
     // form a 2D 2 * (numberOfProcess*Nx) matrix where Nx is 4 here
-    const std::string fname("BPWriteReadSpan2D2x4Test.bp");
+    const std::string fname("BPWriteReadSpan2D2x4.bp");
 
     int mpiRank = 0, mpiSize = 1;
     // Number of rows
@@ -338,46 +339,45 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
         // Declare 2D variables (Ny * (NumOfProcesses * Nx))
         // The local process' part (start, count) can be defined now or later
         // before Write().
-        {
-            const adios2::Dims shape{Ny, static_cast<size_t>(Nx * mpiSize)};
-            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
-            const adios2::Dims count{Ny, Nx};
+        const adios2::Dims shape{Ny, static_cast<size_t>(Nx * mpiSize)};
+        const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
+        const adios2::Dims count{Ny, Nx};
 
-            io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims);
-            io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims);
-            io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims);
-            io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims);
+        auto var_String = io.DefineVariable<std::string>("iString");
+        auto var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_i16 = io.DefineVariable<int16_t>("i16", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_i32 = io.DefineVariable<int32_t>("i32", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_i64 = io.DefineVariable<int64_t>("i64", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_u8 = io.DefineVariable<uint8_t>("u8", shape, start, count,
+                                                 adios2::ConstantDims);
+        auto var_u16 = io.DefineVariable<uint16_t>("u16", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_u32 = io.DefineVariable<uint32_t>("u32", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_u64 = io.DefineVariable<uint64_t>("u64", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+        auto var_cr32 = io.DefineVariable<std::complex<float>>(
+            "cr32", shape, start, count, adios2::ConstantDims);
+        auto var_cr64 = io.DefineVariable<std::complex<double>>(
+            "cr64", shape, start, count, adios2::ConstantDims);
 
-            io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims);
-
-            io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims);
-            io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims);
-            io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims);
-
-            io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims);
-            io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims);
-        }
-
-        if (!engineName.empty())
-        {
-            io.SetEngine(engineName);
-        }
-        else
-        {
-            // Create the BP Engine
-            io.SetEngine("BPFile");
-        }
-        io.AddTransport("file");
+        //        if (!engineName.empty())
+        //        {
+        //            io.SetEngine(engineName);
+        //        }
+        //        else
+        //        {
+        //            // Create the BP Engine
+        //            io.SetEngine("BPFile");
+        //        }
 
         adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
 
@@ -389,16 +389,54 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
             EXPECT_EQ(bpWriter.CurrentStep(), step);
 
             bpWriter.BeginStep();
-            bpWriter.Put<int8_t>("i8", currentTestData.I8.data());
-            bpWriter.Put<int16_t>("i16", currentTestData.I16.data());
-            bpWriter.Put<int32_t>("i32", currentTestData.I32.data());
-            bpWriter.Put<int64_t>("i64", currentTestData.I64.data());
-            bpWriter.Put<uint8_t>("u8", currentTestData.U8.data());
-            bpWriter.Put<uint16_t>("u16", currentTestData.U16.data());
-            bpWriter.Put<uint32_t>("u32", currentTestData.U32.data());
-            bpWriter.Put<uint64_t>("u64", currentTestData.U64.data());
-            bpWriter.Put<float>("r32", currentTestData.R32.data());
-            bpWriter.Put<double>("r64", currentTestData.R64.data());
+            adios2::Variable<int8_t>::Span i8Span = bpWriter.Put(var_i8);
+            adios2::Variable<int16_t>::Span i16Span = bpWriter.Put(var_i16);
+            adios2::Variable<int32_t>::Span i32Span = bpWriter.Put(var_i32);
+            adios2::Variable<int64_t>::Span i64Span = bpWriter.Put(var_i64);
+            adios2::Variable<uint8_t>::Span u8Span = bpWriter.Put(var_u8);
+            adios2::Variable<uint16_t>::Span u16Span = bpWriter.Put(var_u16);
+            adios2::Variable<uint32_t>::Span u32Span = bpWriter.Put(var_u32);
+            adios2::Variable<uint64_t>::Span u64Span = bpWriter.Put(var_u64);
+            adios2::Variable<float>::Span r32Span = bpWriter.Put(var_r32);
+            adios2::Variable<double>::Span r64Span = bpWriter.Put(var_r64);
+            adios2::Variable<std::complex<float>>::Span cr32Span =
+                bpWriter.Put(var_cr32);
+            adios2::Variable<std::complex<double>>::Span cr64Span =
+                bpWriter.Put(var_cr64);
+
+            // Testing Data()
+            std::copy(currentTestData.I8.begin(),
+                      currentTestData.I8.begin() + Nx * Ny, i8Span.data());
+            std::copy(currentTestData.I16.begin(),
+                      currentTestData.I16.begin() + Nx * Ny, i16Span.data());
+
+            size_t i = 0;
+            for (auto &i32 : i32Span)
+            {
+                i32 = currentTestData.I32[i];
+                ++i;
+            }
+            i = 0;
+            for (auto &i64 : i64Span)
+            {
+                i64 = currentTestData.I64[i];
+                ++i;
+            }
+
+            // Testing operator[] and At
+            for (auto i = 0; i < Nx * Ny; ++i)
+            {
+                u8Span[i] = currentTestData.U8[i];
+                u16Span[i] = currentTestData.U16[i];
+                u32Span[i] = currentTestData.U32[i];
+                u64Span[i] = currentTestData.U64[i];
+
+                r32Span.at(i) = currentTestData.R32[i];
+                r64Span.at(i) = currentTestData.R64[i];
+                cr32Span.at(i) = currentTestData.CR32[i];
+                cr64Span.at(i) = currentTestData.CR64[i];
+            }
+
             bpWriter.EndStep();
         }
 
@@ -408,10 +446,10 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
     {
         adios2::IO io = adios.DeclareIO("ReadIO");
 
-        if (!engineName.empty())
-        {
-            io.SetEngine(engineName);
-        }
+        //        if (!engineName.empty())
+        //        {
+        //            io.SetEngine(engineName);
+        //        }
 
         adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
 
@@ -489,6 +527,20 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
             ASSERT_EQ(var_r64.Shape()[0], Ny);
             ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
+            auto var_cr32 = io.InquireVariable<std::complex<float>>("cr32");
+            EXPECT_TRUE(var_cr32);
+            ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_cr32.Steps(), NSteps);
+            ASSERT_EQ(var_cr32.Shape()[0], Ny);
+            ASSERT_EQ(var_cr32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+            auto var_cr64 = io.InquireVariable<std::complex<double>>("cr64");
+            EXPECT_TRUE(var_cr64);
+            ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_cr64.Steps(), NSteps);
+            ASSERT_EQ(var_cr64.Shape()[0], Ny);
+            ASSERT_EQ(var_cr64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
             std::array<int8_t, Nx * Ny> I8;
             std::array<int16_t, Nx * Ny> I16;
             std::array<int32_t, Nx * Ny> I32;
@@ -499,6 +551,8 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
             std::array<uint64_t, Nx * Ny> U64;
             std::array<float, Nx * Ny> R32;
             std::array<double, Nx * Ny> R64;
+            std::array<std::complex<float>, Nx * Ny> CR32;
+            std::array<std::complex<double>, Nx * Ny> CR64;
 
             const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
             const adios2::Dims count{Ny, Nx};
@@ -517,6 +571,8 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
 
             var_r32.SetSelection(sel);
             var_r64.SetSelection(sel);
+            var_cr32.SetSelection(sel);
+            var_cr64.SetSelection(sel);
 
             const size_t currentStep = bpReader.CurrentStep();
             EXPECT_EQ(currentStep, static_cast<size_t>(t));
@@ -537,7 +593,9 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
             bpReader.Get(var_r32, R32.data());
             bpReader.Get(var_r64, R64.data());
 
-            bpReader.PerformGets();
+            bpReader.Get(var_cr32, CR32.data());
+            bpReader.Get(var_cr64, CR64.data());
+
             bpReader.EndStep();
 
             for (size_t i = 0; i < Nx * Ny; ++i)
@@ -556,6 +614,8 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
                 EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
                 EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
                 EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+                EXPECT_EQ(CR32[i], currentTestData.CR32[i]) << msg;
+                EXPECT_EQ(CR64[i], currentTestData.CR64[i]) << msg;
             }
             ++t;
         }
@@ -565,17 +625,281 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D2x4)
     }
 }
 
-TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D4x2)
+TEST_F(BPWriteReadSpan, BPWriteRead1D8Local)
 {
-    // Each process would write a 4x2 array and all processes would
-    // form a 2D 4 * (NumberOfProcess * Nx) matrix where Nx is 2 here
-    const std::string fname("BPWriteReadSpan2D4x2Test.bp");
+    const std::string fname("BPWriteReadSpan1D8Local.bp");
 
     int mpiRank = 0, mpiSize = 1;
     // Number of rows
-    const std::size_t Nx = 2;
-    // Number of cols
-    const std::size_t Ny = 4;
+    const size_t Nx = 8;
+
+    // Number of steps
+    const size_t NSteps = 5;
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+// Write test data using BP
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        //        if (!engineName.empty())
+        //        {
+        //            io.SetEngine(engineName);
+        //        }
+
+        const adios2::Dims shape{};
+        const adios2::Dims start{};
+        const adios2::Dims count{Nx};
+
+        auto var_String = io.DefineVariable<std::string>("iString");
+        auto var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_i16 = io.DefineVariable<int16_t>("i16", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_i32 = io.DefineVariable<int32_t>("i32", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_i64 = io.DefineVariable<int64_t>("i64", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_u8 = io.DefineVariable<uint8_t>("u8", shape, start, count,
+                                                 adios2::ConstantDims);
+        auto var_u16 = io.DefineVariable<uint16_t>("u16", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_u32 = io.DefineVariable<uint32_t>("u32", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_u64 = io.DefineVariable<uint64_t>("u64", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+        auto var_cr32 = io.DefineVariable<std::complex<float>>(
+            "cr32", shape, start, count, adios2::ConstantDims);
+        auto var_cr64 = io.DefineVariable<std::complex<double>>(
+            "cr64", shape, start, count, adios2::ConstantDims);
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            EXPECT_EQ(bpWriter.CurrentStep(), step);
+
+            bpWriter.BeginStep();
+            bpWriter.Put<std::string>("iString", currentTestData.S1);
+
+            adios2::Variable<int8_t>::Span i8Span = bpWriter.Put(var_i8);
+            adios2::Variable<int16_t>::Span i16Span = bpWriter.Put(var_i16);
+            adios2::Variable<int32_t>::Span i32Span = bpWriter.Put(var_i32);
+            adios2::Variable<int64_t>::Span i64Span = bpWriter.Put(var_i64);
+            adios2::Variable<uint8_t>::Span u8Span = bpWriter.Put(var_u8);
+            adios2::Variable<uint16_t>::Span u16Span = bpWriter.Put(var_u16);
+            adios2::Variable<uint32_t>::Span u32Span = bpWriter.Put(var_u32);
+            adios2::Variable<uint64_t>::Span u64Span = bpWriter.Put(var_u64);
+            adios2::Variable<float>::Span r32Span = bpWriter.Put(var_r32);
+            adios2::Variable<double>::Span r64Span = bpWriter.Put(var_r64);
+            adios2::Variable<std::complex<float>>::Span cr32Span =
+                bpWriter.Put(var_cr32);
+            adios2::Variable<std::complex<double>>::Span cr64Span =
+                bpWriter.Put(var_cr64);
+
+            // Testing Data()
+            std::copy(currentTestData.I8.begin(),
+                      currentTestData.I8.begin() + Nx, i8Span.begin());
+            std::copy(currentTestData.I16.begin(),
+                      currentTestData.I16.begin() + Nx, i16Span.begin());
+            std::copy(currentTestData.I32.begin(),
+                      currentTestData.I32.begin() + Nx, i32Span.data());
+            std::copy(currentTestData.I64.begin(),
+                      currentTestData.I64.begin() + Nx, i64Span.data());
+            // Testing operator[] and At
+            for (auto i = 0; i < Nx; ++i)
+            {
+                u8Span[i] = currentTestData.U8[i];
+                u16Span[i] = currentTestData.U16[i];
+                u32Span[i] = currentTestData.U32[i];
+                u64Span[i] = currentTestData.U64[i];
+
+                r32Span.at(i) = currentTestData.R32[i];
+                r64Span.at(i) = currentTestData.R64[i];
+                cr32Span.at(i) = currentTestData.CR32[i];
+                cr64Span.at(i) = currentTestData.CR64[i];
+            }
+
+            // TODO: update min/max for spans
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        //        if (!engineName.empty())
+        //        {
+        //            io.SetEngine(engineName);
+        //        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        std::string IString;
+        std::array<int8_t, Nx> I8;
+        std::array<int16_t, Nx> I16;
+        std::array<int32_t, Nx> I32;
+        std::array<int64_t, Nx> I64;
+        std::array<uint8_t, Nx> U8;
+        std::array<uint16_t, Nx> U16;
+        std::array<uint32_t, Nx> U32;
+        std::array<uint64_t, Nx> U64;
+        std::array<float, Nx> R32;
+        std::array<double, Nx> R64;
+        std::array<std::complex<float>, Nx> CR32;
+        std::array<std::complex<double>, Nx> CR64;
+
+        size_t t = 0;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            const size_t currentStep = bpReader.CurrentStep();
+            EXPECT_EQ(currentStep, static_cast<size_t>(t));
+
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(currentStep), mpiRank, mpiSize);
+
+            auto var_iString = io.InquireVariable<std::string>("iString");
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            auto var_i16 = io.InquireVariable<int16_t>("i16");
+            auto var_i32 = io.InquireVariable<int32_t>("i32");
+            auto var_i64 = io.InquireVariable<int64_t>("i64");
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            auto var_u16 = io.InquireVariable<uint16_t>("u16");
+            auto var_u32 = io.InquireVariable<uint32_t>("u32");
+            auto var_u64 = io.InquireVariable<uint64_t>("u64");
+            auto var_r32 = io.InquireVariable<float>("r32");
+            auto var_r64 = io.InquireVariable<double>("r64");
+            auto var_cr32 = io.InquireVariable<std::complex<float>>("cr32");
+            auto var_cr64 = io.InquireVariable<std::complex<double>>("cr64");
+
+            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_i8.Steps(), NSteps);
+
+            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_i16.Steps(), NSteps);
+
+            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_i32.Steps(), NSteps);
+
+            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_i64.Steps(), NSteps);
+
+            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_u8.Steps(), NSteps);
+
+            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_u16.Steps(), NSteps);
+
+            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_u32.Steps(), NSteps);
+
+            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_u64.Steps(), NSteps);
+
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_r32.Steps(), NSteps);
+
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_r64.Steps(), NSteps);
+
+            ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_cr32.Steps(), NSteps);
+
+            ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_cr64.Steps(), NSteps);
+
+            const size_t rankBlock = static_cast<size_t>(mpiRank);
+            var_i8.SetBlockSelection(rankBlock);
+            var_i16.SetBlockSelection(rankBlock);
+            var_i32.SetBlockSelection(rankBlock);
+            var_i64.SetBlockSelection(rankBlock);
+            var_u8.SetBlockSelection(rankBlock);
+            var_u16.SetBlockSelection(rankBlock);
+            var_u32.SetBlockSelection(rankBlock);
+            var_u64.SetBlockSelection(rankBlock);
+            var_r32.SetBlockSelection(rankBlock);
+            var_r64.SetBlockSelection(rankBlock);
+            var_cr32.SetBlockSelection(rankBlock);
+            var_cr64.SetBlockSelection(rankBlock);
+
+            bpReader.Get(var_iString, IString);
+            bpReader.Get(var_i8, I8.data());
+            bpReader.Get(var_i16, I16.data());
+            bpReader.Get(var_i32, I32.data());
+            bpReader.Get(var_i64, I64.data());
+            bpReader.Get(var_u8, U8.data());
+            bpReader.Get(var_u16, U16.data());
+            bpReader.Get(var_u32, U32.data());
+            bpReader.Get(var_u64, U64.data());
+            bpReader.Get(var_r32, R32.data());
+            bpReader.Get(var_r64, R64.data());
+            bpReader.Get(var_cr32, CR32.data());
+            bpReader.Get(var_cr64, CR64.data());
+
+            bpReader.EndStep();
+
+            EXPECT_EQ(IString, currentTestData.S1);
+
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+                EXPECT_EQ(CR32[i], currentTestData.CR32[i]) << msg;
+                EXPECT_EQ(CR64[i], currentTestData.CR64[i]) << msg;
+            }
+
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+TEST_F(BPWriteReadSpan, BPWriteRead2D2x4Local)
+{
+    // Each process would write a 2x4 array and all processes would
+    // form a 2D 2 * (numberOfProcess*Nx) matrix where Nx is 4 here
+    const std::string fname("BPWriteReadSpan2D2x4Local.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const std::size_t Nx = 4;
+
+    // Number of rows
+    const std::size_t Ny = 2;
 
     // Number of steps
     const std::size_t NSteps = 3;
@@ -595,53 +919,45 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D4x2)
     {
         adios2::IO io = adios.DeclareIO("TestIO");
 
-        // Declare 2D variables (4 * (NumberOfProcess * Nx))
-        // The local process' part (start, count) can be defined now or later
-        // before Write().
-        {
-            adios2::Dims shape{static_cast<unsigned int>(Ny),
-                               static_cast<unsigned int>(mpiSize * Nx)};
-            adios2::Dims start{static_cast<unsigned int>(0),
-                               static_cast<unsigned int>(mpiRank * Nx)};
-            adios2::Dims count{static_cast<unsigned int>(Ny),
-                               static_cast<unsigned int>(Nx)};
+        const adios2::Dims shape{};
+        const adios2::Dims start{};
+        const adios2::Dims count{Ny, Nx};
 
-            io.DefineVariable<int8_t>("i8", shape, start, count,
-                                      adios2::ConstantDims);
-            io.DefineVariable<int16_t>("i16", shape, start, count,
-                                       adios2::ConstantDims);
-            io.DefineVariable<int32_t>("i32", shape, start, count,
-                                       adios2::ConstantDims);
-            io.DefineVariable<int64_t>("i64", shape, start, count,
-                                       adios2::ConstantDims);
+        auto var_String = io.DefineVariable<std::string>("iString");
+        auto var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_i16 = io.DefineVariable<int16_t>("i16", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_i32 = io.DefineVariable<int32_t>("i32", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_i64 = io.DefineVariable<int64_t>("i64", shape, start, count,
+                                                  adios2::ConstantDims);
+        auto var_u8 = io.DefineVariable<uint8_t>("u8", shape, start, count,
+                                                 adios2::ConstantDims);
+        auto var_u16 = io.DefineVariable<uint16_t>("u16", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_u32 = io.DefineVariable<uint32_t>("u32", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_u64 = io.DefineVariable<uint64_t>("u64", shape, start, count,
+                                                   adios2::ConstantDims);
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+        auto var_cr32 = io.DefineVariable<std::complex<float>>(
+            "cr32", shape, start, count, adios2::ConstantDims);
+        auto var_cr64 = io.DefineVariable<std::complex<double>>(
+            "cr64", shape, start, count, adios2::ConstantDims);
 
-            io.DefineVariable<uint8_t>("u8", shape, start, count,
-                                       adios2::ConstantDims);
-
-            io.DefineVariable<uint16_t>("u16", shape, start, count,
-                                        adios2::ConstantDims);
-            io.DefineVariable<uint32_t>("u32", shape, start, count,
-                                        adios2::ConstantDims);
-            io.DefineVariable<uint64_t>("u64", shape, start, count,
-                                        adios2::ConstantDims);
-
-            io.DefineVariable<float>("r32", shape, start, count,
-                                     adios2::ConstantDims);
-            io.DefineVariable<double>("r64", shape, start, count,
-                                      adios2::ConstantDims);
-        }
-
-        if (!engineName.empty())
-        {
-            io.SetEngine(engineName);
-        }
-        else
-        {
-            // Create the BP Engine
-            io.SetEngine("BPFile");
-        }
-
-        io.AddTransport("file");
+        //        if (!engineName.empty())
+        //        {
+        //            io.SetEngine(engineName);
+        //        }
+        //        else
+        //        {
+        //            // Create the BP Engine
+        //            io.SetEngine("BPFile");
+        //        }
 
         adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
 
@@ -653,16 +969,54 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D4x2)
             EXPECT_EQ(bpWriter.CurrentStep(), step);
 
             bpWriter.BeginStep();
-            bpWriter.Put<int8_t>("i8", currentTestData.I8.data());
-            bpWriter.Put<int16_t>("i16", currentTestData.I16.data());
-            bpWriter.Put<int32_t>("i32", currentTestData.I32.data());
-            bpWriter.Put<int64_t>("i64", currentTestData.I64.data());
-            bpWriter.Put<uint8_t>("u8", currentTestData.U8.data());
-            bpWriter.Put<uint16_t>("u16", currentTestData.U16.data());
-            bpWriter.Put<uint32_t>("u32", currentTestData.U32.data());
-            bpWriter.Put<uint64_t>("u64", currentTestData.U64.data());
-            bpWriter.Put<float>("r32", currentTestData.R32.data());
-            bpWriter.Put<double>("r64", currentTestData.R64.data());
+            adios2::Variable<int8_t>::Span i8Span = bpWriter.Put(var_i8);
+            adios2::Variable<int16_t>::Span i16Span = bpWriter.Put(var_i16);
+            adios2::Variable<int32_t>::Span i32Span = bpWriter.Put(var_i32);
+            adios2::Variable<int64_t>::Span i64Span = bpWriter.Put(var_i64);
+            adios2::Variable<uint8_t>::Span u8Span = bpWriter.Put(var_u8);
+            adios2::Variable<uint16_t>::Span u16Span = bpWriter.Put(var_u16);
+            adios2::Variable<uint32_t>::Span u32Span = bpWriter.Put(var_u32);
+            adios2::Variable<uint64_t>::Span u64Span = bpWriter.Put(var_u64);
+            adios2::Variable<float>::Span r32Span = bpWriter.Put(var_r32);
+            adios2::Variable<double>::Span r64Span = bpWriter.Put(var_r64);
+            adios2::Variable<std::complex<float>>::Span cr32Span =
+                bpWriter.Put(var_cr32);
+            adios2::Variable<std::complex<double>>::Span cr64Span =
+                bpWriter.Put(var_cr64);
+
+            // Testing Data()
+            std::copy(currentTestData.I8.begin(),
+                      currentTestData.I8.begin() + Nx * Ny, i8Span.data());
+            std::copy(currentTestData.I16.begin(),
+                      currentTestData.I16.begin() + Nx * Ny, i16Span.data());
+
+            size_t i = 0;
+            for (auto &i32 : i32Span)
+            {
+                i32 = currentTestData.I32[i];
+                ++i;
+            }
+            i = 0;
+            for (auto it = i64Span.begin(); it != i64Span.end(); ++it)
+            {
+                *it = currentTestData.I64[i];
+                ++i;
+            }
+
+            // Testing operator[] and At
+            for (auto i = 0; i < Nx * Ny; ++i)
+            {
+                u8Span[i] = currentTestData.U8[i];
+                u16Span[i] = currentTestData.U16[i];
+                u32Span[i] = currentTestData.U32[i];
+                u64Span[i] = currentTestData.U64[i];
+
+                r32Span.at(i) = currentTestData.R32[i];
+                r64Span.at(i) = currentTestData.R64[i];
+                cr32Span.at(i) = currentTestData.CR32[i];
+                cr64Span.at(i) = currentTestData.CR64[i];
+            }
+
             bpWriter.EndStep();
         }
 
@@ -672,10 +1026,10 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D4x2)
     {
         adios2::IO io = adios.DeclareIO("ReadIO");
 
-        if (!engineName.empty())
-        {
-            io.SetEngine(engineName);
-        }
+        //        if (!engineName.empty())
+        //        {
+        //            io.SetEngine(engineName);
+        //        }
 
         adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
 
@@ -683,80 +1037,66 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D4x2)
 
         while (bpReader.BeginStep() == adios2::StepStatus::OK)
         {
-
             auto var_i8 = io.InquireVariable<int8_t>("i8");
             EXPECT_TRUE(var_i8);
-            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_i8.Steps(), NSteps);
-            ASSERT_EQ(var_i8.Shape()[0], Ny);
-            ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i16 = io.InquireVariable<int16_t>("i16");
             EXPECT_TRUE(var_i16);
-            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_i16.Steps(), NSteps);
-            ASSERT_EQ(var_i16.Shape()[0], Ny);
-            ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i32 = io.InquireVariable<int32_t>("i32");
             EXPECT_TRUE(var_i32);
-            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_i32.Steps(), NSteps);
-            ASSERT_EQ(var_i32.Shape()[0], Ny);
-            ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i64 = io.InquireVariable<int64_t>("i64");
             EXPECT_TRUE(var_i64);
-            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_i64.Steps(), NSteps);
-            ASSERT_EQ(var_i64.Shape()[0], Ny);
-            ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u8 = io.InquireVariable<uint8_t>("u8");
             EXPECT_TRUE(var_u8);
-            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_u8.Steps(), NSteps);
-            ASSERT_EQ(var_u8.Shape()[0], Ny);
-            ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u16 = io.InquireVariable<uint16_t>("u16");
             EXPECT_TRUE(var_u16);
-            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_u16.Steps(), NSteps);
-            ASSERT_EQ(var_u16.Shape()[0], Ny);
-            ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u32 = io.InquireVariable<uint32_t>("u32");
             EXPECT_TRUE(var_u32);
-            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_u32.Steps(), NSteps);
-            ASSERT_EQ(var_u32.Shape()[0], Ny);
-            ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u64 = io.InquireVariable<uint64_t>("u64");
             EXPECT_TRUE(var_u64);
-            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_u64.Steps(), NSteps);
-            ASSERT_EQ(var_u64.Shape()[0], Ny);
-            ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_r32 = io.InquireVariable<float>("r32");
             EXPECT_TRUE(var_r32);
-            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_r32.Steps(), NSteps);
-            ASSERT_EQ(var_r32.Shape()[0], Ny);
-            ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_r64 = io.InquireVariable<double>("r64");
             EXPECT_TRUE(var_r64);
-            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::LocalArray);
             ASSERT_EQ(var_r64.Steps(), NSteps);
-            ASSERT_EQ(var_r64.Shape()[0], Ny);
-            ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
-            // If the size of the array is smaller than the data
-            // the result is weird... double and uint64_t would get
-            // completely garbage data
+            auto var_cr32 = io.InquireVariable<std::complex<float>>("cr32");
+            EXPECT_TRUE(var_cr32);
+            ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_cr32.Steps(), NSteps);
+
+            auto var_cr64 = io.InquireVariable<std::complex<double>>("cr64");
+            EXPECT_TRUE(var_cr64);
+            ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::LocalArray);
+            ASSERT_EQ(var_cr64.Steps(), NSteps);
+
             std::array<int8_t, Nx * Ny> I8;
             std::array<int16_t, Nx * Ny> I16;
             std::array<int32_t, Nx * Ny> I32;
@@ -767,24 +1107,22 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D4x2)
             std::array<uint64_t, Nx * Ny> U64;
             std::array<float, Nx * Ny> R32;
             std::array<double, Nx * Ny> R64;
+            std::array<std::complex<float>, Nx * Ny> CR32;
+            std::array<std::complex<double>, Nx * Ny> CR64;
 
-            const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
-            const adios2::Dims count{Ny, Nx};
-
-            const adios2::Box<adios2::Dims> sel(start, count);
-
-            var_i8.SetSelection(sel);
-            var_i16.SetSelection(sel);
-            var_i32.SetSelection(sel);
-            var_i64.SetSelection(sel);
-
-            var_u8.SetSelection(sel);
-            var_u16.SetSelection(sel);
-            var_u32.SetSelection(sel);
-            var_u64.SetSelection(sel);
-
-            var_r32.SetSelection(sel);
-            var_r64.SetSelection(sel);
+            const size_t rankBlock = static_cast<size_t>(mpiRank);
+            var_i8.SetBlockSelection(rankBlock);
+            var_i16.SetBlockSelection(rankBlock);
+            var_i32.SetBlockSelection(rankBlock);
+            var_i64.SetBlockSelection(rankBlock);
+            var_u8.SetBlockSelection(rankBlock);
+            var_u16.SetBlockSelection(rankBlock);
+            var_u32.SetBlockSelection(rankBlock);
+            var_u64.SetBlockSelection(rankBlock);
+            var_r32.SetBlockSelection(rankBlock);
+            var_r64.SetBlockSelection(rankBlock);
+            var_cr32.SetBlockSelection(rankBlock);
+            var_cr64.SetBlockSelection(rankBlock);
 
             const size_t currentStep = bpReader.CurrentStep();
             EXPECT_EQ(currentStep, static_cast<size_t>(t));
@@ -804,8 +1142,8 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D4x2)
 
             bpReader.Get(var_r32, R32.data());
             bpReader.Get(var_r64, R64.data());
-
-            bpReader.PerformGets();
+            bpReader.Get(var_cr32, CR32.data());
+            bpReader.Get(var_cr64, CR64.data());
 
             bpReader.EndStep();
 
@@ -825,124 +1163,14 @@ TEST_F(BPWriteReadSpan, DISABLED_BPWriteRead2D4x2)
                 EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
                 EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
                 EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+                EXPECT_EQ(CR32[i], currentTestData.CR32[i]) << msg;
+                EXPECT_EQ(CR64[i], currentTestData.CR64[i]) << msg;
             }
             ++t;
         }
         EXPECT_EQ(t, NSteps);
+
         bpReader.Close();
-    }
-}
-
-TEST_F(BPWriteReadSpan, DISABLED_ReaderWriterDefineVariable)
-{
-    const std::string fnameFloat("BPReaderWriterDefineVariable_float.bp");
-    const std::string fname("BPReaderWriterDefineVariable_all.bp");
-
-    int mpiRank = 0, mpiSize = 1;
-    // Number of rows
-    const std::size_t Nx = 2;
-    // Number of cols
-    const std::size_t Ny = 4;
-
-    // Number of steps
-    const std::size_t NSteps = 3;
-
-#ifdef ADIOS2_HAVE_MPI
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
-#endif
-
-// Write test data using ADIOS2
-
-#ifdef ADIOS2_HAVE_MPI
-    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
-#else
-    adios2::ADIOS adios(true);
-#endif
-
-    const adios2::Dims shape{Ny, static_cast<size_t>(Nx * mpiSize)};
-    const adios2::Dims start{0, static_cast<size_t>(mpiRank * Nx)};
-    const adios2::Dims count{Ny, Nx};
-    // simple writer to generate content
-    {
-        adios2::IO io = adios.DeclareIO("Writer");
-        if (!engineName.empty())
-        {
-            io.SetEngine(engineName);
-        }
-
-        io.DefineVariable<float>("r32", shape, start, count,
-                                 adios2::ConstantDims);
-
-        adios2::Engine bpWriter = io.Open(fnameFloat, adios2::Mode::Write);
-
-        for (size_t step = 0; step < NSteps; ++step)
-        {
-            SmallTestData currentTestData = generateNewSmallTestData(
-                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
-            bpWriter.BeginStep();
-            bpWriter.Put<float>("r32", currentTestData.R32.data());
-            bpWriter.EndStep();
-        }
-
-        bpWriter.Close();
-    }
-#ifdef ADIOS2_HAVE_MPI
-    MPI_Barrier(MPI_COMM_WORLD);
-#endif
-    {
-        adios2::IO io = adios.DeclareIO("ReaderWriter");
-        if (!engineName.empty())
-        {
-            io.SetEngine(engineName);
-        }
-
-        adios2::Engine reader = io.Open(fnameFloat, adios2::Mode::Read);
-        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
-        for (size_t step = 0; step < NSteps; ++step)
-        {
-            reader.BeginStep();
-            adios2::Variable<float> varR32 = io.InquireVariable<float>("r32");
-            EXPECT_TRUE(varR32);
-            reader.EndStep();
-
-            if (step == 0)
-            {
-                adios2::Variable<double> varR64 = io.DefineVariable<double>(
-                    "r64", shape, start, count, adios2::ConstantDims);
-                EXPECT_TRUE(varR64);
-            }
-
-            SmallTestData currentTestData = generateNewSmallTestData(
-                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
-            writer.BeginStep();
-            writer.Put<float>("r32", currentTestData.R32.data());
-            writer.Put<double>("r64", currentTestData.R64.data());
-            writer.EndStep();
-        }
-
-        writer.Close();
-        reader.Close();
-    }
-#ifdef ADIOS2_HAVE_MPI
-    MPI_Barrier(MPI_COMM_WORLD);
-#endif
-    {
-        adios2::IO io = adios.DeclareIO("Reader");
-        if (!engineName.empty())
-        {
-            io.SetEngine(engineName);
-        }
-        adios2::Engine reader = io.Open(fname, adios2::Mode::Read);
-        while (reader.BeginStep() == adios2::StepStatus::OK)
-        {
-            adios2::Variable<float> varR32 = io.InquireVariable<float>("r32");
-            EXPECT_TRUE(varR32);
-            adios2::Variable<double> varR64 = io.InquireVariable<double>("r64");
-            EXPECT_TRUE(varR32);
-            reader.EndStep();
-        }
-        reader.Close();
     }
 }
 

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -115,36 +115,29 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
                 bpWriter.Put(var_cr64);
 
             // Testing Data()
-            int8_t *i8_data = i8Span.Data();
-            EXPECT_EQ(i8_data, nullptr);
+            std::copy(currentTestData.I8.begin(),
+                      currentTestData.I8.begin() + Nx, i8Span.Data());
+            std::copy(currentTestData.I16.begin(),
+                      currentTestData.I16.begin() + Nx, i16Span.Data());
+            std::copy(currentTestData.I32.begin(),
+                      currentTestData.I32.begin() + Nx, i32Span.Data());
+            std::copy(currentTestData.I64.begin(),
+                      currentTestData.I64.begin() + Nx, i64Span.Data());
+            // Testing operator[] and At
+            for (auto i = 0; i < Nx; ++i)
+            {
+                u8Span[i] = currentTestData.U8[i];
+                u16Span[i] = currentTestData.U16[i];
+                u32Span[i] = currentTestData.U32[i];
+                u64Span[i] = currentTestData.U64[i];
 
-            //            std::copy(currentTestData.I8.begin(),
-            //                      currentTestData.I8.begin() + Nx,
-            //                      i8Span.Data());
-            //            std::copy(currentTestData.I16.begin(),
-            //                      currentTestData.I16.begin() + Nx,
-            //                      i16Span.Data());
-            //            std::copy(currentTestData.I32.begin(),
-            //                      currentTestData.I32.begin() + Nx,
-            //                      i32Span.Data());
-            //            std::copy(currentTestData.I64.begin(),
-            //                      currentTestData.I64.begin() + Nx,
-            //                      i64Span.Data());
-            //            // Testing operator[] and At
-            //            for (auto i = 0; i < Nx; ++i)
-            //            {
-            //                u8Span[i] = currentTestData.U8[i];
-            //                u16Span[i] = currentTestData.U16[i];
-            //                u32Span[i] = currentTestData.U32[i];
-            //                u64Span[i] = currentTestData.U64[i];
-            //
-            //                r32Span.At(i) = currentTestData.R32[i];
-            //                r64Span.At(i) = currentTestData.R64[i];
-            //                cr32Span.At(i) = currentTestData.CR32[i];
-            //                cr64Span.At(i) = currentTestData.CR64[i];
-            //            }
+                r32Span.At(i) = currentTestData.R32[i];
+                r64Span.At(i) = currentTestData.R64[i];
+                cr32Span.At(i) = currentTestData.CR32[i];
+                cr64Span.At(i) = currentTestData.CR64[i];
+            }
 
-            // here get update min/max for spans
+            // TODO: update min/max for spans
             bpWriter.EndStep();
         }
 


### PR DESCRIPTION
This PR exposes pre-allocated buffer memory to the app so it can be filled out.

Addresses several issues for write use-cases:

1. Avoid buffer duplication if application is memory-bound
2. Reduce the number of sub-block metadata by pre-allocating larger block memory in adios2 which is exposed to the app as in #1165
3. Allow for non-contiguous data to populate the contiguous buffer data directly (e.g. MFEM nodes in element) without the need of temporaries

Will explore Read use-cases (single buffer for streaming engines) in future PRs.