### PR TITLE
Some template-related cleanup for Span

### DIFF
--- a/bindings/CXX11/cxx11/Variable.cpp
+++ b/bindings/CXX11/cxx11/Variable.cpp
@@ -233,59 +233,48 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #define declare_type(T)                                                        \
                                                                                \
     template <>                                                                \
-    Variable<T>::Span::Span(CoreSpan *coreSpan) : m_Span(coreSpan)             \
+    Variable<T>::Span::Span(core::Span<IOType> *coreSpan)                      \
+    : m_Span(coreSpan)                                                         \
     {                                                                          \
     }                                                                          \
                                                                                \
     template <>                                                                \
     size_t Variable<T>::Span::size() const noexcept                            \
     {                                                                          \
-        const core::Variable<IOType>::Span *coreSpan =                         \
-            reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
-        return coreSpan->Size();                                               \
+        return m_Span->Size();                                                 \
     }                                                                          \
                                                                                \
     template <>                                                                \
     T *Variable<T>::Span::data() const noexcept                                \
     {                                                                          \
-        const core::Variable<IOType>::Span *coreSpan =                         \
-            reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
-        return reinterpret_cast<T *>(coreSpan->Data());                        \
+        return reinterpret_cast<T *>(m_Span->Data());                          \
     }                                                                          \
                                                                                \
     template <>                                                                \
     T &Variable<T>::Span::at(const size_t position)                            \
     {                                                                          \
-        core::Variable<IOType>::Span *coreSpan =                               \
-            reinterpret_cast<core::Variable<IOType>::Span *>(m_Span);          \
-        IOType &data = coreSpan->At(position);                                 \
+        IOType &data = m_Span->At(position);                                   \
         return reinterpret_cast<T &>(data);                                    \
     }                                                                          \
                                                                                \
     template <>                                                                \
     const T &Variable<T>::Span::at(const size_t position) const                \
     {                                                                          \
-        const core::Variable<IOType>::Span *coreSpan =                         \
-            reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
-        const IOType &data = coreSpan->At(position);                           \
+        const IOType &data = m_Span->At(position);                             \
         return reinterpret_cast<const T &>(data);                              \
     }                                                                          \
                                                                                \
     template <>                                                                \
     T &Variable<T>::Span::operator[](const size_t position)                    \
     {                                                                          \
-        core::Variable<IOType>::Span *coreSpan =                               \
-            reinterpret_cast<core::Variable<IOType>::Span *>(m_Span);          \
-        IOType &data = coreSpan->Access(position);                             \
+        IOType &data = m_Span->Access(position);                               \
         return reinterpret_cast<T &>(data);                                    \
     }                                                                          \
                                                                                \
     template <>                                                                \
     const T &Variable<T>::Span::operator[](const size_t position) const        \
     {                                                                          \
-        const core::Variable<IOType>::Span *coreSpan =                         \
-            reinterpret_cast<const core::Variable<IOType>::Span *>(m_Span);    \
-        const IOType &data = coreSpan->Access(position);                       \
+        const IOType &data = m_Span->Access(position);                         \
         return reinterpret_cast<const T &>(data);                              \
     }
 

--- a/bindings/CXX11/cxx11/Variable.cpp
+++ b/bindings/CXX11/cxx11/Variable.cpp
@@ -226,59 +226,11 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 
 #define declare_template_instantiation(T)                                      \
     template std::string ToString(const Variable<T> &var);
-
 ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
