### PR TITLE
fix IO::RemoveVariable/Attribute

### DIFF
--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -165,7 +165,7 @@ bool IO::RemoveVariable(const std::string &name) noexcept
 #define declare_type(T)                                                        \
     else if (type == helper::GetType<T>())                                     \
     {                                                                          \
-        auto variableMap = GetVariableMap<T>();                                \
+        auto &variableMap = GetVariableMap<T>();                               \
         variableMap.erase(index);                                              \
         isRemoved = true;                                                      \
     }
@@ -208,7 +208,7 @@ bool IO::RemoveAttribute(const std::string &name) noexcept
 #define declare_type(T)                                                        \
     else if (type == helper::GetType<T>())                                     \
     {                                                                          \
-        auto attributeMap = GetAttributeMap<T>();                              \
+        auto &attributeMap = GetAttributeMap<T>();                             \
         attributeMap.erase(index);                                             \
         isRemoved = true;                                                      \
     }

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -67,7 +67,7 @@ StepStatus SstWriter::BeginStep(StepMode mode, const float timeout_sec)
 void SstWriter::FFSMarshalAttributes()
 {
     TAU_SCOPED_TIMER_FUNC();
-    const auto attributesDataMap = m_IO.GetAttributesDataMap();
+    const auto &attributesDataMap = m_IO.GetAttributesDataMap();
 
     const uint32_t attributesCount =
         static_cast<uint32_t>(attributesDataMap.size());

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -390,7 +390,7 @@ void BP3Serializer::UpdateOffsetsInMetadata()
 // PRIVATE FUNCTIONS
 void BP3Serializer::PutAttributes(core::IO &io)
 {
-    const auto attributesDataMap = io.GetAttributesDataMap();
+    const auto &attributesDataMap = io.GetAttributesDataMap();
 
     auto &buffer = m_Data.m_Buffer;
     auto &position = m_Data.m_Position;

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
@@ -440,7 +440,7 @@ void BP4Serializer::UpdateOffsetsInMetadata()
 // PRIVATE FUNCTIONS
 void BP4Serializer::PutAttributes(core::IO &io)
 {
-    const auto attributesDataMap = io.GetAttributesDataMap();
+    const auto &attributesDataMap = io.GetAttributesDataMap();
 
     auto &buffer = m_Data.m_Buffer;
     auto &position = m_Data.m_Position;

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -282,7 +282,7 @@ bool DataManSerializer::IsCompressionAvailable(const std::string &method,
 
 void DataManSerializer::PutAttributes(core::IO &io)
 {
-    const auto attributesDataMap = io.GetAttributesDataMap();
+    const auto &attributesDataMap = io.GetAttributesDataMap();
     for (const auto &attributePair : attributesDataMap)
     {
         const std::string name(attributePair.first);
@@ -306,7 +306,7 @@ void DataManSerializer::GetAttributes(core::IO &io)
     std::lock_guard<std::mutex> lStaticDataJson(m_StaticDataJsonMutex);
     for (const auto &staticVar : m_StaticDataJson["S"])
     {
-        const auto attributesDataMap = io.GetAttributesDataMap();
+        const auto &attributesDataMap = io.GetAttributesDataMap();
         const std::string type(staticVar["Y"].get<std::string>());
         if (type == "")
         {

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -306,7 +306,6 @@ void DataManSerializer::GetAttributes(core::IO &io)
     std::lock_guard<std::mutex> lStaticDataJson(m_StaticDataJsonMutex);
     for (const auto &staticVar : m_StaticDataJson["S"])
     {
-        const auto &attributesDataMap = io.GetAttributesDataMap();
         const std::string type(staticVar["Y"].get<std::string>());
         if (type == "")
         {
@@ -314,6 +313,7 @@ void DataManSerializer::GetAttributes(core::IO &io)
 #define declare_type(T)                                                        \
     else if (type == helper::GetType<T>())                                     \
     {                                                                          \
+        const auto &attributesDataMap = io.GetAttributesDataMap();             \
         auto it = attributesDataMap.find(staticVar["N"].get<std::string>());   \
         if (it == attributesDataMap.end())                                     \
         {                                                                      \


### PR DESCRIPTION
For background, see #1193 .

I had suggested a fix in PR #1267, which was rejected. @williamfgc then fixed it himself in #1278, except that that fix only fixed part of the issue. (I.e., it made sure that indices would be unique even after the variable is removed from the 2nd level map, but still failed to actually do the removal.)

As I already said before, @williamfgc's fix for the uniqueness issue was clearly better than mine.

I can't help but point out, though, that the I don't agree with the contention that making data types that wrap STL containers is categorically a bad idea. Specifically, if one were to wrap these data types, one could prevent bugs where a data structure is mistakenly copied in its entirety when taking a reference was intended (by deleting the copy constructor). This PR fixes the places where that currently happened in the code, including actual bugs (that prevent 2nd level removal) and performance bugs (taking a copy doesn't hurt, but is unnecessarily expensive). It doesn't to anything do prevent these kind of bugs from happening again in the future. 
