### PR TITLE
Generate the most advanced instructions for the architecture when use…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,14 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
+
+if(CMAKE_BUILD_TYPE MATCHES "Release" AND NOT MSVC)
+  set(CMAKE_CXXFLAGS "-g -O3 -march-native -ffast-math -Wfatal-errors")
+elseif(NOT MSVC)
+  set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O2 -Wfatal-errors -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
+endif()
+
+
 # Force C++11 and C99
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,9 +72,11 @@ endif()
 
 
 if(CMAKE_BUILD_TYPE MATCHES "Release" AND NOT MSVC)
-  set(CMAKE_CXXFLAGS "-g -O3 -march-native -ffast-math -Wfatal-errors")
-elseif(NOT MSVC)
-  set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O2 -Wfatal-errors -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
+  set(CMAKE_CXX_FLAGS "-g -O3 -march-native -ffast-math -Wfatal-errors")
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR
+       "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
+       "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -O0 -Wfatal-errors -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer")
 endif()
 
 

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -514,7 +514,7 @@ void Resize(std::vector<T> &vec, const size_t dataSize, const bool debugMode,
 // functions) and copies to the output buffer in blocks. the memory address
 // calculation complexity for copying each block is minimized to O(1), which is
 // independent of the number of dimensions.
-static void NdCopyRecurDFSeqPadding(size_t curDim, const char *&inOvlpBase,
+static inline void NdCopyRecurDFSeqPadding(size_t curDim, const char *&inOvlpBase,
                                     char *&outOvlpBase, Dims &inOvlpGapSize,
                                     Dims &outOvlpGapSize, Dims &ovlpCount,
                                     size_t &minContDim, size_t &blockSize)
@@ -557,7 +557,7 @@ static void NdCopyRecurDFSeqPadding(size_t curDim, const char *&inOvlpBase,
 // each element is minimized to average O(1), which is independent of
 // the number of dimensions.
 
-static void
+static inline void
 NdCopyRecurDFSeqPaddingRevEndian(size_t curDim, const char *&inOvlpBase,
                                  char *&outOvlpBase, Dims &inOvlpGapSize,
                                  Dims &outOvlpGapSize, Dims &ovlpCount,
@@ -598,11 +598,11 @@ NdCopyRecurDFSeqPaddingRevEndian(size_t curDim, const char *&inOvlpBase,
 // used for buffer of Column major
 // the memory address calculation complexity for copying each element is
 // minimized to average O(1), which is independent of the number of dimensions.
-static void NdCopyRecurDFNonSeqDynamic(size_t curDim, const char *inBase,
-                                       char *outBase, Dims &inRltvOvlpSPos,
-                                       Dims &outRltvOvlpSPos, Dims &inStride,
-                                       Dims &outStride, Dims &ovlpCount,
-                                       size_t elmSize)
+static inline void NdCopyRecurDFNonSeqDynamic(size_t curDim, const char *inBase,
+                                              char *outBase, Dims &inRltvOvlpSPos,
+                                              Dims &outRltvOvlpSPos, Dims &inStride,
+                                              Dims &outStride, Dims &ovlpCount,
+                                              size_t elmSize)
 {
     if (curDim == inStride.size())
     {
@@ -628,7 +628,7 @@ static void NdCopyRecurDFNonSeqDynamic(size_t curDim, const char *inBase,
 // The memory address calculation complexity for copying each element is
 // minimized to average O(1), which is independent of the number of dimensions.
 
-static void NdCopyRecurDFNonSeqDynamicRevEndian(
+static inline void NdCopyRecurDFNonSeqDynamicRevEndian(
     size_t curDim, const char *inBase, char *outBase, Dims &inRltvOvlpSPos,
     Dims &outRltvOvlpSPos, Dims &inStride, Dims &outStride, Dims &ovlpCount,
     size_t elmSize)
@@ -654,7 +654,7 @@ static void NdCopyRecurDFNonSeqDynamicRevEndian(
     }
 }
 
-static void NdCopyIterDFSeqPadding(const char *&inOvlpBase, char *&outOvlpBase,
+static inline void NdCopyIterDFSeqPadding(const char *&inOvlpBase, char *&outOvlpBase,
                                    Dims &inOvlpGapSize, Dims &outOvlpGapSize,
                                    Dims &ovlpCount, size_t minContDim,
                                    size_t blockSize)
@@ -685,7 +685,7 @@ static void NdCopyIterDFSeqPadding(const char *&inOvlpBase, char *&outOvlpBase,
     }
 }
 
-static void NdCopyIterDFSeqPaddingRevEndian(
+static inline void NdCopyIterDFSeqPaddingRevEndian(
     const char *&inOvlpBase, char *&outOvlpBase, Dims &inOvlpGapSize,
     Dims &outOvlpGapSize, Dims &ovlpCount, size_t minContDim, size_t blockSize,
     size_t elmSize, size_t numElmsPerBlock)
@@ -721,7 +721,7 @@ static void NdCopyIterDFSeqPaddingRevEndian(
         } while (pos[curDim] == ovlpCount[curDim]);
     }
 }
-static void NdCopyIterDFDynamic(const char *inBase, char *outBase,
+static inline void NdCopyIterDFDynamic(const char *inBase, char *outBase,
                                 Dims &inRltvOvlpSPos, Dims &outRltvOvlpSPos,
                                 Dims &inStride, Dims &outStride,
                                 Dims &ovlpCount, size_t elmSize)
@@ -758,7 +758,7 @@ static void NdCopyIterDFDynamic(const char *inBase, char *outBase,
     }
 }
 
-static void NdCopyIterDFDynamicRevEndian(const char *inBase, char *outBase,
+static inline void NdCopyIterDFDynamicRevEndian(const char *inBase, char *outBase,
                                          Dims &inRltvOvlpSPos,
                                          Dims &outRltvOvlpSPos, Dims &inStride,
                                          Dims &outStride, Dims &ovlpCount,

--- a/source/adios2/toolkit/format/BufferSTL.h
+++ b/source/adios2/toolkit/format/BufferSTL.h
@@ -32,9 +32,6 @@ public:
     void Resize(const size_t size, const std::string hint);
 
     size_t GetAvailableSize() const;
-
-private:
-    const bool m_DebugMode = false;
 };
 
 } // end namespace adios2


### PR DESCRIPTION
…rs do a source build. Add sanitizers for debug builds and keep the frame pointers. Remove unused private variable warnings and mark static functions in headers with definitions as inline to cut down on warnings.