### PR TITLE
Modify SST writer to deal with the ReleaseTimestep race differently

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -87,7 +87,9 @@ typedef struct _CPTimestepEntry
     struct _SstData Data;
     struct _TimestepMetadataMsg *Msg;
     int ReferenceCount;
+    int NeverSent;
     void **DP_TimestepInfo;
+    int DPRegistered;
     SstData MetadataArray;
     DataFreeFunc FreeTimestep;
     void *FreeClientData;

--- a/source/adios2/toolkit/sst/cp/cp_reader.c
+++ b/source/adios2/toolkit/sst/cp/cp_reader.c
@@ -938,7 +938,7 @@ static TSMetadataList waitForNextMetadata(SstStream Stream, long LastTimestep)
         {
             CP_verbose(Stream, "Examining metadata for Timestep %d\n",
                        Next->MetadataMsg->Timestep);
-            if (Next->MetadataMsg->Metadata == NULL)
+            if ((Next->MetadataMsg->Metadata == NULL) && (FoundTS == NULL))
             {
                 /*
                  * This is a dummy timestep for something that was
@@ -953,7 +953,7 @@ static TSMetadataList waitForNextMetadata(SstStream Stream, long LastTimestep)
                 TSMetadataList Tmp = Next;
                 Next = Next->Next;
                 FreeTimestep(Stream, Tmp->MetadataMsg->Timestep);
-                break;
+                continue;
             }
             if (Next->MetadataMsg->Timestep >= LastTimestep)
             {


### PR DESCRIPTION
Modify SST writer to deal with the ReleaseTimestep race differently, eliminating an MPI_Barrier()