### PR TITLE
Bp4 buffer tags

### DIFF
--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -612,16 +612,18 @@ void BP4Writer::WriteCollectiveMetadataFile(const bool isFinal)
 void BP4Writer::WriteData(const bool isFinal, const int transportIndex)
 {
     TAU_SCOPED_TIMER("BP4Writer::WriteData");
-    size_t dataSize = m_BP4Serializer.m_Data.m_Position;
+    size_t dataSize; // = m_BP4Serializer.m_Data.m_Position;
 
     if (isFinal)
     {
         m_BP4Serializer.CloseData(m_IO);
         dataSize = m_BP4Serializer.m_Data.m_Position;
+        // write data + footer
     }
     else
     {
-        m_BP4Serializer.CloseStream(m_IO);
+        dataSize = m_BP4Serializer.CloseStream(m_IO, false);
+        // write data only without footer
     }
 
     m_FileDataManager.WriteFiles(m_BP4Serializer.m_Data.m_Buffer.data(),

--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -11,6 +11,7 @@
 #include "adiosMemory.h"
 
 #include <algorithm>
+#include <stddef.h> // max_align_t
 
 #include "adios2/helper/adiosType.h"
 
@@ -283,6 +284,22 @@ void CopyPayload(char *dest, const Dims &destStart, const Dims &destCount,
                         srcCount, destMemStart, destMemCount, srcMemStart,
                         srcMemCount, endianReverse, destType);
     }
+}
+
+size_t PaddingToAlignPointer(const void *ptr)
+{
+    auto memLocation = reinterpret_cast<std::uintptr_t>(ptr);
+    size_t padSize = sizeof(max_align_t) - (memLocation % sizeof(max_align_t));
+    if (padSize == sizeof(max_align_t))
+    {
+        padSize = 0;
+    }
+    /*std::cout << " -- Pad pointer with " << std::to_string(padSize)
+              << " bytes. original pointer = " << std::to_string(memLocation)
+              << " aligned pointer = " << std::to_string(memLocation + padSize)
+              << " sizeof(max_align_t) = "
+              << std::to_string(sizeof(max_align_t)) << std::endl;*/
+    return padSize;
 }
 
 } // end namespace helper

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -229,6 +229,13 @@ int NdCopy(const char *in, const Dims &inStart, const Dims &inCount,
 template <class T>
 size_t PayloadSize(const T *data, const Dims &count) noexcept;
 
+/** Calculate how many bytes away is a memory location to be aligned to the
+ * size of max_align_t.
+ * @param a pointer
+ * @return padding value in [0..sizeof(max_align_t)-1]
+ */
+size_t PaddingToAlignPointer(const void *ptr);
+
 } // end namespace helper
 } // end namespace adios2
 

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.h
@@ -86,8 +86,10 @@ public:
     /**
      * Finishes bp buffer by serializing data and adding trailing metadata
      * @param io
+     * @return the position of the data buffer before writing the metadata
+     * footer into it (in case someone wants to write only the data portion)
      */
-    void CloseData(core::IO &io);
+    size_t CloseData(core::IO &io);
 
     /**
      * Closes bp buffer for streaming mode...must reset metadata for the next
@@ -95,10 +97,12 @@ public:
      * @param io object containing all attributes
      * @param addMetadata true: process metadata and add to data buffer
      * (minifooter)
+     * @return the position of the data buffer before writing the metadata
+     * footer into it (in case someone wants to write only the data portion)
      */
-    void CloseStream(core::IO &io, const bool addMetadata = true);
-    void CloseStream(core::IO &io, size_t &metadataStart, size_t &metadataCount,
-                     const bool addMetadata = true);
+    size_t CloseStream(core::IO &io, const bool addMetadata = true);
+    size_t CloseStream(core::IO &io, size_t &metadataStart,
+                       size_t &metadataCount, const bool addMetadata = true);
 
     void ResetIndices();
 
@@ -158,11 +162,13 @@ private:
      * specialized functions
      * @param attribute input
      * @param stats BP4 Stats
