### PR TITLE
fix Install test adios_c_test w/MPI

### DIFF
--- a/testing/adios2/install/C/main_mpi.c
+++ b/testing/adios2/install/C/main_mpi.c
@@ -7,8 +7,9 @@
 
 #include <stdio.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    MPI_Init(&argc, &argv);
     adios2_adios *adios = adios2_init(MPI_COMM_WORLD, adios2_debug_mode_on);
     if (!adios)
     {
@@ -16,5 +17,6 @@ int main(void)
         return 1;
     }
     adios2_finalize(adios);
+    MPI_Finalize();
     return 0;
 }


### PR DESCRIPTION
Not sure how that passed the CI before, maybe it got exposed by my
PR that switches no-mpi mode per communicator.

Actually, that's probably the explanation, this passed the CI before my last update to the no-mpi unification thing, and the combination of merging those two then failed. But I'd argue it's clearly a bug in the test, fixed here.
