### PR TITLE
Initial support for Blosc compression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ cmake_dependent_option(BUILD_SHARED_LIBS
 )
 mark_as_advanced(BUILD_SHARED_LIBS)
 
+adios_option(Blosc     "Enable support for Blosc transforms" AUTO)
 adios_option(BZip2     "Enable support for BZip2 transforms" AUTO)
 adios_option(ZFP       "Enable support for ZFP transforms" AUTO)
 adios_option(SZ        "Enable support for SZ transforms" AUTO)
@@ -120,7 +121,7 @@ adios_option(Python    "Enable support for Python bindings" AUTO)
 adios_option(Fortran   "Enable support for Fortran bindings" AUTO)
 adios_option(SysVShMem "Enable support for SysV Shared Memory IPC on *NIX" AUTO)
 adios_option(Profiling "Enable support for profiling" AUTO)
-adios_option(Endian_Reverse "Enable support for Little/Big Endian Interoprability" AUTO)
+adios_option(Endian_Reverse "Enable support for Little/Big Endian Interoperability" AUTO)
 include(${PROJECT_SOURCE_DIR}/cmake/DetectOptions.cmake)
 
 if(ADIOS2_HAVE_MPI)
@@ -134,7 +135,7 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 set(ADIOS2_CONFIG_OPTS
-    BZip2 ZFP SZ MGARD PNG MPI DataMan SSC SST ZeroMQ HDF5 Python Fortran SysVShMem Profiling Endian_Reverse
+    Blosc BZip2 ZFP SZ MGARD PNG MPI DataMan SSC SST ZeroMQ HDF5 Python Fortran SysVShMem Profiling Endian_Reverse
 )
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})
 configure_file(

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -9,7 +9,17 @@
 # them, otherwise we disable it.  If explicitly ON then a failure to find
 # dependencies is an error,
 
-# BZIP2
+# Blosc
+if(ADIOS2_USE_Blosc STREQUAL AUTO)
+  find_package(Blosc)
+elseif(ADIOS2_USE_Blosc)
+  find_package(Blosc REQUIRED)
+endif()
+if(BLOSC_FOUND)
+  set(ADIOS2_HAVE_Blosc TRUE)
+endif()
+
+# BZip2
 if(ADIOS2_USE_BZip2 STREQUAL AUTO)
   find_package(BZip2)
 elseif(ADIOS2_USE_BZip2)

--- a/cmake/FindBlosc.cmake
+++ b/cmake/FindBlosc.cmake
@@ -1,0 +1,73 @@
+#------------------------------------------------------------------------------#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#------------------------------------------------------------------------------#
+#
+# FindBLOSC
+# -----------
+#
+# Try to find the BLOSC library
+#
+# This module defines the following variables:
+#
+#   BLOSC_FOUND        - System has BLOSC
+#   BLOSC_INCLUDE_DIRS - The BLOSC include directory
+#   BLOSC_LIBRARIES    - Link these to use BLOSC
+#   BLOSC_VERSION      - Version of the BLOSC library to support
+#
+# and the following imported targets:
+#   Blosc::Blosc - The core BLOSC library
+#
+# You can also set the following variable to help guide the search:
+#   BLOSC_ROOT - The install prefix for BLOSC containing the
+#                     include and lib folders
+#                     Note: this can be set as a CMake variable or an
+#                           environment variable.  If specified as a CMake
+#                           variable, it will override any setting specified
+#                           as an environment variable.
+
+if(NOT BLOSC_FOUND)
+  if((NOT BLOSC_ROOT) AND (NOT (ENV{BLOSC_ROOT} STREQUAL "")))
+    set(BLOSC_ROOT "$ENV{BLOSC_ROOT}")
+  endif()
+  if(BLOSC_ROOT)
+    set(BLOSC_INCLUDE_OPTS HINTS ${BLOSC_ROOT}/include NO_DEFAULT_PATHS)
+    set(BLOSC_LIBRARY_OPTS
+      HINTS ${BLOSC_ROOT}/lib ${BLOSC_ROOT}/lib64
+      NO_DEFAULT_PATHS
+    )
+  endif()
+
+  find_path(BLOSC_INCLUDE_DIR blosc.h ${BLOSC_INCLUDE_OPTS})
+  find_library(BLOSC_LIBRARY blosc ${BLOSC_LIBRARY_OPTS})
+  if(BLOSC_INCLUDE_DIR)
+    file(STRINGS ${BLOSC_INCLUDE_DIR}/blosc.h _ver_strings
+      REGEX "BLOSC_VERSION_[^ ]* [0-9]+"
+    )
+    foreach(v IN LISTS _ver_strings)
+      string(REGEX MATCH "BLOSC_VERSION_([^ ]+) ([0-9]+)" v "${v}")
+      set(BLOSC_VERSION_${CMAKE_MATCH_1} ${CMAKE_MATCH_2})
+    endforeach()
+    set(BLOSC_VERSION
+      ${BLOSC_VERSION_MAJOR}.${BLOSC_VERSION_MINOR}.${BLOSC_VERSION_PATCH}
+    )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Blosc
+    FOUND_VAR BLOSC_FOUND
+    VERSION_VAR BLOSC_VERSION
+    REQUIRED_VARS BLOSC_LIBRARY BLOSC_INCLUDE_DIR
+  )
+  if(BLOSC_FOUND)
+    set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIR})
+    set(BLOSC_LIBRARIES ${BLOSC_LIBRARY})
+    if(BLOSC_FOUND AND NOT TARGET Blosc::Blosc)
+      add_library(Blosc::Blosc UNKNOWN IMPORTED)
+      set_target_properties(Blosc::Blosc PROPERTIES
+        IMPORTED_LOCATION             "${BLOSC_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${BLOSC_INCLUDE_DIR}"
+      )
+    endif()
+  endif()
+endif()

