### PR TITLE
Added busy command for adios_iotest

### DIFF
--- a/source/utils/adios_iotest/adios_iotest.cpp
+++ b/source/utils/adios_iotest/adios_iotest.cpp
@@ -187,6 +187,25 @@ int main(int argc, char *argv[])
                             std::chrono::microseconds(cmdS->sleepTime_us));
                         break;
                     }
+                    case Operation::Busy:
+                    {
+                        auto cmdS =
+                            dynamic_cast<const CommandBusy *>(cmd.get());
+                        std::chrono::high_resolution_clock::time_point start =
+                            std::chrono::high_resolution_clock::now();
+                        if (!settings.myRank && settings.verbose)
+                        {
+                            double t = static_cast<double>(cmdS->busyTime_us) /
+                                       1000000.0;
+                            std::cout << "    Be busy for " << t << "  seconds "
+                                      << std::endl;
+                        }
+                        while (std::chrono::high_resolution_clock::now() <
+                               start +
+                                   std::chrono::microseconds(cmdS->busyTime_us))
+                            ;
+                        break;
+                    }
                     case Operation::Write:
                     {
                         auto cmdW = dynamic_cast<CommandWrite *>(cmd.get());

--- a/source/utils/adios_iotest/iotest-config/pipe2_06_busy.txt
+++ b/source/utils/adios_iotest/iotest-config/pipe2_06_busy.txt
@@ -1,0 +1,37 @@
+# Config file for Task 1 in a pipeline
+#   - Produce variables  a  b  c 
+#   - Write variables    a  b  c     to    stream_T1.bp
+
+# Config file for Task 2 in a pipeline
+#   - Read in variables  a  b  from Task 1 (ignore c) from stream_T1.bp
+#     using a different decomposition
+
+
+group  io_T1
+  # item  type    varname     N   [dim1 dim2 ... dimN  decomp1 decomp2 ... decompN]
+  array   double  a           2    100   200              X       YZ
+  array   float   b           1    100                    XYZ 
+  array   float   c           3    100   200   300        XY      z     1
+
+group  io_T2_in
+  # item  type    varname     N   [dim1 dim2 ... dimN  decomp1 decomp2 ... decompN]
+  array   double  a           2    100   200              XY      Z
+  array   float   b           1    100                    XYZ 
+
+# Task 1 actions
+app 1
+  steps   3
+  busy   5.0      
+    # write all of io_T1 into stream_T1.bp
+  write   stream_T1.bp    io_T1
+
+# Task 2 actions
+app 2
+  steps   3
+  # read a & b from stream_T1.bp using io_T2_in definition with blocking wait
+  read  next  stream_T1.bp    io_T2_in  -1 
+  busy   2.0      
+
+
+
+

--- a/source/utils/adios_iotest/processConfig.cpp
+++ b/source/utils/adios_iotest/processConfig.cpp
@@ -24,6 +24,10 @@ CommandSleep::CommandSleep(size_t time)
 : Command(Operation::Sleep), sleepTime_us(time){};
 CommandSleep::~CommandSleep(){};
 
+CommandBusy::CommandBusy(size_t time)
+: Command(Operation::Busy), busyTime_us(time){};
+CommandBusy::~CommandBusy(){};
+
 CommandWrite::CommandWrite(std::string stream, std::string group)
 : Command(Operation::Write), streamName(stream), groupName(group){};
 CommandWrite::~CommandWrite(){};
@@ -309,6 +313,13 @@ void printConfig(const Config &cfg)
                       << " microseconds " << std::endl;
             break;
         }
+        case Operation::Busy:
+        {
+            auto cmdS = dynamic_cast<const CommandBusy *>(cmd.get());
+            std::cout << "          Be busy for " << cmdS->busyTime_us
+                      << " microseconds " << std::endl;
+            break;
+        }
         case Operation::Write:
         {
             auto cmdW = dynamic_cast<CommandWrite *>(cmd.get());
@@ -544,6 +555,23 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
                     }
                     size_t t_us = static_cast<size_t>(d * 1000000);
                     auto cmd = std::make_shared<CommandSleep>(t_us);
+                    cmd->conditionalStream = conditionalStream;
+                    cfg.commands.push_back(cmd);
+                }
+            }
+            else if (key == "busy")
+            {
+                if (currentAppId == settings.appId)
+                {
+                    double d = stringToDouble(words, 1, "busy");
+                    if (verbose0)
+                    {
+                        std::cout
+                            << "--> Command Busy for: " << std::setprecision(7)
+                            << d << " seconds" << std::endl;
+                    }
+                    size_t t_us = static_cast<size_t>(d * 1000000);
+                    auto cmd = std::make_shared<CommandBusy>(t_us);
                     cmd->conditionalStream = conditionalStream;
                     cfg.commands.push_back(cmd);
                 }

--- a/source/utils/adios_iotest/processConfig.h
+++ b/source/utils/adios_iotest/processConfig.h
@@ -35,6 +35,7 @@ struct VariableInfo
 enum Operation
 {
     Sleep,
+    Busy,
     Write,
     Read
 };
@@ -54,6 +55,14 @@ public:
     const size_t sleepTime_us = 0; // in microseconds
     CommandSleep(size_t time);
     ~CommandSleep();
+};
+
+class CommandBusy : public Command
+{
+public:
+    const size_t busyTime_us = 0; // in microseconds
+    CommandBusy(size_t time);
+    ~CommandBusy();
 };
 
 class CommandWrite : public Command


### PR DESCRIPTION
Busy continuously checks the high resolution clock until enough time has elapsed. I think this might be nice to emulate potential CPU interference from the user app on a node.