### PR TITLE
mpi_aggregator: don't pass a local variable to MPI_Isend

### DIFF
--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -333,9 +333,8 @@ void BP3Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
         std::vector<MPI_Request> dataRequests =
             m_BP3Serializer.m_Aggregator.IExchange(m_BP3Serializer.m_Data, r);
 
-        std::vector<MPI_Request> absolutePositionRequests =
-            m_BP3Serializer.m_Aggregator.IExchangeAbsolutePosition(
-                m_BP3Serializer.m_Data, r);
+        m_BP3Serializer.m_Aggregator.IExchangeAbsolutePosition(
+            m_BP3Serializer.m_Data, r);
 
         if (m_BP3Serializer.m_Aggregator.m_IsConsumer)
         {
@@ -349,8 +348,7 @@ void BP3Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
             m_FileDataManager.FlushFiles(transportIndex);
         }
 
-        m_BP3Serializer.m_Aggregator.WaitAbsolutePosition(
-            absolutePositionRequests, r);
+        m_BP3Serializer.m_Aggregator.WaitAbsolutePosition(r);
 
         m_BP3Serializer.m_Aggregator.Wait(dataRequests, r);
         m_BP3Serializer.m_Aggregator.SwapBuffers(r);

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -330,8 +330,7 @@ void BP3Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
     // async?
     for (int r = 0; r < m_BP3Serializer.m_Aggregator.m_Size; ++r)
     {
-        std::vector<MPI_Request> dataRequests =
-            m_BP3Serializer.m_Aggregator.IExchange(m_BP3Serializer.m_Data, r);
+        m_BP3Serializer.m_Aggregator.IExchange(m_BP3Serializer.m_Data, r);
 
         m_BP3Serializer.m_Aggregator.IExchangeAbsolutePosition(
             m_BP3Serializer.m_Data, r);
@@ -350,7 +349,7 @@ void BP3Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
 
         m_BP3Serializer.m_Aggregator.WaitAbsolutePosition(r);
 
-        m_BP3Serializer.m_Aggregator.Wait(dataRequests, r);
+        m_BP3Serializer.m_Aggregator.Wait(r);
         m_BP3Serializer.m_Aggregator.SwapBuffers(r);
     }
 

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -533,9 +533,8 @@ void BP4Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
         std::vector<MPI_Request> dataRequests =
             m_BP4Serializer.m_Aggregator.IExchange(m_BP4Serializer.m_Data, r);
 
-        std::vector<MPI_Request> absolutePositionRequests =
-            m_BP4Serializer.m_Aggregator.IExchangeAbsolutePosition(
-                m_BP4Serializer.m_Data, r);
+        m_BP4Serializer.m_Aggregator.IExchangeAbsolutePosition(
+            m_BP4Serializer.m_Data, r);
 
         if (m_BP4Serializer.m_Aggregator.m_IsConsumer)
         {
@@ -549,8 +548,7 @@ void BP4Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
             m_FileDataManager.FlushFiles(transportIndex);
         }
 
-        m_BP4Serializer.m_Aggregator.WaitAbsolutePosition(
-            absolutePositionRequests, r);
+        m_BP4Serializer.m_Aggregator.WaitAbsolutePosition(r);
 
         m_BP4Serializer.m_Aggregator.Wait(dataRequests, r);
         m_BP4Serializer.m_Aggregator.SwapBuffers(r);

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -530,8 +530,7 @@ void BP4Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
     // async?
     for (int r = 0; r < m_BP4Serializer.m_Aggregator.m_Size; ++r)
     {
-        std::vector<MPI_Request> dataRequests =
-            m_BP4Serializer.m_Aggregator.IExchange(m_BP4Serializer.m_Data, r);
+        m_BP4Serializer.m_Aggregator.IExchange(m_BP4Serializer.m_Data, r);
 
         m_BP4Serializer.m_Aggregator.IExchangeAbsolutePosition(
             m_BP4Serializer.m_Data, r);
@@ -550,7 +549,7 @@ void BP4Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
 
         m_BP4Serializer.m_Aggregator.WaitAbsolutePosition(r);
 
-        m_BP4Serializer.m_Aggregator.Wait(dataRequests, r);
+        m_BP4Serializer.m_Aggregator.Wait(r);
         m_BP4Serializer.m_Aggregator.SwapBuffers(r);
     }
 