-#define declare_type(T)                                                        \
-                                                                               \
-    template <>                                                                \
-    Variable<T>::Span::Span(core::Span<IOType> *coreSpan)                      \
-    : m_Span(coreSpan)                                                         \
-    {                                                                          \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    size_t Variable<T>::Span::size() const noexcept                            \
-    {                                                                          \
-        return m_Span->Size();                                                 \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    T *Variable<T>::Span::data() const noexcept                                \
-    {                                                                          \
-        return reinterpret_cast<T *>(m_Span->Data());                          \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    T &Variable<T>::Span::at(const size_t position)                            \
-    {                                                                          \
-        IOType &data = m_Span->At(position);                                   \
-        return reinterpret_cast<T &>(data);                                    \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    const T &Variable<T>::Span::at(const size_t position) const                \
-    {                                                                          \
-        const IOType &data = m_Span->At(position);                             \
-        return reinterpret_cast<const T &>(data);                              \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    T &Variable<T>::Span::operator[](const size_t position)                    \
-    {                                                                          \
-        IOType &data = m_Span->Access(position);                               \
-        return reinterpret_cast<T &>(data);                                    \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    const T &Variable<T>::Span::operator[](const size_t position) const        \
-    {                                                                          \
-        const IOType &data = m_Span->Access(position);                         \
-        return reinterpret_cast<const T &>(data);                              \
-    }
-
-ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_type)
-#undef declare_type
+#define declare_template_instantiation(T) template class detail::Span<T>;
+ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
 
 } // end namespace adios2

--- a/bindings/CXX11/cxx11/Variable.h
+++ b/bindings/CXX11/cxx11/Variable.h
@@ -28,6 +28,9 @@ namespace core
 
 template <class T>
 class Variable; // private implementation
+
+template <class T>
+class Span; // private implementation
 }
 /// \endcond
 
@@ -352,7 +355,7 @@ public:
         ADIOS2_iterators_functions(data(), size());
 
     private:
-        class CoreSpan;
+        using CoreSpan = core::Span<IOType>;
         Span(CoreSpan *span);
         CoreSpan *m_Span = nullptr;
     };

--- a/bindings/CXX11/cxx11/Variable.tcc
+++ b/bindings/CXX11/cxx11/Variable.tcc
@@ -124,14 +124,14 @@ const T &Span<T>::at(const size_t position) const
 template <class T>
 T &Span<T>::operator[](const size_t position)
 {
-    IOType &data = m_Span->Access(position);
+    IOType &data = (*m_Span)[position];
     return reinterpret_cast<T &>(data);
 }
 
 template <class T>
 const T &Span<T>::operator[](const size_t position) const
 {
-    const IOType &data = m_Span->Access(position);
+    const IOType &data = (*m_Span)[position];
     return reinterpret_cast<const T &>(data);
 }
 

--- a/bindings/CXX11/cxx11/Variable.tcc
+++ b/bindings/CXX11/cxx11/Variable.tcc
@@ -87,6 +87,56 @@ std::string ToString(const Variable<T> &variable)
            variable.Name() + "\")";
 }
 
+namespace detail
+{
+// Span
+template <class T>
+Span<T>::Span(core::Span<IOType> *coreSpan) : m_Span(coreSpan)
+{
+}
+
+template <class T>
+size_t Span<T>::size() const noexcept
+{
+    return m_Span->Size();
+}
+
+template <class T>
+T *Span<T>::data() const noexcept
+{
+    return reinterpret_cast<T *>(m_Span->Data());
+}
+
+template <class T>
+T &Span<T>::at(const size_t position)
+{
+    IOType &data = m_Span->At(position);
+    return reinterpret_cast<T &>(data);
+}
+
+template <class T>
+const T &Span<T>::at(const size_t position) const
+{
+    const IOType &data = m_Span->At(position);
+    return reinterpret_cast<const T &>(data);
+}
+
+template <class T>
+T &Span<T>::operator[](const size_t position)
+{
+    IOType &data = m_Span->Access(position);
+    return reinterpret_cast<T &>(data);
+}
+
+template <class T>
+const T &Span<T>::operator[](const size_t position) const
+{
+    const IOType &data = m_Span->Access(position);
+    return reinterpret_cast<const T &>(data);
+}
+
+} // end namespace detail
+
 } // end namespace adios2
 
 #endif /* ADIOS2_BINDINGS_CXX11_CXX11_VARIABLE_TCC_ */

--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -277,11 +277,6 @@
 
 #define ADIOS2_iterators_functions(DATA_FUNCTION, SIZE_FUNCTION)               \
     iterator begin() noexcept { return iterator(DATA_FUNCTION); }              \
-    iterator end() noexcept                                                    \
-    {                                                                          \
-        return iterator(DATA_FUNCTION + SIZE_FUNCTION);                        \
-    }                                                                          \
-    iterator rbegin() noexcept { return --end(); }                             \
-    iterator rend() noexcept { return --begin(); }
+    iterator end() noexcept { return iterator(DATA_FUNCTION + SIZE_FUNCTION); }
 
 #endif /* ADIOS2_ADIOSMACROS_H */

