### PR TITLE
Small quality of life improvements to basic examples.

### DIFF
--- a/examples/hello/bpReader/helloBPReader.cpp
+++ b/examples/hello/bpReader/helloBPReader.cpp
@@ -67,13 +67,14 @@ int main(int argc, char *argv[])
             // myFloats.data is pre-allocated
             bpReader.Get<float>(bpFloats, myFloats, adios2::Mode::Sync);
 
-            if (rank == 0) {
-            std::cout << "MyFloats: \n";
-            for (const auto number : myFloats)
+            if (rank == 0)
             {
-                std::cout << number << " ";
-            }
-            std::cout << "\n";
+                std::cout << "MyFloats: \n";
+                for (const auto number : myFloats)
+                {
+                    std::cout << number << " ";
+                }
+                std::cout << "\n";
             }
         }
 
@@ -85,13 +86,14 @@ int main(int argc, char *argv[])
 
             bpReader.Get<int>(bpInts, myInts, adios2::Mode::Sync);
 
-            if (rank == 0) {
-            std::cout << "myInts: \n";
-            for (const auto number : myInts)
+            if (rank == 0)
             {
-                std::cout << number << " ";
-            }
-            std::cout << "\n";
+                std::cout << "myInts: \n";
+                for (const auto number : myInts)
+                {
+                    std::cout << number << " ";
+                }
+                std::cout << "\n";
             }
         }
 
@@ -107,6 +109,7 @@ int main(int argc, char *argv[])
                 << rank << "\n";
             std::cerr << e.what() << "\n";
         }
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     catch (std::ios_base::failure &e)
     {
@@ -121,6 +124,7 @@ int main(int argc, char *argv[])
                          "been run."
                       << " Run ./hello_bpWriter before running this program.\n";
         }
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     catch (std::exception &e)
     {
@@ -130,6 +134,7 @@ int main(int argc, char *argv[])
                       << "\n";
             std::cerr << e.what() << "\n";
         }
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
 
     MPI_Finalize();

--- a/examples/hello/bpReader/helloBPReader.cpp
+++ b/examples/hello/bpReader/helloBPReader.cpp
@@ -67,12 +67,14 @@ int main(int argc, char *argv[])
             // myFloats.data is pre-allocated
             bpReader.Get<float>(bpFloats, myFloats, adios2::Mode::Sync);
 
+            if (rank == 0) {
             std::cout << "MyFloats: \n";
             for (const auto number : myFloats)
             {
                 std::cout << number << " ";
             }
             std::cout << "\n";
+            }
         }
 
         if (bpInts) // means not found
@@ -83,12 +85,14 @@ int main(int argc, char *argv[])
 
             bpReader.Get<int>(bpInts, myInts, adios2::Mode::Sync);
 
+            if (rank == 0) {
             std::cout << "myInts: \n";
             for (const auto number : myInts)
             {
                 std::cout << number << " ";
             }
             std::cout << "\n";
+            }
         }
 
         /** Close bp file, engine becomes unreachable after this*/
@@ -96,25 +100,36 @@ int main(int argc, char *argv[])
     }
     catch (std::invalid_argument &e)
     {
-        std::cerr << "Invalid argument exception, STOPPING PROGRAM from rank "
-                  << rank << "\n";
-        std::cerr << e.what() << "\n";
+        if (rank == 0)
+        {
+            std::cerr
+                << "Invalid argument exception, STOPPING PROGRAM from rank "
+                << rank << "\n";
+            std::cerr << e.what() << "\n";
+        }
     }
     catch (std::ios_base::failure &e)
     {
-        std::cerr << "IO System base failure exception, STOPPING PROGRAM "
-                     "from rank "
-                  << rank << "\n";
-        std::cerr << e.what() << "\n";
-        std::cerr
-            << "The file " << filename << " does not exist."
-            << " Presumably this is because hello_bpWriter has not been run."
-            << " Run ./hello_bpWriter before running this program.\n";
+        if (rank == 0)
+        {
+            std::cerr << "IO System base failure exception, STOPPING PROGRAM "
+                         "from rank "
+                      << rank << "\n";
+            std::cerr << e.what() << "\n";
+            std::cerr << "The file " << filename << " does not exist."
+                      << " Presumably this is because hello_bpWriter has not "
+                         "been run."
+                      << " Run ./hello_bpWriter before running this program.\n";
+        }
     }
     catch (std::exception &e)
     {
-        std::cerr << "Exception, STOPPING PROGRAM from rank " << rank << "\n";
-        std::cerr << e.what() << "\n";
+        if (rank == 0)
+        {
+            std::cerr << "Exception, STOPPING PROGRAM from rank " << rank
+                      << "\n";
+            std::cerr << e.what() << "\n";
+        }
     }
 
     MPI_Finalize();

