### PR TITLE
added ChunkSupport for h5

### DIFF
--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -117,6 +117,8 @@ public:
     static const std::string PREFIX_STAT;
 
     static const std::string PARAMETER_COLLECTIVE;
+    static const std::string PARAMETER_CHUNK_FLAG;
+    static const std::string PARAMETER_CHUNK_VARS;
 
     void ParseParameters(core::IO &io);
     void Init(const std::string &name, MPI_Comm comm, bool toWrite);
@@ -214,6 +216,10 @@ private:
     template <class T>
     void AddStats(const core::Variable<T> &variable, hid_t parentId,
                   std::vector<T> &stats);
+
+    hid_t m_ChunkPID;
+    int m_ChunkDim;
+    std::set<std::string> m_ChunkVarNames;
 };
 
 // Explicit declaration of the public template methods

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1455,10 +1455,10 @@ int readVar(core::Engine *fp, core::IO *io, core::Variable<T> *variable)
     // size_t elemsize;                   // size in bytes of one element
     uint64_t st, ct;
     std::vector<T> dataV;
-    uint64_t sum;      // working var to sum up things
-    uint64_t maxreadn; // max number of elements to read once up to a limit
-                       // (10MB of data)
-    uint64_t actualreadn;     // our decision how much to read at once
+    uint64_t sum;         // working var to sum up things
+    uint64_t maxreadn;    // max number of elements to read once up to a limit
+                          // (10MB of data)
+    uint64_t actualreadn; // our decision how much to read at once
     uint64_t readn[MAX_DIMS]; // how big chunk to read in in each dimension?
     bool incdim;              // used in incremental reading in
     int ndigits_dims[32];     // # of digits (to print) of each dimension
@@ -1702,10 +1702,10 @@ int readVarBlock(core::Engine *fp, core::IO *io, core::Variable<T> *variable,
     int tidx;
     uint64_t st, ct;
     std::vector<T> dataV;
-    uint64_t sum;      // working var to sum up things
-    uint64_t maxreadn; // max number of elements to read once up to a limit
-                       // (10MB of data)
-    uint64_t actualreadn;     // our decision how much to read at once
+    uint64_t sum;         // working var to sum up things
+    uint64_t maxreadn;    // max number of elements to read once up to a limit
+                          // (10MB of data)
+    uint64_t actualreadn; // our decision how much to read at once
     uint64_t readn[MAX_DIMS]; // how big chunk to read in in each dimension?
     bool incdim;              // used in incremental reading in
     int ndigits_dims[32];     // # of digits (to print) of each dimension


### PR DESCRIPTION
Added Chunk option. Example:
  <parameter key="H5ChunkDim" value="4 4"/> 
  <parameter key="H5ChunkVars" value="T"/> 

If you do not specify H5ChunkVars, it applies to all vars.
