### PR TITLE
add easy ToString / ostream output for adios2 enums and cxx11 interface classes

### DIFF
--- a/bindings/CXX11/cxx11/Attribute.cpp
+++ b/bindings/CXX11/cxx11/Attribute.cpp
@@ -62,6 +62,13 @@ namespace adios2
             return reinterpret_cast<std::vector<T> &>(                         \
                 m_Attribute->m_DataArray);                                     \
         }                                                                      \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
+    std::string ToString(const Attribute<T> &attribute)                        \
+    {                                                                          \
+        return std::string("Attribute<") + attribute.Type() + ">(Name: \"" +   \
+               attribute.Name() + "\")";                                       \
     }
 
 ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_type)

--- a/bindings/CXX11/cxx11/Attribute.h
+++ b/bindings/CXX11/cxx11/Attribute.h
@@ -72,6 +72,9 @@ private:
     core::Attribute<IOType> *m_Attribute = nullptr;
 };
 
+template <typename T>
+std::string ToString(const Attribute<T> &attribute);
+
 } // end namespace adios2
 
 #endif /* ADIOS2_BINDINGS_CXX11_CXX11_ATTRIBUTE_H_ */

--- a/bindings/CXX11/cxx11/Engine.cpp
+++ b/bindings/CXX11/cxx11/Engine.cpp
@@ -161,4 +161,10 @@ ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
 ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
+std::string ToString(const Engine &engine)
+{
+    return std::string("Engine(Name: \"" + engine.Name() + "\", Type: \"" +
+                       engine.Type() + "\")");
+}
+
 } // end namespace adios2

--- a/bindings/CXX11/cxx11/Engine.h
+++ b/bindings/CXX11/cxx11/Engine.h
@@ -441,6 +441,8 @@ ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
 ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
+std::string ToString(const Engine &engine);
+
 } // end namespace adios2
 
 #endif /* ADIOS2_BINDINGS_CXX11_CXX11_ENGINE_H_ */

--- a/bindings/CXX11/cxx11/IO.cpp
+++ b/bindings/CXX11/cxx11/IO.cpp
@@ -19,6 +19,12 @@ namespace adios2
 
 IO::operator bool() const noexcept { return (m_IO == nullptr) ? false : true; }
 
+std::string IO::Name() const
+{
+    helper::CheckForNullptr(m_IO, "in call to IO::InConfigFile");
+    return m_IO->m_Name;
+}
+
 bool IO::InConfigFile() const
 {
     helper::CheckForNullptr(m_IO, "in call to IO::InConfigFile");

--- a/bindings/CXX11/cxx11/IO.cpp
+++ b/bindings/CXX11/cxx11/IO.cpp
@@ -188,4 +188,9 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
+std::string ToString(const IO &io)
+{
+    return std::string("IO(Name: \"" + io.Name() + "\")");
+}
+
 } // end namespace adios2

--- a/bindings/CXX11/cxx11/IO.h
+++ b/bindings/CXX11/cxx11/IO.h
@@ -55,6 +55,12 @@ public:
     explicit operator bool() const noexcept;
 
     /**
+     * Inspects IO name
+     * @return name
+     */
+    std::string Name() const;
+
+    /**
      * @brief Checks if IO exists in a config file passed to ADIOS object that
      * created this IO
      * @return true: in config file, false: not in config file

--- a/bindings/CXX11/cxx11/IO.h
+++ b/bindings/CXX11/cxx11/IO.h
@@ -381,6 +381,8 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
+std::string ToString(const IO &io);
+
 } // end namespace adios2
 
 #endif /* ADIOS2_BINDINGS_CXX11_CXX11_IO_H_ */

--- a/bindings/CXX11/cxx11/Operator.cpp
+++ b/bindings/CXX11/cxx11/Operator.cpp
@@ -46,4 +46,9 @@ Params Operator::Parameters() const
 // PRIVATE
 Operator::Operator(core::Operator *op) : m_Operator(op) {}
 
+std::string ToString(const Operator &op)
+{
+    return std::string("Operator(Type: \"" + op.Type() + "\")");
+}
+
 } // end namespace adios2

--- a/bindings/CXX11/cxx11/Operator.h
+++ b/bindings/CXX11/cxx11/Operator.h
@@ -78,6 +78,8 @@ private:
     core::Operator *m_Operator = nullptr;
 };
 
