### PR TITLE
Fix BP3Serializer crash on big-endian machines if Endian_Reverse is enabled

### DIFF
--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -312,11 +312,12 @@ void BP3Serializer::UpdateOffsetsInMetadata()
     auto lf_UpdatePGIndexOffsets = [&]() {
         auto &buffer = m_MetadataSet.PGIndex.Buffer;
         size_t &currentPosition = m_MetadataSet.PGIndex.LastUpdatedPosition;
+        const bool isLittleEndian = helper::IsLittleEndian();
 
         while (currentPosition < buffer.size())
         {
-            ProcessGroupIndex pgIndex =
-                ReadProcessGroupIndexHeader(buffer, currentPosition);
+            ProcessGroupIndex pgIndex = ReadProcessGroupIndexHeader(
+                buffer, currentPosition, isLittleEndian);
 
             const uint64_t updatedOffset =
                 pgIndex.Offset +
@@ -331,8 +332,8 @@ void BP3Serializer::UpdateOffsetsInMetadata()
 
         // First get the type:
         size_t headerPosition = 0;
-        ElementIndexHeader header =
-            ReadElementIndexHeader(buffer, headerPosition);
+        ElementIndexHeader header = ReadElementIndexHeader(
+            buffer, headerPosition, helper::IsLittleEndian());
         const DataTypes dataTypeEnum = static_cast<DataTypes>(header.DataType);
 
         size_t &currentPosition = index.LastUpdatedPosition;
@@ -871,8 +872,8 @@ BP3Serializer::AggregateCollectiveMetadataIndices(MPI_Comm comm,
         while (localPosition < endPosition)
         {
             size_t indexPosition = localPosition;
-            const ElementIndexHeader header =
-                ReadElementIndexHeader(serialized, indexPosition);
+            const ElementIndexHeader header = ReadElementIndexHeader(
+                serialized, indexPosition, helper::IsLittleEndian());
             if (isRankConstant && deserialized.count(header.Name) == 1)
             {
                 return;
@@ -994,6 +995,7 @@ BP3Serializer::AggregateCollectiveMetadataIndices(MPI_Comm comm,
         const std::vector<char> &serialized = bufferSTL.m_Buffer;
         size_t serializedPosition = 0;
         std::vector<size_t> headerInfo(4);
+        const bool isLittleEndian = helper::IsLittleEndian();
 
         // if (m_Threads == 1)
         {
@@ -1001,13 +1003,15 @@ BP3Serializer::AggregateCollectiveMetadataIndices(MPI_Comm comm,
             {
                 size_t localPosition = serializedPosition;
 
-                const int rankSource = static_cast<int>(
-                    helper::ReadValue<uint32_t>(serialized, localPosition));
+                const int rankSource =
+                    static_cast<int>(helper::ReadValue<uint32_t>(
+                        serialized, localPosition, isLittleEndian));
 
                 for (auto i = 0; i < 4; ++i)
                 {
-                    headerInfo[i] = static_cast<size_t>(
-                        helper::ReadValue<uint64_t>(serialized, localPosition));
+                    headerInfo[i] =
+                        static_cast<size_t>(helper::ReadValue<uint64_t>(
+                            serialized, localPosition, isLittleEndian));
                 }
 
                 lf_DeserializeAllIndices(rankSource, headerInfo, serialized,
@@ -1056,6 +1060,7 @@ void BP3Serializer::MergeSerializeIndices(
 
     {
         const DataTypes dataTypeEnum = static_cast<DataTypes>(dataType);
+        const bool isLittleEndian = helper::IsLittleEndian();
 
         switch (dataTypeEnum)
         {
@@ -1064,7 +1069,7 @@ void BP3Serializer::MergeSerializeIndices(
     case (TypeTraits<T>::type_enum):                                           \
     {                                                                          \
         const auto characteristics = ReadElementIndexCharacteristics<T>(       \
-            buffer, position, TypeTraits<T>::type_enum, true);                 \
+            buffer, position, TypeTraits<T>::type_enum, true, isLittleEndian); \
         count = characteristics.EntryCount;                                    \
         length = characteristics.EntryLength;                                  \
         timeStep = characteristics.Statistics.Step;                            \
@@ -1077,7 +1082,7 @@ void BP3Serializer::MergeSerializeIndices(
         {
             const auto characteristics =
                 ReadElementIndexCharacteristics<std::string>(
-                    buffer, position, type_string_array, true);
+                    buffer, position, type_string_array, true, isLittleEndian);
             count = characteristics.EntryCount;
             length = characteristics.EntryLength;
             timeStep = characteristics.Statistics.Step;
@@ -1107,6 +1112,8 @@ void BP3Serializer::MergeSerializeIndices(
             // merge index length
             size_t headerSize = 0;
 
+            const bool isLittleEndian = helper::IsLittleEndian();
+
             for (size_t r = 0; r < indices.size(); ++r)
             {
                 const auto &buffer = indices[r].Buffer;
@@ -1116,7 +1123,8 @@ void BP3Serializer::MergeSerializeIndices(
                 }
                 size_t &position = positions[r];
 
-                header = ReadElementIndexHeader(buffer, position);
+                header =
+                    ReadElementIndexHeader(buffer, position, isLittleEndian);
                 firstRank = r;
 
                 headerSize = position;
@@ -1225,6 +1233,8 @@ void BP3Serializer::MergeSerializeIndices(
         // merge index length
         size_t headerSize = 0;
 
+        const bool isLittleEndian = helper::IsLittleEndian();
+
         for (size_t r = 0; r < indices.size(); ++r)
         {
             const auto &buffer = indices[r].Buffer;
@@ -1234,7 +1244,7 @@ void BP3Serializer::MergeSerializeIndices(
             }
             size_t &position = positions[r];
 
-            header = ReadElementIndexHeader(buffer, position);
+            header = ReadElementIndexHeader(buffer, position, isLittleEndian);
             firstRank = r;
 
             headerSize = position;

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
@@ -882,18 +882,20 @@ void BP3Serializer::UpdateIndexOffsetsCharacteristics(size_t &currentPosition,
                                                       const DataTypes dataType,
                                                       std::vector<char> &buffer)
 {
+    const bool isLittleEndian = helper::IsLittleEndian();
     const uint8_t characteristicsCount =
-        helper::ReadValue<uint8_t>(buffer, currentPosition);
+        helper::ReadValue<uint8_t>(buffer, currentPosition, isLittleEndian);
 
     const uint32_t characteristicsLength =
-        helper::ReadValue<uint32_t>(buffer, currentPosition);
+        helper::ReadValue<uint32_t>(buffer, currentPosition, isLittleEndian);
 
     const size_t endPosition =
         currentPosition + static_cast<size_t>(characteristicsLength);
 
     while (currentPosition < endPosition)
     {
-        const uint8_t id = helper::ReadValue<uint8_t>(buffer, currentPosition);
+        const uint8_t id =
+            helper::ReadValue<uint8_t>(buffer, currentPosition, isLittleEndian);
 
         switch (id)
         {
@@ -915,7 +917,9 @@ void BP3Serializer::UpdateIndexOffsetsCharacteristics(size_t &currentPosition,
             {
                 // first get the length of the string
                 const size_t length = static_cast<size_t>(
-                    helper::ReadValue<uint16_t>(buffer, currentPosition));
+
+                    helper::ReadValue<uint16_t>(buffer, currentPosition,
+                                                isLittleEndian));
 
                 currentPosition += length;
             }
@@ -940,8 +944,8 @@ void BP3Serializer::UpdateIndexOffsetsCharacteristics(size_t &currentPosition,
         }
         case (characteristic_offset):
         {
-            const uint64_t currentOffset =
-                helper::ReadValue<uint64_t>(buffer, currentPosition);
+            const uint64_t currentOffset = helper::ReadValue<uint64_t>(
+                buffer, currentPosition, isLittleEndian);
 
             const uint64_t updatedOffset =
                 currentOffset +
@@ -953,8 +957,8 @@ void BP3Serializer::UpdateIndexOffsetsCharacteristics(size_t &currentPosition,
         }
         case (characteristic_payload_offset):
         {
-            const uint64_t currentPayloadOffset =
-                helper::ReadValue<uint64_t>(buffer, currentPosition);
+            const uint64_t currentPayloadOffset = helper::ReadValue<uint64_t>(
+                buffer, currentPosition, isLittleEndian);
 
             const uint64_t updatedPayloadOffset =
                 currentPayloadOffset +
@@ -968,7 +972,9 @@ void BP3Serializer::UpdateIndexOffsetsCharacteristics(size_t &currentPosition,
         case (characteristic_dimensions):
         {
             const size_t dimensionsSize = static_cast<size_t>(
-                helper::ReadValue<uint8_t>(buffer, currentPosition));
+
+                helper::ReadValue<uint8_t>(buffer, currentPosition,
+                                           isLittleEndian));
 
             currentPosition +=
                 3 * sizeof(uint64_t) * dimensionsSize + 2; // 2 is for length


### PR DESCRIPTION
BP3Serializer assumes little-endian and crashes with the following error on big-endian machines when compiled with Endian_Reverse=ON.

```
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
```