### PR TITLE
Remove semicolon from macro define

### DIFF
--- a/source/adios2/ADIOSMacros.h
+++ b/source/adios2/ADIOSMacros.h
@@ -277,7 +277,7 @@
                                                                                \
     private:                                                                   \
         pointer ptr_;                                                          \
-    };
+    }
 
 #define ADIOS2_iterators_functions(DATA_FUNCTION, SIZE_FUNCTION)               \
     iterator begin() noexcept { return iterator(DATA_FUNCTION); }              \


### PR DESCRIPTION
The iterator class is defined via the macro `ADIOS2_CLASS_iterator`.  The define ends with a semicolon.  When the symbol is used in source code,  the developer will add a semicolon after the symbol as is done for most code.  This will result in a warning from some compilers about a double semicolon on that line (one from macro, one from line of code)