### PR TITLE
Consistently use BZip2 in CMake code instead of BZIP2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ cmake_dependent_option(BUILD_SHARED_LIBS
 )
 mark_as_advanced(BUILD_SHARED_LIBS)
 
-adios_option(BZIP2     "Enable support for BZIP2 transforms" AUTO)
+adios_option(BZip2     "Enable support for BZip2 transforms" AUTO)
 adios_option(ZFP       "Enable support for ZFP transforms" AUTO)
 adios_option(SZ        "Enable support for SZ transforms" AUTO)
 adios_option(MGARD     "Enable support for MGARD transforms" AUTO)
@@ -134,7 +134,7 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 set(ADIOS2_CONFIG_OPTS
-    BZIP2 ZFP SZ MGARD PNG MPI DataMan SSC SST ZeroMQ HDF5 Python Fortran SysVShMem Profiling Endian_Reverse
+    BZip2 ZFP SZ MGARD PNG MPI DataMan SSC SST ZeroMQ HDF5 Python Fortran SysVShMem Profiling Endian_Reverse
 )
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})
 configure_file(

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -10,13 +10,13 @@
 # dependencies is an error,
 
 # BZIP2
-if(ADIOS2_USE_BZIP2 STREQUAL AUTO)
+if(ADIOS2_USE_BZip2 STREQUAL AUTO)
   find_package(BZip2)
-elseif(ADIOS2_USE_BZIP2)
+elseif(ADIOS2_USE_BZip2)
   find_package(BZip2 REQUIRED)
 endif()
 if(BZIP2_FOUND)
-  set(ADIOS2_HAVE_BZIP2 TRUE)
+  set(ADIOS2_HAVE_BZip2 TRUE)
 endif()
 
 # ZFP

--- a/docs/user_guide/source/installation/cmake.rst
+++ b/docs/user_guide/source/installation/cmake.rst
@@ -383,7 +383,7 @@ CMake VAR Option               Values                     Description
 ``ADIOS2_USE_Python``          **`AUTO`**/``ON``/OFF      Python >= 2.7 bindings. mpi4py and numpy. Python 3 will be used if Python 2 and 3 are found. If you want a python version not in the path then choose the right pyhton executable by -DPYTHON_EXECUTABLE=... 
 ``ADIOS2_USE_Fortran``         **`AUTO`**/``ON``/OFF      Fortran 90 or above bindings. Must have a Fortran compiler. Default is OFF, must be explicitly set to ON.
 ``ADIOS2_USE_SST``             **`AUTO`**/``ON``/OFF      Simplified Staging Engine (SST) and its dependencies, requires MPI. Can optionally use LibFabric for RDMA transport. Specify the LibFabric install manually with the -DLIBFABRIC_ROOT=... option. 
-``ADIOS2_USE_BZIP2``           **`AUTO`**/``ON``/OFF      `BZIP2 <http://www.bzip.org>`_ compression.              
+``ADIOS2_USE_BZip2``           **`AUTO`**/``ON``/OFF      `BZIP2 <http://www.bzip.org>`_ compression.
 ``ADIOS2_USE_ZFP``             **`AUTO`**/``ON``/OFF      `ZFP <https://github.com/LLNL/zfp>`_ compression (experimental).
 ``ADIOS2_USE_SZ``              **`AUTO`**/``ON``/OFF      `SZ <https://github.com/disheng222/SZ>`_ compression (experimental).
 ``ADIOS2_USE_MGARD``           **`AUTO`**/``ON``/OFF      `MGARD <https://github.com/CODARcode/MGARD>`_ compression (experimental).

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -152,7 +152,7 @@ if(ADIOS2_HAVE_SST)
 endif()
 
 
-if(ADIOS2_HAVE_BZIP2)
+if(ADIOS2_HAVE_BZip2)
   target_sources(adios2 PRIVATE operator/compress/CompressBZIP2.cpp)
   target_link_libraries(adios2 PRIVATE BZip2::BZip2)
 endif()


### PR DESCRIPTION
Other parts of the code use ADIOS_HAVE_BZip2, and this inconsistency
was causing installation failures. Fix the usage to make it consistent.