--- a/examples/hello/bpReader/helloBPReader_nompi.cpp
+++ b/examples/hello/bpReader/helloBPReader_nompi.cpp
@@ -11,6 +11,7 @@
 
 #include <ios>       //std::ios_base::failure
 #include <iostream>  //std::cout
+#include <fstream>   //std::fstream
 #include <stdexcept> //std::invalid_argument std::exception
 #include <vector>
 
@@ -18,10 +19,20 @@
 
 int main(int argc, char *argv[])
 {
-    /** Application variable */
-    const std::size_t Nx = 10;
-    std::vector<float> myFloats(Nx);
-    std::vector<int> myInts(Nx);
+    // Test if the file has been written by hello_bpWriter:
+    std::string filename = "myVector_cpp.bp";
+    std::ifstream f(filename.c_str());
+    if (!f.good())
+    {
+       std::cerr << "The file " << filename << " does not exist."
+                 << " Presumably this is because hello_bpWriter has not been run. Run ./hello_bpWriter before running this program.\n";
+       return 1;
+    }
+    else
+    {
+       f.close();
+    }
+
 
     try
     {
@@ -34,7 +45,7 @@ int main(int argc, char *argv[])
 
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpReader =
-            bpIO.Open("myVector_cpp.bp", adios2::Mode::Read);
+            bpIO.Open(filename.c_str(), adios2::Mode::Read);
 
         /** Write variable for buffering */
         adios2::Variable<float> bpFloats =
@@ -44,12 +55,23 @@ int main(int argc, char *argv[])
 
         if (bpFloats)
         {
-            bpReader.Get<float>(bpFloats, myFloats.data(), adios2::Mode::Sync);
+            std::vector<float> myFloats;
+            bpReader.Get<float>(bpFloats, myFloats, adios2::Mode::Sync);
+            std::cout << "Float vector inside " << filename << ": {";
+            for (auto & x : myFloats) {
+              std::cout << x << ", ";
+            }
+            std::cout << "}\n";
         }
 
         if (bpInts)
         {
-            bpReader.Get<int>(bpInts, myInts.data(), adios2::Mode::Sync);
+            std::vector<int> myInts;
+            bpReader.Get<int>(bpInts, myInts, adios2::Mode::Sync);
+        }
+        else
+        {
+            std::cout << "There are no integer datasets in " << filename << ".\n";
         }
 
         /** Close bp file, engine becomes unreachable after this*/

--- a/examples/hello/bpReader/helloBPReader_nompi.cpp
+++ b/examples/hello/bpReader/helloBPReader_nompi.cpp
@@ -11,7 +11,6 @@
 
 #include <ios>       //std::ios_base::failure
 #include <iostream>  //std::cout
-#include <fstream>   //std::fstream
 #include <stdexcept> //std::invalid_argument std::exception
 #include <vector>
 
@@ -19,20 +18,7 @@
 
 int main(int argc, char *argv[])
 {
-    // Test if the file has been written by hello_bpWriter:
     std::string filename = "myVector_cpp.bp";
-    std::ifstream f(filename.c_str());
-    if (!f.good())
-    {
-       std::cerr << "The file " << filename << " does not exist."
-                 << " Presumably this is because hello_bpWriter has not been run. Run ./hello_bpWriter before running this program.\n";
-       return 1;
-    }
-    else
-    {
-       f.close();
-    }
-
 
     try
     {
@@ -44,8 +30,7 @@ int main(int argc, char *argv[])
         adios2::IO bpIO = adios.DeclareIO("ReadBP");
 
         /** Engine derived class, spawned to start IO operations */
-        adios2::Engine bpReader =
-            bpIO.Open(filename.c_str(), adios2::Mode::Read);
+        adios2::Engine bpReader = bpIO.Open(filename, adios2::Mode::Read);
 
         /** Write variable for buffering */
         adios2::Variable<float> bpFloats =
@@ -58,8 +43,9 @@ int main(int argc, char *argv[])
             std::vector<float> myFloats;
             bpReader.Get<float>(bpFloats, myFloats, adios2::Mode::Sync);
             std::cout << "Float vector inside " << filename << ": {";
-            for (auto & x : myFloats) {
-              std::cout << x << ", ";
+            for (auto &x : myFloats)
+            {
+                std::cout << x << ", ";
             }
             std::cout << "}\n";
         }
@@ -71,7 +57,8 @@ int main(int argc, char *argv[])
         }
         else
         {
-            std::cout << "There are no integer datasets in " << filename << ".\n";
+            std::cout << "There are no integer datasets in " << filename
+                      << ".\n";
         }
 
         /** Close bp file, engine becomes unreachable after this*/
@@ -79,18 +66,21 @@ int main(int argc, char *argv[])
     }
     catch (std::invalid_argument &e)
     {
-        std::cout << "Invalid argument exception, STOPPING PROGRAM\n";
-        std::cout << e.what() << "\n";
+        std::cerr << "Invalid argument exception, STOPPING PROGRAM\n";
+        std::cerr << e.what() << "\n";
     }
     catch (std::ios_base::failure &e)
     {
-        std::cout << "IO System base failure exception, STOPPING PROGRAM\n";
-        std::cout << e.what() << "\n";
+        std::cerr << "IO System base failure exception, STOPPING PROGRAM\n";
+        std::cerr << e.what() << "\n";
+        std::cerr << "The file " << filename << " does not exist."
+                  << " Presumably this is because hello_bpWriter has not been "
+                     "run. Run ./hello_bpWriter before running this program.\n";
     }
     catch (std::exception &e)
     {
-        std::cout << "Exception, STOPPING PROGRAM\n";
-        std::cout << e.what() << "\n";
+        std::cerr << "Exception, STOPPING PROGRAM\n";
+        std::cerr << e.what() << "\n";
     }
 
     return 0;

--- a/examples/hello/bpWriter/helloBPWriter.cpp
+++ b/examples/hello/bpWriter/helloBPWriter.cpp
@@ -53,9 +53,10 @@ int main(int argc, char *argv[])
         adios2::Variable<std::string> bpString =
             bpIO.DefineVariable<std::string>("bpString");
 
+        std::string filename = "myVector_cpp.bp";
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpFileWriter =
-            bpIO.Open("myVector_cpp.bp", adios2::Mode::Write);
+            bpIO.Open(filename, adios2::Mode::Write);
 
         /** Put variables for buffering, template type is optional */
         bpFileWriter.Put<float>(bpFloats, myFloats.data());
@@ -64,6 +65,7 @@ int main(int argc, char *argv[])
 
         /** Create bp file, engine becomes unreachable after this*/
         bpFileWriter.Close();
+        std::cout << "Wrote file " << filename << " to disk. It can now be read by running ./bin/hello_bpReader.\n";
     }
     catch (std::invalid_argument &e)
     {

--- a/examples/hello/bpWriter/helloBPWriter.cpp
+++ b/examples/hello/bpWriter/helloBPWriter.cpp
@@ -80,6 +80,7 @@ int main(int argc, char *argv[])
                 << rank << "\n";
             std::cerr << e.what() << "\n";
         }
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     catch (std::ios_base::failure &e)
     {
@@ -90,6 +91,7 @@ int main(int argc, char *argv[])
                       << rank << "\n";
             std::cerr << e.what() << "\n";
         }
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     catch (std::exception &e)
     {
@@ -99,6 +101,7 @@ int main(int argc, char *argv[])
                       << "\n";
             std::cerr << e.what() << "\n";
         }
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
 
     MPI_Finalize();

--- a/examples/hello/bpWriter/helloBPWriter.cpp
+++ b/examples/hello/bpWriter/helloBPWriter.cpp
@@ -55,8 +55,7 @@ int main(int argc, char *argv[])
 
         std::string filename = "myVector_cpp.bp";
         /** Engine derived class, spawned to start IO operations */
-        adios2::Engine bpFileWriter =
-            bpIO.Open(filename, adios2::Mode::Write);
+        adios2::Engine bpFileWriter = bpIO.Open(filename, adios2::Mode::Write);
 
         /** Put variables for buffering, template type is optional */
         bpFileWriter.Put<float>(bpFloats, myFloats.data());
@@ -65,7 +64,9 @@ int main(int argc, char *argv[])
 
         /** Create bp file, engine becomes unreachable after this*/
         bpFileWriter.Close();
-        std::cout << "Wrote file " << filename << " to disk. It can now be read by running ./bin/hello_bpReader.\n";
+        std::cout << "Wrote file " << filename
+                  << " to disk. It can now be read by running "
+                     "./bin/hello_bpReader.\n";
     }
     catch (std::invalid_argument &e)
     {

--- a/examples/hello/bpWriter/helloBPWriter.cpp
+++ b/examples/hello/bpWriter/helloBPWriter.cpp
@@ -64,27 +64,41 @@ int main(int argc, char *argv[])
 
         /** Create bp file, engine becomes unreachable after this*/
         bpFileWriter.Close();
-        std::cout << "Wrote file " << filename
-                  << " to disk. It can now be read by running "
-                     "./bin/hello_bpReader.\n";
+        if (rank == 0)
+        {
+            std::cout << "Wrote file " << filename
+                      << " to disk. It can now be read by running "
+                         "./bin/hello_bpReader.\n";
+        }
     }
     catch (std::invalid_argument &e)
     {
-        std::cout << "Invalid argument exception, STOPPING PROGRAM from rank "
-                  << rank << "\n";
-        std::cout << e.what() << "\n";
+        if (rank == 0)
+        {
+            std::cerr
+                << "Invalid argument exception, STOPPING PROGRAM from rank "
+                << rank << "\n";
+            std::cerr << e.what() << "\n";
+        }
     }
     catch (std::ios_base::failure &e)
     {
-        std::cout << "IO System base failure exception, STOPPING PROGRAM "
-                     "from rank "
-                  << rank << "\n";
-        std::cout << e.what() << "\n";
+        if (rank == 0)
+        {
+            std::cerr << "IO System base failure exception, STOPPING PROGRAM "
+                         "from rank "
+                      << rank << "\n";
+            std::cerr << e.what() << "\n";
+        }
     }
     catch (std::exception &e)
     {
-        std::cout << "Exception, STOPPING PROGRAM from rank " << rank << "\n";
-        std::cout << e.what() << "\n";
+        if (rank == 0)
+        {
+            std::cerr << "Exception, STOPPING PROGRAM from rank " << rank
+                      << "\n";
+            std::cerr << e.what() << "\n";
+        }
     }
 
     MPI_Finalize();