+std::string ToString(const IO &io);
+
 } // end namespace adios2
 
 #endif /* ADIOS2_BINDINGS_CXX11_CXX11_OPERATOR_H_ */

--- a/bindings/CXX11/cxx11/Variable.cpp
+++ b/bindings/CXX11/cxx11/Variable.cpp
@@ -224,6 +224,12 @@ namespace adios2
 ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
 
+#define declare_template_instantiation(T)                                      \
+    template std::string ToString(Variable<T> var);
+
+ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+
 #define declare_type(T)                                                        \
                                                                                \
     template <>                                                                \

--- a/bindings/CXX11/cxx11/Variable.cpp
+++ b/bindings/CXX11/cxx11/Variable.cpp
@@ -225,7 +225,7 @@ ADIOS2_FOREACH_TYPE_1ARG(declare_type)
 #undef declare_type
 
 #define declare_template_instantiation(T)                                      \
-    template std::string ToString(Variable<T> var);
+    template std::string ToString(const Variable<T> &var);
 
 ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/bindings/CXX11/cxx11/Variable.h
+++ b/bindings/CXX11/cxx11/Variable.h
@@ -365,6 +365,23 @@ private:
     std::vector<std::vector<typename Variable<T>::Info>> DoAllStepsBlocksInfo();
 };
 
+namespace
+{
+template <typename T>
+struct IsVariable : std::false_type
+{
+};
+
+template <typename T>
+struct IsVariable<Variable<T>> : std::true_type
+{
+};
+} // namespace
+
+template <typename T,
+          typename std::enable_if<IsVariable<T>::value, int>::type = 0>
+std::string ToString(T value);
+
 } // end namespace adios2
 
 #endif /* ADIOS2_BINDINGS_CXX11_CXX11_VARIABLE_H_ */

--- a/bindings/CXX11/cxx11/Variable.h
+++ b/bindings/CXX11/cxx11/Variable.h
@@ -365,22 +365,8 @@ private:
     std::vector<std::vector<typename Variable<T>::Info>> DoAllStepsBlocksInfo();
 };
 
-namespace
-{
 template <typename T>
-struct IsVariable : std::false_type
-{
-};
-
-template <typename T>
-struct IsVariable<Variable<T>> : std::true_type
-{
-};
-} // namespace
-
-template <typename T,
-          typename std::enable_if<IsVariable<T>::value, int>::type = 0>
-std::string ToString(T value);
+std::string ToString(const Variable<T> &variable);
 
 } // end namespace adios2
 

--- a/bindings/CXX11/cxx11/Variable.tcc
+++ b/bindings/CXX11/cxx11/Variable.tcc
@@ -80,6 +80,13 @@ Variable<T>::DoAllStepsBlocksInfo()
     return allStepsBlocksInfo;
 }
 
+template <typename T, typename std::enable_if<IsVariable<T>::value, int>::type>
+std::string ToString(T var)
+{
+    return std::string("Variable<") + var.Type() + ">(Name: \"" + var.Name() +
+           "\")";
+}
+
 } // end namespace adios2
 
 #endif /* ADIOS2_BINDINGS_CXX11_CXX11_VARIABLE_TCC_ */

--- a/bindings/CXX11/cxx11/Variable.tcc
+++ b/bindings/CXX11/cxx11/Variable.tcc
@@ -80,11 +80,11 @@ Variable<T>::DoAllStepsBlocksInfo()
     return allStepsBlocksInfo;
 }
 
-template <typename T, typename std::enable_if<IsVariable<T>::value, int>::type>
-std::string ToString(T var)
+template <typename T>
+std::string ToString(const Variable<T> &variable)
 {
-    return std::string("Variable<") + var.Type() + ">(Name: \"" + var.Name() +
-           "\")";
+    return std::string("Variable<") + variable.Type() + ">(Name: \"" +
+           variable.Name() + "\")";
 }
 
 } // end namespace adios2

--- a/docs/user_guide/source/api_full/cxx11.rst
+++ b/docs/user_guide/source/api_full/cxx11.rst
@@ -86,3 +86,32 @@ The following section provides a summary of the available functionality for each
    :project: CXX11
    :path: ../../bindings/CXX11/cxx11/
    :members:
