### PR TITLE
Allow Isend Irecv 64-bit data sizes in batches

### DIFF
--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -344,10 +344,10 @@ void BP3Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
     // async?
     for (int r = 0; r < m_BP3Serializer.m_Aggregator.m_Size; ++r)
     {
-        std::vector<MPI_Request> dataRequests =
+        std::vector<std::vector<MPI_Request>> dataRequests =
             m_BP3Serializer.m_Aggregator.IExchange(m_BP3Serializer.m_Data, r);
 
-        std::vector<MPI_Request> absolutePositionRequests =
+        std::vector<std::vector<MPI_Request>> absolutePositionRequests =
             m_BP3Serializer.m_Aggregator.IExchangeAbsolutePosition(
                 m_BP3Serializer.m_Data, r);
 

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -542,10 +542,10 @@ void BP4Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
     // async?
     for (int r = 0; r < m_BP4Serializer.m_Aggregator.m_Size; ++r)
     {
-        std::vector<MPI_Request> dataRequests =
+        std::vector<std::vector<MPI_Request>> dataRequests =
             m_BP4Serializer.m_Aggregator.IExchange(m_BP4Serializer.m_Data, r);
 
-        std::vector<MPI_Request> absolutePositionRequests =
+        std::vector<std::vector<MPI_Request>> absolutePositionRequests =
             m_BP4Serializer.m_Aggregator.IExchangeAbsolutePosition(
                 m_BP4Serializer.m_Data, r);
 

--- a/source/adios2/helper/adiosMPIFunctions.h
+++ b/source/adios2/helper/adiosMPIFunctions.h
@@ -117,6 +117,16 @@ std::string BroadcastFile(const std::string &fileName, MPI_Comm mpiComm,
                           const std::string hint = "",
                           const int rankSource = 0);
 
+template <class T>
+std::vector<MPI_Request> Isend64(const T *buffer, const size_t count,
+                                 int destination, int tag, MPI_Comm mpiComm,
+                                 const std::string &hint);
+
+template <class T>
+std::vector<MPI_Request> Irecv64(T *buffer, const size_t count, int source,
+                                 int tag, MPI_Comm mpiComm,
+                                 const std::string &hint);
+
 } // end namespace helper
 } // end namespace adios2
 

--- a/source/adios2/helper/adiosMPIFunctions.tcc
+++ b/source/adios2/helper/adiosMPIFunctions.tcc
@@ -254,6 +254,98 @@ void GathervArrays(const size_t *source, const size_t sourceCount,
     }
 }
 
+template <>
+std::vector<MPI_Request> Isend64<char>(const char *buffer, const size_t count,
+                                       int dest, int tag, MPI_Comm mpiComm,
+                                       const std::string &hint)
+{
+    const size_t batches = count / DefaultMaxFileBatchSize;
+    std::vector<MPI_Request> requests(batches + 1);
+
+    if (batches > 1)
+    {
+        size_t position = 0;
+        for (size_t b = 0; b < batches; ++b)
+        {
+            int batchSize = static_cast<int>(DefaultMaxFileBatchSize);
+            CheckMPIReturn(
+                MPI_Isend(const_cast<char *>(buffer + position), batchSize,
+                          MPI_CHAR, dest, tag, mpiComm, &requests[b]),
+                "in call to Isend64 batch " + std::to_string(b) + "/" +
+                    std::to_string(batches) + " " + hint + "\n");
+
+            position += DefaultMaxFileBatchSize;
+        }
+        const size_t remainder = count % DefaultMaxFileBatchSize;
+        if (remainder > 0)
+        {
+            int batchSize = static_cast<int>(remainder);
+            CheckMPIReturn(MPI_Isend(const_cast<char *>(buffer + position),
+                                     batchSize, MPI_CHAR, dest, tag, mpiComm,
+                                     &requests[batches - 1]),
+                           "in call to Isend64 last batch " + hint + "\n");
+        }
+    }
+    else
+    {
+        int batchSize = static_cast<int>(count);
+        CheckMPIReturn(MPI_Isend(const_cast<char *>(buffer), batchSize,
+                                 MPI_CHAR, dest, tag, mpiComm, &requests[0]),
+                       " in call to Isend64 with single batch " + hint + "\n");
+    }
+
+    return requests;
+}
+
+template <>
+std::vector<MPI_Request> Irecv64<char>(char *buffer, const size_t count,
+                                       int source, int tag, MPI_Comm mpiComm,
+                                       const std::string &hint)
+{
+    const size_t batches = count / DefaultMaxFileBatchSize;
+    std::vector<MPI_Request> requests(batches + 1);
+
+    if (requests.size() != batches + 1)
+    {
+        throw std::runtime_error(
+            "ERROR: number of Irecv requests doesn't match number of batches = "
+            "count/DefaultMaxFileBatchSize\n");
+    }
+
+    if (batches > 1)
+    {
+        size_t position = 0;
+        for (size_t b = 0; b < batches; ++b)
+        {
+            int batchSize = static_cast<int>(DefaultMaxFileBatchSize);
+            CheckMPIReturn(MPI_Irecv(buffer + position, batchSize, MPI_CHAR,
+                                     source, tag, mpiComm, &requests[b]),
+                           "in call to Irecv64 batch " + std::to_string(b) +
+                               "/" + std::to_string(batches) + " " + hint +
+                               "\n");
+
+            position += DefaultMaxFileBatchSize;
+        }
+        const size_t remainder = count % DefaultMaxFileBatchSize;
+        if (remainder > 0)
+        {
+            int batchSize = static_cast<int>(remainder);
+            CheckMPIReturn(MPI_Irecv(buffer + position, batchSize, MPI_CHAR,
+                                     source, tag, mpiComm,
+                                     &requests[batches - 1]),
+                           "in call to Irecv64 last batch " + hint + "\n");
+        }
+    }
+    else
+    {
+        int batchSize = static_cast<int>(count);
+        CheckMPIReturn(MPI_Irecv(buffer, batchSize, MPI_CHAR, source, tag,
+                                 mpiComm, &requests[0]),
+                       " in call to Isend64 with single batch " + hint + "\n");
+    }
+    return requests;
+}
+
 } // end namespace helper
 } // end namespace adios2
 

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
@@ -31,18 +31,6 @@ MPIAggregator::~MPIAggregator()
 
 void MPIAggregator::Init(const size_t subStreams, MPI_Comm parentComm) {}
 
