### PR TITLE
bpls: fix some warnings for size_t printf arguments

### DIFF
--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1530,12 +1530,12 @@ int readVar(core::Engine *fp, core::IO *io, core::Variable<T> *variable)
     auto shape = variable->Shape(absstep);
     if (verbose > 2)
     {
-        printf("    starting step=%" PRIu64 " absolute step=%" PRIu64
+        printf("    starting step=%" PRIu64 " absolute step=%zu"
                ", dims={",
                stepStart, absstep);
         for (auto dim : shape)
         {
-            printf("%" PRIu64 " ", dim);
+            printf("%zu", dim);
         }
         printf("}\n");
     }


### PR DESCRIPTION
`%PRIu64` is for `uint64_t`, `%zu` is for `size_t`, which on the Mac (and 32-bit
archs) aren't aliases.

[This tiny patch isn't likely to break anything since `%zu` is already used elsewhere in `bpls.cpp`, so I'd consider it safe for the release, though I think these kind of last minute changes are generally better avoided. Anyway, it's certainly not a critical fix, so it could just go into `master` if that's preferred.]

Mentioning @pnorbert .