+
+Debugging
+---------
+
+To help debugging, functionality is provided that creates
+human-readable representations of adios2 C++11 class instances and
+enums. To get a string representation, use ``ToString(object)``. You
+can also directly pass objects to ``ostream``s.
+
+Example:
+
+.. code-block:: c++
+
+    auto myVar = io.DefineVariable<double>("myVar");
+    std::cout << myVar << " has shape id " << myVar.ShapeID() << std::endl;
+
+    // will print:
+    // Variable<double>(Name: "myVar") has shape id ShapeID::GlobalValue
+
+    if (myVar.ShapeID() != adios2::ShapeID::GlobalArray)
+    {
+        throw std::invalid_argument("can't handle " +
+                                    ToString(myVar.ShapeID()) + " in " +
+                                    ToString(myVar));
+    }
+
+    // will throw exception like this:
+    // C++ exception with description "can't handle ShapeID::GlobalValue
+    // in Variable<double>(Name: "myVar")" thrown

--- a/source/adios2/ADIOSTypes.cpp
+++ b/source/adios2/ADIOSTypes.cpp
@@ -1,0 +1,33 @@
+
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * ADIOSTypes.cpp: implementation of enum-related functions
+ *
+ *  Created on: Feb 22, 2019
+ *      Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+ */
+
+#include "ADIOSTypes.h"
+
+namespace adios2
+{
+
+namespace
+{
+
+std::map<ShapeID, std::string> MapShapeID2String = {
+    {ShapeID::Unknown, "ShapeID::Unknown"},
+    {ShapeID::GlobalValue, "ShapeID::GlobalValue"},
+    {ShapeID::GlobalArray, "ShapeID::GlobalArray"},
+    {ShapeID::JoinedArray, "ShapeID::JoinedArray"},
+    {ShapeID::LocalValue, "ShapeID::LocalValue"},
+    {ShapeID::LocalArray, "ShapeID::LocalArray"},
+};
+
+} // end anonymous namespace
+
+std::string ToString(ShapeID value) { return MapShapeID2String.at(value); }
+
+} // end namespace adios2

--- a/source/adios2/ADIOSTypes.cpp
+++ b/source/adios2/ADIOSTypes.cpp
@@ -14,35 +14,59 @@
 namespace adios2
 {
 
-namespace
+std::string ToString(ShapeID value)
 {
+    switch (value)
+    {
+    case ShapeID::Unknown:
+        return "ShapeID::Unknown";
+    case ShapeID::GlobalValue:
+        return "ShapeID::GlobalValue";
+    case ShapeID::GlobalArray:
+        return "ShapeID::GlobalArray";
+    case ShapeID::JoinedArray:
+        return "ShapeID::JoinedArray";
+    case ShapeID::LocalValue:
+        return "ShapeID::LocalValue";
+    case ShapeID::LocalArray:
+        return "ShapeID::LocalArray";
+    default:
+        return "ToString: Unknown ShapeID";
+    }
+}
 
-std::map<ShapeID, std::string> MapShapeID2String = {
-    {ShapeID::Unknown, "ShapeID::Unknown"},
-    {ShapeID::GlobalValue, "ShapeID::GlobalValue"},
-    {ShapeID::GlobalArray, "ShapeID::GlobalArray"},
-    {ShapeID::JoinedArray, "ShapeID::JoinedArray"},
-    {ShapeID::LocalValue, "ShapeID::LocalValue"},
-    {ShapeID::LocalArray, "ShapeID::LocalArray"},
-};
+std::string ToString(IOMode value)
+{
+    switch (value)
+    {
+    case IOMode::Independent:
+        return "IOMode::Independent";
+    case IOMode::Collective:
+        return "IOMode::Collective";
+    default:
+        return "ToString: Unknown IOMode";
+    }
+}
 
-std::map<IOMode, std::string> MapIOMode2String = {
-    {IOMode::Independent, "IOMode::Independent"},
-    {IOMode::Collective, "IOMode::Collective"},
-};
-
-std::map<Mode, std::string> MapMode2String = {
-    {Mode::Undefined, "Mode::Undefined"}, {Mode::Write, "Mode::Write"},
-    {Mode::Read, "Mode::Read"},           {Mode::Append, "Mode::Append"},
-    {Mode::Sync, "Mode::Sync"},           {Mode::Deferred, "Mode::Deferred"},
-};
-
-} // end anonymous namespace
-
-std::string ToString(ShapeID value) { return MapShapeID2String.at(value); }
-
-std::string ToString(IOMode value) { return MapIOMode2String.at(value); }
-
-std::string ToString(Mode value) { return MapMode2String.at(value); }
+std::string ToString(Mode value)
+{
+    switch (value)
+    {
+    case Mode::Undefined:
+        return "Mode::Undefined";
+    case Mode::Write:
+        return "Mode::Write";
+    case Mode::Read:
+        return "Mode::Read";
+    case Mode::Append:
+        return "Mode::Append";
+    case Mode::Sync:
+        return "Mode::Sync";
+    case Mode::Deferred:
+        return "Mode::Deferred";
+    default:
+        return "ToString: Unknown Mode";
+    }
+}
 
 } // end namespace adios2

