### PR TITLE
fixed a few problems in ssc tests

### DIFF
--- a/testing/adios2/engine/ssc/CMakeLists.txt
+++ b/testing/adios2/engine/ssc/CMakeLists.txt
@@ -5,26 +5,46 @@
 
 
 if(ADIOS2_HAVE_MPI AND ADIOS2_HAVE_ZeroMQ)
-    add_executable(SscTest SscTest.cpp)
-    target_link_libraries(SscTest adios2 gtest MPI::MPI_C)
-    add_test(NAME SscTest COMMAND "mpirun" "-n" "8" $<TARGET_FILE:SscTest>)
+    add_executable(SscBase SscBase.cpp)
+    target_link_libraries(SscBase adios2 gtest MPI::MPI_C)
+    add_test(
+        NAME SscBase
+        COMMAND ${CMAKE_COMMAND}
+        -DCMD1=SscBase.ssc
+        -DCMD2=$<TARGET_FILE:SscBase>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/RunTest.cmake)
 endif()
 
 if(ADIOS2_HAVE_MPI AND ADIOS2_HAVE_ZeroMQ)
-    add_executable(SscTestNoAttributes SscTestNoAttributes.cpp)
-    target_link_libraries(SscTestNoAttributes adios2 gtest MPI::MPI_C)
-    add_test(NAME SscTestNoAttributes COMMAND "mpirun" "-n" "8" $<TARGET_FILE:SscTestNoAttributes>)
+    add_executable(SscNoAttributes SscNoAttributes.cpp)
+    target_link_libraries(SscNoAttributes adios2 gtest MPI::MPI_C)
+    add_test(
+        NAME SscNoAttributes
+        COMMAND ${CMAKE_COMMAND}
+        -DCMD1=SscNoAttributes.ssc
+        -DCMD2=$<TARGET_FILE:SscNoAttributes>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/RunTest.cmake)
 endif()
 
 if(ADIOS2_HAVE_MPI AND ADIOS2_HAVE_ZeroMQ)
-    add_executable(SscTestNoSelection SscTestNoSelection.cpp)
-    target_link_libraries(SscTestNoSelection adios2 gtest MPI::MPI_C)
-    add_test(NAME SscTestNoSelection COMMAND "mpirun" "-n" "8" $<TARGET_FILE:SscTestNoSelection>)
+    add_executable(SscNoSelection SscNoSelection.cpp)
+    target_link_libraries(SscNoSelection adios2 gtest MPI::MPI_C)
+    add_test(
+        NAME SscNoSelection
+        COMMAND ${CMAKE_COMMAND}
+        -DCMD1=SscNoSelection.ssc
+        -DCMD2=$<TARGET_FILE:SscNoSelection>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/RunTest.cmake)
 endif()
 
 if(ADIOS2_HAVE_MPI AND ADIOS2_HAVE_ZeroMQ)
-    add_executable(SscTest7d SscTest7d.cpp)
-    target_link_libraries(SscTest7d adios2 gtest MPI::MPI_C)
-    add_test(NAME SscTest7d COMMAND "mpirun" "-n" "8" $<TARGET_FILE:SscTest7d>)
+    add_executable(Ssc7d Ssc7d.cpp)
+    target_link_libraries(Ssc7d adios2 gtest MPI::MPI_C)
+    add_test(
+        NAME Ssc7d
+        COMMAND ${CMAKE_COMMAND}
+        -DCMD1=Ssc7d.ssc
+        -DCMD2=$<TARGET_FILE:Ssc7d>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/RunTest.cmake)
 endif()
 

--- a/testing/adios2/engine/ssc/RunTest.cmake
+++ b/testing/adios2/engine/ssc/RunTest.cmake
@@ -1,0 +1,13 @@
+macro(EXEC CMD)
+    execute_process(COMMAND "rm" "-f" ${CMD} RESULT_VARIABLE CMD_RESULT)
+endmacro()
+
+macro(EXEC_CHECK CMD)
+    execute_process(COMMAND "mpirun" "-n" "8" ${CMD} RESULT_VARIABLE CMD_RESULT)
+    if(CMD_RESULT)
+        message(FATAL_ERROR "Error running ${CMD}")
+    endif()
+endmacro()
+
+exec(${CMD1})
+exec_check(${CMD2})

--- a/testing/adios2/engine/ssc/Ssc7d.cpp
+++ b/testing/adios2/engine/ssc/Ssc7d.cpp
@@ -335,8 +335,11 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
     print_lines = 0;
 }
 