--- a/docs/user_guide/source/installation/cmake.rst
+++ b/docs/user_guide/source/installation/cmake.rst
@@ -388,6 +388,7 @@ CMake VAR Option               Values                     Description
 ``ADIOS2_USE_SZ``              **`AUTO`**/``ON``/OFF      `SZ <https://github.com/disheng222/SZ>`_ compression (experimental).
 ``ADIOS2_USE_MGARD``           **`AUTO`**/``ON``/OFF      `MGARD <https://github.com/CODARcode/MGARD>`_ compression (experimental).
 ``ADIOS2_USE_PNG``             **`AUTO`**/``ON``/OFF      `PNG <https://libpng.org>`_ compression (experimental).
+``ADIOS2_USE_Blosc``           **`AUTO`**/``ON``/OFF      `Blosc <http://blosc.org/>`_ compression (experimental).
 ``ADIOS2_USE_Endian_Reverse``  **`AUTO`**/ON/``OFF``      Big/Little Endian Interoperability for different endianness platforms at write and read.
 ============================= ========================= ==========================================================================================================================================================================================================================
 

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(adios2
   toolkit/format/bpOperation/compress/BPMGARD.cpp
   toolkit/format/bpOperation/compress/BPPNG.cpp
   toolkit/format/bpOperation/compress/BPBZIP2.cpp toolkit/format/bpOperation/compress/BPBZIP2.tcc
+  toolkit/format/bpOperation/compress/BPBlosc.cpp
   
   toolkit/profiling/iochrono/Timer.cpp
 
@@ -152,7 +153,7 @@ if(ADIOS2_HAVE_SST)
 endif()
 
 if(ADIOS2_HAVE_Blosc)
-  target_sources(adios2 PRIVATE operator/compress/CompressBLOSC.cpp)
+  target_sources(adios2 PRIVATE operator/compress/CompressBlosc.cpp)
   target_link_libraries(adios2 PRIVATE Blosc::Blosc)
 endif()
 

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -151,6 +151,10 @@ if(ADIOS2_HAVE_SST)
   target_link_libraries(adios2 PRIVATE sst)
 endif()
 
+if(ADIOS2_HAVE_Blosc)
+  target_sources(adios2 PRIVATE operator/compress/CompressBLOSC.cpp)
+  target_link_libraries(adios2 PRIVATE Blosc::Blosc)
+endif()
 
 if(ADIOS2_HAVE_BZip2)
   target_sources(adios2 PRIVATE operator/compress/CompressBZIP2.cpp)

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -262,7 +262,7 @@ constexpr char precision[] = "precision";
 // MGARD PARAMETERS
 #ifdef ADIOS2_HAVE_MGARD
 
-constexpr char LossyGARD[] = "mgard";
+constexpr char LossyMGARD[] = "mgard";
 
 namespace mgard
 {
@@ -355,59 +355,43 @@ constexpr char blockSize100k_9[] = "9";
 // BBlosc PARAMETERS
 #ifdef ADIOS2_HAVE_BLOSC
 
-constexpr char BLOSC[] = "blosc";
+constexpr char LosslessBlosc[] = "blosc";
 namespace blosc
 {
 
 namespace key
 {
-constexpr char NTHREADS[] = "nthreads";
-constexpr char COMPRESSOR[] = "compressor";
-constexpr char CLEVEL[] = "clevel";
-constexpr char DOSHUFFLE[] = "doshuffle";
-constexpr char BLOCKSIZE[] = "blocksize";
+constexpr char nthreads[] = "nthreads";
+constexpr char compressor[] = "compressor";
+constexpr char clevel[] = "clevel";
+constexpr char doshuffle[] = "doshuffle";
+constexpr char blocksize[] = "blocksize";
 }
 
 namespace value
 {
 
-constexpr char DOSHUFFLE_SHUFFLE[] = "BLOSC_SHUFFLE";
-constexpr char DOSHUFFLE_NOSHUFFLE[] = "BLOSC_NOSHUFFLE";
-constexpr char DOSHUFFLE_BITSHUFFLE[] = "BLOSC_BITSHUFFLE";
+constexpr char compressor_blosclz[] = "blosclz";
+constexpr char compressor_lz4[] = "lz4";
+constexpr char compressor_lz4hc[] = "lz4hc";
+constexpr char compressor_snappy[] = "snappy";
+constexpr char compressor_zlib[] = "zlib";
+constexpr char compressor_zstd[] = "zstd";
 
-#ifdef BLOSC_BLOSCLZ
-constexpr char COMPRESSOR_BLOSCLZ[] = "blosclz";
-#endif
+constexpr char clevel_0[] = "0";
+constexpr char clevel_1[] = "1";
+constexpr char clevel_2[] = "2";
+constexpr char clevel_3[] = "3";
+constexpr char clevel_4[] = "4";
+constexpr char clevel_5[] = "5";
+constexpr char clevel_6[] = "6";
+constexpr char clevel_7[] = "7";
+constexpr char clevel_8[] = "8";
+constexpr char clevel_9[] = "9";
 
-#ifdef BLOSC_LZ4
-constexpr char COMPRESSOR_LZ4[] = "lz4";
-#endif
-
-#ifdef BLOSC_LZ4HC
-constexpr char COMPRESSOR_LZ4HC[] = "lz4hc";
-#endif
-
-#ifdef BLOSC_SNAPPY
-constexpr char COMPRESSOR_SNAPPY[] = "snappy";
-#endif
-
-#ifdef BLOSC_ZLIB
-constexpr char COMPRESSOR_ZLIB[] = "zlib";
-#endif
-
-#ifdef BLOSC_ZSTD
-constexpr char COMPRESSOR_ZSTD[] = "zstd";
-#endif
-
-constexpr char CLEVEL_1[] = "1";
-constexpr char CLEVEL_2[] = "2";
-constexpr char CLEVEL_3[] = "3";
-constexpr char CLEVEL_4[] = "4";
-constexpr char CLEVEL_5[] = "5";
-constexpr char CLEVEL_6[] = "6";
-constexpr char CLEVEL_7[] = "7";
-constexpr char CLEVEL_8[] = "8";
-constexpr char CLEVEL_9[] = "9";
+constexpr char doshuffle_shuffle[] = "BLOSC_SHUFFLE";
+constexpr char doshuffle_noshuffle[] = "BLOSC_NOSHUFFLE";
+constexpr char doshuffle_bitshuffle[] = "BLOSC_BITSHUFFLE";
 
 } // end namespace value
 

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -352,6 +352,69 @@ constexpr char blockSize100k_9[] = "9";
 } // end namespace bzip2
 #endif
 
+// BBlosc PARAMETERS
+#ifdef ADIOS2_HAVE_BLOSC
+
+constexpr char BLOSC[] = "blosc";
+namespace blosc
+{
+
+namespace key
+{
+constexpr char NTHREADS[] = "nthreads";
+constexpr char COMPRESSOR[] = "compressor";
+constexpr char CLEVEL[] = "clevel";
+constexpr char DOSHUFFLE[] = "doshuffle";
+constexpr char BLOCKSIZE[] = "blocksize";
+}
+
+namespace value
+{
+
+constexpr char DOSHUFFLE_SHUFFLE[] = "BLOSC_SHUFFLE";
+constexpr char DOSHUFFLE_NOSHUFFLE[] = "BLOSC_NOSHUFFLE";
+constexpr char DOSHUFFLE_BITSHUFFLE[] = "BLOSC_BITSHUFFLE";
+
+#ifdef BLOSC_BLOSCLZ
+constexpr char COMPRESSOR_BLOSCLZ[] = "blosclz";
+#endif
+
+#ifdef BLOSC_LZ4
+constexpr char COMPRESSOR_LZ4[] = "lz4";
+#endif
+
+#ifdef BLOSC_LZ4HC
+constexpr char COMPRESSOR_LZ4HC[] = "lz4hc";
+#endif
+
+#ifdef BLOSC_SNAPPY
+constexpr char COMPRESSOR_SNAPPY[] = "snappy";
+#endif
+
+#ifdef BLOSC_ZLIB
+constexpr char COMPRESSOR_ZLIB[] = "zlib";
+#endif
+
+#ifdef BLOSC_ZSTD
+constexpr char COMPRESSOR_ZSTD[] = "zstd";
+#endif
+
+constexpr char CLEVEL_1[] = "1";
+constexpr char CLEVEL_2[] = "2";
+constexpr char CLEVEL_3[] = "3";
+constexpr char CLEVEL_4[] = "4";
+constexpr char CLEVEL_5[] = "5";
+constexpr char CLEVEL_6[] = "6";
+constexpr char CLEVEL_7[] = "7";
+constexpr char CLEVEL_8[] = "8";
+constexpr char CLEVEL_9[] = "9";
+
+} // end namespace value
+
+} // end namespace blosc
+
+#endif
+
 } // end namespace ops
 
 } // end namespace adios2

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -44,6 +44,10 @@
 #include "adios2/operator/compress/CompressPNG.h"
 #endif
 