--- a/source/adios2/helper/mpidummy.cpp
+++ b/source/adios2/helper/mpidummy.cpp
@@ -34,6 +34,8 @@ namespace helper
 namespace mpi
 {
 
+MPI_Status *MPI_STATUS_IGNORE;
+
 static char mpierrmsg[MPI_MAX_ERROR_STRING];
 
 int MPI_Init(int * /*argc*/, char *** /*argv*/)

--- a/source/adios2/helper/mpidummy.h
+++ b/source/adios2/helper/mpidummy.h
@@ -83,6 +83,8 @@ using MPI_Op = int;
 
 #define MPI_MAX_PROCESSOR_NAME 32
 
+extern MPI_Status *MPI_STATUS_IGNORE;
+
 int MPI_Init(int *argc, char ***argv);
 int MPI_Finalize();
 int MPI_Initialized(int *flag);

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
@@ -31,11 +31,8 @@ MPIAggregator::~MPIAggregator()
 
 void MPIAggregator::Init(const size_t subStreams, MPI_Comm parentComm) {}
 
-std::vector<MPI_Request> MPIAggregator::IExchange(BufferSTL & /**bufferSTL*/,
-                                                  const int /** step*/)
+void MPIAggregator::IExchange(BufferSTL & /**bufferSTL*/, const int /** step*/)
 {
-    std::vector<MPI_Request> requests;
-    return requests;
 }
 
 void MPIAggregator::IExchangeAbsolutePosition(BufferSTL &bufferSTL,
@@ -103,10 +100,7 @@ void MPIAggregator::WaitAbsolutePosition(const int step)
     }
 }
 
-void MPIAggregator::Wait(std::vector<MPI_Request> & /**requests*/,
-                         const int /**step*/)
-{
-}
+void MPIAggregator::Wait(const int /**step*/) {}
 
 void MPIAggregator::SwapBuffers(const int step) noexcept {}
 

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
@@ -80,13 +80,12 @@ void MPIAggregator::WaitAbsolutePosition(const int step)
         return;
     }
 
-    MPI_Status status;
     const int destination = (step != m_Size - 1) ? step + 1 : 0;
 
     if (m_Rank == destination)
     {
         helper::CheckMPIReturn(
-            MPI_Wait(&m_AbsolutePositionRequests[1], &status),
+            MPI_Wait(&m_AbsolutePositionRequests[1], MPI_STATUS_IGNORE),
             ", aggregation Irecv Wait absolute position at iteration " +
                 std::to_string(step) + "\n");
     }
@@ -94,7 +93,7 @@ void MPIAggregator::WaitAbsolutePosition(const int step)
     if (m_Rank == step)
     {
         helper::CheckMPIReturn(
-            MPI_Wait(&m_AbsolutePositionRequests[0], &status),
+            MPI_Wait(&m_AbsolutePositionRequests[0], MPI_STATUS_IGNORE),
             ", aggregation Isend Wait absolute position at iteration " +
                 std::to_string(step) + "\n");
     }

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
@@ -57,16 +57,12 @@ MPIAggregator::IExchangeAbsolutePosition(BufferSTL &bufferSTL, const int step)
 
     if (m_Rank == step)
     {
-        const size_t position = (m_Rank == 0)
-                                    ? m_SizeSend
-                                    : m_SizeSend + bufferSTL.m_AbsolutePosition;
+        m_AbsolutePositionSend =
+            (m_Rank == 0) ? m_SizeSend
+                          : m_SizeSend + bufferSTL.m_AbsolutePosition;
 
-        // While the MPI_Isend function should take a const void* as it's first
-        // argument, some MPICH implementations provide a broken signature
-        // which takes a non-const first argument.  The explicit const_cast
-        // here works around this.
         helper::CheckMPIReturn(
-            MPI_Isend(const_cast<size_t *>(&position), 1, ADIOS2_MPI_SIZE_T,
+            MPI_Isend(&m_AbsolutePositionSend, 1, ADIOS2_MPI_SIZE_T,
                       destination, 0, m_Comm, &requests[0]),
             ", aggregation Isend absolute position at iteration " +
                 std::to_string(step) + "\n");

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
@@ -15,6 +15,8 @@
 #include "adios2/ADIOSTypes.h"
 #include "adios2/toolkit/format/BufferSTL.h"
 
+#include <array>
+
 namespace adios2
 {
 namespace aggregator
@@ -63,11 +65,9 @@ public:
     virtual std::vector<MPI_Request> IExchange(BufferSTL &bufferSTL,
                                                const int step);
 
-    std::vector<MPI_Request> IExchangeAbsolutePosition(BufferSTL &bufferSTL,
-                                                       const int step);
+    void IExchangeAbsolutePosition(BufferSTL &bufferSTL, const int step);
 
-    void WaitAbsolutePosition(std::vector<MPI_Request> &requests,
-                              const int step);
+    void WaitAbsolutePosition(const int step);
 
     virtual void Wait(std::vector<MPI_Request> &requests, const int step);
 
@@ -90,6 +90,9 @@ protected:
 
     /** assigning extra buffers for aggregation */
     std::vector<BufferSTL> m_Buffers;
+
+private:
+    std::array<MPI_Request, 2> m_AbsolutePositionRequests;
 };
 
 } // end namespace aggregator

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
@@ -62,14 +62,13 @@ public:
 
     virtual void Init(const size_t subStreams, MPI_Comm parentComm);
 
-    virtual std::vector<MPI_Request> IExchange(BufferSTL &bufferSTL,
-                                               const int step);
+    virtual void IExchange(BufferSTL &bufferSTL, const int step);
 
     void IExchangeAbsolutePosition(BufferSTL &bufferSTL, const int step);
 
     void WaitAbsolutePosition(const int step);
 
-    virtual void Wait(std::vector<MPI_Request> &requests, const int step);
+    virtual void Wait(const int step);
 
     virtual void SwapBuffers(const int step) noexcept;
 

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
@@ -52,6 +52,7 @@ public:
     int m_ConsumerRank = -1;
 
     size_t m_SizeSend = 0;
+    size_t m_AbsolutePositionSend;
 
     MPIAggregator();
 

--- a/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
@@ -71,9 +71,8 @@ void MPIChain::IExchange(BufferSTL &bufferSTL, const int step)
                                ", aggregation Irecv size at iteration " +
                                    std::to_string(step) + "\n");
 
