### PR TITLE
Bp4 buffer tags and bp4dbg.py tool

### DIFF
--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -11,6 +11,7 @@
 #include "adiosMemory.h"
 
 #include <algorithm>
+#include <stddef.h> // max_align_t
 
 #include "adios2/helper/adiosType.h"
 
@@ -283,6 +284,22 @@ void CopyPayload(char *dest, const Dims &destStart, const Dims &destCount,
                         srcCount, destMemStart, destMemCount, srcMemStart,
                         srcMemCount, endianReverse, destType);
     }
+}
+
+size_t PaddingToAlignPointer(const void *ptr)
+{
+    auto memLocation = reinterpret_cast<std::uintptr_t>(ptr);
+    size_t padSize = sizeof(max_align_t) - (memLocation % sizeof(max_align_t));
+    if (padSize == sizeof(max_align_t))
+    {
+        padSize = 0;
+    }
+    /*std::cout << " -- Pad pointer with " << std::to_string(padSize)
+              << " bytes. original pointer = " << std::to_string(memLocation)
+              << " aligned pointer = " << std::to_string(memLocation + padSize)
+              << " sizeof(max_align_t) = "
+              << std::to_string(sizeof(max_align_t)) << std::endl;*/
+    return padSize;
 }
 
 } // end namespace helper

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -229,6 +229,13 @@ int NdCopy(const char *in, const Dims &inStart, const Dims &inCount,
 template <class T>
 size_t PayloadSize(const T *data, const Dims &count) noexcept;
 
+/** Calculate how many bytes away is a memory location to be aligned to the
+ * size of max_align_t.
+ * @param a pointer
+ * @return padding value in [0..sizeof(max_align_t)-1]
+ */
+size_t PaddingToAlignPointer(const void *ptr);
+
 } // end namespace helper
 } // end namespace adios2
 