+#ifdef ADIOS2_HAVE_BLOSC
+#include "adios2/operator/compress/CompressBlosc.h"
+#endif
+
 // callbacks
 #include "adios2/operator/callback/Signature1.h"
 #include "adios2/operator/callback/Signature2.h"
@@ -250,6 +254,19 @@ Operator &ADIOS::DefineOperator(const std::string name, const std::string type,
         throw std::invalid_argument(
             "ERROR: this version of ADIOS2 didn't compile with the "
             "PNG library (minimum v1.6), in call to DefineOperator\n");
+#endif
+    }
+    else if (typeLowerCase == "blosc")
+    {
+#ifdef ADIOS2_HAVE_BLOSC
+        auto itPair = m_Operators.emplace(
+            name,
+            std::make_shared<compress::CompressBlosc>(parameters, m_DebugMode));
+        operatorPtr = itPair.first->second;
+#else
+        throw std::invalid_argument(
+            "ERROR: this version of ADIOS2 didn't compile with the "
+            "Blosc library, in call to DefineOperator\n");
 #endif
     }
     else

--- a/source/adios2/operator/compress/CompressBlosc.cpp
+++ b/source/adios2/operator/compress/CompressBlosc.cpp
@@ -1,0 +1,155 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * CompressBlosc.cpp
+ *
+ *  Created on: Jun 18, 2019
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#include "CompressBlosc.h"
+
+extern "C" {
+#include <blosc.h>
+}
+
+#include "adios2/helper/adiosFunctions.h"
+
+namespace adios2
+{
+namespace core
+{
+namespace compress
+{
+
+const std::map<std::string, uint32_t> CompressBlosc::m_Shuffles = {
+    {"BLOSC_NOSHUFFLE", BLOSC_NOSHUFFLE},
+    {"BLOSC_SHUFFLE", BLOSC_SHUFFLE},
+    {"BLOSC_BITSHUFFLE", BLOSC_BITSHUFFLE}};
+
+const std::set<std::string> CompressBlosc::m_Compressors = {
+    "blosclz", "lz4", "lz4hc", "snappy", "zlib", "zstd"};
+
+CompressBlosc::CompressBlosc(const Params &parameters, const bool debugMode)
+: Operator("blosc", parameters, debugMode)
+{
+}
+
+size_t CompressBlosc::Compress(const void *dataIn, const Dims &dimensions,
+                               const size_t elementSize, const std::string type,
+                               void *bufferOut, const Params &parameters,
+                               Params &info) const
+{
+    const size_t sizeIn =
+        static_cast<size_t>(helper::GetTotalSize(dimensions) * elementSize);
+
+    blosc_init();
+
+    size_t threads = 1; // defaults
+    int compressionLevel = 1;
+    int doShuffle = BLOSC_NOSHUFFLE;
+    std::string compressor = "blosclz";
+    size_t blockSize = 0;
+
+    for (const auto &itParameter : parameters)
+    {
+        const std::string key = itParameter.first;
+        const std::string value = itParameter.second;
+
+        if (key == "compression_level" || key == "clevel")
+        {
+            compressionLevel = static_cast<int>(helper::StringTo<int32_t>(
+                value, m_DebugMode, "when setting Blosc clevel parameter\n"));
+            if (m_DebugMode)
+            {
+                if (compressionLevel < 0 || compressionLevel > 9)
+                {
+                    throw std::invalid_argument(
+                        "ERROR: compression_level must be an "
+                        "integer between 0 (default: no compression) and 9 "
+                        "(more compression, more memory) inclusive, in call to "
+                        "ADIOS2 Blosc Compress\n");
+                }
+            }
+        }
+        else if (key == "doshuffle")
+        {
+            auto itShuffle = m_Shuffles.find(value);
+            if (m_DebugMode)
+            {
+                if (itShuffle == m_Shuffles.end())
+                {
+                    throw std::invalid_argument(
+                        "ERROR: invalid shuffle vale " + value +
+                        " must be BLOSC_SHUFFLE, BLOSC_NOSHUFFLE or "
+                        "BLOSC_BITSHUFFLE,  "
+                        " in call to ADIOS2 Blosc Compress\n");
+                }
+            }
+            doShuffle = itShuffle->second;
+        }
+        else if (key == "nthreads")
+        {
+            threads = static_cast<int>(helper::StringTo<int32_t>(
+                value, m_DebugMode, "when setting Blosc nthreads parameter\n"));
+        }
+        else if (key == "compressor")
+        {
+            compressor = value;
+            if (m_DebugMode && m_Compressors.count(compressor) == 0)
+            {
+                throw std::invalid_argument(
+                    "ERROR: invalid compressor " + compressor +
+                    " valid values: blosclz (default), lz4, lz4hc, snappy, "
+                    "zlib, or ztsd, in call to ADIOS2 Blosc Compression\n");
+            }
+        }
+        else if (key == "blocksize")
+        {
+            blockSize = static_cast<size_t>(helper::StringTo<uint64_t>(
+                value, m_DebugMode,
+                "when setting Blosc blocksize parameter\n"));
+        }
+    }
+
+    const int result = blosc_set_compressor(compressor.c_str());
+    if (m_DebugMode && result == -1)
+    {
+        throw std::invalid_argument("ERROR: invalid compressor " + compressor +
+                                    " check if supported by blosc build, in "
+                                    "call to ADIOS2 Blosc Compression\n");
+    }
+
+    blosc_set_nthreads(threads);
+    blosc_set_blocksize(blockSize);
+
+    const size_t compressedSize =
+        blosc_compress(compressionLevel, doShuffle, elementSize, sizeIn, dataIn,
+                       bufferOut, sizeIn);
+
+    if (m_DebugMode && compressedSize < 0)
+    {
+        throw std::invalid_argument(
+            "ERROR: Blosc error code " + std::to_string(compressedSize) +
+            " compression failed in ADIOS2 Blosc compresion\n");
+    }
+
+    blosc_destroy();
+    return compressedSize;
+}
+
+size_t CompressBlosc::Decompress(const void *bufferIn, const size_t sizeIn,
+                                 void *dataOut, const size_t sizeOut,
+                                 Params &info) const
+{
+    blosc_init();
+    const size_t decompressedSize =
+        blosc_decompress(bufferIn, dataOut, sizeOut);
+    blosc_destroy();
+    return decompressedSize;
+}
+
+} // end namespace compress
+} // end namespace core
+} // end namespace adios2

