### PR TITLE
Do early release of timesteps if we know a stream always wants Latest…

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -124,35 +124,47 @@ static char *SstQueueFullStr[] = {"Block", "Discard"};
 static char *SstCompressStr[] = {"None", "ZFP"};
 static char *SstCommPatternStr[] = {"Min", "Peer"};
 
-extern void CP_dumpParams(SstStream Stream, struct _SstParams *Params)
+extern void CP_dumpParams(SstStream Stream, struct _SstParams *Params,
+                          int ReaderSide)
 {
     if (!Stream->CPVerbose)
         return;
 
     fprintf(stderr, "Param -   RegistrationMethod:%s\n",
             SstRegStr[Params->RegistrationMethod]);
-    fprintf(stderr, "Param -   RendezvousReaderCount:%d\n",
-            Params->RendezvousReaderCount);
-    fprintf(stderr, "Param -   QueueLimit:%d %s\n", Params->QueueLimit,
-            (Params->QueueLimit == 0) ? "(unlimited)" : "");
-    fprintf(stderr, "Param -   QueueFullPolicy:%s\n",
-            SstQueueFullStr[Params->QueueFullPolicy]);
+    if (!ReaderSide)
+    {
+        fprintf(stderr, "Param -   RendezvousReaderCount:%d\n",
+                Params->RendezvousReaderCount);
+        fprintf(stderr, "Param -   QueueLimit:%d %s\n", Params->QueueLimit,
+                (Params->QueueLimit == 0) ? "(unlimited)" : "");
+        fprintf(stderr, "Param -   QueueFullPolicy:%s\n",
+                SstQueueFullStr[Params->QueueFullPolicy]);
+    }
     fprintf(stderr, "Param -   DataTransport:%s\n",
             Params->DataTransport ? Params->DataTransport : "");
     fprintf(stderr, "Param -   ControlTransport:%s\n",
             Params->ControlTransport);
     fprintf(stderr, "Param -   NetworkInterface:%s\n",
-            Params->NetworkInterface ? Params->NetworkInterface : "");
-    fprintf(stderr, "Param -   CompressionMethod:%s\n",
-            SstCompressStr[Params->CompressionMethod]);
-    fprintf(stderr, "Param -   CPCommPattern:%s\n",
-            SstCommPatternStr[Params->CPCommPattern]);
-    fprintf(stderr, "Param -   MarshalMethod:%s\n",
-            SstMarshalStr[Params->MarshalMethod]);
-    fprintf(stderr, "Param -   FirstTimestepPrecious:%s\n",
-            Params->FirstTimestepPrecious ? "True" : "False");
-    fprintf(stderr, "Param -   IsRowMajor:%d  (not user settable) \n",
-            Params->IsRowMajor);
+            Params->NetworkInterface ? Params->NetworkInterface : "(default)");
+    if (!ReaderSide)
+    {
+        fprintf(stderr, "Param -   CompressionMethod:%s\n",
+                SstCompressStr[Params->CompressionMethod]);
+        fprintf(stderr, "Param -   CPCommPattern:%s\n",
+                SstCommPatternStr[Params->CPCommPattern]);
+        fprintf(stderr, "Param -   MarshalMethod:%s\n",
+                SstMarshalStr[Params->MarshalMethod]);
+        fprintf(stderr, "Param -   FirstTimestepPrecious:%s\n",
+                Params->FirstTimestepPrecious ? "True" : "False");
+        fprintf(stderr, "Param -   IsRowMajor:%d  (not user settable) \n",
+                Params->IsRowMajor);
+    }
+    if (ReaderSide)
+    {
+        fprintf(stderr, "Param -   AlwaysProvideLatestTimestep:%s\n",
+                Params->AlwaysProvideLatestTimestep ? "True" : "False");
+    }
 }
 
 static FMField CP_SstParamsList_RAW[] = {

--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -484,7 +484,8 @@ extern void AddToLastCallFreeList(void *Block);
 extern void CP_verbose(SstStream Stream, char *Format, ...);
 extern void CP_error(SstStream Stream, char *Format, ...);
 extern struct _CP_Services Svcs;
-extern void CP_dumpParams(SstStream Stream, struct _SstParams *Params);
+extern void CP_dumpParams(SstStream Stream, struct _SstParams *Params,
+                          int ReaderSide);
 
 typedef void (*CPNetworkInfoFunc)(int dataID, const char *net_string,
                                   const char *data_string);

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -1133,7 +1133,7 @@ SstStream SstWriterOpen(const char *Name, SstParams Params, MPI_Comm comm)
     if (Stream->Rank == 0)
     {
         CP_verbose(Stream, "Writer stream params are:\n");
-        CP_dumpParams(Stream, Stream->ConfigParams);
+        CP_dumpParams(Stream, Stream->ConfigParams, 0 /* writer side */);
     }
 
     if (globalNetinfoCallback)

--- a/testing/adios2/engine/staging-common/CMakeLists.txt
+++ b/testing/adios2/engine/staging-common/CMakeLists.txt
@@ -115,7 +115,7 @@ if(ADIOS2_HAVE_Fortran)
   set (FORTRAN_TESTS "FtoC.1x1;CtoF.1x1;FtoF.1x1")
 endif()
 
-set (SPECIAL_TESTS "TimeoutReader;LatestReader;DiscardWriter;PreciousTimestep;PreciousTimestepDiscard")
+set (SPECIAL_TESTS "TimeoutReader;LatestReader;LatestReaderHold;DiscardWriter;PreciousTimestep;PreciousTimestepDiscard")
 if (MPIEXEC_IS_BINARY)
     # run_test.py can only kill readers/writers if mpiexec is not a shell script
     list(APPEND SPECIAL_TESTS "KillReadersSerialized;KillReaders3Max;KillWriter_2x2;KillWriterTimeout_2x2")

--- a/testing/adios2/engine/staging-common/TestCommonClient.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonClient.cpp
@@ -28,6 +28,7 @@ int ExpectWriterFailure = 0;
 int WriterFailed = 0;
 int IgnoreTimeGap = 1;
 int IncreasingDelay = 0;
+int DelayWhileHoldingStep = 0;
 int FirstTimestepMustBeZero = 0;
 int NonBlockingBeginStep = 0;
 int Latest = 0;
@@ -316,6 +317,12 @@ TEST_F(SstReadTest, ADIOS2SstRead)
         engine.Get(var_r64_2d_rev, in_R64_2d_rev.data());
         std::time_t write_time;
         engine.Get(var_time, (int64_t *)&write_time);
+        if (IncreasingDelay && DelayWhileHoldingStep)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(
+                DelayMS)); /* sleep for DelayMS milliseconds */
+            DelayMS += 200;
+        }
         try
         {
             engine.EndStep();
@@ -338,7 +345,7 @@ TEST_F(SstReadTest, ADIOS2SstRead)
                 break;
             }
         }
