### PR TITLE
Remove LockWriterDefinitions/LockReaderSelections from IO

### DIFF
--- a/bindings/CXX11/cxx11/IO.h
+++ b/bindings/CXX11/cxx11/IO.h
@@ -278,23 +278,6 @@ public:
     void FlushAll();
 
     /**
-     * @brief Promise that no more definitions or changes to defined variables
-     * will occur. Useful information if called before the first EndStep() of an
-     * output Engine, as it will know that the definitions are complete and
-     * constant for the entire lifetime of the output and may optimize metadata
-     * handling.
-     */
-    void LockWriterDefinitions();
-
-    /**
-     * @brief Promise that the reader data selections of are fixed and
-     * will not change in future timesteps. This information, provided
-     * before the EndStep() representing a fixed read pattern, may be
-     * utilized by the input Engine to optimize data flow.
-     */
-    void LockReaderSelections();
-
-    /**
      * Returns a map with variable information
      * @return map:
      * <pre>


### PR DESCRIPTION
I was seeing weird link-time errors because of this. I guess these are remnants from a previous design. Seems to have been accidentally added in #1478.