--- a/source/adios2/core/Variable.cpp
+++ b/source/adios2/core/Variable.cpp
@@ -112,52 +112,6 @@ namespace core
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
-template <class T>
-Span<T>::Span(Engine &engine, const size_t size)
-: m_Engine(engine), m_Size(size)
-{
-}
-
-template <class T>
-size_t Span<T>::Size() const noexcept
-{
-    return m_Size;
-}
-
-template <class T>
-T *Span<T>::Data() const noexcept
-{
-    return m_Engine.BufferData<T>(m_PayloadPosition);
-}
-
-template <class T>
-T &Span<T>::At(const size_t position)
-{
-    T &data = DoAt(position);
-    return data;
-}
-
-template <class T>
-const T &Span<T>::At(const size_t position) const
-{
-    const T &data = DoAt(position);
-    return data;
-}
-
-template <class T>
-T &Span<T>::Access(const size_t position)
-{
-    T &data = DoAccess(position);
-    return data;
-}
-
-template <class T>
-const T &Span<T>::Access(const size_t position) const
-{
-    const T &data = DoAccess(position);
-    return data;
-}
-
 #define declare_template_instantiation(T) template class Span<T>;
 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_type

--- a/source/adios2/core/Variable.cpp
+++ b/source/adios2/core/Variable.cpp
@@ -112,55 +112,54 @@ namespace core
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
-#define declare_type(T)                                                        \
-                                                                               \
-    template <>                                                                \
-    Variable<T>::Span::Span(Engine &engine, const size_t size)                 \
-    : m_Engine(engine), m_Size(size)                                           \
-    {                                                                          \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    size_t Variable<T>::Span::Size() const noexcept                            \
-    {                                                                          \
-        return m_Size;                                                         \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    T *Variable<T>::Span::Data() const noexcept                                \
-    {                                                                          \
-        return m_Engine.BufferData<T>(m_PayloadPosition);                      \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    T &Variable<T>::Span::At(const size_t position)                            \
-    {                                                                          \
-        T &data = DoAt(position);                                              \
-        return data;                                                           \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    const T &Variable<T>::Span::At(const size_t position) const                \
-    {                                                                          \
-        const T &data = DoAt(position);                                        \
-        return data;                                                           \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    T &Variable<T>::Span::Access(const size_t position)                        \
-    {                                                                          \
-        T &data = DoAccess(position);                                          \
-        return data;                                                           \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    const T &Variable<T>::Span::Access(const size_t position) const            \
-    {                                                                          \
-        const T &data = DoAccess(position);                                    \
-        return data;                                                           \
-    }
+template <class T>
+Span<T>::Span(Engine &engine, const size_t size)
+: m_Engine(engine), m_Size(size)
+{
+}
 
-ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
+template <class T>
+size_t Span<T>::Size() const noexcept
+{
+    return m_Size;
+}
+
+template <class T>
+T *Span<T>::Data() const noexcept
+{
+    return m_Engine.BufferData<T>(m_PayloadPosition);
+}
+
+template <class T>
+T &Span<T>::At(const size_t position)
+{
+    T &data = DoAt(position);
+    return data;
+}
+
+template <class T>
+const T &Span<T>::At(const size_t position) const
+{
+    const T &data = DoAt(position);
+    return data;
+}
+
+template <class T>
+T &Span<T>::Access(const size_t position)
+{
+    T &data = DoAccess(position);
+    return data;
+}
+
+template <class T>
+const T &Span<T>::Access(const size_t position) const
+{
+    const T &data = DoAccess(position);
+    return data;
+}
+
+#define declare_template_instantiation(T) template class Span<T>;
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_type
 
 } // end namespace core

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -52,12 +52,6 @@ public:
 private:
     Engine &m_Engine;
     size_t m_Size = 0;
-
-    T &DoAt(const size_t position);
-    const T &DoAt(const size_t position) const;
-
-    T &DoAccess(const size_t position);
-    const T &DoAccess(const size_t position) const;
 };
 
 /**

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -28,6 +28,38 @@ namespace adios2
 namespace core
 {
 
+template <class T>
+class Span
+{
+public:
+    std::pair<size_t, size_t> m_MinMaxDataPositions;
+    std::pair<size_t, size_t> m_MinMaxMetadataPositions;
+    size_t m_PayloadPosition = 0;
+    T m_Value = T{};
+
+    Span(Engine &engine, const size_t size);
+    ~Span() = default;
+
+    size_t Size() const noexcept;
+    T *Data() const noexcept;
+
+    T &At(const size_t position);
+    const T &At(const size_t position) const;
+
+    T &Access(const size_t position);
+    const T &Access(const size_t position) const;
+
+private:
+    Engine &m_Engine;
+    size_t m_Size = 0;
+
+    T &DoAt(const size_t position);
+    const T &DoAt(const size_t position) const;
+
+    T &DoAccess(const size_t position);
+    const T &DoAccess(const size_t position) const;
+};
+
 /**
  * @param Base (parent) class for template derived (child) class Variable.
  */
@@ -80,36 +112,7 @@ public:
     /** use for multiblock info */
     std::vector<Info> m_BlocksInfo;
 
-    class Span
-    {
-    public:
-        std::pair<size_t, size_t> m_MinMaxDataPositions;
-        std::pair<size_t, size_t> m_MinMaxMetadataPositions;
-        size_t m_PayloadPosition = 0;
-        T m_Value = T{};
-
-        Span(Engine &engine, const size_t size);
-        ~Span() = default;
-
-        size_t Size() const noexcept;
-        T *Data() const noexcept;
-
-        T &At(const size_t position);
-        const T &At(const size_t position) const;
-
-        T &Access(const size_t position);
-        const T &Access(const size_t position) const;
-
-    private:
-        Engine &m_Engine;
-        size_t m_Size = 0;
-
-        T &DoAt(const size_t position);
-        const T &DoAt(const size_t position) const;
-
-        T &DoAccess(const size_t position);
-        const T &DoAccess(const size_t position) const;
-    };
+    using Span = core::Span<T>;
 
     /** Needs a map to preserve iterator as it resizes and the key to match the
      * m_BlocksInfo index */

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -46,8 +46,8 @@ public:
     T &At(const size_t position);
     const T &At(const size_t position) const;
 
-    T &Access(const size_t position);
-    const T &Access(const size_t position) const;
+    T &operator[](const size_t position);
+    const T &operator[](const size_t position) const;
 
 private:
     Engine &m_Engine;

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -222,44 +222,44 @@ void Variable<T>::CheckRandomAccess(const size_t step,
     }
 }
 
-// Variable<T>::Span functions
+// Span functions
 template <class T>
-T &Variable<T>::Span::DoAt(const size_t position)
+T &Span<T>::DoAt(const size_t position)
 {
     if (position > m_Size)
     {
         throw std::invalid_argument(
             "ERROR: position " + std::to_string(position) +
             " is out of bounds for span of size " + std::to_string(m_Size) +
-            " , in call to T& Variable<T>::Span::At\n");
+            " , in call to T& Span<T>::At\n");
     }
 
     return DoAccess(position);
 }
 
 template <class T>
-const T &Variable<T>::Span::DoAt(const size_t position) const
+const T &Span<T>::DoAt(const size_t position) const
 {
     if (position > m_Size)
     {
         throw std::invalid_argument(
             "ERROR: position " + std::to_string(position) +
             " is out of bounds for span of size " + std::to_string(m_Size) +
-            " , in call to const T& Variable<T>::Span::At\n");
+            " , in call to const T& Span<T>::At\n");
     }
 
     return DoAccess(position);
 }
 
 template <class T>
-T &Variable<T>::Span::DoAccess(const size_t position)
+T &Span<T>::DoAccess(const size_t position)
 {
     T &data = *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));
     return data;
 }
 
 template <class T>