-std::vector<MPI_Request> MPIAggregator::IExchange(BufferSTL & /**bufferSTL*/,
-                                                  const int /** step*/)
-{
-    std::vector<MPI_Request> requests;
-    return requests;
-}
-
-void MPIAggregator::Wait(std::vector<MPI_Request> & /**requests*/,
-                         const int /**step*/)
-{
-}
-
 void MPIAggregator::SwapBuffers(const int step) noexcept {}
 
 void MPIAggregator::ResetBuffers() noexcept {}

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
@@ -57,16 +57,18 @@ public:
 
     virtual void Init(const size_t subStreams, MPI_Comm parentComm);
 
-    virtual std::vector<MPI_Request> IExchange(BufferSTL &bufferSTL,
-                                               const int step);
+    virtual std::vector<std::vector<MPI_Request>>
+    IExchange(BufferSTL &bufferSTL, const int step) = 0;
 
-    virtual std::vector<MPI_Request>
+    virtual std::vector<std::vector<MPI_Request>>
     IExchangeAbsolutePosition(BufferSTL &bufferSTL, const int step) = 0;
 
-    virtual void WaitAbsolutePosition(std::vector<MPI_Request> &requests,
-                                      const int step) = 0;
+    virtual void
+    WaitAbsolutePosition(std::vector<std::vector<MPI_Request>> &requests,
+                         const int step) = 0;
 
-    virtual void Wait(std::vector<MPI_Request> &requests, const int step);
+    virtual void Wait(std::vector<std::vector<MPI_Request>> &requests,
+                      const int step) = 0;
 
     virtual void SwapBuffers(const int step) noexcept;
 

--- a/source/adios2/toolkit/aggregator/mpi/MPIChain.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIChain.h
@@ -28,15 +28,16 @@ public:
 
     void Init(const size_t subStreams, MPI_Comm parentComm) final;
 
-    std::vector<MPI_Request> IExchange(BufferSTL &bufferSTL,
-                                       const int step) final;
+    std::vector<std::vector<MPI_Request>> IExchange(BufferSTL &bufferSTL,
+                                                    const int step) final;
 
-    std::vector<MPI_Request> IExchangeAbsolutePosition(BufferSTL &bufferSTL,
-                                                       const int step) final;
+    std::vector<std::vector<MPI_Request>>
+    IExchangeAbsolutePosition(BufferSTL &bufferSTL, const int step) final;
 
-    void Wait(std::vector<MPI_Request> &request, const int step) final;
+    void Wait(std::vector<std::vector<MPI_Request>> &request,
+              const int step) final;
 
-    void WaitAbsolutePosition(std::vector<MPI_Request> &requests,
+    void WaitAbsolutePosition(std::vector<std::vector<MPI_Request>> &requests,
                               const int step) final;
 
     void SwapBuffers(const int step) noexcept final;


### PR DESCRIPTION
Refactor MPI Aggregation
Separate recv from send requests and checks
Addressing #1433 