### PR TITLE
Fix BP3Reader so that you can open for read a file with the same name…

### DIFF
--- a/source/adios2/engine/bp3/BP3Reader.cpp
+++ b/source/adios2/engine/bp3/BP3Reader.cpp
@@ -150,8 +150,17 @@ void BP3Reader::InitTransports()
     if (m_BP3Deserializer.m_RankMPI == 0)
     {
         const bool profile = m_BP3Deserializer.m_Profiler.IsActive;
-        m_FileManager.OpenFiles({m_Name}, adios2::Mode::Read,
-                                m_IO.m_TransportsParameters, profile);
+        try
+        {
+            m_FileManager.OpenFiles({m_Name}, adios2::Mode::Read,
+                                    m_IO.m_TransportsParameters, profile);
+        }
+        catch (...)
+        {
+            const std::string bpName = helper::AddExtension(m_Name, ".bp");
+            m_FileManager.OpenFiles({bpName}, adios2::Mode::Read,
+                                    m_IO.m_TransportsParameters, profile);
+        }
     }
 }
 


### PR DESCRIPTION
… you used for opening for write.

This addresses Issue #1499.  It doesn't change current behavior where the current behavior is successful.  However, where current behavior would fail because a file isn't found, this tries again, adding the .bp suffix.  This allows using the same string in reader-side open as was used in writer-side open.  There might be an easier way to do this, but this was the least messy way I could come up with.

