### PR TITLE
Fix places where 0.0 was used as a timeout in BeginStep

### DIFF
--- a/docs/user_guide/source/api_full/fortran.rst
+++ b/docs/user_guide/source/api_full/fortran.rst
@@ -544,7 +544,7 @@ ADIOS2 Fortran bindings handlers are mapped 1-to-1 to the ADIOS components descr
    
       ! Full signature
       subroutine adios2_begin_step(engine, adios2_step_mode, timeout_seconds, status, ierr)
-      ! Default Timeout = 0.
+      ! Default Timeout = -1.    (block until step available)
       subroutine adios2_begin_step(engine, adios2_step_mode, ierr)
       ! Default step_mode for read and write
       subroutine adios2_begin_step(engine, ierr)

--- a/testing/adios2/bindings/C/TestBPWriteAggregateReadLocal.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteAggregateReadLocal.cpp
@@ -67,7 +67,7 @@ void LocalAggregate1D(const std::string substreams)
         adios2_step_status step_status;
         for (size_t i = 0; i < NSteps; ++i)
         {
-            adios2_begin_step(bpWriter, adios2_step_mode_read, 0.,
+            adios2_begin_step(bpWriter, adios2_step_mode_read, -1.,
                               &step_status);
 
             std::iota(inumbers.begin() + i * Nx, inumbers.begin() + i * Nx + Nx,
@@ -105,7 +105,8 @@ void LocalAggregate1D(const std::string substreams)
         adios2_step_status step_status;
         while (true)
         {
-            adios2_begin_step(bpReader, adios2_step_mode_read, 0, &step_status);
+            adios2_begin_step(bpReader, adios2_step_mode_read, -1,
+                              &step_status);
 
             if (step_status == adios2_step_status_end_of_stream)
             {
@@ -205,7 +206,7 @@ void LocalAggregate1DBlock0(const std::string substreams)
         adios2_step_status step_status;
         for (size_t i = 0; i < NSteps; ++i)
         {
-            adios2_begin_step(bpWriter, adios2_step_mode_read, 0.,
+            adios2_begin_step(bpWriter, adios2_step_mode_read, -1.,
                               &step_status);
 
             std::iota(inumbers.begin() + i * Nx, inumbers.begin() + i * Nx + Nx,
@@ -251,8 +252,9 @@ void LocalAggregate1DBlock0(const std::string substreams)
         adios2_step_status step_status;
         while (true)
         {
-            adios2_begin_step(bpReader, adios2_step_mode_read, 0, &step_status);
-            adios2_begin_step(bpReader0, adios2_step_mode_read, 0,
+            adios2_begin_step(bpReader, adios2_step_mode_read, -1,
+                              &step_status);
+            adios2_begin_step(bpReader0, adios2_step_mode_read, -1,
                               &step_status);
 
             if (step_status == adios2_step_status_end_of_stream)

--- a/testing/adios2/bindings/C/TestNullWriteRead.cpp
+++ b/testing/adios2/bindings/C/TestNullWriteRead.cpp
@@ -66,7 +66,8 @@ TEST_F(NullWriteReadTests_C_API, NullWriteRead1D8)
 
         for (size_t step = 0; step < NSteps; ++step)
         {
-            adios2_begin_step(nullWriter, adios2_step_mode_append, 0., &status);
+            adios2_begin_step(nullWriter, adios2_step_mode_append, -1.,
+                              &status);
             adios2_put(nullWriter, var, nullptr, adios2_mode_deferred);
             adios2_perform_puts(nullWriter);
             adios2_end_step(nullWriter);
@@ -90,7 +91,7 @@ TEST_F(NullWriteReadTests_C_API, NullWriteRead1D8)
 
         for (size_t t = 0; t < NSteps; ++t)
         {
-            adios2_begin_step(nullReader, adios2_step_mode_read, 0., &status);
+            adios2_begin_step(nullReader, adios2_step_mode_read, -1., &status);
             EXPECT_EQ(status, adios2_step_status_end_of_stream);
 
             adios2_variable *var = adios2_inquire_variable(io, "r64");

--- a/testing/adios2/bindings/fortran/TestBPWriteMemorySelectionRead2D.f90
+++ b/testing/adios2/bindings/fortran/TestBPWriteMemorySelectionRead2D.f90
@@ -144,7 +144,7 @@ program TestBPWriteMemorySelectionRead2D
 
   do
 
-    call adios2_begin_step(bpReader, adios2_step_mode_read, 0., &
+    call adios2_begin_step(bpReader, adios2_step_mode_read, -1., &
                            step_status, ierr)
 
     if(step_status == adios2_step_status_end_of_stream) exit

--- a/testing/adios2/bindings/fortran/TestBPWriteMemorySelectionRead3D.f90
+++ b/testing/adios2/bindings/fortran/TestBPWriteMemorySelectionRead3D.f90
@@ -144,7 +144,7 @@ program TestBPWriteMemorySelectionRead3D
   allocate (in_data_r8(nx, ny, isize*nz))
 
   do
-    call adios2_begin_step(bpReader, adios2_step_mode_read, 0., &
+    call adios2_begin_step(bpReader, adios2_step_mode_read, -1., &
                            step_status, ierr)
 
     if(step_status == adios2_step_status_end_of_stream) exit

--- a/testing/adios2/bindings/fortran/TestBPWriteTypes.f90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypes.f90
@@ -178,7 +178,7 @@
 
      ! Put array contents to bp buffer, based on var1 metadata
      do i = 1, 3
-         call adios2_begin_step(bpWriter, adios2_step_mode_append, 0.0, &
+         call adios2_begin_step(bpWriter, adios2_step_mode_append, -1.0, &
                                 step_status, ierr)
 
          if (irank == 0 .and. i == 1) then

--- a/testing/adios2/bindings/fortran/TestBPWriteTypesByName.f90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypesByName.f90
@@ -91,7 +91,7 @@
      call adios2_open(bpWriter, ioWrite, "ftypes.bp", adios2_mode_write, ierr)
 
      do i = 1, 3
-         call adios2_begin_step(bpWriter, adios2_step_mode_append, 0.0, &
+         call adios2_begin_step(bpWriter, adios2_step_mode_append, -1.0, &
                                step_status, ierr)
          ! Put array contents to bp buffer, based on var1 metadata
          if (irank == 0 .and. i == 1) then

--- a/testing/adios2/bindings/fortran/TestBPWriteTypesLocal.f90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypesLocal.f90
@@ -157,7 +157,7 @@
      call adios2_open(bpReader, ioRead, "ftypes_local.bp", adios2_mode_read, ierr)
 
      do
-         call adios2_begin_step(bpReader, adios2_step_mode_read, 0.0, &
+         call adios2_begin_step(bpReader, adios2_step_mode_read, -1.0, &
                                 step_status, ierr)
          if (step_status == adios2_step_status_end_of_stream) exit
 

--- a/testing/adios2/bindings/fortran/TestNullEngine.f90
+++ b/testing/adios2/bindings/fortran/TestNullEngine.f90
@@ -64,7 +64,7 @@
      call adios2_open(nullReader, ioRead, "fnull.bp", adios2_mode_read, ierr)
 
      do s = 1, 3
-         call adios2_begin_step(nullReader, adios2_step_mode_read, 0.0, &
+         call adios2_begin_step(nullReader, adios2_step_mode_read, -1.0, &
                                 step_status, ierr)
          if (step_status /= adios2_step_status_end_of_stream) then
              stop 'null engine status failed'


### PR DESCRIPTION
At one point, before timeout was implemented anywhere, 0.0 was thought to be a good choice to mean no timeout, or blocking.  Turns out 0.0 more naturally means "poll and return immediately if no data".  So, a negative timeout means "blocking".  By convention we're using -1.0, but anything negative would work.