-        MPI_Status receiveStatus;
         helper::CheckMPIReturn(
-            MPI_Wait(&receiveSizeRequest, &receiveStatus),
+            MPI_Wait(&receiveSizeRequest, MPI_STATUS_IGNORE),
             ", aggregation waiting for receiver size at iteration " +
                 std::to_string(step) + "\n");
 
@@ -103,11 +102,10 @@ void MPIChain::Wait(const int step)
     const bool sender = (m_Rank >= 1 && m_Rank <= endRank) ? true : false;
     const bool receiver = (m_Rank < endRank) ? true : false;
 
-    MPI_Status status;
     if (receiver)
     {
         helper::CheckMPIReturn(
-            MPI_Wait(&m_DataRequests[2], &status),
+            MPI_Wait(&m_DataRequests[2], MPI_STATUS_IGNORE),
             ", aggregation waiting for receiver data at iteration " +
                 std::to_string(step) + "\n");
     }
@@ -115,12 +113,12 @@ void MPIChain::Wait(const int step)
     if (sender)
     {
         helper::CheckMPIReturn(
-            MPI_Wait(&m_DataRequests[0], &status),
+            MPI_Wait(&m_DataRequests[0], MPI_STATUS_IGNORE),
             ", aggregation waiting for sender size at iteration " +
                 std::to_string(step) + "\n");
 
         helper::CheckMPIReturn(
-            MPI_Wait(&m_DataRequests[1], &status),
+            MPI_Wait(&m_DataRequests[1], MPI_STATUS_IGNORE),
             ", aggregation waiting for sender data at iteration " +
                 std::to_string(step) + "\n");
     }
@@ -159,17 +157,15 @@ void MPIChain::HandshakeLinks()
                       &receiveRequest),
             "Irecv handshake with neighbor, MPIChain aggregator, at Open");
 
-        MPI_Status receiveStatus;
         helper::CheckMPIReturn(
-            MPI_Wait(&receiveRequest, &receiveStatus),
+            MPI_Wait(&receiveRequest, MPI_STATUS_IGNORE),
             "Irecv Wait handshake with neighbor, MPIChain aggregator, at Open");
     }
 
     if (m_Rank > 0)
     {
-        MPI_Status sendStatus;
         helper::CheckMPIReturn(
-            MPI_Wait(&sendRequest, &sendStatus),
+            MPI_Wait(&sendRequest, MPI_STATUS_IGNORE),
             "Isend wait handshake with neighbor, MPIChain aggregator, at Open");
     }
 }

--- a/source/adios2/toolkit/aggregator/mpi/MPIChain.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIChain.h
@@ -28,10 +28,9 @@ public:
 
     void Init(const size_t subStreams, MPI_Comm parentComm) final;
 
-    std::vector<MPI_Request> IExchange(BufferSTL &bufferSTL,
-                                       const int step) final;
+    void IExchange(BufferSTL &bufferSTL, const int step) final;
 
-    void Wait(std::vector<MPI_Request> &request, const int step) final;
+    void Wait(const int step) final;
 
     void SwapBuffers(const int step) noexcept final;
 
@@ -73,6 +72,8 @@ private:
      */
     void ResizeUpdateBufferSTL(const size_t newSize, BufferSTL &bufferSTL,
                                const std::string hint);
+
+    std::array<MPI_Request, 3> m_DataRequests;
 };
 
 } // end namespace aggregator


### PR DESCRIPTION
The data passed to MPI_Isend needs to remain available until after
MPI_Wait, so use a class member variable instead.

This also means the member variable can't be const, so the workaround for some MPI_Isend implementations isn't needed anymore.
