### PR TITLE
Close domain and fabric when finalizing RDMA dataplane

### DIFF
--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -216,6 +216,9 @@ static void fini_fabric(struct fabric_state *fabric)
         status = fi_close((struct fid *)fabric->cq_signal);
     } while (status == FI_EBUSY);
 
+    fi_close((struct fid *)fabric->domain);
+    fi_close((struct fid *)fabric->fabric);
+
     if (status)
     {
         // TODO: error handling

--- a/source/utils/adios_iotest/settings.cpp
+++ b/source/utils/adios_iotest/settings.cpp
@@ -23,12 +23,13 @@ struct option options[] = {{"help", no_argument, NULL, 'h'},
                            {"xml", required_argument, NULL, 'x'},
                            {"strong-scaling", no_argument, NULL, 's'},
                            {"weak-scaling", no_argument, NULL, 'w'},
+                           {"timer", no_argument, NULL, 't'},
 #ifdef ADIOS2_HAVE_HDF5
                            {"hdf5", no_argument, NULL, 'H'},
 #endif
                            {NULL, 0, NULL, 0}};
 
-static const char *optstring = "-hvswHa:c:d:x:";
+static const char *optstring = "-hvswtHa:c:d:x:";
 
 size_t Settings::ndigits(size_t n) const
 {


### PR DESCRIPTION
This avoids an occasional crash at user program exit due to pending interface operations.