### PR TITLE
Python Module: __version__

### DIFF
--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -11,6 +11,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <sstream>
 #include <stdexcept>
 
 #include <adios2.h>
@@ -118,6 +119,11 @@ PYBIND11_MODULE(adios2, m)
     m.attr("LocalValueDim") = adios2::LocalValueDim;
     m.attr("GlobalValue") = false;
     m.attr("LocalValue") = true;
+
+    std::ostringstream versionss;
+    versionss << ADIOS2_VERSION_MAJOR << "." << ADIOS2_VERSION_MINOR << "."
+              << ADIOS2_VERSION_PATCH;
+    m.attr("__version__") = versionss.str();
 
     // enum classes
     pybind11::enum_<adios2::Mode>(m, "Mode")


### PR DESCRIPTION
The `__version__` attribute is a standardized and recommended attribute for Python modules ([PEP 396](https://www.python.org/dev/peps/pep-0396)). It also comes in very handy to check if one imported a suitable minimum version. These versions
should be strings.
```python
import adios2

print(adios2.__version__)
# '2.4.0'
```

In case we want to add suffixes, such as release candidate identifiers, please be aware of the specifics in [PEP440](https://www.python.org/dev/peps/pep-0440).
Examples:
```
X.YaN    # Alpha release
X.YbN    # Beta release
X.YrcN   # Release Candidate
X.Y      # Final release
X.Y.devN # Development release
```