--- a/source/adios2/operator/compress/CompressBlosc.h
+++ b/source/adios2/operator/compress/CompressBlosc.h
@@ -1,0 +1,73 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * CompressBlosc.h
+ *
+ *  Created on: Jun 18, 2019
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#ifndef ADIOS2_OPERATOR_COMPRESS_COMPRESSBLOSC_H_
+#define ADIOS2_OPERATOR_COMPRESS_COMPRESSBLOSC_H_
+
+#include <map>
+#include <set>
+
+#include "adios2/core/Operator.h"
+
+namespace adios2
+{
+namespace core
+{
+namespace compress
+{
+
+class CompressBlosc : public Operator
+{
+
+public:
+    /**
+     * Unique constructor
+     * @param debugMode
+     */
+    CompressBlosc(const Params &parameters, const bool debugMode);
+
+    ~CompressBlosc() = default;
+
+    /**
+     * Compression signature for legacy libraries that use void*
+     * @param dataIn
+     * @param dimensions
+     * @param type
+     * @param bufferOut
+     * @param parameters
+     * @return size of compressed buffer in bytes
+     */
+    size_t Compress(const void *dataIn, const Dims &dimensions,
+                    const size_t elementSize, const std::string type,
+                    void *bufferOut, const Params &parameters,
+                    Params &info) const final;
+
+    /**
+     * Decompression signature for legacy libraries that use void*
+     * @param bufferIn
+     * @param sizeIn
+     * @param dataOut
+     * @param dimensions
+     * @param type
+     * @return size of decompressed buffer in bytes
+     */
+    size_t Decompress(const void *bufferIn, const size_t sizeIn, void *dataOut,
+                      const size_t sizeOut, Params &info) const override;
+
+private:
+    static const std::map<std::string, uint32_t> m_Shuffles;
+    static const std::set<std::string> m_Compressors;
+};
+
+} // end namespace compress
+} // end namespace core
+} // end namespace adios2
+
+#endif /* ADIOS2_OPERATOR_COMPRESS_COMPRESSBLOSC_H_ */