-const T &Variable<T>::Span::DoAccess(const size_t position) const
+const T &Span<T>::DoAccess(const size_t position) const
 {
     const T &data =
         *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -252,7 +252,7 @@ T &Span<T>::At(const size_t position)
             " , in call to T& Span<T>::At\n");
     }
 
-    return Access(position);
+    return (*this)[position];
 }
 
 template <class T>
@@ -266,18 +266,18 @@ const T &Span<T>::At(const size_t position) const
             " , in call to const T& Span<T>::At\n");
     }
 
-    return Access(position);
+    return (*this)[position];
 }
 
 template <class T>
-T &Span<T>::Access(const size_t position)
+T &Span<T>::operator[](const size_t position)
 {
     T &data = *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));
     return data;
 }
 
 template <class T>
-const T &Span<T>::Access(const size_t position) const
+const T &Span<T>::operator[](const size_t position) const
 {
     const T &data =
         *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -224,49 +224,6 @@ void Variable<T>::CheckRandomAccess(const size_t step,
 
 // Span functions
 template <class T>
-T &Span<T>::DoAt(const size_t position)
-{
-    if (position > m_Size)
-    {
-        throw std::invalid_argument(
-            "ERROR: position " + std::to_string(position) +
-            " is out of bounds for span of size " + std::to_string(m_Size) +
-            " , in call to T& Span<T>::At\n");
-    }
-
-    return DoAccess(position);
-}
-
-template <class T>
-const T &Span<T>::DoAt(const size_t position) const
-{
-    if (position > m_Size)
-    {
-        throw std::invalid_argument(
-            "ERROR: position " + std::to_string(position) +
-            " is out of bounds for span of size " + std::to_string(m_Size) +
-            " , in call to const T& Span<T>::At\n");
-    }
-
-    return DoAccess(position);
-}
-
-template <class T>
-T &Span<T>::DoAccess(const size_t position)
-{
-    T &data = *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));
-    return data;
-}
-
-template <class T>
-const T &Span<T>::DoAccess(const size_t position) const
-{
-    const T &data =
-        *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));
-    return data;
-}
-
-template <class T>
 Span<T>::Span(Engine &engine, const size_t size)
 : m_Engine(engine), m_Size(size)
 {
@@ -287,28 +244,43 @@ T *Span<T>::Data() const noexcept
 template <class T>
 T &Span<T>::At(const size_t position)
 {
-    T &data = DoAt(position);
-    return data;
+    if (position > m_Size)
+    {
+        throw std::invalid_argument(
+            "ERROR: position " + std::to_string(position) +
+            " is out of bounds for span of size " + std::to_string(m_Size) +
+            " , in call to T& Span<T>::At\n");
+    }
+
+    return Access(position);
 }
 
 template <class T>
 const T &Span<T>::At(const size_t position) const
 {
-    const T &data = DoAt(position);
-    return data;
+    if (position > m_Size)
+    {
+        throw std::invalid_argument(
+            "ERROR: position " + std::to_string(position) +
+            " is out of bounds for span of size " + std::to_string(m_Size) +
+            " , in call to const T& Span<T>::At\n");
+    }
+
+    return Access(position);
 }
 
 template <class T>
 T &Span<T>::Access(const size_t position)
 {
-    T &data = DoAccess(position);
+    T &data = *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));
     return data;
 }
 
 template <class T>
 const T &Span<T>::Access(const size_t position) const
 {
-    const T &data = DoAccess(position);
+    const T &data =
+        *m_Engine.BufferData<T>(m_PayloadPosition + position * sizeof(T));
     return data;
 }
 

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -266,6 +266,52 @@ const T &Span<T>::DoAccess(const size_t position) const
     return data;
 }
 
