### PR TITLE
Allocate memory for variables at first use instead of in processConfi…

### DIFF
--- a/source/utils/adios_iotest/adiosStream.cpp
+++ b/source/utils/adios_iotest/adiosStream.cpp
@@ -95,6 +95,11 @@ void adiosStream::putADIOSArray(const std::shared_ptr<VariableInfo> ov)
 
 void adiosStream::getADIOSArray(std::shared_ptr<VariableInfo> ov)
 {
+    // Allocate memory on first access
+    if (!ov->data.size())
+    {
+        ov->data.resize(ov->datasize);
+    }
     if (ov->type == "double")
     {
         adios2::Variable<double> v = io.InquireVariable<double>(ov->name);
@@ -258,6 +263,11 @@ void adiosStream::writeADIOS(CommandWrite *cmdW, Config &cfg,
     std::map<std::string, adios2::Params> definedVars = io.AvailableVariables();
     for (auto ov : cmdW->variables)
     {
+        // Allocate memory on first access
+        if (!ov->data.size())
+        {
+            ov->data.resize(ov->datasize);
+        }
         // if the variable is not in the IO group it means
         // we have not defined it yet (e.g. a write-only variable or a linked
         // variable defined in another read group)

--- a/source/utils/adios_iotest/hdf5Stream.cpp
+++ b/source/utils/adios_iotest/hdf5Stream.cpp
@@ -167,6 +167,11 @@ void hdf5Stream::Write(CommandWrite *cmdW, Config &cfg,
 
     for (auto ov : cmdW->variables)
     {
+        // Allocate memory on first access
+        if (!ov->data.size())
+        {
+            ov->data.resize(ov->datasize);
+        }
         if (step == 1)
         {
             if (!settings.myRank && settings.verbose)
@@ -259,6 +264,12 @@ void hdf5Stream::getHDF5Array(std::shared_ptr<VariableInfo> ov, size_t step)
     {
         start[d] = ov->start[d - 1];
         count[d] = ov->count[d - 1];
+    }
+
+    // Allocate memory on first access
+    if (!ov->data.size())
+    {
+        ov->data.resize(ov->datasize);
     }
 
     hid_t memspace = H5Screate_simple(ndim, count, NULL);


### PR DESCRIPTION
…g. Writers don't allocate memory for read variables this way.