-        if (IncreasingDelay)
+        if (IncreasingDelay && !DelayWhileHoldingStep)
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(
                 DelayMS)); /* sleep for DelayMS milliseconds */
@@ -443,6 +450,10 @@ int main(int argc, char **argv)
         {
             IncreasingDelay = 1;
             Discard = 1;
+        }
+        else if (std::string(argv[1]) == "--delay_while_holding")
+        {
+            DelayWhileHoldingStep = 1;
         }
         else if (std::string(argv[1]) == "--precious_first")
         {

--- a/testing/adios2/engine/staging-common/TestSupp.cmake
+++ b/testing/adios2/engine/staging-common/TestSupp.cmake
@@ -120,6 +120,9 @@ set (TimeoutReader_PROPERTIES "RUN_SERIAL;1")
 set (LatestReader_CMD "run_test.py --test_protocol one_client -nw 1 -nr 1 --warg=--ms_delay --warg=250 --warg=--engine_params --warg=ENGINE_PARAMS --rarg=--latest --rarg=--long_first_delay")
 set (LatestReader_PROPERTIES "RUN_SERIAL;1")
 
+set (LatestReaderHold_CMD "run_test.py --test_protocol one_client -nw 1 -nr 1 --warg=--ms_delay --warg=250 --warg=--engine_params --warg=ENGINE_PARAMS --rarg=--latest --rarg=--long_first_delay --rarg=--delay_while_holding")
+set (LatestReaderHold_PROPERTIES "RUN_SERIAL;1")
+
 # A faster writer and a queue policy that will cause timesteps to be discarded
 set (DiscardWriter_CMD "run_test.py --test_protocol one_client -nw 1 -nr 1 --warg=--engine_params --warg=QueueLimit:1,QueueFullPolicy:discard,ENGINE_PARAMS --warg=--ms_delay --warg=250 --rarg=--discard")
 


### PR DESCRIPTION
…Available.  Change the dumpParams output to be specific to reader/writer streams.  Add a test for LatestAvailable behaviour if we're holding a timestep when new ones come in