+template <class T>
+Span<T>::Span(Engine &engine, const size_t size)
+: m_Engine(engine), m_Size(size)
+{
+}
+
+template <class T>
+size_t Span<T>::Size() const noexcept
+{
+    return m_Size;
+}
+
+template <class T>
+T *Span<T>::Data() const noexcept
+{
+    return m_Engine.BufferData<T>(m_PayloadPosition);
+}
+
+template <class T>
+T &Span<T>::At(const size_t position)
+{
+    T &data = DoAt(position);
+    return data;
+}
+
+template <class T>
+const T &Span<T>::At(const size_t position) const
+{
+    const T &data = DoAt(position);
+    return data;
+}
+
+template <class T>
+T &Span<T>::Access(const size_t position)
+{
+    T &data = DoAccess(position);
+    return data;
+}
+
+template <class T>
+const T &Span<T>::Access(const size_t position) const
+{
+    const T &data = DoAccess(position);
+    return data;
+}
+
 } // end namespace core
 } // end namespace adios2
 


### PR DESCRIPTION
This is basically all cleanup only. The one API change is that `cxx11::Span` and `core::Span` become top-level classes (ie, not nested within `Variable`). That is for two reasons:
* So that `core::Span` can be forward declared and hence directly used in the pimpl-type `cxx11::Span` without resorting to `reinterpret_cast`.
* So that the `Spans` can be defined / instantiated as a whole class, rather than being all specialized by a macro loop for each type. 

There is no user-visible change, except that `Span` is now also available as `adios2::Span<T>` in addition to `adios2::Variable<T>::Span`, which I'd argue makes life a bit easier. But if you want avoid polluting of the `adios2` namespace, it could be moved to `adios2::detail`.

The patch does remove `Span::rbegin` and `Span::rend` because they were broken (wouldn't compile, but that didn't show because they were never instantiated). They obviously could be added back if one were to properly implement bidirectional or random access operators.

This PR reduces code size (lines of code):
```
 7 files changed, 146 insertions(+), 186 deletions(-)
```