--- a/source/adios2/toolkit/format/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Base.cpp
@@ -278,6 +278,7 @@ size_t BP4Base::GetBPIndexSizeInData(const std::string &variableName,
                                      const Dims &count) const noexcept
 {
     size_t indexSize = 23; // header
+    indexSize += 4 + 32;   // "[VMD" and padded " *VMD]" up to 31 char length
     indexSize += variableName.size();
 
     // characteristics 3 and 4, check variable number of dimensions
@@ -305,7 +306,9 @@ size_t BP4Base::GetBPIndexSizeInData(const std::string &variableName,
         indexSize += 28 * dimensions + 1;
     }
 
-    return indexSize + 12; // extra 12 bytes in case of attributes
+    // extra 12 bytes for attributes in case of last variable
+    // extra 4 bytes for PGI] in case of last variable
+    return indexSize + 12 + 4;
 }
 
 void BP4Base::ResetBuffer(BufferSTL &bufferSTL,

--- a/source/adios2/toolkit/format/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Base.cpp
@@ -332,8 +332,8 @@ BP4Base::ResizeResult BP4Base::ResizeBuffer(const size_t dataIn,
                                             const std::string hint)
 {
     ProfilerStart("buffering");
-    const size_t currentCapacity = m_Data.m_Buffer.capacity();
-    const size_t requiredCapacity = dataIn + m_Data.m_Position;
+    const size_t currentSize = m_Data.m_Buffer.size();
+    const size_t requiredSize = dataIn + m_Data.m_Position;
 
     ResizeResult result = ResizeResult::Unchanged;
 
@@ -349,13 +349,13 @@ BP4Base::ResizeResult BP4Base::ResizeBuffer(const size_t dataIn,
             hint + "\n");
     }
 
-    if (requiredCapacity <= currentCapacity)
+    if (requiredSize <= currentSize)
     {
         // do nothing, unchanged is default
     }
-    else if (requiredCapacity > m_MaxBufferSize)
+    else if (requiredSize > m_MaxBufferSize)
     {
-        if (currentCapacity < m_MaxBufferSize)
+        if (currentSize < m_MaxBufferSize)
         {
             m_Data.Resize(m_MaxBufferSize, " when resizing buffer to " +
                                                std::to_string(m_MaxBufferSize) +
@@ -365,12 +365,12 @@ BP4Base::ResizeResult BP4Base::ResizeBuffer(const size_t dataIn,
     }
     else // buffer must grow
     {
-        if (currentCapacity < m_MaxBufferSize)
+        if (currentSize < m_MaxBufferSize)
         {
-            const size_t nextSize = std::min(
-                m_MaxBufferSize,
-                helper::NextExponentialSize(requiredCapacity, currentCapacity,
-                                            m_GrowthFactor));
+            const size_t nextSize =
+                std::min(m_MaxBufferSize,
+                         helper::NextExponentialSize(requiredSize, currentSize,
+                                                     m_GrowthFactor));
             m_Data.Resize(nextSize, " when resizing buffer to " +
                                         std::to_string(nextSize) + "bytes, " +
                                         hint);

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.cpp
@@ -44,6 +44,11 @@ void BP4Serializer::PutProcessGroupIndex(
 
     std::vector<char> &dataBuffer = m_Data.m_Buffer;
     size_t &dataPosition = m_Data.m_Position;
+    const size_t pgBeginPosition = dataPosition;
+
+    // write a block identifier [PGI
+    const char pgi[] = "[PGI"; //  don't write \0!
+    helper::CopyToBuffer(dataBuffer, dataPosition, pgi, sizeof(pgi) - 1);
 
     m_MetadataSet.DataPGLengthPosition = dataPosition;
     dataPosition += 8; // skip pg length (8)
@@ -106,8 +111,7 @@ void BP4Serializer::PutProcessGroupIndex(
     }
 
     // update absolute position
-    m_Data.m_AbsolutePosition +=
-        dataPosition - m_MetadataSet.DataPGLengthPosition;
+    m_Data.m_AbsolutePosition += dataPosition - pgBeginPosition;
     // pg vars count and position
     m_MetadataSet.DataPGVarsCount = 0;
     m_MetadataSet.DataPGVarsCountPosition = dataPosition;
@@ -133,18 +137,19 @@ void BP4Serializer::SerializeData(core::IO &io, const bool advanceStep)
     ProfilerStop("buffering");
 }
 
-void BP4Serializer::CloseData(core::IO &io)
+size_t BP4Serializer::CloseData(core::IO &io)
 {
     ProfilerStart("buffering");
-
+    size_t dataEndsAt = m_Data.m_Position;
     if (!m_IsClosed)
     {
         if (m_MetadataSet.DataPGIsOpen)
         {
             SerializeDataBuffer(io);
         }
+        dataEndsAt = m_Data.m_Position;
 
-        SerializeMetadataInData();
+        SerializeMetadataInData(false, false);
 
         if (m_Profiler.IsActive)
         {
@@ -156,16 +161,17 @@ void BP4Serializer::CloseData(core::IO &io)
     }
 
     ProfilerStop("buffering");
+    return dataEndsAt;
 }
 
-void BP4Serializer::CloseStream(core::IO &io, const bool addMetadata)
+size_t BP4Serializer::CloseStream(core::IO &io, const bool addMetadata)
 {
     ProfilerStart("buffering");
     if (m_MetadataSet.DataPGIsOpen)
     {
         SerializeDataBuffer(io);
     }
-
+    size_t dataEndsAt = m_Data.m_Position;
     SerializeMetadataInData(false, addMetadata);
 
     if (m_Profiler.IsActive)
@@ -173,10 +179,12 @@ void BP4Serializer::CloseStream(core::IO &io, const bool addMetadata)
         m_Profiler.Bytes.at("buffering") += m_Data.m_Position;
     }
     ProfilerStop("buffering");
+
+    return dataEndsAt;
 }
 
-void BP4Serializer::CloseStream(core::IO &io, size_t &metadataStart,
-                                size_t &metadataCount, const bool addMetadata)
+size_t BP4Serializer::CloseStream(core::IO &io, size_t &metadataStart,
+                                  size_t &metadataCount, const bool addMetadata)
 {
 
     ProfilerStart("buffering");
@@ -184,9 +192,8 @@ void BP4Serializer::CloseStream(core::IO &io, size_t &metadataStart,
     {
         SerializeDataBuffer(io);
     }
-
+    size_t dataEndsAt = m_Data.m_Position;
     metadataStart = m_Data.m_Position;
-
     SerializeMetadataInData(false, addMetadata);
 
     metadataCount = m_Data.m_Position - metadataStart;
@@ -196,6 +203,7 @@ void BP4Serializer::CloseStream(core::IO &io, size_t &metadataStart,
         m_Profiler.Bytes.at("buffering") += m_Data.m_Position;
     }
     ProfilerStop("buffering");
+    return dataEndsAt;
 }
 
 void BP4Serializer::ResetIndices()
@@ -623,8 +631,10 @@ void BP4Serializer::SerializeDataBuffer(core::IO &io) noexcept
     helper::CopyToBuffer(buffer, m_MetadataSet.DataPGVarsCountPosition,
                          &m_MetadataSet.DataPGVarsCount);
     // without record itself and vars count
+    // Note: m_MetadataSet.DataPGVarsCount has been incremented by 4
+    // in previous CopyToBuffer operation!
     const uint64_t varsLength =
-        position - m_MetadataSet.DataPGVarsCountPosition - 8 - 4;
+        position - m_MetadataSet.DataPGVarsCountPosition - 8;
     helper::CopyToBuffer(buffer, m_MetadataSet.DataPGVarsCountPosition,
                          &varsLength);
 
@@ -632,24 +642,28 @@ void BP4Serializer::SerializeDataBuffer(core::IO &io) noexcept
     size_t attributesSizeInData = GetAttributesSizeInData(io);
     if (attributesSizeInData)
     {
-        attributesSizeInData += 12; // count + length
-        m_Data.Resize(position + attributesSizeInData,
-                      "when writing Attributes in rank=0\n");
-
+        attributesSizeInData += 12; // count + length + end ID
+        ResizeBuffer(position + attributesSizeInData + 4,
+                     "when writing Attributes in rank=0\n ");
         PutAttributes(io);
     }
     else
     {
-        m_Data.Resize(position + 12, "for empty Attributes\n");
+        ResizeBuffer(position + 12 + 4, "for empty Attributes\n");
         // Attribute index header for zero attributes: 0, 0LL
         // Resize() already takes care of this
         position += 12;
         absolutePosition += 12;
     }
 
-    // Finish writing pg group length without record itself
-    const uint64_t dataPGLength =
-        position - m_MetadataSet.DataPGLengthPosition - 8;
+    // write a block identifier PGI]
+    const char pgiend[] = "PGI]"; // no \0
+    helper::CopyToBuffer(buffer, position, pgiend, sizeof(pgiend) - 1);
+    absolutePosition += sizeof(pgiend) - 1;
+
+    // Finish writing pg group length INCLUDING the record itself and
+    // including the closing padding but NOT the opening [PGI
+    const uint64_t dataPGLength = position - m_MetadataSet.DataPGLengthPosition;
     helper::CopyToBuffer(buffer, m_MetadataSet.DataPGLengthPosition,
                          &dataPGLength);
 
@@ -692,6 +706,8 @@ void BP4Serializer::SerializeMetadataInData(const bool updateAbsolutePosition,
             }
         };
 
+    size_t dataEndsAt = m_Data.m_Position;
+
     // Finish writing metadata counts and lengths
     // PG Index
     const uint64_t pgCount = m_MetadataSet.DataPGCount;
@@ -725,6 +741,14 @@ void BP4Serializer::SerializeMetadataInData(const bool updateAbsolutePosition,
     // must replace with growth buffer strategy?
     m_Data.Resize(position + footerSize,
                   " when writing metadata in bp data buffer");
+
+    /*
+    std::cout << " -- Write footer at position " << std::to_string(position)
+              << " with footer length " << std::to_string(footerSize)
+              << " in buffer  = "
+              << std::to_string(reinterpret_cast<std::uintptr_t>(buffer.data()))
+              << std::endl;
+    */
 
     // write pg index
     helper::CopyToBuffer(buffer, position, &pgCount);

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.h
@@ -86,8 +86,10 @@ public:
     /**
      * Finishes bp buffer by serializing data and adding trailing metadata
      * @param io
+     * @return the position of the data buffer before writing the metadata
+     * footer into it (in case someone wants to write only the data portion)
      */
-    void CloseData(core::IO &io);
+    size_t CloseData(core::IO &io);
 
     /**
      * Closes bp buffer for streaming mode...must reset metadata for the next
@@ -95,10 +97,12 @@ public:
      * @param io object containing all attributes
      * @param addMetadata true: process metadata and add to data buffer
      * (minifooter)
+     * @return the position of the data buffer before writing the metadata
+     * footer into it (in case someone wants to write only the data portion)
      */
-    void CloseStream(core::IO &io, const bool addMetadata = true);
-    void CloseStream(core::IO &io, size_t &metadataStart, size_t &metadataCount,
-                     const bool addMetadata = true);
+    size_t CloseStream(core::IO &io, const bool addMetadata = true);
+    size_t CloseStream(core::IO &io, size_t &metadataStart,
+                       size_t &metadataCount, const bool addMetadata = true);
 
     void ResetIndices();
 
@@ -158,11 +162,13 @@ private:
      * specialized functions
      * @param attribute input
      * @param stats BP4 Stats
+     * @param headerID  short string to identify block ("[AMD")
      * @return attribute length position
      */
     template <class T>
     size_t PutAttributeHeaderInData(const core::Attribute<T> &attribute,
-                                    Stats<T> &stats) noexcept;
+                                    Stats<T> &stats, const char *headerID,
+                                    const size_t headerIDLength) noexcept;
 
     /**
      * Called from WriteAttributeInData specialized functions
@@ -242,8 +248,8 @@ private:
     void PutVariableCharacteristics(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::Info &blockInfo,
-        const Stats<T> &stats, std::vector<char> &buffer,
-        size_t &position) noexcept;
+        const Stats<T> &stats, std::vector<char> &buffer, size_t &position,
+        const bool putDimensions = true) noexcept;
 
     /**
      * Writes from &buffer[position]:  [2

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
@@ -573,7 +573,8 @@ inline void BP4Serializer::PutVariableMetadataInData(
     position += 5; // skipping characteristics
 
     // write a block identifier VMD]
-    const char vmdend[] = "VMD]"; // no \0
+    // byte 4 and then four characters (as len+str without terminating 0)
+    const char vmdend[] = "\4VMD]"; // no \0
     helper::CopyToBuffer(buffer, position, vmdend, sizeof(vmdend) - 1);
 
     // Back to varLength including payload size

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
@@ -86,7 +86,7 @@ inline void BP4Serializer::PutVariablePayload(
     const bool sourceRowMajor) noexcept
 {
     ProfilerStart("buffering");
-    /*const size_t startingPos = m_Data.m_Position;*/
+    const size_t startingPos = m_Data.m_Position;
     if (blockInfo.Operations.empty())
     {
         PutPayloadInBuffer(variable, blockInfo, sourceRowMajor);
@@ -96,7 +96,6 @@ inline void BP4Serializer::PutVariablePayload(
         PutOperationPayloadInBuffer(variable, blockInfo);
     }
 
-    /*
     std::cout << " -- Var payload name=" << variable.m_Name
               << " startPos = " << std::to_string(startingPos)
               << " end position = " << std::to_string(m_Data.m_Position)
@@ -110,7 +109,6 @@ inline void BP4Serializer::PutVariablePayload(
               << " 4 bytes ahead = '"
               << std::string(m_Data.m_Buffer.data() + startingPos - 4, 4) << "'"
               << std::endl;
-    */
 
     ProfilerStop("buffering");
 }
@@ -501,20 +499,22 @@ void BP4Serializer::PutVariableMetadataInData(
     // format: length in 1 byte + padding characters + VMD]
     // we would write at minimum 5 bytes, byte for length + "VMD]"
     // hence the +5 in the calculation below
-    size_t padSize =
-        helper::PaddingToAlignPointer(buffer.data() + position + 5);
+    size_t padSize = rand() % 32;
+    // helper::PaddingToAlignPointer(buffer.data() + position + 5);
 
     const char vmdEnd[] = "                                VMD]";
     unsigned char vmdEndLen = static_cast<unsigned char>(padSize + 4);
     // starting position in vmdEnd from where we copy to buffer
     // we don't copy the \0 from vmdEnd !
     const char *ptr = vmdEnd + (sizeof(vmdEnd) - 1 - vmdEndLen);
-    /*std::cout << " -- Pad metadata with " << std::to_string(padSize)
-              << " bytes. position = " << std::to_string(position)
-              << " pad string = '" << ptr << "'"
-              << " buffer memory address = "
-              << std::to_string(reinterpret_cast<std::uintptr_t>(buffer.data()))
-              << std::endl;*/
+    std::cout << " -- Pad metadata with " << std::to_string(padSize)
+              << " bytes. var = " << variable.m_Name << " rank = " << m_RankMPI
+              << " position = " << std::to_string(position) << " pad string = '"
+              << ptr << "'" << std::endl;
+    /*              << " buffer memory address = "
+                  <<
+       std::to_string(reinterpret_cast<std::uintptr_t>(buffer.data()))
+                  << std::endl;*/
     helper::CopyToBuffer(buffer, position, &vmdEndLen, 1);
     helper::CopyToBuffer(buffer, position, ptr, vmdEndLen);
 

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -38,3 +38,6 @@ if(ADIOS2_HAVE_MPI)
   add_subdirectory(adios_iotest)
 endif()
 
+# bp4dbg Python tool
+install(PROGRAMS bp4dbg/bp4dbg.py bp4dbg/bp4dbg_data.py bp4dbg/bp4dbg_utils.py
+        DESTINATION ${CMAKE_INSTALL_BINDIR}/bp4dbg)

--- a/source/utils/bp4dbg/bp4dbg.py
+++ b/source/utils/bp4dbg/bp4dbg.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 import argparse
-import time
 from os.path import basename, exists, isdir
 import glob
 from bp4dbg_data import DumpData
+from bp4dbg_idxtable import DumpIndexTable
 
 
 def SetupArgs():
@@ -16,7 +17,8 @@ def SetupArgs():
     parser.add_argument("--verbose", "-v",
                         help="More verbosity", action="store_true")
     parser.add_argument("--no-indextable", "-x",
-                        help="Do not print index table md.idx", action="store_true")
+                        help="Do not print index table md.idx",
+                        action="store_true")
     parser.add_argument("--no-metadata", "-m",
                         help="Do not print metadata md.0", action="store_true")
     parser.add_argument(
@@ -65,7 +67,7 @@ def CheckFileName(args):
 
 
 def DumpIndexTableFile(args):
-    print("=== Index Table: " + args.idxFileName + " ====")
+    DumpIndexTable(args.idxFileName)
 
 
 def DumpMetadataFiles(args):

--- a/source/utils/bp4dbg/bp4dbg.py
+++ b/source/utils/bp4dbg/bp4dbg.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import absolute_import, division, print_function, unicode_literals
+import argparse
+import time
+from os.path import basename, exists, isdir
+import glob
+from bp4dbg_data import DumpData
+
+
+def SetupArgs():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--infile", "-i", help="Name of the input file", required=True)
+    parser.add_argument("--printdata", "-p",
+                        help="Dump data of this variable as well", default="")
+    parser.add_argument("--verbose", "-v",
+                        help="More verbosity", action="store_true")
+    parser.add_argument("--no-indextable", "-x",
+                        help="Do not print index table md.idx", action="store_true")
+    parser.add_argument("--no-metadata", "-m",
+                        help="Do not print metadata md.0", action="store_true")
+    parser.add_argument(
+        "--no-data", "-d", help="Do not print data data.*", action="store_true")
+    args = parser.parse_args()
+
+    # default values
+    args.idxFileName = ""
+    args.dumpIdx = False
+    args.metadataFileName = ""
+    args.dumpMetadata = False
+    args.dataFileName = ""
+    args.dumpData = False
+
+    return args
+
+
+def CheckFileName(args):
+    if (not exists(args.infile)):
+        print("ERROR: File " + args.infile + " does not exist", flush=True)
+        exit(1)
+    if (isdir(args.infile)):
+        if (not args.no_indextable):
+            args.idxFileName = args.infile + "/" + "md.idx"
+            args.dumpIdx = True
+        if (not args.no_metadata):
+            args.metadataFileName = args.infile + "/" + "md.[0-9]*"
+            args.dumpMetadata = True
+        if (not args.no_data):
+            args.dataFileName = args.infile + "/" + "data.[0-9]*"
+            args.dumpData = True
+        return
+
+    name = basename(args.infile)
+    if (name.startswith("data.")):
+        args.dataFileName = args.infile
+        args.dumpData = True
+
+    elif (name == "md.idx"):
+        args.idxFileName = args.infile
+        args.dumpIdx = True
+
+    elif (name.startswith("md.")):
+        args.metadataFileName = args.infile
+        args.dumpMetadata = True
+
+
+def DumpIndexTableFile(args):
+    print("=== Index Table: " + args.idxFileName + " ====")
+
+
+def DumpMetadataFiles(args):
+    mdFileList = glob.glob(args.metadataFileName)
+    for fname in mdFileList:
+        print("=== Metadata File: " + fname + " ====")
+
+
+def DumpDataFiles(args):
+    dataFileList = glob.glob(args.dataFileName)
+    for fname in dataFileList:
+        DumpData(fname)
+
+
+if __name__ == "__main__":
+
+    args = SetupArgs()
+#    print(args)
+
+#    print("Debug file {0}".format(args.infile), flush=True)
+    CheckFileName(args)
+
+    if (args.dumpIdx):
+        DumpIndexTableFile(args)
+
+    if (args.dumpMetadata):
+        DumpMetadataFiles(args)
+
+    if (args.dumpData):
+        DumpDataFiles(args)

--- a/source/utils/bp4dbg/bp4dbg_data.py
+++ b/source/utils/bp4dbg/bp4dbg_data.py
@@ -1,0 +1,405 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import time
+import numpy as np
+from os.path import basename, exists, isdir
+from os import fstat
+import bp4dbg_utils
+
+
+def ReadEncodedString(f, ID, limit):
+    # 2 bytes length + string without \0
+    namelen = np.fromfile(f, dtype=np.uint16, count=1)[0]
+    if (namelen > limit):
+        print("ERROR: " + ID + " string length ({0}) is longer than the limit to stay inside the block ({1})".format(
+            namelen, limit))
+        return ""
+    name = f.read(namelen)
+    return name
+
+
+def ReadHeader(f):
+    # There is no header at this time in data.*\
+    print("Header info: There is no header in data.*")
+
+
+def ReadCharacteristicsFromData(f, limit, typeID):
+    # 1 byte NCharacteristics
+    nCharacteristics = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    print("      # of Characteristics    : {0}".format(nCharacteristics))
+    # 4 bytes length
+    charLen = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("      Characteristics Length  : {0}".format(charLen))
+
+    for i in range(nCharacteristics):
+        print("      Characteristics[{0}]".format(i))
+        # 1 byte TYPE
+        cID = np.fromfile(f, dtype=np.uint8, count=1)[0]
+        print("          Type        : {0} ({1}) ".format(
+            bp4dbg_utils.GetCharacteristicName(cID), cID))
+        cLen = bp4dbg_utils.GetCharacteristicDataLength(cID, typeID)
+        cData = f.read(cLen)
+        print("          Content     : {0} bytes = {1}".format(
+            cLen, cData))
+    return True
+
+
+# Read Variable data
+def ReadVarData(f, nElements, typeID, ldims, expectedSize, varsStartPosition, varsTotalLength):
+    typeSize = bp4dbg_utils.GetTypeSize(typeID)
+    if (typeSize == 0):
+        print("ERROR: Cannot process variable data block with unknown type size")
+        return False
+
+    currentPosition = f.tell()
+    print("      Payload offset  : {0}".format(currentPosition))
+    nBytes = np.ones(1, dtype=np.uint64)
+    nBytes[0] = nElements[0] * typeSize
+    if (currentPosition + nBytes[0] > varsStartPosition + varsTotalLength):
+        print("ERROR: Variable data block of size would reach beyond all variable blocks")
+        print("VarsStartPosition = {0} varsTotalLength = {1}".format(
+            varsStartPosition, varsTotalLength))
+        print("current Position = {0} var block length = {1}".format(
+            currentPosition, nBytes[0]))
+        # return False
+    if (nBytes[0] != expectedSize):
+        print("ERROR: Variable data block size does not equal the size calculated from var block length")
+        print("Expected size = {0}  calculated size from dimensions = {1}".format(
+            expectedSize, nBytes[0]))
+    print("      Variable Data   : {0} bytes".format(nBytes[0]))
+    data = f.read(nBytes[0])
+    return True
+
+# Read a variable's metadata
+
+
+def ReadVMD(f, varidx, varsStartPosition, varsTotalLength):
+    startPosition = f.tell()
+    print("  Var {0:5d}".format(varidx))
+    print("      Starting offset : {0}".format(startPosition))
+    # 4 bytes TAG
+    tag = f.read(4)
+    if (tag != b"[VMD"):
+        print("  Tag: " + str(tag))
+        print("ERROR: VAR group does not start with [VMD")
+        return False
+    print("      Tag             : " + tag.decode('ascii'))
+
+    # 8 bytes VMD Length
+    vmdlen = np.fromfile(f, dtype=np.uint64, count=1)[0]
+    print("      Var block size  : {0} bytes (+4 for Tag)".format(vmdlen))
+    expectedVarBlockLength = vmdlen + 4  # [VMD is not included in vmdlen
+
+    if (startPosition + expectedVarBlockLength > varsStartPosition + varsTotalLength):
+        print("ERROR: There is not enough bytes inside this PG to read this Var block")
+        print("VarsStartPosition = {0} varsTotalLength = {1}".format(
+            varsStartPosition, varsTotalLength))
+        print("current var's start position = {0} var block length = {1}".format(
+            startPosition, expectedVarBlockLength))
+        return False
+
+    # 4 bytes VAR MEMBER ID
+    memberID = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("      Member ID       : {0}".format(memberID))
+
+    # VAR NAME, 2 bytes length + string without \0
+    sizeLimit = expectedVarBlockLength - (f.tell() - startPosition)
+    varname = ReadEncodedString(f, "Var Name", sizeLimit)
+    if (varname == ""):
+        return False
+    print("      Var Name        : " + varname.decode('ascii'))
+
+    # VAR PATH, 2 bytes length + string without \0
+    sizeLimit = expectedVarBlockLength - (f.tell() - startPosition)
+    varpath = ReadEncodedString(f, "Var Path", sizeLimit)
+    if (varname == ""):
+        return False
+    print("      Var Path        : " + varpath.decode('ascii'))
+
+    # 1 byte TYPE
+    typeID = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    print("      Type            : {0} ({1}) ".format(
+        bp4dbg_utils.GetTypeName(typeID), typeID))
+
+    # ISDIMENSIONS 1 byte, 'y' or 'n'
+    isDimensionVar = f.read(1)
+    if (isDimensionVar != b'y' and isDimensionVar != b'n'):
+        print(
+            "ERROR: Next byte for isDimensionVar must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+        return False
+    print("      isDimensionVar  : " + isDimensionVar.decode('ascii'))
+
+    # 1 byte NDIMENSIONS
+    ndims = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    print("      # of Dimensions : {0}".format(
+        ndims))
+
+    # DIMLENGTH
+    dimsLen = np.fromfile(f, dtype=np.uint16, count=1)[0]
+    print("      Dims Length     : {0}".format(
+        dimsLen))
+
+    nElements = np.ones(1, dtype=np.uint64)
+    ldims = np.zeros(ndims, dtype=np.uint64)
+    for i in range(ndims):
+        print("      Dim[{0}]".format(i))
+        # Read Local Dimensions (1 byte flag + 8 byte value)
+        # Is Dimension a variable ID 1 byte, 'y' or 'n' or '\0'
+        isDimensionVarID = f.read(1)
+        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and isDimensionsVarID != b'\0'):
+            print(
+                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+            return False
+        if (isDimensionVarID == b'\0'):
+            isDimensionVarID = b'n'
+        ldims[i] = np.fromfile(f, dtype=np.uint64, count=1)[0]
+        print("           local  dim : {0}".format(ldims[i]))
+        nElements = nElements * ldims[i]
+        # Read Global Dimensions (1 byte flag + 8 byte value)
+        # Is Dimension a variable ID 1 byte, 'y' or 'n' or '\0'
+        isDimensionVarID = f.read(1)
+        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and isDimensionsVarID != b'\0'):
+            print(
+                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+            return False
+        if (isDimensionVarID == b'\0'):
+            isDimensionVarID = b'n'
+        gdim = np.fromfile(f, dtype=np.uint64, count=1)[0]
+        print("           global dim : {0}".format(gdim))
+
+        # Read Offset Dimensions (1 byte flag + 8 byte value)
+        # Is Dimension a variable ID 1 byte, 'y' or 'n' or '\0'
+        isDimensionVarID = f.read(1)
+        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and isDimensionsVarID != b'\0'):
+            print(
+                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+            return False
+        if (isDimensionVarID == b'\0'):
+            isDimensionVarID = b'n'
+        offset = np.fromfile(f, dtype=np.uint64, count=1)[0]
+        print("           offset dim : {0}".format(offset))
+
+    sizeLimit = expectedVarBlockLength - (f.tell() - startPosition)
+    status = ReadCharacteristicsFromData(f, sizeLimit, typeID)
+    if (not status):
+        return False
+
+    # Padded end TAG
+    # 1 byte length of tag
+    endTagLen = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    tag = f.read(endTagLen)
+    if (not tag.endswith(b"VMD]")):
+        print("  Tag: " + str(tag))
+        print("ERROR: VAR group metadata does not end with VMD]")
+        return False
+    print("      Tag (pad {0:2d})    : {1}".format(
+        endTagLen - 4, tag.decode('ascii')))
+
+    expectedVarDataSize = expectedVarBlockLength - (f.tell() - startPosition)
+    status = ReadVarData(f, nElements, typeID, ldims, expectedVarDataSize,
+                         varsStartPosition, varsTotalLength)
+    if (not status):
+        return False
+
+    return True
+
+# Read an attribute's metadata and value
+
+
+def ReadAMD(f, attridx, attrsStartPosition, attrsTotalLength):
+    startPosition = f.tell()
+    print("  attr {0:5d}".format(attridx))
+    print("      Starting offset : {0}".format(startPosition))
+    # 4 bytes TAG
+    tag = f.read(4)
+    if (tag != b"[AMD"):
+        print("  Tag: " + str(tag))
+        print("ERROR: ATTR group does not start with [AMD")
+        return False
+    print("      Tag             : " + tag.decode('ascii'))
+
+    # 8 bytes VMD Length
+    vmdlen = np.fromfile(f, dtype=np.uint64, count=1)[0]
+    print("      Attr block size : {0} bytes (+4 for Tag)".format(vmdlen))
+    expectedAttrBlockLength = vmdlen + 4  # [VMD is not included in vmdlen
+    print("AttrsStartPosition = {0} attrsTotalLength = {1}".format(
+        attrsStartPosition, attrsTotalLength))
+    print("current attr's start position = {0} attr block length = {1}".format(
+        startPosition, expectedAttrBlockLength))
+    if (startPosition + expectedAttrBlockLength > attrsStartPosition + attrsTotalLength):
+        print("ERROR: There is not enough bytes inside this PG to read this Attr block")
+        return False
+
+    # 4 bytes ATTR MEMBER ID
+    memberID = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("      Member ID       : {0}".format(memberID))
+
+    # ATTR NAME, 2 bytes length + string without \0
+    sizeLimit = expectedAttrBlockLength - (f.tell() - startPosition)
+    attrname = ReadEncodedString(f, "Attr Name", sizeLimit)
+    if (attrname == ""):
+        return False
+    print("      Attr Name       : " + attrname.decode('ascii'))
+
+    # ATTR PATH, 2 bytes length + string without \0
+    sizeLimit = expectedAttrBlockLength - (f.tell() - startPosition)
+    attrpath = ReadEncodedString(f, "Attr Path", sizeLimit)
+    if (attrname == ""):
+        return False
+    print("      Attr Path       : " + attrpath.decode('ascii'))
+
+    # 1 byte TYPE
+    typeID = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    print("      Type            : {0} ({1}) ".format(
+        bp4dbg_utils.GetTypeName(typeID), typeID))
+
+    # End TAG AMD]
+    tag = f.read(4)
+    if (tag != b"AMD]"):
+        print("  Tag: " + str(tag))
+        print("ERROR: PG group metadata does not end with AMD]")
+        return False
+    print("      Tag             : {0}".format(tag.decode('ascii')))
+
+
+# Read one PG process group (variables and attributes from one process in
+# one step)
+def ReadPG(f, fileSize, pgidx):
+    pgStartPosition = f.tell()
+    print("PG {0}: ".format(pgidx))
+    print("  Starting offset : {0}".format(pgStartPosition))
+    tag = f.read(4)
+    if (tag != b"[PGI"):
+        print("  Tag: " + str(tag))
+        print("ERROR: PG group does not start with [PGI")
+        return False
+
+    print("  Tag             : " + tag.decode('ascii'))
+
+    # 8 bytes PG Length
+    pglen = np.fromfile(f, dtype=np.uint64, count=1)[0]
+    print("  PG length       : {0} bytes (+4 for Tag)".format(pglen))
+    expectedPGLength = pglen + 4  # total length does not include opening tag
+    if (pgStartPosition + expectedPGLength > fileSize):
+        print("ERROR: There is not enough bytes in file to read this PG")
+        return False
+
+    # RowMajor 1 byte, 'y' or 'n'
+    isRowMajor = f.read(1)
+    if (isRowMajor != b'y' and isRowMajor != b'n'):
+        print(
+            "ERROR: Next byte for isRowMajor must be 'y' or 'n' but it isn't = {0}".format(isRowMajor))
+        return False
+    print("  isRowMajor      : " + isRowMajor.decode('ascii'))
+
+    # PG Name, 2 bytes length + string without \0
+    sizeLimit = expectedPGLength - (f.tell() - pgStartPosition)
+    pgname = ReadEncodedString(
+        f, "PG Name", sizeLimit)
+    if (pgname == ""):
+        return False
+    print("  PG Name         : " + pgname.decode('ascii'))
+
+    # 4 bytes unused (for Coordination variable)
+    tag = f.read(4)
+    print("  Unused 4 bytes  : " + str(tag))
+
+    # Timestep name
+    sizeLimit = expectedPGLength - (f.tell() - pgStartPosition)
+    tsname = ReadEncodedString(f, "Timestep Name", sizeLimit)
+    if (tsname == ""):
+        return False
+    print("  Step Name       : " + tsname.decode('ascii'))
+
+    # STEP 4 bytes
+    step = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("  Step Value      : {0}".format(step))
+
+    # Method Count 1 byte1
+    nMethods = np.fromfile(f, dtype=np.uint8, count=1)[0]
+    print("  Methods count   : {0}".format(nMethods))
+
+    # Method Length 2 byte1
+    lenMethods = np.fromfile(f, dtype=np.uint16, count=1)[0]
+    print("  Methods length  : {0}".format(lenMethods))
+
+    print("  Methods info")
+    for i in range(nMethods):
+        # Method ID
+        methodID = np.fromfile(f, dtype=np.uint8, count=1)[0]
+        print("      Method ID   : {0}".format(nMethods))
+        sizeLimit = expectedPGLength - (f.tell() - pgStartPosition)
+        methodParams = ReadEncodedString(
+            f, "Method Parameters", sizeLimit)
+        if (methodParams == ""):
+            return False
+        print('      M. params   : "' +
+              methodParams.decode('ascii') + '"')
+
+    # VARIABLES
+
+    # VARS COUNT 4 bytes
+    nVars = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("  # of Variables  : {0}".format(nVars))
+
+    # VARS SIZE 8 bytes
+    varlen = np.fromfile(f, dtype=np.uint64, count=1)[0]
+    print("  Vars length     : {0} bytes".format(varlen))
+    sizeLimit = expectedPGLength - (f.tell() - pgStartPosition)
+    expectedVarsLength = varlen  # need to read this more
+    if (expectedVarsLength > sizeLimit):
+        print("ERROR: There is not enough bytes in PG to read the variables")
+        return False
+
+    varsStartPosition = f.tell()
+    for i in range(nVars):
+        # VMD block
+        status = ReadVMD(f, i, varsStartPosition, expectedVarsLength)
+        if (not status):
+            return False
+
+    # ATTRIBUTES
+
+    # ATTRS COUNT 4 bytes
+    nAttrs = np.fromfile(f, dtype=np.uint32, count=1)[0]
+    print("  # of Attributes : {0}".format(nAttrs))
+
+    # ATTS SIZE 8 bytes
+    attlen = np.fromfile(f, dtype=np.uint64, count=1)[0]
+    print("  Attrs length    : {0} bytes".format(attlen))
+    sizeLimit = expectedPGLength - (f.tell() - pgStartPosition)
+    expectedAttrsLength = attlen  # need to read this more
+    if (expectedAttrsLength > sizeLimit):
+        print("ERROR: There is not enough bytes in PG to read the attributes")
+        return False
+
+    attrsStartPosition = f.tell()
+    for i in range(nAttrs):
+        # AMD block
+        status = ReadAMD(f, i, attrsStartPosition, expectedAttrsLength)
+        if (not status):
+            return False
+
+    # End TAG PGI]
+    tag = f.read(4)
+    if (tag != b"PGI]"):
+        print("  Tag: " + str(tag))
+        print("ERROR: PG group metadata does not end with PGI]")
+        return False
+    print("  Tag               : {0}".format(tag.decode('ascii')))
+
+    return True
+
+
+def DumpData(fileName):
+    print("=== Data File: " + fileName + " ====")
+    with open(fileName, "rb") as f:
+        fileSize = fstat(f.fileno()).st_size
+        status = True
+        pgidx = 0
+        while (f.tell() < fileSize - 12 and status):
+            status = ReadPG(f, fileSize, pgidx)
+            pgidx = pgidx + 1
+
+
+if __name__ == "__main__":
+    print("ERROR: Utility main program is bp4dbg.py")

--- a/source/utils/bp4dbg/bp4dbg_data.py
+++ b/source/utils/bp4dbg/bp4dbg_data.py
@@ -42,10 +42,32 @@ def ReadCharacteristicsFromData(f, limit, typeID):
             cLen, cData))
     return True
 
+# Read String Variable data
+
+
+def ReadStringVarData(f, expectedSize,
+                      varsStartPosition):
+    # 2 bytes String Length
+    len = np.fromfile(f, dtype=np.uint16, count=1)[0]
+    if len != expectedSize - 2:
+        print("ERROR: Variable data block size does not equal the size "
+              "calculated from var block length")
+        print("Expected size = {0}  calculated size "
+              "from encoded length info {1}".
+              format(expectedSize, len + 2))
+        return False
+
+    str = f.read(len).decode('ascii')
+    print("      Variable Data   : '" + str + "'")
+    return True
 
 # Read Variable data
+
+
 def ReadVarData(f, nElements, typeID, ldims, expectedSize,
                 varsStartPosition, varsTotalLength):
+    if typeID == 9:  # string type
+        return ReadStringVarData(f, expectedSize, varsStartPosition)
     typeSize = bp4dbg_utils.GetTypeSize(typeID)
     if (typeSize == 0):
         print("ERROR: Cannot process variable data block with "

--- a/source/utils/bp4dbg/bp4dbg_data.py
+++ b/source/utils/bp4dbg/bp4dbg_data.py
@@ -1,7 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-import time
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 import numpy as np
-from os.path import basename, exists, isdir
 from os import fstat
 import bp4dbg_utils
 
@@ -10,8 +9,9 @@ def ReadEncodedString(f, ID, limit):
     # 2 bytes length + string without \0
     namelen = np.fromfile(f, dtype=np.uint16, count=1)[0]
     if (namelen > limit):
-        print("ERROR: " + ID + " string length ({0}) is longer than the limit to stay inside the block ({1})".format(
-            namelen, limit))
+        print("ERROR: " + ID + " string length ({0}) is longer than the "
+              "limit to stay inside the block ({1})".format(
+                  namelen, limit))
         return ""
     name = f.read(namelen)
     return name
@@ -44,10 +44,12 @@ def ReadCharacteristicsFromData(f, limit, typeID):
 
 
 # Read Variable data
-def ReadVarData(f, nElements, typeID, ldims, expectedSize, varsStartPosition, varsTotalLength):
+def ReadVarData(f, nElements, typeID, ldims, expectedSize,
+                varsStartPosition, varsTotalLength):
     typeSize = bp4dbg_utils.GetTypeSize(typeID)
     if (typeSize == 0):
-        print("ERROR: Cannot process variable data block with unknown type size")
+        print("ERROR: Cannot process variable data block with "
+              "unknown type size")
         return False
 
     currentPosition = f.tell()
@@ -55,18 +57,20 @@ def ReadVarData(f, nElements, typeID, ldims, expectedSize, varsStartPosition, va
     nBytes = np.ones(1, dtype=np.uint64)
     nBytes[0] = nElements[0] * typeSize
     if (currentPosition + nBytes[0] > varsStartPosition + varsTotalLength):
-        print("ERROR: Variable data block of size would reach beyond all variable blocks")
+        print("ERROR: Variable data block of size would reach beyond all "
+              "variable blocks")
         print("VarsStartPosition = {0} varsTotalLength = {1}".format(
             varsStartPosition, varsTotalLength))
         print("current Position = {0} var block length = {1}".format(
             currentPosition, nBytes[0]))
         # return False
     if (nBytes[0] != expectedSize):
-        print("ERROR: Variable data block size does not equal the size calculated from var block length")
-        print("Expected size = {0}  calculated size from dimensions = {1}".format(
-            expectedSize, nBytes[0]))
+        print("ERROR: Variable data block size does not equal the size "
+              "calculated from var block length")
+        print("Expected size = {0}  calculated size from dimensions = {1}".
+              format(expectedSize, nBytes[0]))
     print("      Variable Data   : {0} bytes".format(nBytes[0]))
-    data = f.read(nBytes[0])
+    f.read(nBytes[0])
     return True
 
 # Read a variable's metadata
@@ -89,12 +93,14 @@ def ReadVMD(f, varidx, varsStartPosition, varsTotalLength):
     print("      Var block size  : {0} bytes (+4 for Tag)".format(vmdlen))
     expectedVarBlockLength = vmdlen + 4  # [VMD is not included in vmdlen
 
-    if (startPosition + expectedVarBlockLength > varsStartPosition + varsTotalLength):
-        print("ERROR: There is not enough bytes inside this PG to read this Var block")
+    if (startPosition + expectedVarBlockLength >
+            varsStartPosition + varsTotalLength):
+        print("ERROR: There is not enough bytes inside this PG to read "
+              "this Var block")
         print("VarsStartPosition = {0} varsTotalLength = {1}".format(
             varsStartPosition, varsTotalLength))
-        print("current var's start position = {0} var block length = {1}".format(
-            startPosition, expectedVarBlockLength))
+        print("current var's start position = {0} var block length = {1}".
+              format(startPosition, expectedVarBlockLength))
         return False
 
     # 4 bytes VAR MEMBER ID
@@ -124,7 +130,8 @@ def ReadVMD(f, varidx, varsStartPosition, varsTotalLength):
     isDimensionVar = f.read(1)
     if (isDimensionVar != b'y' and isDimensionVar != b'n'):
         print(
-            "ERROR: Next byte for isDimensionVar must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+            "ERROR: Next byte for isDimensionVar must be 'y' or 'n' "
+            "but it isn't = {0}".format(isDimensionVar))
         return False
     print("      isDimensionVar  : " + isDimensionVar.decode('ascii'))
 
@@ -145,9 +152,11 @@ def ReadVMD(f, varidx, varsStartPosition, varsTotalLength):
         # Read Local Dimensions (1 byte flag + 8 byte value)
         # Is Dimension a variable ID 1 byte, 'y' or 'n' or '\0'
         isDimensionVarID = f.read(1)
-        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and isDimensionsVarID != b'\0'):
+        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and
+                isDimensionVarID != b'\0'):
             print(
-                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' "
+                "but it isn't = {0}".format(isDimensionVarID))
             return False
         if (isDimensionVarID == b'\0'):
             isDimensionVarID = b'n'
@@ -157,9 +166,11 @@ def ReadVMD(f, varidx, varsStartPosition, varsTotalLength):
         # Read Global Dimensions (1 byte flag + 8 byte value)
         # Is Dimension a variable ID 1 byte, 'y' or 'n' or '\0'
         isDimensionVarID = f.read(1)
-        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and isDimensionsVarID != b'\0'):
+        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and
+                isDimensionVarID != b'\0'):
             print(
-                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' "
+                "but it isn't = {0}".format(isDimensionVarID))
             return False
         if (isDimensionVarID == b'\0'):
             isDimensionVarID = b'n'
@@ -169,9 +180,11 @@ def ReadVMD(f, varidx, varsStartPosition, varsTotalLength):
         # Read Offset Dimensions (1 byte flag + 8 byte value)
         # Is Dimension a variable ID 1 byte, 'y' or 'n' or '\0'
         isDimensionVarID = f.read(1)
-        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and isDimensionsVarID != b'\0'):
+        if (isDimensionVarID != b'y' and isDimensionVarID != b'n' and
+                isDimensionVarID != b'\0'):
             print(
-                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' but it isn't = {0}".format(isDimension))
+                "ERROR: Next byte for isDimensionVarID must be 'y' or 'n' "
+                "but it isn't = {0}".format(isDimensionVarID))
             return False
         if (isDimensionVarID == b'\0'):
             isDimensionVarID = b'n'
@@ -225,8 +238,10 @@ def ReadAMD(f, attridx, attrsStartPosition, attrsTotalLength):
         attrsStartPosition, attrsTotalLength))
     print("current attr's start position = {0} attr block length = {1}".format(
         startPosition, expectedAttrBlockLength))
-    if (startPosition + expectedAttrBlockLength > attrsStartPosition + attrsTotalLength):
-        print("ERROR: There is not enough bytes inside this PG to read this Attr block")
+    if (startPosition + expectedAttrBlockLength >
+            attrsStartPosition + attrsTotalLength):
+        print("ERROR: There is not enough bytes inside this PG "
+              "to read this Attr block")
         return False
 
     # 4 bytes ATTR MEMBER ID
@@ -287,7 +302,8 @@ def ReadPG(f, fileSize, pgidx):
     isRowMajor = f.read(1)
     if (isRowMajor != b'y' and isRowMajor != b'n'):
         print(
-            "ERROR: Next byte for isRowMajor must be 'y' or 'n' but it isn't = {0}".format(isRowMajor))
+            "ERROR: Next byte for isRowMajor must be 'y' or 'n' "
+            "but it isn't = {0}".format(isRowMajor))
         return False
     print("  isRowMajor      : " + isRowMajor.decode('ascii'))
 