--- a/source/adios2/ADIOSTypes.cpp
+++ b/source/adios2/ADIOSTypes.cpp
@@ -26,8 +26,23 @@ std::map<ShapeID, std::string> MapShapeID2String = {
     {ShapeID::LocalArray, "ShapeID::LocalArray"},
 };
 
+std::map<IOMode, std::string> MapIOMode2String = {
+    {IOMode::Independent, "IOMode::Independent"},
+    {IOMode::Collective, "IOMode::Collective"},
+};
+
+std::map<Mode, std::string> MapMode2String = {
+    {Mode::Undefined, "Mode::Undefined"}, {Mode::Write, "Mode::Write"},
+    {Mode::Read, "Mode::Read"},           {Mode::Append, "Mode::Append"},
+    {Mode::Sync, "Mode::Sync"},           {Mode::Deferred, "Mode::Deferred"},
+};
+
 } // end anonymous namespace
 
 std::string ToString(ShapeID value) { return MapShapeID2String.at(value); }
+
+std::string ToString(IOMode value) { return MapIOMode2String.at(value); }
+
+std::string ToString(Mode value) { return MapMode2String.at(value); }
 
 } // end namespace adios2

--- a/source/adios2/ADIOSTypes.cpp
+++ b/source/adios2/ADIOSTypes.cpp
@@ -69,4 +69,117 @@ std::string ToString(Mode value)
     }
 }
 
+std::string ToString(ReadMultiplexPattern value)
+{
+    switch (value)
+    {
+    case ReadMultiplexPattern::GlobalReaders:
+        return "ReadMultiplexPattern::GlobalReaders";
+    case ReadMultiplexPattern::RoundRobin:
+        return "ReadMultiplexPattern::RoundRobin";
+    case ReadMultiplexPattern::FirstInFirstOut:
+        return "ReadMultiplexPattern::FirstInFirstOut";
+    case ReadMultiplexPattern::OpenAllSteps:
+        return "ReadMultiplexPattern::OpenAllSteps";
+    default:
+        return "ToString: Unknown ReadMultiplexPattern";
+    }
+}
+
+std::string ToString(StreamOpenMode value)
+{
+    switch (value)
+    {
+    case StreamOpenMode::Wait:
+        return "StreamOpenMode::Wait";
+    case StreamOpenMode::NoWait:
+        return "StreamOpenMode::NoWait";
+    default:
+        return "ToString: Unknown StreamOpenMode";
+    }
+}
+
+std::string ToString(ReadMode value)
+{
+    switch (value)
+    {
+    case ReadMode::NonBlocking:
+        return "ReadMode::NonBlocking";
+    case ReadMode::Blocking:
+        return "ReadMode::Blocking";
+    default:
+        return "ToString: Unknown ReadMode";
+    }
+}
+
+std::string ToString(StepMode value)
+{
+    switch (value)
+    {
+    case StepMode::Append:
+        return "StepMode::Append";
+    case StepMode::Update:
+        return "StepMode::Update";
+    case StepMode::NextAvailable:
+        return "StepMode::NextAvailable";
+    case StepMode::LatestAvailable:
+        return "StepMode::LatestAvailable";
+    default:
+        return "ToString: Unknown StepMode";
+    }
+}
+
+std::string ToString(StepStatus value)
+{
+    switch (value)
+    {
+    case StepStatus::OK:
+        return "StepStatus::OK";
+    case StepStatus::NotReady:
+        return "StepStatus::NotReady";
+    case StepStatus::EndOfStream:
+        return "StepStatus::EndOfStream";
+    case StepStatus::OtherError:
+        return "StepStatus::OtherError";
+    default:
+        return "ToString: Unknown StepStatus";
+    }
+}
+
+std::string ToString(TimeUnit value)
+{
+    switch (value)
+    {
+    case TimeUnit::Microseconds:
+        return "TimeUnit::Microseconds";
+    case TimeUnit::Milliseconds:
+        return "TimeUnit::Milliseconds";
+    case TimeUnit::Seconds:
+        return "TimeUnit::Seconds";
+    case TimeUnit::Minutes:
+        return "TimeUnit::Minutes";
+    case TimeUnit::Hours:
+        return "TimeUnit::Hours";
+    default:
+        return "ToString: Unknown TimeUnit";
+    }
+}
+
+std::string ToString(SelectionType value)
+{
+    switch (value)
+    {
+    case SelectionType::BoundingBox:
+        return "SelectionType::BoundingBox";
+    case SelectionType::Points:
+        return "SelectionType::Points";
+    case SelectionType::WriteBlock:
+        return "SelectionType::WriteBlock";
+    case SelectionType::Auto:
+        return "SelectionType::Auto";
+    default:
+        return "ToString: Unknown SelectionType";
+    }
+}
+
 } // end namespace adios2

