### PR TITLE
Calculate and use absolute step instead of relative step where necessary

### DIFF
--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -2613,7 +2613,6 @@ Dims get_global_array_signature(core::Engine *fp, core::IO *io,
     for (int step = 0; step < nsteps; step++)
     {
         const size_t absstep = itStep->first;
-        std::cout << "\n  check step " << absstep - 1;
         Dims d = variable->Shape(absstep - 1);
         if (d.empty())
         {

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -2584,7 +2584,7 @@ size_t relative_to_absolute_step(core::Variable<T> *variable,
 {
     const std::map<size_t, std::vector<size_t>> &indices =
         variable->m_AvailableStepBlockIndexOffsets;
-    auto itStep = std::next(indices.begin(), 0);
+    auto itStep = indices.begin();
     size_t absstep = itStep->first - 1;
 
     for (int step = 0; step < relstep; step++)
@@ -2608,7 +2608,7 @@ Dims get_global_array_signature(core::Engine *fp, core::IO *io,
     // is not supported by a simple API function
     const std::map<size_t, std::vector<size_t>> &indices =
         variable->m_AvailableStepBlockIndexOffsets;
-    auto itStep = std::next(indices.begin(), 0);
+    auto itStep = indices.begin();
 
     for (int step = 0; step < nsteps; step++)
     {

--- a/source/utils/bpls/bpls.h
+++ b/source/utils/bpls/bpls.h
@@ -95,6 +95,9 @@ int readVarBlock(core::Engine *fp, core::IO *io, core::Variable<T> *variable,
                  int blockid);
 
 template <class T>
+size_t relative_to_absolute_step(core::Variable<T> *variable,
+                                 const size_t relstep);
+template <class T>
 Dims get_global_array_signature(core::Engine *fp, core::IO *io,
                                 core::Variable<T> *variable);
 template <class T>


### PR DESCRIPTION
An example where bpls is using data structures directly to do something that is not available in the public API. A refactoring would bring out issues with the public API. 