-TEST_F(SscEngineTest, BaseTest7d)
+TEST_F(SscEngineTest, Ssc7d)
 {
+    std::string filename = "Ssc7d";
+    adios2::Params engineParams = {{"Port", "12306"}, {"Verbose", "0"}};
+
     int worldRank, worldSize;
     MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
     MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
@@ -350,15 +353,12 @@ TEST_F(SscEngineTest, BaseTest7d)
     Dims start = {0, 0, 0, (size_t)mpiRank, 0, 0, 0};
     Dims count = {10, 2, 2, 1, 2, 8, 10};
 
-    adios2::Params engineParams = {{"Port", "12306"}, {"Verbose", "0"}};
-    std::string filename = "BaseTest";
-
     if (mpiGroup == 0)
     {
         Writer(shape, start, count, 200, engineParams, filename);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
     if (mpiGroup == 1)
     {

--- a/testing/adios2/engine/ssc/SscNoAttributes.cpp
+++ b/testing/adios2/engine/ssc/SscNoAttributes.cpp
@@ -120,7 +120,7 @@ void Writer(const Dims &shape, const Dims &start, const Dims &count,
     size_t datasize = std::accumulate(count.begin(), count.end(), 1,
                                       std::multiplies<size_t>());
     adios2::ADIOS adios(mpiComm, adios2::DebugON);
-    adios2::IO dataManIO = adios.DeclareIO("WAN");
+    adios2::IO dataManIO = adios.DeclareIO("staging");
     dataManIO.SetEngine("ssc");
     dataManIO.SetParameters(engineParams);
     std::vector<char> myChars(datasize);
@@ -152,7 +152,6 @@ void Writer(const Dims &shape, const Dims &start, const Dims &count,
         "bpComplexes", shape, start, count);
     auto bpDComplexes = dataManIO.DefineVariable<std::complex<double>>(
         "bpDComplexes", shape, start, count);
-    dataManIO.DefineAttribute<int>("AttInt", 110);
     adios2::Engine dataManWriter = dataManIO.Open(name, adios2::Mode::Write);
     for (int i = 0; i < steps; ++i)
     {
@@ -188,7 +187,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             const std::string &name)
 {
     adios2::ADIOS adios(mpiComm, adios2::DebugON);
-    adios2::IO dataManIO = adios.DeclareIO("Test");
+    adios2::IO dataManIO = adios.DeclareIO("staging");
     dataManIO.SetEngine("ssc");
     dataManIO.SetParameters(engineParams);
     adios2::Engine dataManReader = dataManIO.Open(name, adios2::Mode::Read);
@@ -210,7 +209,6 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
     size_t i;
     for (i = 0; i < steps; ++i)
     {
-
         adios2::StepStatus status = dataManReader.BeginStep(StepMode::Read, 5);
 
         if (status == adios2::StepStatus::OK)
@@ -294,21 +292,15 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             break;
         }
     }
-    if (received_steps)
-    {
-        auto attInt = dataManIO.InquireAttribute<int>("AttInt");
-        std::cout << "[Rank " + std::to_string(mpiRank) +
-                         "] Attribute received "
-                  << attInt.Data()[0] << ", expected 110" << std::endl;
-        ASSERT_EQ(110, attInt.Data()[0]);
-        ASSERT_NE(111, attInt.Data()[0]);
-    }
     dataManReader.Close();
     print_lines = 0;
 }
 
-TEST_F(SscEngineTest, BaseTest)
+TEST_F(SscEngineTest, SscNoAttributes)
 {
+    std::string filename = "SscNoAttributes";
+    adios2::Params engineParams = {{"Port", "12326"}, {"Verbose", "0"}};
+
     int worldRank, worldSize;
     MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
     MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
@@ -322,15 +314,12 @@ TEST_F(SscEngineTest, BaseTest)
     Dims start = {2, (size_t)mpiRank * 2};
     Dims count = {5, 2};
 
-    adios2::Params engineParams = {{"Port", "12306"}, {"Verbose", "0"}};
-    std::string filename = "BaseTest";
-
     if (mpiGroup == 0)
     {
         Writer(shape, start, count, 1000, engineParams, filename);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
     if (mpiGroup == 1)
     {

--- a/testing/adios2/engine/ssc/SscNoSelection.cpp
+++ b/testing/adios2/engine/ssc/SscNoSelection.cpp
@@ -305,8 +305,11 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
     print_lines = 0;
 }
 
-TEST_F(SscEngineTest, BaseTest)
+TEST_F(SscEngineTest, SscNoSelection)
 {
+    std::string filename = "SscNoSelection";
+    adios2::Params engineParams = {{"Port", "12336"}, {"Verbose", "0"}};
+
     int worldRank, worldSize;
     MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
     MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
@@ -320,15 +323,12 @@ TEST_F(SscEngineTest, BaseTest)
     Dims start = {(size_t)mpiRank, 0};
     Dims count = {1, 10};
 
-    adios2::Params engineParams = {{"Port", "12306"}, {"Verbose", "0"}};
-    std::string filename = "BaseTest";
-
     if (mpiGroup == 0)
     {
         Writer(shape, start, count, 1000, engineParams, filename);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
     if (mpiGroup == 1)
     {


### PR DESCRIPTION
@chuckatkins Could you help check the cmake stuff and see if there is any smarter ways of doing this? Basically what I needed here is that I need to delete the .ssc file that is generated from previous test runs before running another time. However, cmake does not allow me to run multiple commands in adding a single test. This is a workaround I found on stackoverflow, but it looks quite ugly. Thanks. 