--- a/source/adios2/ADIOSTypes.h
+++ b/source/adios2/ADIOSTypes.h
@@ -206,6 +206,9 @@ struct TypeInfo;
  */
 
 std::string ToString(ShapeID value);
+std::string ToString(IOMode value);
+std::string ToString(Mode value);
+
 } // end namespace adios2
 
 #include "ADIOSTypes.inl"

--- a/source/adios2/ADIOSTypes.h
+++ b/source/adios2/ADIOSTypes.h
@@ -200,6 +200,12 @@ using Box = std::pair<T, T>;
 template <typename T, typename Enable = void>
 struct TypeInfo;
 
+/**
+ * ToString
+ * makes a string from an enum class like ShapeID etc, for debugging etc
+ */
+
+std::string ToString(ShapeID value);
 } // end namespace adios2
 
 #include "ADIOSTypes.inl"

--- a/source/adios2/ADIOSTypes.h
+++ b/source/adios2/ADIOSTypes.h
@@ -209,6 +209,14 @@ std::string ToString(ShapeID value);
 std::string ToString(IOMode value);
 std::string ToString(Mode value);
 
+/**
+ * operator<<(ostream&, T enum_val)
+ * enables output of enum classes directly to std::cout etc,
+ * if ToString() can handle it
+ */
+template <typename T, typename Enable = decltype(ToString(std::declval<T>()))>
+std::ostream &operator<<(std::ostream &os, const T &value);
+
 } // end namespace adios2
 
 #include "ADIOSTypes.inl"

--- a/source/adios2/ADIOSTypes.h
+++ b/source/adios2/ADIOSTypes.h
@@ -203,16 +203,24 @@ struct TypeInfo;
 /**
  * ToString
  * makes a string from an enum class like ShapeID etc, for debugging etc
+ * It is also overloaded elsewhere to allow for a readable representation of
+ * Variable, Attribute, etc.
  */
 
 std::string ToString(ShapeID value);
 std::string ToString(IOMode value);
 std::string ToString(Mode value);
+std::string ToString(ReadMultiplexPattern value);
+std::string ToString(StreamOpenMode value);
+std::string ToString(ReadMode value);
+std::string ToString(StepMode value);
+std::string ToString(StepStatus value);
+std::string ToString(TimeUnit value);
+std::string ToString(SelectionType value);
 
 /**
- * operator<<(ostream&, T enum_val)
- * enables output of enum classes directly to std::cout etc,
- * if ToString() can handle it
+ * os << [adios2_type] enables output of adios2 enums/classes directly
+ * to output streams (e.g. std::cout), if ToString() can handle [adios2_type].
  */
 template <typename T, typename Enable = decltype(ToString(std::declval<T>()))>
 std::ostream &operator<<(std::ostream &os, const T &value);

--- a/source/adios2/ADIOSTypes.inl
+++ b/source/adios2/ADIOSTypes.inl
@@ -111,6 +111,12 @@ struct TypeInfo<
     using ValueType = T;
 };
 
