### PR TITLE
append: incredibly ugly but very simple append works (serial, no attrs)

### DIFF
--- a/source/adios2/toolkit/format/bp3/BP3Base.h
+++ b/source/adios2/toolkit/format/bp3/BP3Base.h
@@ -280,7 +280,7 @@ public:
 
     void ProfilerStop(const std::string process) noexcept;
 
-protected:
+    // protected:
     /** might be used in large payload copies to buffer */
     unsigned int m_Threads = 1;
     const bool m_DebugMode = false;

--- a/source/adios2/toolkit/format/bp3/BP3Deserializer.h
+++ b/source/adios2/toolkit/format/bp3/BP3Deserializer.h
@@ -173,7 +173,6 @@ public:
      */
     size_t MetadataStart(const BufferSTL &bufferSTL);
 
-private:
     std::map<std::string, helper::SubFileInfoMap> m_DeferredVariablesMap;
 
     static std::mutex m_Mutex;
@@ -184,6 +183,7 @@ private:
     void ParseVariablesIndex(const BufferSTL &bufferSTL, core::Engine &engine);
     void ParseAttributesIndex(const BufferSTL &bufferSTL, core::Engine &engine);
 
+private:
     /**
      * Reads a variable index element (serialized) and calls IO.DefineVariable
      * to deserialize the Variable metadata

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -392,6 +392,31 @@ TYPED_TEST(ADIOS2_CXX11_API_MultiBlock, Put2Writers)
 }
 #endif
 
+TYPED_TEST(ADIOS2_CXX11_API_MultiBlock, Append)
+{
+    using T = typename TypeParam::DataType;
+
+    std::string filename = "append.bp";
+    this->GenerateOutput(filename);
+
+    auto writer = this->m_Io.Open(filename, adios2::Mode::Append);
+    auto var2 = this->m_Io.template DefineVariable<T>("var2", this->m_Shape);
+
+    MyData<T> myData(this->m_Selections);
+    for (int b = 0; b < myData.NBlocks(); ++b)
+    {
+        myData[b][0] = 1000 + b;
+    }
+
+    for (int b = 0; b < myData.NBlocks(); ++b)
+    {
+        var2.SetSelection(myData.Selection(b));
+        writer.Put(var2, &myData[b][0], TypeParam::PutMode);
+    }
+
+    writer.Close();
+}
+
 int main(int argc, char **argv)
 {
 #ifdef ADIOS2_HAVE_MPI


### PR DESCRIPTION
This PR shows that appending to a BP3 file isn't all that hard to implement. This is by no means done, it's buggy, limited, and most of all extremely hacky. But it works for one simple test case: Writing 1 variable to a file, then opening that file again with `Mode::Append` and writing a second variable.

Doing this "right" will be quite a bit more work, though not really hard.