@@ -326,7 +342,7 @@ def ReadPG(f, fileSize, pgidx):
     for i in range(nMethods):
         # Method ID
         methodID = np.fromfile(f, dtype=np.uint8, count=1)[0]
-        print("      Method ID   : {0}".format(nMethods))
+        print("      Method ID   : {0}".format(methodID))
         sizeLimit = expectedPGLength - (f.tell() - pgStartPosition)
         methodParams = ReadEncodedString(
             f, "Method Parameters", sizeLimit)

--- a/source/utils/bp4dbg/bp4dbg_idxtable.py
+++ b/source/utils/bp4dbg/bp4dbg_idxtable.py
@@ -1,0 +1,122 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+from os import fstat
+
+
+# Read one PG process group (variables and attributes from one process in
+# one step)
+def ReadIndexHeader(f, fileSize):
+    status = True
+    if (fileSize < 64):
+        print("ERROR: Invalid Index Table. File is smaller "
+              "than the index header (64 bytes)")
+        return False
+    header = f.read(64)
+    hStr = header.decode('ascii')
+
+    versionStr = hStr[0:24].replace('\0', ' ')
+    major = hStr[24]
+    minor = hStr[25]
+    micro = hStr[26]
+#    unused = hStr[27]
+
+    endianValue = header[28]
+    if endianValue == 0:
+        endian = 'yes'
+    elif endianValue == 1:
+        endian = 'no'
+    else:
+        print("ERROR: byte 28 must be 0 or 1 to indicate endianness of "
+              "the data. It is however {0} in this file".format(
+                  endianValue))
+        status = False
+
+#    subfile1 = header[29]
+    subfile2 = header[30]
+    if subfile2 == 0:
+        hasSubfiles = 'no'
+    else:
+        hasSubfiles = 'yes'
+
+    bpversion = int(header[31])
+
+    # 32..55 unused
+
+    live = np.frombuffer(header, dtype=np.uint64, count=1, offset=56)
+    if live == 0:
+        isLive = 'no'
+    elif live == 1:
+        isLive = 'yes'
+    else:
+        print(
+            "ERROR: bytes 57-64 must be an uint64 integer with value "
+            "0 or 1 to indicate if the data is still being producer. "
+            "It is however {0} in this file".format(live))
+        status = False
+
+    print("------------------------------------------------------------"
+          "-----------------------------------------------------")
+    print("|      Version string      | Major | Minor | Micro | N/A 1B "
+          "| Endian | Subfiles | BP version | N/A 24B | isLive |")
+    print("+-----------------------------------------------------------"
+          "----------------------------------------------------+")
+    print(
+        "| {0} |   {1}   |   {2}   |   {3}   |        |  {4}   |    {5}   |"
+        "      {6}     |         |   {7}  |"
+        .format(versionStr, major, minor, micro, endian, hasSubfiles,
+                bpversion, isLive))
+    print("------------------------------------------------------------"
+          "-----------------------------------------------------")
+    return status
+
+
+def ReadIndex(f, fileSize):
+    nBytes = fileSize - f.tell()
+    if nBytes <= 0:
+        return True
+    nRows = int(nBytes / 64)
+    table = f.read(nBytes)
+    print(" ")
+    print("-----------------------------------------------------"
+          "--------------------------")
+    print("| Step |  Rank  |   PGPtr   |  VarPtr   |  AttPtr   |"
+          "  EndPtr   |   Timestep  |")
+    print("+----------------------------------------------------"
+          "-------------------------+")
+    for r in range(0, nRows):
+        pos = r * 64
+        data = np.frombuffer(table, dtype=np.uint64, count=8, offset=pos)
+        step = str(data[0]).rjust(5)
+        rank = str(data[1]).rjust(8)
+        pgptr = str(data[2]).center(10)
+        varptr = str(data[3]).center(10)
+        attptr = str(data[4]).center(10)
+        endptr = str(data[5]).center(10)
+        time = str(data[6]).rjust(12)
+        print("|" + step + " |" + rank + "|" + pgptr + " |" + varptr + " |" +
+              attptr + " |" + endptr + " |" + time + " |")
+
+    print("-----------------------------------------------------"
+          "--------------------------")
+
+    if fileSize - f.tell() > 1:
+        print("ERROR: There are {0} bytes at the end of file"
+              " that cannot be interpreted".format(fileSize - f.tell() - 1))
+        return False
+
+    return True
+
+
+def DumpIndexTable(fileName):
+    print("=== Index Table File: " + fileName + " ====")
+    with open(fileName, "rb") as f:
+        fileSize = fstat(f.fileno()).st_size
+        status = ReadIndexHeader(f, fileSize)
+        if (status):
+            status = ReadIndex(f, fileSize)
+
+
+if __name__ == "__main__":
+    print("ERROR: Utility main program is bp4dbg.py")

