### PR TITLE
workaround xl-16 compiler bug(?)

### DIFF
--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -206,7 +206,7 @@ int process_unused_args(adios2sys::CommandLineArguments &arg)
     arg.GetUnusedArguments(&nuargs, &uargs);
 
     std::vector<char *> retry_args;
-    retry_args.push_back(new char[4]{});
+    retry_args.push_back(new char[4]());
 
     // first arg is argv[0], so skip that
     for (int i = 1; i < nuargs; i++)


### PR DESCRIPTION
This attempts an alternate fix to the issue encountered in #1364.

I think that using new style initialization {} was legal in this context,
but I might be wrong. Let's see whether the compiler is happier with the
alternate style.

This isn't actually tested on the compiler that's giving the trouble, so hopefully @chuckatkins can o that.