--- a/source/adios2/operator/compress/CompressBlosc.h
+++ b/source/adios2/operator/compress/CompressBlosc.h
@@ -59,7 +59,7 @@ public:
      * @return size of decompressed buffer in bytes
      */
     size_t Decompress(const void *bufferIn, const size_t sizeIn, void *dataOut,
-                      const size_t sizeOut, Params &info) const override;
+                      const size_t sizeOut, Params &info) const final;
 
 private:
     static const std::map<std::string, uint32_t> m_Shuffles;

--- a/source/adios2/operator/compress/CompressPNG.h
+++ b/source/adios2/operator/compress/CompressPNG.h
@@ -58,7 +58,7 @@ public:
      * @return size of decompressed buffer in bytes
      */
     size_t Decompress(const void *bufferIn, const size_t sizeIn, void *dataOut,
-                      const size_t sizeOut, Params &info) const override;
+                      const size_t sizeOut, Params &info) const final;
 
 private:
     /**

--- a/source/adios2/toolkit/format/bp3/BP3Base.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Base.cpp
@@ -17,6 +17,7 @@
 #include "adios2/helper/adiosFunctions.h" //CreateDirectory, StringToTimeUnit,
 
 #include "adios2/toolkit/format/bpOperation/compress/BPBZIP2.h"
+#include "adios2/toolkit/format/bpOperation/compress/BPBlosc.h"
 #include "adios2/toolkit/format/bpOperation/compress/BPMGARD.h"
 #include "adios2/toolkit/format/bpOperation/compress/BPPNG.h"
 #include "adios2/toolkit/format/bpOperation/compress/BPSZ.h"
@@ -28,17 +29,15 @@ namespace format
 {
 
 const std::set<std::string> BP3Base::m_TransformTypes = {
-    {"unknown", "none", "identity", "bzip2", "sz", "zfp", "mgard", "png"}};
+    {"unknown", "none", "identity", "bzip2", "sz", "zfp", "mgard", "png",
+     "blosc"}};
 
 const std::map<int, std::string> BP3Base::m_TransformTypesToNames = {
-    {transform_unknown, "unknown"},
-    {transform_none, "none"},
-    {transform_identity, "identity"},
-    {transform_sz, "sz"},
-    {transform_zfp, "zfp"},
-    {transform_mgard, "mgard"},
-    {transform_png, "png"},
-    {transform_bzip2, "bzip2"}
+    {transform_unknown, "unknown"},   {transform_none, "none"},
+    {transform_identity, "identity"}, {transform_sz, "sz"},
+    {transform_zfp, "zfp"},           {transform_mgard, "mgard"},
+    {transform_png, "png"},           {transform_bzip2, "bzip2"},
+    {transform_blosc, "blosc"}
     //    {transform_szip, "szip"},
     //    {transform_isobar, "isobar"},
     //    {transform_aplod, "aplod"},
@@ -46,7 +45,7 @@ const std::map<int, std::string> BP3Base::m_TransformTypesToNames = {
 
     //    {transform_sz, "sz"},
     //    {transform_lz4, "lz4"},
-    //    {transform_blosc, "blosc"},
+    //
 };
 
 BP3Base::BP3Base(MPI_Comm mpiComm, const bool debugMode)
@@ -839,12 +838,15 @@ BP3Base::SetBPOperation(const std::string type) const noexcept
     }
     else if (type == "bzip2")
     {
-        // TODO
         bpOp = std::make_shared<BPBZIP2>();
     }
     else if (type == "png")
     {
         bpOp = std::make_shared<BPPNG>();
+    }
+    else if (type == "blosc")
+    {
+        bpOp = std::make_shared<BPBlosc>();
     }
 
     return bpOp;

--- a/source/adios2/toolkit/format/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Base.cpp
@@ -17,6 +17,7 @@
 #include "adios2/helper/adiosFunctions.h" //CreateDirectory, StringToTimeUnit,
 
 #include "adios2/toolkit/format/bpOperation/compress/BPBZIP2.h"
+#include "adios2/toolkit/format/bpOperation/compress/BPBlosc.h"
 #include "adios2/toolkit/format/bpOperation/compress/BPMGARD.h"
 #include "adios2/toolkit/format/bpOperation/compress/BPPNG.h"
 #include "adios2/toolkit/format/bpOperation/compress/BPSZ.h"
@@ -28,17 +29,15 @@ namespace format
 {
 
 const std::set<std::string> BP4Base::m_TransformTypes = {
-    {"unknown", "none", "identity", "bzip2", "sz", "zfp", "mgard", "png"}};
+    {"unknown", "none", "identity", "bzip2", "sz", "zfp", "mgard", "png",
+     "blosc"}};
 
 const std::map<int, std::string> BP4Base::m_TransformTypesToNames = {
-    {transform_unknown, "unknown"},
-    {transform_none, "none"},
-    {transform_identity, "identity"},
-    {transform_sz, "sz"},
-    {transform_zfp, "zfp"},
-    {transform_mgard, "mgard"},
-    {transform_png, "png"},
-    {transform_bzip2, "bzip2"}
+    {transform_unknown, "unknown"},   {transform_none, "none"},
+    {transform_identity, "identity"}, {transform_sz, "sz"},
+    {transform_zfp, "zfp"},           {transform_mgard, "mgard"},
+    {transform_png, "png"},           {transform_bzip2, "bzip2"},
+    {transform_blosc, "blosc"}
     // {transform_zlib, "zlib"},
     //    {transform_szip, "szip"},
     //    {transform_isobar, "isobar"},
@@ -47,7 +46,6 @@ const std::map<int, std::string> BP4Base::m_TransformTypesToNames = {
 
     //    {transform_sz, "sz"},
     //    {transform_lz4, "lz4"},
-    //    {transform_blosc, "blosc"},
 };
 
 BP4Base::BP4Base(MPI_Comm mpiComm, const bool debugMode)
@@ -912,6 +910,10 @@ BP4Base::SetBPOperation(const std::string type) const noexcept
     else if (type == "png")
     {
         bpOp = std::make_shared<BPPNG>();
+    }
+    else if (type == "blosc")
+    {
+        bpOp = std::make_shared<BPBlosc>();
     }
 
     return bpOp;

--- a/source/adios2/toolkit/format/bpOperation/compress/BPBlosc.cpp
+++ b/source/adios2/toolkit/format/bpOperation/compress/BPBlosc.cpp
@@ -1,0 +1,92 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * BPBlosc.cpp
+ *
+ *  Created on: Jun 21, 2019
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#include "BPBlosc.h"
+
+#include "adios2/helper/adiosFunctions.h"
+
+#ifdef ADIOS2_HAVE_BLOSC
+#include "adios2/operator/compress/CompressBlosc.h"
+#endif
+
+namespace adios2
+{
+namespace format
+{
+
+#define declare_type(T)                                                        \
+    void BPBlosc::SetData(                                                     \
+        const core::Variable<T> &variable,                                     \
+        const typename core::Variable<T>::Info &blockInfo,                     \
+        const typename core::Variable<T>::Operation &operation,                \
+        BufferSTL &bufferSTL) const noexcept                                   \
+    {                                                                          \
+        SetDataDefault(variable, blockInfo, operation, bufferSTL);             \
+    }                                                                          \
+                                                                               \
+    void BPBlosc::SetMetadata(                                                 \
+        const core::Variable<T> &variable,                                     \
+        const typename core::Variable<T>::Info &blockInfo,                     \
+        const typename core::Variable<T>::Operation &operation,                \
+        std::vector<char> &buffer) const noexcept                              \
+    {                                                                          \
+        SetMetadataDefault(variable, blockInfo, operation, buffer);            \
+    }                                                                          \
+                                                                               \
+    void BPBlosc::UpdateMetadata(                                              \
+        const core::Variable<T> &variable,                                     \
+        const typename core::Variable<T>::Info &blockInfo,                     \
+        const typename core::Variable<T>::Operation &operation,                \
+        std::vector<char> &buffer) const noexcept                              \
+    {                                                                          \
+        UpdateMetadataDefault(variable, blockInfo, operation, buffer);         \
+    }
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+void BPBlosc::GetMetadata(const std::vector<char> &buffer, Params &info) const
+    noexcept
+{
+    size_t position = 0;
+    info["InputSize"] =
+        std::to_string(helper::ReadValue<uint64_t>(buffer, position));
+    info["OutputSize"] =
+        std::to_string(helper::ReadValue<uint64_t>(buffer, position));
+}
+
+void BPBlosc::GetData(const char *input,
+                      const helper::BlockOperationInfo &blockOperationInfo,
+                      char *dataOutput) const
+{
+#ifdef ADIOS2_HAVE_BLOSC
+    core::compress::CompressBlosc op(Params(), true);
+    const size_t sizeOut = (sizeof(size_t) == 8)
+                               ? static_cast<size_t>(helper::StringTo<uint64_t>(
+                                     blockOperationInfo.Info.at("InputSize"),
+                                     true, "when reading Blosc input size"))
+                               : static_cast<size_t>(helper::StringTo<uint32_t>(
+                                     blockOperationInfo.Info.at("InputSize"),
+                                     true, "when reading Blosc input size"));
+
+    Params &info = const_cast<Params &>(blockOperationInfo.Info);
+    op.Decompress(input, blockOperationInfo.PayloadSize, dataOutput, sizeOut,
+                  info);
+
+#else
+    throw std::runtime_error(
+        "ERROR: current ADIOS2 library didn't compile "
+        "with Blosc, can't read Blosc compressed data, in call "
+        "to Get\n");
+#endif
+}
+
+} // end namespace format
+} // end namespace adios2

--- a/source/adios2/toolkit/format/bpOperation/compress/BPBlosc.h
+++ b/source/adios2/toolkit/format/bpOperation/compress/BPBlosc.h
@@ -1,0 +1,62 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * BPBlosc.h
+ *
+ *  Created on: Jun 21, 2019
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#ifndef ADIOS2_TOOLKIT_FORMAT_BPOPERATION_COMPRESS_BPBLOSC_H_
+#define ADIOS2_TOOLKIT_FORMAT_BPOPERATION_COMPRESS_BPBLOSC_H_
+
+#include "adios2/toolkit/format/bpOperation/BPOperation.h"
+
+namespace adios2
+{
+namespace format
+{
+
+class BPBlosc : public BPOperation
+{
+public:
+    BPBlosc() = default;
+
+    ~BPBlosc() = default;
+
+    using BPOperation::SetData;
+    using BPOperation::SetMetadata;
+    using BPOperation::UpdateMetadata;
+#define declare_type(T)                                                        \
+    void SetData(const core::Variable<T> &variable,                            \
+                 const typename core::Variable<T>::Info &blockInfo,            \
+                 const typename core::Variable<T>::Operation &operation,       \
+                 BufferSTL &bufferSTL) const noexcept override;                \
+                                                                               \
+    void SetMetadata(const core::Variable<T> &variable,                        \
+                     const typename core::Variable<T>::Info &blockInfo,        \
+                     const typename core::Variable<T>::Operation &operation,   \
+                     std::vector<char> &buffer) const noexcept override;       \
+                                                                               \
+    void UpdateMetadata(                                                       \
+        const core::Variable<T> &variable,                                     \
+        const typename core::Variable<T>::Info &blockInfo,                     \
+        const typename core::Variable<T>::Operation &operation,                \
+        std::vector<char> &buffer) const noexcept override;
+
+    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+    void GetMetadata(const std::vector<char> &buffer, Params &info) const
+        noexcept final;
+
+    void GetData(const char *input,
+                 const helper::BlockOperationInfo &blockOperationInfo,
+                 char *dataOutput) const final;
+};
+
+} // end namespace format
+} // end namespace adios2
+
+#endif /* ADIOS2_TOOLKIT_FORMAT_BPOPERATION_COMPRESS_BPBLOSC_H_ */

