### PR TITLE
mpidummy: proper size in snprintf

### DIFF
--- a/source/adios2/helper/mpidummy.cpp
+++ b/source/adios2/helper/mpidummy.cpp
@@ -170,7 +170,8 @@ int MPI_Gather(const void *sendbuf, int sendcnt, MPI_Datatype sendtype,
     }
     else
     {
-        std::snprintf(mpierrmsg, ier, "could not gather data\n");
+        std::snprintf(mpierrmsg, MPI_MAX_ERROR_STRING,
+                      "could not gather data\n");
     }
 
     return ier;
@@ -247,7 +248,8 @@ int MPI_Scatter(const void *sendbuf, int sendcnt, MPI_Datatype sendtype,
     }
     else
     {
-        std::snprintf(mpierrmsg, ier, "could not scatter data\n");
+        std::snprintf(mpierrmsg, MPI_MAX_ERROR_STRING,
+                      "could not scatter data\n");
     }
 
     return ier;


### PR DESCRIPTION
Fix maximum buffer size and warning
```
  "could not gather data" directive output truncated writing
  22 bytes into a region of size 5 [-Wformat-truncation]
```