### PR TITLE
Move Fortran modules from include/fortran to include/adios2/fortran

### DIFF
--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(adios2_f
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/fortran>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/adios2/fortran>
 )
 
 target_link_libraries(adios2_f PRIVATE adios2)
@@ -70,7 +70,7 @@ install(
 )
 install(
   DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fortran
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/adios2/fortran
   FILES_MATCHING 
     PATTERN "adios2*.mod" 
     PATTERN "CMakeFiles" EXCLUDE

--- a/docs/user_guide/source/installation/fortran.rst
+++ b/docs/user_guide/source/installation/fortran.rst
@@ -16,6 +16,6 @@ To enable the Fortran bindings in ADIOS2 follow these guidelines:
       -  ``lib/libadios2.*``
       
     * Modules 
-      -  ``include/fortran/*.mod``  
+      -  ``include/adios2/fortran/*.mod``
 
 3. **Module adios2:** only module required to be used in an application ``use adios``


### PR DESCRIPTION
Fixes: #1477