--- a/testing/adios2/engine/bp/operations/CMakeLists.txt
+++ b/testing/adios2/engine/bp/operations/CMakeLists.txt
@@ -65,7 +65,7 @@ if(ADIOS2_HAVE_MGARD)
   gtest_add_tests(TARGET TestBPWriteReadMGARD ${extra_test_args} WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4" TEST_SUFFIX _BP4)
 endif()
 
-if(ADIOS2_HAVE_BZIP2)
+if(ADIOS2_HAVE_BZip2)
   add_executable(TestBPWriteReadBZIP2 TestBPWriteReadBZIP2.cpp)
   target_link_libraries(TestBPWriteReadBZIP2 adios2 gtest)
   
@@ -87,4 +87,16 @@ if(ADIOS2_HAVE_PNG)
   
   gtest_add_tests(TARGET TestBPWriteReadPNG ${extra_test_args} WORKING_DIRECTORY ${BP3_DIR})
   gtest_add_tests(TARGET TestBPWriteReadPNG ${extra_test_args} WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4" TEST_SUFFIX _BP4)
+endif()
+
+if(ADIOS2_HAVE_Blosc)
+  add_executable(TestBPWriteReadBlosc TestBPWriteReadBlosc.cpp)
+  target_link_libraries(TestBPWriteReadBlosc adios2 gtest)
+  
+  if(ADIOS2_HAVE_MPI)
+    target_link_libraries(TestBPWriteReadBlosc MPI::MPI_C)
+  endif()
+  
+  gtest_add_tests(TARGET TestBPWriteReadBlosc ${extra_test_args} WORKING_DIRECTORY ${BP3_DIR})
+  gtest_add_tests(TARGET TestBPWriteReadBlosc ${extra_test_args} WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4" TEST_SUFFIX _BP4)
 endif()

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc.cpp
@@ -1,0 +1,912 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <numeric> //std::iota
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+std::string engineName; // comes from command line
+
+void BloscAccuracy1D(const std::string accuracy)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("BPWR_Blosc_1D_" + accuracy + ".bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 1000;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx);
+    std::vector<double> r64s(Nx);
+
+    // range 0 to 999
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize)};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
+        const adios2::Dims count{Nx};
+
+        adios2::Variable<float> var_r32 = io.DefineVariable<float>(
+            "r32", shape, start, count, adios2::ConstantDims);
+        adios2::Variable<double> var_r64 = io.DefineVariable<double>(
+            "r64", shape, start, count, adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator BloscOp =
+            adios.DefineOperator("BloscCompressor", adios2::ops::LosslessBlosc);
+
+        var_r32.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+        var_r64.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        EXPECT_TRUE(var_r32);
+        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32.Steps(), NSteps);
+        ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Steps(), NSteps);
+        ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+
+        const adios2::Dims start{mpiRank * Nx};
+        const adios2::Dims count{Nx};
+        const adios2::Box<adios2::Dims> sel(start, count);
+        var_r32.SetSelection(sel);
+        var_r64.SetSelection(sel);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[i]) << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+void BloscAccuracy2D(const std::string accuracy)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("BPWRBlosc2D_" + accuracy + ".bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 100;
+    const size_t Ny = 50;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx * Ny);
+    std::vector<double> r64s(Nx * Ny);
+
+    // range 0 to 100*50
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize), Ny};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank), 0};
+        const adios2::Dims count{Nx, Ny};
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator BloscOp =
+            adios.DefineOperator("BloscCompressor", adios2::ops::LosslessBlosc);
+
+        var_r32.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+        var_r64.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (auto step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        EXPECT_TRUE(var_r32);
+        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32.Steps(), NSteps);
+        ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+        ASSERT_EQ(var_r32.Shape()[1], Ny);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Steps(), NSteps);
+        ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+        ASSERT_EQ(var_r64.Shape()[1], Ny);
+
+        const adios2::Dims start{mpiRank * Nx, 0};
+        const adios2::Dims count{Nx, Ny};
+        const adios2::Box<adios2::Dims> sel(start, count);
+        var_r32.SetSelection(sel);
+        var_r64.SetSelection(sel);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx * Ny; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[i]) << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+void BloscAccuracy3D(const std::string accuracy)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("BPWRBlosc3D_" + accuracy + ".bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 10;
+    const size_t Ny = 20;
+    const size_t Nz = 15;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx * Ny * Nz);
+    std::vector<double> r64s(Nx * Ny * Nz);
+
+    // range 0 to 100*50
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize), Ny, Nz};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank), 0, 0};
+        const adios2::Dims count{Nx, Ny, Nz};
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator BloscOp =
+            adios.DefineOperator("BloscCompressor", adios2::ops::LosslessBlosc);
+
+        var_r32.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+        var_r64.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (auto step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        EXPECT_TRUE(var_r32);
+        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32.Steps(), NSteps);
+        ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+        ASSERT_EQ(var_r32.Shape()[1], Ny);
+        ASSERT_EQ(var_r32.Shape()[2], Nz);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Steps(), NSteps);
+        ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+        ASSERT_EQ(var_r64.Shape()[1], Ny);
+        ASSERT_EQ(var_r64.Shape()[2], Nz);
+
+        const adios2::Dims start{mpiRank * Nx, 0, 0};
+        const adios2::Dims count{Nx, Ny, Nz};
+        const adios2::Box<adios2::Dims> sel(start, count);
+        var_r32.SetSelection(sel);
+        var_r64.SetSelection(sel);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (auto i = 0; i < Nx * Ny * Nz; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[i]) << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+void BloscAccuracy1DSel(const std::string accuracy)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("BPWRBlosc1DSel_" + accuracy + ".bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 1000;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx);
+    std::vector<double> r64s(Nx);
+
+    // range 0 to 999
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize)};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
+        const adios2::Dims count{Nx};
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator BloscOp =
+            adios.DefineOperator("BloscCompressor", adios2::ops::LosslessBlosc);
+
+        var_r32.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+        var_r64.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        EXPECT_TRUE(var_r32);
+        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32.Steps(), NSteps);
+        ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Steps(), NSteps);
+        ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+
+        const adios2::Dims start{mpiRank * Nx + Nx / 2};
+        const adios2::Dims count{Nx / 2};
+        const adios2::Box<adios2::Dims> sel(start, count);
+        var_r32.SetSelection(sel);
+        var_r64.SetSelection(sel);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx / 2; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[Nx / 2 + i]) << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[Nx / 2 + i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+void BloscAccuracy2DSel(const std::string accuracy)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("BPWRBlosc2DSel_" + accuracy + ".bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 100;
+    const size_t Ny = 50;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx * Ny);
+    std::vector<double> r64s(Nx * Ny);
+
+    // range 0 to 100*50
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize), Ny};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank), 0};
+        const adios2::Dims count{Nx, Ny};
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator BloscOp =
+            adios.DefineOperator("BloscCompressor", adios2::ops::LosslessBlosc);
+
+        var_r32.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+        var_r64.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (auto step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        EXPECT_TRUE(var_r32);
+        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32.Steps(), NSteps);
+        ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+        ASSERT_EQ(var_r32.Shape()[1], Ny);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Steps(), NSteps);
+        ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+        ASSERT_EQ(var_r64.Shape()[1], Ny);
+
+        const adios2::Dims start{mpiRank * Nx + Nx / 2, 0};
+        const adios2::Dims count{Nx / 2, Ny};
+        const adios2::Box<adios2::Dims> sel(start, count);
+        var_r32.SetSelection(sel);
+        var_r64.SetSelection(sel);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx / 2 * Ny; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[Nx / 2 * Ny + i]) << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[Nx / 2 * Ny + i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+void BloscAccuracy3DSel(const std::string accuracy)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("BPWRBlosc3DSel_" + accuracy + ".bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 10;
+    const size_t Ny = 20;
+    const size_t Nz = 15;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx * Ny * Nz);
+    std::vector<double> r64s(Nx * Ny * Nz);
+
+    // range 0 to 100*50
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+#ifdef ADIOS2_HAVE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+#else
+    adios2::ADIOS adios(true);
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize), Ny, Nz};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank), 0, 0};
+        const adios2::Dims count{Nx, Ny, Nz};
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator BloscOp =
+            adios.DefineOperator("BloscCompressor", adios2::ops::LosslessBlosc);
+
+        var_r32.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+        var_r64.AddOperation(BloscOp,
+                             {{adios2::ops::blosc::key::clevel, accuracy}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (auto step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        EXPECT_TRUE(var_r32);
+        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32.Steps(), NSteps);
+        ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+        ASSERT_EQ(var_r32.Shape()[1], Ny);
+        ASSERT_EQ(var_r32.Shape()[2], Nz);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Steps(), NSteps);
+        ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+        ASSERT_EQ(var_r64.Shape()[1], Ny);
+        ASSERT_EQ(var_r64.Shape()[2], Nz);
+
+        const adios2::Dims start{mpiRank * Nx + Nx / 2, 0, 0};
+        const adios2::Dims count{Nx / 2, Ny, Nz};
+        const adios2::Box<adios2::Dims> sel(start, count);
+        var_r32.SetSelection(sel);
+        var_r64.SetSelection(sel);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (auto i = 0; i < Nx / 2 * Ny * Nz; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[Nx / 2 * Ny * Nz + i])
+                    << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[Nx / 2 * Ny * Nz + i])
+                    << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+class BPWriteReadBlosc : public ::testing::TestWithParam<std::string>
+{
+public:
+    BPWriteReadBlosc() = default;
+    virtual void SetUp(){};
+    virtual void TearDown(){};
+};
+
+TEST_P(BPWriteReadBlosc, ADIOS2BPWriteReadBlosc1D)
+{
+    BloscAccuracy1D(GetParam());
+}
+TEST_P(BPWriteReadBlosc, ADIOS2BPWriteReadBlosc2D)
+{
+    BloscAccuracy2D(GetParam());
+}
+TEST_P(BPWriteReadBlosc, ADIOS2BPWriteReadBlosc3D)
+{
+    BloscAccuracy3D(GetParam());
+}
+TEST_P(BPWriteReadBlosc, ADIOS2BPWriteReadBlosc1DSel)
+{
+    BloscAccuracy1DSel(GetParam());
+}
+TEST_P(BPWriteReadBlosc, ADIOS2BPWriteReadBlosc2DSel)
+{
+    BloscAccuracy2DSel(GetParam());
+}
+TEST_P(BPWriteReadBlosc, ADIOS2BPWriteReadBlosc3DSel)
+{
+    BloscAccuracy3DSel(GetParam());
+}
+
+INSTANTIATE_TEST_CASE_P(BloscAccuracy, BPWriteReadBlosc,
+                        ::testing::Values(adios2::ops::blosc::value::clevel_1,
+                                          adios2::ops::blosc::value::clevel_2,
+                                          adios2::ops::blosc::value::clevel_3,
+                                          adios2::ops::blosc::value::clevel_4,
+                                          adios2::ops::blosc::value::clevel_5,
+                                          adios2::ops::blosc::value::clevel_6,
+                                          adios2::ops::blosc::value::clevel_7,
+                                          adios2::ops::blosc::value::clevel_8,
+                                          adios2::ops::blosc::value::clevel_9));
+
+int main(int argc, char **argv)
+{
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+    result = RUN_ALL_TESTS();
+
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}


### PR DESCRIPTION
Addressing #1486 
Not yet tested:
1. multithread support
2. noshuffling
3. data > 2Gb (seems not supported by blosc as it returns an int for the compressed size), will implement a loop in the future.