--- a/source/utils/bp4dbg/bp4dbg_utils.py
+++ b/source/utils/bp4dbg/bp4dbg_utils.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 dataTypes = {
     -1: 'unknown',
@@ -47,14 +48,14 @@ dataTypeSize = {
 
 def GetTypeName(typeID):
     name = dataTypes.get(typeID)
-    if (name == None):
+    if name is None:
         name = "unknown type"
     return name
 
 
 def GetTypeSize(typeID):
     size = dataTypeSize.get(typeID)
-    if (size == None):
+    if size is None:
         size = 0
     return size
 
@@ -77,7 +78,7 @@ CharacteristicNames = {
 
 def GetCharacteristicName(cID):
     name = CharacteristicNames.get(cID)
-    if (name == None):
+    if name is None:
         name = "unknown characteristic"
     return name
 

--- a/source/utils/bp4dbg/bp4dbg_utils.py
+++ b/source/utils/bp4dbg/bp4dbg_utils.py
@@ -1,0 +1,98 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+dataTypes = {
+    -1: 'unknown',
+    0: 'byte',
+    1: 'short',
+    2: 'integer',
+    4: 'long',
+
+    50: 'unsigned_byte',
+    51: 'unsigned_short',
+    52: 'unsigned_integer',
+    54: 'unsigned_long',
+
+    5: 'real',
+    6: 'double',
+    7: 'long_double',
+
+    9: 'string',
+    10: 'complex',
+    11: 'double_complex',
+    12: 'string_array'
+}
+
+dataTypeSize = {
+    -1: 0,
+    0: 1,
+    1: 2,
+    2: 4,
+    4: 8,
+
+    50: 1,
+    51: 2,
+    52: 4,
+    54: 8,
+
+    5: 4,
+    6: 8,
+    7: 16,
+
+    9: 0,
+    10: 8,
+    11: 16,
+    12: 0
+}
+
+
+def GetTypeName(typeID):
+    name = dataTypes.get(typeID)
+    if (name == None):
+        name = "unknown type"
+    return name
+
+
+def GetTypeSize(typeID):
+    size = dataTypeSize.get(typeID)
+    if (size == None):
+        size = 0
+    return size
+
+
+CharacteristicNames = {
+    0: 'value',
+    1: 'min',
+    2: 'max',
+    3: 'offset',
+    4: 'dimensions',
+    5: 'var_id',
+    6: 'payload_offset',
+    7: 'file_index',
+    8: 'time_index',
+    9: 'bitmap',
+    10: 'stat',
+    11: 'transform_type'
+}
+
+
+def GetCharacteristicName(cID):
+    name = CharacteristicNames.get(cID)
+    if (name == None):
+        name = "unknown characteristic"
+    return name
+
+
+def GetCharacteristicDataLength(cID, typeID):
+    name = CharacteristicNames.get(cID)
+    if (name == 'value' or name == 'min' or name == 'max'):
+        return dataTypeSize[typeID]
+    elif (name == 'offset' or name == 'payload offset'):
+        return 8
+    elif (name == 'file_index' or name == 'time_index'):
+        return 4
+    else:
+        return 0
+
+
+if __name__ == "__main__":
+    print("ERROR: Utility main program is bp4dbg.py")


### PR DESCRIPTION
Tags are added for adding more error checking possibility when we do recovery of BP4 data.
Padding is added to ensure data arrays always start on aligned memory (in the memory buffering, not in the data file).
bp4dbg.py is a start for making a 'bpdump' tool for BP4