+     * @param headerID  short string to identify block ("[AMD")
      * @return attribute length position
      */
     template <class T>
     size_t PutAttributeHeaderInData(const core::Attribute<T> &attribute,
-                                    Stats<T> &stats) noexcept;
+                                    Stats<T> &stats, const char *headerID,
+                                    const size_t headerIDLength) noexcept;
 
     /**
      * Called from WriteAttributeInData specialized functions

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.h
@@ -248,8 +248,8 @@ private:
     void PutVariableCharacteristics(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::Info &blockInfo,
-        const Stats<T> &stats, std::vector<char> &buffer,
-        size_t &position) noexcept;
+        const Stats<T> &stats, std::vector<char> &buffer, size_t &position,
+        const bool putDimensions = true) noexcept;
 
     /**
      * Writes from &buffer[position]:  [2

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
@@ -86,7 +86,7 @@ inline void BP4Serializer::PutVariablePayload(
     const bool sourceRowMajor) noexcept
 {
     ProfilerStart("buffering");
-    /*const size_t startingPos = m_Data.m_Position;*/
+    const size_t startingPos = m_Data.m_Position;
     if (blockInfo.Operations.empty())
     {
         PutPayloadInBuffer(variable, blockInfo, sourceRowMajor);
@@ -96,7 +96,6 @@ inline void BP4Serializer::PutVariablePayload(
         PutOperationPayloadInBuffer(variable, blockInfo);
     }
 
-    /*
     std::cout << " -- Var payload name=" << variable.m_Name
               << " startPos = " << std::to_string(startingPos)
               << " end position = " << std::to_string(m_Data.m_Position)
@@ -110,7 +109,6 @@ inline void BP4Serializer::PutVariablePayload(
               << " 4 bytes ahead = '"
               << std::string(m_Data.m_Buffer.data() + startingPos - 4, 4) << "'"
               << std::endl;
-    */
 
     ProfilerStop("buffering");
 }