+template <typename T, typename Enable>
+inline std::ostream &operator<<(std::ostream &os, const T &value)
+{
+    return os << ToString(value);
+}
+
 } // end namespace adios2
 
 #endif /* ADIOS2_ADIOSTYPES_INL_ */

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(taustubs
 )
 
 add_library(adios2
+  ADIOSTypes.cpp
+  
   core/Attribute.cpp 
   core/AttributeBase.cpp
   core/ADIOS.cpp

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -23,6 +23,8 @@ TEST(ADIOSInterface, MPICommRemoved)
 
 #endif
 
+/** ADIOS2_CXX11_API
+ */
 class ADIOS2_CXX11_API : public ::testing::Test
 {
 public:
@@ -44,6 +46,50 @@ public:
     int m_MpiSize = 1;
 };
 
+TEST_F(ADIOS2_CXX11_API, ToString)
+{
+    EXPECT_EQ(ToString(adios2::ShapeID::Unknown), "ShapeID::Unknown");
+    EXPECT_EQ(ToString(adios2::ShapeID::GlobalValue), "ShapeID::GlobalValue");
+    EXPECT_EQ(ToString(adios2::ShapeID::GlobalArray), "ShapeID::GlobalArray");
+    EXPECT_EQ(ToString(adios2::ShapeID::JoinedArray), "ShapeID::JoinedArray");
+    EXPECT_EQ(ToString(adios2::ShapeID::LocalValue), "ShapeID::LocalValue");
+    EXPECT_EQ(ToString(adios2::ShapeID::LocalArray), "ShapeID::LocalArray");
+
+    EXPECT_EQ(ToString(adios2::IOMode::Independent), "IOMode::Independent");
+    EXPECT_EQ(ToString(adios2::IOMode::Collective), "IOMode::Collective");
+
+    EXPECT_EQ(ToString(adios2::Mode::Undefined), "Mode::Undefined");
+    EXPECT_EQ(ToString(adios2::Mode::Write), "Mode::Write");
+    EXPECT_EQ(ToString(adios2::Mode::Read), "Mode::Read");
+    EXPECT_EQ(ToString(adios2::Mode::Append), "Mode::Append");
+    EXPECT_EQ(ToString(adios2::Mode::Sync), "Mode::Sync");
+    EXPECT_EQ(ToString(adios2::Mode::Deferred), "Mode::Deferred");
+}
+
+TEST_F(ADIOS2_CXX11_API, APIToString)
+{
+    auto io = m_Ad.DeclareIO("CXX11_API_TestIO");
+    EXPECT_EQ(ToString(io), "IO(Name: \"CXX11_API_TestIO\")");
+
+    auto variable = io.DefineVariable<double>("var_double");
+    EXPECT_EQ(ToString(variable), "Variable<double>(Name: \"var_double\")");
+
+    auto attribute = io.DefineAttribute<float>("attr_float", 1.f);
+    EXPECT_EQ(ToString(attribute), "Attribute<float>(Name: \"attr_float\")");
+
+    auto engine = io.Open("test.bp", adios2::Mode::Write);
+    EXPECT_EQ(ToString(engine), "Engine(Name: \"test.bp\", Type: \"BP3\")");
+}
+
+TEST_F(ADIOS2_CXX11_API, operatorLL)
+{
+    std::stringstream result;
+    result << adios2::Mode::Write;
+    EXPECT_EQ(result.str(), "Mode::Write");
+}
+
+/** ADIOS2_CXX11_API_IO
+ */
 class ADIOS2_CXX11_API_IO : public ADIOS2_CXX11_API
 {
 public:

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -64,6 +64,51 @@ TEST_F(ADIOS2_CXX11_API, ToString)
     EXPECT_EQ(ToString(adios2::Mode::Append), "Mode::Append");
     EXPECT_EQ(ToString(adios2::Mode::Sync), "Mode::Sync");
     EXPECT_EQ(ToString(adios2::Mode::Deferred), "Mode::Deferred");
+
+    EXPECT_EQ(ToString(adios2::ReadMultiplexPattern::GlobalReaders),
+              "ReadMultiplexPattern::GlobalReaders");
+    EXPECT_EQ(ToString(adios2::ReadMultiplexPattern::RoundRobin),
+              "ReadMultiplexPattern::RoundRobin");
+    EXPECT_EQ(ToString(adios2::ReadMultiplexPattern::FirstInFirstOut),
+              "ReadMultiplexPattern::FirstInFirstOut");
+    EXPECT_EQ(ToString(adios2::ReadMultiplexPattern::OpenAllSteps),
+              "ReadMultiplexPattern::OpenAllSteps");
+
+    EXPECT_EQ(ToString(adios2::StreamOpenMode::Wait), "StreamOpenMode::Wait");
+    EXPECT_EQ(ToString(adios2::StreamOpenMode::NoWait),
+              "StreamOpenMode::NoWait");
+
+    EXPECT_EQ(ToString(adios2::ReadMode::NonBlocking), "ReadMode::NonBlocking");
+    EXPECT_EQ(ToString(adios2::ReadMode::Blocking), "ReadMode::Blocking");
+
+    EXPECT_EQ(ToString(adios2::StepMode::Append), "StepMode::Append");
+    EXPECT_EQ(ToString(adios2::StepMode::Update), "StepMode::Update");
+    EXPECT_EQ(ToString(adios2::StepMode::NextAvailable),
+              "StepMode::NextAvailable");
+    EXPECT_EQ(ToString(adios2::StepMode::LatestAvailable),
+              "StepMode::LatestAvailable");
+
+    EXPECT_EQ(ToString(adios2::StepStatus::OK), "StepStatus::OK");
+    EXPECT_EQ(ToString(adios2::StepStatus::NotReady), "StepStatus::NotReady");
+    EXPECT_EQ(ToString(adios2::StepStatus::EndOfStream),
+              "StepStatus::EndOfStream");
+    EXPECT_EQ(ToString(adios2::StepStatus::OtherError),
+              "StepStatus::OtherError");
+
+    EXPECT_EQ(ToString(adios2::TimeUnit::Microseconds),
+              "TimeUnit::Microseconds");
+    EXPECT_EQ(ToString(adios2::TimeUnit::Milliseconds),
+              "TimeUnit::Milliseconds");
+    EXPECT_EQ(ToString(adios2::TimeUnit::Seconds), "TimeUnit::Seconds");
+    EXPECT_EQ(ToString(adios2::TimeUnit::Minutes), "TimeUnit::Minutes");
+    EXPECT_EQ(ToString(adios2::TimeUnit::Hours), "TimeUnit::Hours");
+
+    EXPECT_EQ(ToString(adios2::SelectionType::BoundingBox),
+              "SelectionType::BoundingBox");
+    EXPECT_EQ(ToString(adios2::SelectionType::Points), "SelectionType::Points");
+    EXPECT_EQ(ToString(adios2::SelectionType::WriteBlock),
+              "SelectionType::WriteBlock");
+    EXPECT_EQ(ToString(adios2::SelectionType::Auto), "SelectionType::Auto");
 }
 
 TEST_F(ADIOS2_CXX11_API, APIToString)


### PR DESCRIPTION
Since I guess #1328 become rather complicated, which I suppose may be why it's been sitting out there, I figured I'll redo just the major part of it. For detailed discussion, #1328 might still provide a useful reference.

I've had this sitting around for a while, and let me start by saying that I don't have strong feelings about it. It adds a somewhat neat feature making it easier to give human-readable output for some enums, but it could also be considered rarely needed bloat.

Essentially, the PR adds `adios::tostring` and overloads for the ostream `operator<<` for enum classes.  It allows you to do, e.g., 
```cxx
std::cout << variable.ShapeID() << std::endl;
```
and get human readable output.
It gets picked up by googletest, so on an (intentionally failing) test, instead of
```
../testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp:186: Failure
Expected equality of these values:
  var_i8.ShapeID()
    Which is: 4-byte object <02-00 00-00>
  adios2::ShapeID::LocalArray
    Which is: 4-byte object <05-00 00-00>
```
you get
```
../testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp:186: Failure
Expected equality of these values:
  var_i8.ShapeID()
    Which is: ShapeID::GlobalArray
  adios2::ShapeID::LocalArray
    Which is: ShapeID::LocalArray
```

It also adds support for printing the man cxx11 interface classes (Variable, Attribute, IO, Engine, Operator). So you can now do `std::cout << variable` to do something akin to Python's `__str__` method, which might be useful for debugging.

Following @chuckatkins comments, I amended the original code to avoid one SFINAE overcomplication and used switch/case instead of maps for mapping enums to strings. I also added tests and some docs, and rebased onto current master.