--- a/examples/hello/bpWriter/helloBPWriter_nompi.cpp
+++ b/examples/hello/bpWriter/helloBPWriter_nompi.cpp
@@ -37,30 +37,31 @@ int main(int argc, char *argv[])
 
         std::string filename = "myVector_cpp.bp";
         /** Engine derived class, spawned to start IO operations */
-        adios2::Engine bpWriter =
-            bpIO.Open(filename, adios2::Mode::Write);
+        adios2::Engine bpWriter = bpIO.Open(filename, adios2::Mode::Write);
 
         /** Write variable for buffering */
         bpWriter.Put<float>(bpFloats, myFloats.data());
 
         /** Create bp file, engine becomes unreachable after this*/
         bpWriter.Close();
-        std::cout << "Wrote file " << filename << " to disk. It can now be read by running ./bin/hello_bpReader.\n";
+        std::cout << "Wrote file " << filename
+                  << " to disk. It can now be read by running "
+                     "./bin/hello_bpReader.\n";
     }
     catch (std::invalid_argument &e)
     {
-        std::cout << "Invalid argument exception, STOPPING PROGRAM\n";
-        std::cout << e.what() << "\n";
+        std::cerr << "Invalid argument exception, STOPPING PROGRAM\n";
+        std::cerr << e.what() << "\n";
     }
     catch (std::ios_base::failure &e)
     {
-        std::cout << "IO System base failure exception, STOPPING PROGRAM\n";
-        std::cout << e.what() << "\n";
+        std::cerr << "IO System base failure exception, STOPPING PROGRAM\n";
+        std::cerr << e.what() << "\n";
     }
     catch (std::exception &e)
     {
-        std::cout << "Exception, STOPPING PROGRAM\n";
-        std::cout << e.what() << "\n";
+        std::cerr << "Exception, STOPPING PROGRAM\n";
+        std::cerr << e.what() << "\n";
     }
 
     return 0;

--- a/examples/hello/bpWriter/helloBPWriter_nompi.cpp
+++ b/examples/hello/bpWriter/helloBPWriter_nompi.cpp
@@ -35,15 +35,17 @@ int main(int argc, char *argv[])
         adios2::Variable<float> bpFloats = bpIO.DefineVariable<float>(
             "bpFloats", {}, {}, {Nx}, adios2::ConstantDims);
 
+        std::string filename = "myVector_cpp.bp";
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpWriter =
-            bpIO.Open("myVector_cpp.bp", adios2::Mode::Write);
+            bpIO.Open(filename, adios2::Mode::Write);
 
         /** Write variable for buffering */
         bpWriter.Put<float>(bpFloats, myFloats.data());
 
         /** Create bp file, engine becomes unreachable after this*/
         bpWriter.Close();
+        std::cout << "Wrote file " << filename << " to disk. It can now be read by running ./bin/hello_bpReader.\n";
     }
     catch (std::invalid_argument &e)
     {


### PR DESCRIPTION
The commit gives a more informative error message when the `.bp` file has not been written by the corresponding writer, and uses the `std::vector<Real>` instead of the `Real*` call so that we avoid segfaults. 