@@ -501,20 +499,22 @@ void BP4Serializer::PutVariableMetadataInData(
     // format: length in 1 byte + padding characters + VMD]
     // we would write at minimum 5 bytes, byte for length + "VMD]"
     // hence the +5 in the calculation below
-    size_t padSize =
-        helper::PaddingToAlignPointer(buffer.data() + position + 5);
+    size_t padSize = rand() % 32;
+    // helper::PaddingToAlignPointer(buffer.data() + position + 5);
 
     const char vmdEnd[] = "                                VMD]";
     unsigned char vmdEndLen = static_cast<unsigned char>(padSize + 4);
     // starting position in vmdEnd from where we copy to buffer
     // we don't copy the \0 from vmdEnd !
     const char *ptr = vmdEnd + (sizeof(vmdEnd) - 1 - vmdEndLen);
-    /*std::cout << " -- Pad metadata with " << std::to_string(padSize)
-              << " bytes. position = " << std::to_string(position)
-              << " pad string = '" << ptr << "'"
-              << " buffer memory address = "
-              << std::to_string(reinterpret_cast<std::uintptr_t>(buffer.data()))
-              << std::endl;*/
+    std::cout << " -- Pad metadata with " << std::to_string(padSize)
+              << " bytes. var = " << variable.m_Name << " rank = " << m_RankMPI
+              << " position = " << std::to_string(position) << " pad string = '"
+              << ptr << "'" << std::endl;
+    /*              << " buffer memory address = "
+                  <<
+       std::to_string(reinterpret_cast<std::uintptr_t>(buffer.data()))
+                  << std::endl;*/
     helper::CopyToBuffer(buffer, position, &vmdEndLen, 1);
     helper::CopyToBuffer(buffer, position, ptr, vmdEndLen);
 

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
@@ -493,7 +493,8 @@ void BP4Serializer::PutVariableMetadataInData(
                         buffer, position);
 
     // CHARACTERISTICS
-    PutVariableCharacteristics(variable, blockInfo, stats, buffer, position);
+    PutVariableCharacteristics(variable, blockInfo, stats, buffer, position,
+                               false);
 
     // pad metadata so that data will fall on aligned position in memory
     // write a padding plus block identifier VMD]
@@ -837,7 +838,8 @@ template <class T>
 void BP4Serializer::PutVariableCharacteristics(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::Info &blockInfo, const Stats<T> &stats,
-    std::vector<char> &buffer, size_t &position) noexcept
+    std::vector<char> &buffer, size_t &position,
+    const bool putDimensions) noexcept
 {
     // going back at the end
     const size_t characteristicsCountPosition = position;
@@ -845,17 +847,21 @@ void BP4Serializer::PutVariableCharacteristics(
     position += 5;
     uint8_t characteristicsCounter = 0;
 
-    // DIMENSIONS
-    uint8_t characteristicID = characteristic_dimensions;
-    helper::CopyToBuffer(buffer, position, &characteristicID);
+    if (putDimensions)
+    {
+        // DIMENSIONS
+        uint8_t characteristicID = characteristic_dimensions;
+        helper::CopyToBuffer(buffer, position, &characteristicID);
 
-    const uint8_t dimensions = static_cast<uint8_t>(blockInfo.Count.size());
-    helper::CopyToBuffer(buffer, position, &dimensions); // count
-    const uint16_t dimensionsLength = static_cast<uint16_t>(24 * dimensions);
-    helper::CopyToBuffer(buffer, position, &dimensionsLength); // length
-    PutDimensionsRecord(blockInfo.Count, blockInfo.Shape, blockInfo.Start,
-                        buffer, position, true);
-    ++characteristicsCounter;
+        const uint8_t dimensions = static_cast<uint8_t>(blockInfo.Count.size());
+        helper::CopyToBuffer(buffer, position, &dimensions); // count
+        const uint16_t dimensionsLength =
+            static_cast<uint16_t>(24 * dimensions);
+        helper::CopyToBuffer(buffer, position, &dimensionsLength); // length
+        PutDimensionsRecord(blockInfo.Count, blockInfo.Shape, blockInfo.Start,
+                            buffer, position, true);
+        ++characteristicsCounter;
+    }
 
     // VALUE for SCALAR or STAT min, max for ARRAY
     if (blockInfo.Data != nullptr)

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -38,3 +38,6 @@ if(ADIOS2_HAVE_MPI)
   add_subdirectory(adios_iotest)
 endif()
 
+# bp4dbg Python tool
+install(PROGRAMS bp4dbg/bp4dbg.py 
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/source/utils/bp4dbg/bp4dbg.py
+++ b/source/utils/bp4dbg/bp4dbg.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import absolute_import, division, print_function, unicode_literals
+import argparse
+import time
+from os.path import basename, exists, isdir
+import glob
+from bp4dbg_data import DumpData
+
+
+def SetupArgs():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--infile", "-i", help="Name of the input file", required=True)
+    parser.add_argument("--printdata", "-p",
+                        help="Dump data of this variable as well", default="")
+    parser.add_argument("--verbose", "-v",
+                        help="More verbosity", action="store_true")
+    parser.add_argument("--no-indextable", "-x",
+                        help="Do not print index table md.idx", action="store_true")
+    parser.add_argument("--no-metadata", "-m",
+                        help="Do not print metadata md.0", action="store_true")
+    parser.add_argument(
+        "--no-data", "-d", help="Do not print data data.*", action="store_true")
+    args = parser.parse_args()
+
+    # default values
+    args.idxFileName = ""
+    args.dumpIdx = False
+    args.metadataFileName = ""
+    args.dumpMetadata = False
+    args.dataFileName = ""
+    args.dumpData = False
+
+    return args
+
+
+def CheckFileName(args):
+    if (not exists(args.infile)):
+        print("ERROR: File " + args.infile + " does not exist", flush=True)
+        exit(1)
+    if (isdir(args.infile)):
+        if (not args.no_indextable):
+            args.idxFileName = args.infile + "/" + "md.idx"
+            args.dumpIdx = True
+        if (not args.no_metadata):
+            args.metadataFileName = args.infile + "/" + "md.[0-9]*"
+            args.dumpMetadata = True
+        if (not args.no_data):
+            args.dataFileName = args.infile + "/" + "data.[0-9]*"
+            args.dumpData = True
+        return
+
+    name = basename(args.infile)
+    if (name.startswith("data.")):
+        args.dataFileName = args.infile
+        args.dumpData = True
+
+    elif (name == "md.idx"):
+        args.idxFileName = args.infile
+        args.dumpIdx = True
+
+    elif (name.startswith("md.")):
+        args.metadataFileName = args.infile
+        args.dumpMetadata = True
+
+
+def DumpIndexTableFile(args):
+    print("=== Index Table: " + args.idxFileName + " ====")
+
+
+def DumpMetadataFiles(args):
+    mdFileList = glob.glob(args.metadataFileName)
+    for fname in mdFileList:
+        print("=== Metadata File: " + fname + " ====")
+
+
+def DumpDataFiles(args):
+    dataFileList = glob.glob(args.dataFileName)
+    for fname in dataFileList:
+        DumpData(fname)
+
+
+if __name__ == "__main__":
+
+    args = SetupArgs()
+#    print(args)
+
+#    print("Debug file {0}".format(args.infile), flush=True)
+    CheckFileName(args)
+
+    if (args.dumpIdx):
+        DumpIndexTableFile(args)
+
+    if (args.dumpMetadata):
+        DumpMetadataFiles(args)
+
+    if (args.dumpData):
+        DumpDataFiles(args)

--- a/source/utils/bp4dbg/bp4dbg_data.py
+++ b/source/utils/bp4dbg/bp4dbg_data.py
@@ -1,0 +1,295 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import time
+import numpy as np
+from os.path import basename, exists, isdir
+from os import fstat
+import bp4dbg_utils
+
+
+def ReadEncodedString(f, ID, limit):
+    # 2 bytes length + string without \0
+    namelen = np.fromfile(f, dtype=np.uint16, count=1)[0]
+    if (namelen > limit):
+        print("ERROR: " + ID + " string length ({0}) is longer than the limit to stay inside the block ({1})".format(
+            namelen, limit))
+        return ""
+    name = f.read(namelen)
+    return name
+
+
+def ReadHeader(f):
+    # There is no header at this time in data.*\
+    print("Header info: There is no header in data.*")
+
+
+def ReadCharacteristicsFromData(f, limit, typeID):
+    # 1 byte NCharacteristics
+    nCharacteristics = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    print("      # of Characteristics    : {0}".format(nCharacteristics))
+    # 4 bytes length
+    charLen = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("      Characteristics Length  : {0}".format(charLen))
+
+    for i in range(nCharacteristics):
+        print("      Characteristics[{0}]".format(i))
+        # 1 byte TYPE
+        cID = np.fromfile(f, dtype=np.uint8, count=1)[0]
+        print("          Type        : {0} ({1}) ".format(
+            bp4dbg_utils.GetCharacteristicName(cID), cID))
+        cLen = bp4dbg_utils.GetCharacteristicDataLength(cID, typeID)
+        cData = f.read(cLen)
+        print("          Content     : {0} bytes = {1}".format(
+            cLen, cData))
+    return True
+
+
+def ReadVarData(f, nElements, typeID, ldims, varsStartPosition, varsTotalLength):
+    typeSize = bp4dbg_utils.GetTypeSize(typeID)
+    if (typeSize == 0):
+        print("ERROR: Cannot process variable data block with unknown type size")
+        return False
+
+    currentPosition = f.tell()
+    print("      Var payload offset: {0}".format(currentPosition))
+    nBytes = np.ones(1, dtype=np.uint64)
+    nBytes[0] = nElements[0] * typeSize
+    if (currentPosition + nBytes[0] > varsStartPosition + varsTotalLength):
+        print("ERROR: Variable data block of size would reach beyond all variable blocks")
+        print("VarsStartPosition = {0} varsTotalLength = {1}".format(
+            varsStartPosition, varsTotalLength))
+        print("current Position = {0} var block length = {1}".format(
+            currentPosition, nBytes[0]))
+        # return False
+    print("      Variable Data   : {0} bytes".format(nBytes[0]))
+    data = f.read(nBytes[0])
+    return True
+
+
+def ReadVMD(f, varidx, varsStartPosition, varsTotalLength):
+    print("  Var {0:5d}".format(varidx))
+    print("      Starting offset : {0}".format(f.tell()))
+    # 4 bytes TAG
+    tag = f.read(4)
+    if (tag != b"[VMD"):
+        print("  Tag: " + str(tag))
+        print("ERROR: VAR group does not start with [VMD")
+        return False
+    print("      Tag             : " + tag.decode('ascii'))
+
+    currentPosition = f.tell()
+    # 8 bytes VMD Length
+    vmdlen = np.fromfile(f, dtype=np.uint64, count=1)[0]
+    print("      Var block size  : {0} bytes (+4 for Tag)".format(vmdlen))
+    expectedVMDLength = vmdlen - 8  # need to read this more
+    print("VarsStartPosition = {0} varsTotalLength = {1}".format(
+        varsStartPosition, varsTotalLength))
+    print("current Position = {0} var block length = {1}".format(
+        currentPosition, expectedVMDLength))
+    if (currentPosition + expectedVMDLength > varsStartPosition + varsTotalLength):
+        print("ERROR: There is not enough bytes inside this PG to read this Var block")
+
+        return False
+
+    # 4 bytes VAR MEMBER ID
+    memberID = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("      Member ID       : {0}".format(memberID))
+
+    # VAR NAME, 2 bytes length + string without \0
+    varname = ReadEncodedString(f, "Var Name", expectedVMDLength)
+    if (varname == ""):
+        return False
+    print("      Var Name        : " + varname.decode('ascii'))
+
+    # VAR PATH, 2 bytes length + string without \0
+    varpath = ReadEncodedString(f, "Var Path", expectedVMDLength)
+    if (varname == ""):
+        return False
+    print("      Var Path        : " + varpath.decode('ascii'))
+
+    # 1 byte TYPE
+    typeID = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    print("      Type            : {0} ({1}) ".format(
+        bp4dbg_utils.GetTypeName(typeID), typeID))
+
+    # ISDIMENSIONS 1 byte, 'y' or 'n'
+    isDimensionVar = f.read(1)
+    if (isDimensionVar != b'y' and isDimensionVar != b'n'):
+        print(
+            "ERROR: Next byte for isDimensionVar must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+        return False
+    print("      isDimensionVar  : " + isDimensionVar.decode('ascii'))
+
+    # 1 byte NDIMENSIONS
+    ndims = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    print("      # of Dimensions : {0}".format(
+        ndims))
+
+    # DIMLENGTH
+    dimsLen = np.fromfile(f, dtype=np.uint16, count=1)[0]
+    print("      Dims Length     : {0}".format(
+        dimsLen))
+
+    nElements = np.ones(1, dtype=np.uint64)
+    ldims = np.zeros(ndims, dtype=np.uint64)
+    for i in range(ndims):
+        print("      Dim[{0}]".format(i))
+        # Read Local Dimensions (1 byte flag + 8 byte value)
+        # Is Dimension a variable ID 1 byte, 'y' or 'n' or '\0'
+        isDimensionVarID = f.read(1)
+        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and isDimensionsVarID != b'\0'):
+            print(
+                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+            return False
+        if (isDimensionVarID == b'\0'):
+            isDimensionVarID = b'n'
+        ldims[i] = np.fromfile(f, dtype=np.uint64, count=1)[0]
+        print("           local  dim : {0}".format(ldims[i]))
+        nElements = nElements * ldims[i]
+        # Read Global Dimensions (1 byte flag + 8 byte value)
+        # Is Dimension a variable ID 1 byte, 'y' or 'n' or '\0'
+        isDimensionVarID = f.read(1)
+        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and isDimensionsVarID != b'\0'):
+            print(
+                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+            return False
+        if (isDimensionVarID == b'\0'):
+            isDimensionVarID = b'n'
+        gdim = np.fromfile(f, dtype=np.uint64, count=1)[0]
+        print("           global dim : {0}".format(gdim))
+
+        # Read Offset Dimensions (1 byte flag + 8 byte value)
+        # Is Dimension a variable ID 1 byte, 'y' or 'n' or '\0'
+        isDimensionVarID = f.read(1)
+        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and isDimensionsVarID != b'\0'):
+            print(
+                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+            return False
+        if (isDimensionVarID == b'\0'):
+            isDimensionVarID = b'n'
+        offset = np.fromfile(f, dtype=np.uint64, count=1)[0]
+        print("           offset dim : {0}".format(offset))
+
+    status = ReadCharacteristicsFromData(f, expectedVMDLength, typeID)
+    if (not status):
+        return False
+
+    # Padded end TAG
+    # 1 byte length of tag
+    endTagLen = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    tag = f.read(endTagLen)
+    if (not tag.endswith(b"VMD]")):
+        print("  Tag: " + str(tag))
+        print("ERROR: VAR group metadata does not end with VMD]")
+        return False
+    print("      Tag (pad {0:2d})    : {1}".format(
+        endTagLen - 4, tag.decode('ascii')))
+
+    status = ReadVarData(f, nElements, typeID, ldims,
+                         varsStartPosition, varsTotalLength)
+    if (not status):
+        return False
+
+    return True
+
+
+def ReadPG(f, fileSize):
+    print("PG: ")
+    print("  Starting offset : {0}".format(f.tell()))
+    # 4 bytes TAG
+    tag = f.read(4)
+    if (tag != b"[PGI"):
+        print("  Tag: " + str(tag))
+        print("ERROR: PG group does not start with [PGI")
+        return False
+
+    print("  Tag             : " + tag.decode('ascii'))
+
+    # 8 bytes PG Length
+    pglen = np.fromfile(f, dtype=np.uint64, count=1)[0]
+    print("  PG length       : {0} bytes (+4 for Tag)".format(pglen))
+    expectedPGLength = pglen - 8  # need to read this more
+    if (f.tell() + expectedPGLength > fileSize):
+        print("ERROR: There is not enough bytes in file to read this PG")
+        return False
+
+    # RowMajor 1 byte, 'y' or 'n'
+    isRowMajor = f.read(1)
+    if (isRowMajor != b'y' and isRowMajor != b'n'):
+        print(
+            "ERROR: Next byte for isRowMajor must be 'y' or 'n' but it isn't = {0}".format(isRowMajor))
+        return False
+    print("  isRowMajor      : " + isRowMajor.decode('ascii'))
+
+    # PG Name, 2 bytes length + string without \0
+    pgname = ReadEncodedString(f, "PG Name", expectedPGLength)
+    if (pgname == ""):
+        return False
+    print("  PG Name         : " + pgname.decode('ascii'))
+
+    # 4 bytes unused (for Coordination variable)
+    tag = f.read(4)
+    print("  Unused 4 bytes  : " + str(tag))
+
+    # Timestep name
+    tsname = ReadEncodedString(f, "Timestep Name", expectedPGLength)
+    if (tsname == ""):
+        return False
+    print("  Step Name       : " + tsname.decode('ascii'))
+
+    # STEP 4 bytes
+    step = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("  Step Value      : {0}".format(step))
+
+    # Method Count 1 byte1
+    nMethods = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    print("  Methods count   : {0}".format(nMethods))
+
+    # Method Length 2 byte1
+    lenMethods = np.fromfile(f, dtype=np.uint16, count=1)[0]
+    print("  Methods length  : {0}".format(lenMethods))
+
+    print("  Methods info")
+    for i in range(nMethods):
+        # Method ID
+        methodID = np.fromfile(f, dtype=np.uint8, count=1)[0]
+        print("      Method ID   : {0}".format(nMethods))
+        methodParams = ReadEncodedString(
+            f, "Method Parameters", expectedPGLength)
+        if (methodParams == ""):
+            return False
+        print('      M. params   : "' +
+              methodParams.decode('ascii') + '"')
+
+    # VARS COUNT 4 bytes
+    nVars = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("  # of Variables  : {0}".format(nVars))
+
+    # VARS SIZE 8 bytes
+    varlen = np.fromfile(f, dtype=np.uint64, count=1)[0]
+    print("  Vars length     : {0} bytes".format(varlen))
+    expectedVarsLength = varlen  # need to read this more
+    if (expectedVarsLength > expectedPGLength):
+        print("ERROR: There is not enough bytes in PG to read the variables")
+        return False
+
+    varsStartPosition = f.tell()
+    for i in range(nVars):
+        # VMD block
+        status = ReadVMD(f, i, varsStartPosition, expectedVarsLength)
+        if (not status):
+            return False
+
+    return True
+
+
+def DumpData(fileName):
+    print("=== Data File: " + fileName + " ====")
+    with open(fileName, "rb") as f:
+        fileSize = fstat(f.fileno()).st_size
+        status = True
+        while (f.tell() < fileSize - 12 and status):
+            status = ReadPG(f, fileSize)
+
+
+if __name__ == "__main__":
+    print("ERROR: Utility main program is bp4dbg.py")

--- a/source/utils/bp4dbg/bp4dbg_utils.py
+++ b/source/utils/bp4dbg/bp4dbg_utils.py
@@ -1,0 +1,98 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+dataTypes = {
+    -1: 'unknown',
+    0: 'byte',
+    1: 'short',
+    2: 'integer',
+    4: 'long',
+
+    50: 'unsigned_byte',
+    51: 'unsigned_short',
+    52: 'unsigned_integer',
+    54: 'unsigned_long',
+
+    5: 'real',
+    6: 'double',
+    7: 'long_double',
+
+    9: 'string',
+    10: 'complex',
+    11: 'double_complex',
+    12: 'string_array'
+}
+
+dataTypeSize = {
+    -1: 0,
+    0: 1,
+    1: 2,
+    2: 4,
+    4: 8,
+
+    50: 1,
+    51: 2,
+    52: 4,
+    54: 8,
+
+    5: 4,
+    6: 8,
+    7: 16,
+
+    9: 0,
+    10: 8,
+    11: 16,
+    12: 0
+}
+
+
+def GetTypeName(typeID):
+    name = dataTypes.get(typeID)
+    if (name == None):
+        name = "unknown type"
+    return name
+
+
+def GetTypeSize(typeID):
+    size = dataTypeSize.get(typeID)
+    if (size == None):
+        size = 0
+    return size
+
+
+CharacteristicNames = {
+    0: 'value',
+    1: 'min',
+    2: 'max',
+    3: 'offset',
+    4: 'dimensions',
+    5: 'var_id',
+    6: 'payload_offset',
+    7: 'file_index',
+    8: 'time_index',
+    9: 'bitmap',
+    10: 'stat',
+    11: 'transform_type'
+}
+
+
+def GetCharacteristicName(cID):
+    name = CharacteristicNames.get(cID)
+    if (name == None):
+        name = "unknown characteristic"
+    return name
+
+
+def GetCharacteristicDataLength(cID, typeID):
+    name = CharacteristicNames.get(cID)
+    if (name == 'value' or name == 'min' or name == 'max'):
+        return dataTypeSize[typeID]
+    elif (name == 'offset' or name == 'payload offset'):
+        return 8
+    elif (name == 'file_index' or name == 'time_index'):
+        return 4
+    else:
+        return 0
+
+
+if __name__ == "__main__":
+    print("ERROR: Utility main program is bp4dbg.py")


### PR DESCRIPTION
Add tags to data buffer for easier error checking for the (future) recovery tool. 
Remove unnecessary duplication of dimensions in the metadata (in the data buffer).
Pad the metadata so that the actual data always falls on max_align_t size (in the memory, not in the file).