### PR TITLE
Fix python bindings for unified serial and parallel library

### DIFF
--- a/bindings/Python/py11ADIOS.cpp
+++ b/bindings/Python/py11ADIOS.cpp
@@ -29,7 +29,7 @@ ADIOS::ADIOS(MPI4PY_Comm mpiComm, const bool debugMode)
 : ADIOS("", mpiComm, debugMode)
 {
 }
-#else
+#endif
 ADIOS::ADIOS(const std::string &configFile, const bool debugMode)
 : m_ADIOS(
       std::make_shared<adios2::core::ADIOS>(configFile, debugMode, "Python"))
@@ -37,7 +37,6 @@ ADIOS::ADIOS(const std::string &configFile, const bool debugMode)
 }
 
 ADIOS::ADIOS(const bool debugMode) : ADIOS("", debugMode) {}
-#endif
 
 ADIOS::operator bool() const noexcept { return m_ADIOS ? true : false; }
 

--- a/bindings/Python/py11ADIOS.h
+++ b/bindings/Python/py11ADIOS.h
@@ -32,10 +32,9 @@ public:
     ADIOS(const std::string &configFile, MPI4PY_Comm comm,
           const bool debugMode = true);
     ADIOS(MPI4PY_Comm comm, const bool debugMode = true);
-#else
+#endif
     ADIOS(const std::string &configFile, const bool debugMode = true);
     ADIOS(const bool debugMode);
-#endif
     ~ADIOS() = default;
 
     /** object inspection true: valid object, false: invalid object */

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -57,7 +57,7 @@ public:
             if (import_mpi4py() < 0)
             {
                 throw std::runtime_error(
-                        "ERROR: mpi4py not loaded correctly\n"); /* Python 2.X */
+                    "ERROR: mpi4py not loaded correctly\n"); /* Python 2.X */
             }
         }
         // If src is not actually a MPI4PY communicator, the next
@@ -96,14 +96,15 @@ adios2::py11::File OpenConfig(const std::string &name, const std::string mode,
 
 #endif
 adios2::py11::File OpenNoComm(const std::string &name, const std::string mode,
-                        const std::string enginetype)
+                              const std::string enginetype)
 {
     return adios2::py11::File(name, mode, enginetype);
 }
 
-adios2::py11::File OpenConfigNoComm(const std::string &name, const std::string mode,
-                              const std::string configfile,
-                              const std::string ioinconfigfile)
+adios2::py11::File OpenConfigNoComm(const std::string &name,
+                                    const std::string mode,
+                                    const std::string configfile,
+                                    const std::string ioinconfigfile)
 {
     return adios2::py11::File(name, mode, configfile, ioinconfigfile);
 }


### PR DESCRIPTION
We rely on this trick to work in the type caster:
```
        // Import mpi4py if it does not exist.
        if (!PyMPIComm_Get)
        {
            if (import_mpi4py() < 0)
            {
                throw std::runtime_error(
                        "ERROR: mpi4py not loaded correctly\n"); /* Python 2.X */
            }
        }
```
