### PR TITLE
- Add header to all BP4 data files, metadata files and index table

### DIFF
--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -94,16 +94,13 @@ private:
      * profilers*/
     void WriteProfilingJSONFile();
 
-    void PopulateMetadataIndexFileHeader(std::vector<char> &buffer,
-                                         size_t &position, const uint8_t,
-                                         const bool addSubfiles);
+    void UpdateActiveFlag(const bool active);
 
     void PopulateMetadataIndexFileContent(
-        const uint64_t currentStep, const uint64_t mpirank,
+        BufferSTL &buffer, const uint64_t currentStep, const uint64_t mpirank,
         const uint64_t pgIndexStart, const uint64_t variablesIndexStart,
         const uint64_t attributesIndexStart, const uint64_t currentStepEndPos,
-        const uint64_t currentTimeStamp, std::vector<char> &buffer,
-        size_t &position);
+        const uint64_t currentTimeStamp);
 
     void WriteCollectiveMetadataFile(const bool isFinal = false);
 

--- a/source/adios2/toolkit/format/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp4/BP4Base.h
@@ -216,6 +216,13 @@ public:
     size_t m_PreMetadataFileLength = 0;
     size_t m_PreDataFileLength = 0;
 
+    /** Positions of flags in Index Table Header that Reader uses */
+    const size_t m_EndianFlagPosition = 36;
+    const size_t m_BPVersionPosition = 37;
+    const size_t m_ActiveFlagPosition = 38;
+    const size_t m_VersionTagPosition = 0;
+    const size_t m_VersionTagLength = 32;
+
     /**
      * Unique constructor
      * @param mpiComm for m_BP1Aggregator
@@ -294,7 +301,7 @@ public:
     };
 
     /**
-     * Resizes the data buffer to hold new dataIn size
+     * Resizes the data buffer to hold  additional new dataIn size
      * @param dataIn input size for new data
      * @param hint for exception handling
      * @return

--- a/source/adios2/toolkit/format/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Deserializer.cpp
@@ -60,8 +60,14 @@ void BP4Deserializer::ParseMetadataIndex(const BufferSTL &bufferSTL)
 {
     const auto &buffer = bufferSTL.m_Buffer;
     const size_t bufferSize = buffer.size();
-    size_t position = 0;
-    position += 28;
+
+    // Read header (64 bytes)
+
+    // long version string
+    size_t position = m_VersionTagPosition;
+    m_Minifooter.VersionTag.assign(&buffer[position], m_VersionTagLength);
+
+    position = m_EndianFlagPosition;
     const uint8_t endianness = helper::ReadValue<uint8_t>(buffer, position);
     m_Minifooter.IsLittleEndian = (endianness == 0) ? true : false;
 #ifndef ADIOS2_HAVE_ENDIAN_REVERSE
@@ -78,33 +84,28 @@ void BP4Deserializer::ParseMetadataIndex(const BufferSTL &bufferSTL)
     }
 #endif
 
-    position += 1;
+    // This has no flag in BP4 header. Always true
+    m_Minifooter.HasSubFiles = true;
 
-    const int8_t fileType = helper::ReadValue<int8_t>(
-        buffer, position, m_Minifooter.IsLittleEndian);
-    if (fileType >= 3)
-    {
-        m_Minifooter.HasSubFiles = true;
-    }
-    else if (fileType == 0 || fileType == 2)
-    {
-        m_Minifooter.HasSubFiles = false;
-    }
-
+    // BP version
+    position = m_BPVersionPosition;
     m_Minifooter.Version = helper::ReadValue<uint8_t>(
         buffer, position, m_Minifooter.IsLittleEndian);
-    if (m_Minifooter.Version < 3)
+    if (m_Minifooter.Version != 4)
     {
-        throw std::runtime_error("ERROR: ADIOS2 only supports bp format "
-                                 "version 3 and above, found " +
-                                 std::to_string(m_Minifooter.Version) +
-                                 " version \n");
+        throw std::runtime_error(
+            "ERROR: ADIOS2 BP4 Engine only supports bp format "
+            "version 4, found " +
+            std::to_string(m_Minifooter.Version) + " version \n");
     }
 
-    position = 0;
-    m_Minifooter.VersionTag.assign(&buffer[position], 28);
+    // active flag, not used yet in the reader
+    position = m_ActiveFlagPosition;
+    const uint8_t activeFlag = helper::ReadValue<uint8_t>(
+        buffer, position, m_Minifooter.IsLittleEndian);
 
-    position += 64;
+    // Read each record now
+    position = 64;
     while (position < bufferSize)
     {
         std::vector<uint64_t> ptrs;

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.h
@@ -35,6 +35,15 @@ public:
 
     ~BP4Serializer() = default;
 
+    /** Writes a 64 byte header into the data/metadata buffer.
+     *  Must be called only when the buffer is empty.
+     *  @param buffer the data or metadata buffer
+     *  @param fileType a small string up to 8 characters that is
+     *  concatenated to the version string
+     */
+    void MakeHeader(BufferSTL &b, const std::string fileType,
+                    const bool isActive);
+
     /**
      * Writes a process group index PGIndex and list of methods (from
      * transports). Done at Open or Advance.

--- a/source/utils/bp4dbg/bp4dbg_idxtable.py
+++ b/source/utils/bp4dbg/bp4dbg_idxtable.py
@@ -3,10 +3,9 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 from os import fstat
+import bp4dbg_utils
 
 
-# Read one PG process group (variables and attributes from one process in
-# one step)
 def ReadIndexHeader(f, fileSize):
     status = True
     if (fileSize < 64):
@@ -119,7 +118,7 @@ def DumpIndexTable(fileName):
     status = False
     with open(fileName, "rb") as f:
         fileSize = fstat(f.fileno()).st_size
-        status = ReadIndexHeader(f, fileSize)
+        status = bp4dbg_utils.ReadHeader(f, fileSize, "Index Table")
         if (status):
             status = ReadIndex(f, fileSize)
     return status

--- a/source/utils/bp4dbg/bp4dbg_metadata.py
+++ b/source/utils/bp4dbg/bp4dbg_metadata.py
@@ -329,7 +329,7 @@ def ReadVarMD(buf, idx, pos, limit, varStartOffset):
         fileOffset = varStartOffset + (pos - varStartPosition)
         status, pos = ReadCharacteristicsFromMetaData(
             buf, i, pos, newlimit, typeID, fileOffset, True)
-        if (not status):
+        if not status:
             return False
 
     return True, pos
@@ -396,7 +396,7 @@ def ReadAttrMD(buf, idx, pos, limit, attrStartOffset):
         fileOffset = attrStartOffset + (pos - attrStartPosition)
         status, pos = ReadCharacteristicsFromMetaData(
             buf, i, pos, newlimit, typeID, fileOffset, False)
-        if (not status):
+        if not status:
             return False
 
     return True, pos
@@ -405,7 +405,8 @@ def ReadAttrMD(buf, idx, pos, limit, attrStartOffset):
 def ReadMetadataStep(f, fileSize, step):
     # Read metadata of one step
     mdStartPosition = f.tell()
-    print("========================================================")
+    if step > 0:
+        print("========================================================")
     print("Step {0}: ".format(step))
     print("    PG Index offset   : {0}".format(mdStartPosition))
 
@@ -430,7 +431,7 @@ def ReadMetadataStep(f, fileSize, step):
         # VMD block
         status, pgmdPos = ReadPGMD(
             pgmd, i, pgmdPos, pgLength, pgStartPosition + pgmdPos)
-        if (not status):
+        if not status:
             return False
 
     # Read the VAR Index
@@ -456,7 +457,7 @@ def ReadMetadataStep(f, fileSize, step):
         # VMD block
         status, varmdPos = ReadVarMD(
             varmd, i, varmdPos, varLength, varsStartPosition + varmdPos)
-        if (not status):
+        if not status:
             return False
 
     # Read the ATTR Index
@@ -483,7 +484,7 @@ def ReadMetadataStep(f, fileSize, step):
         # VMD block
         status, attrmdPos = ReadAttrMD(
             attrmd, i, attrmdPos, attrLength, attrsStartPosition + attrmdPos)
-        if (not status):
+        if not status:
             return False
 
     return True
@@ -492,13 +493,15 @@ def ReadMetadataStep(f, fileSize, step):
 def DumpMetaData(fileName):
     print("========================================================")
     print("    Metadata File: " + fileName)
+    print("========================================================")
     with open(fileName, "rb") as f:
         fileSize = fstat(f.fileno()).st_size
-        status = True
+        status = bp4dbg_utils.ReadHeader(f, fileSize, "Metadata")
         step = 0
         while (f.tell() < fileSize - 12 and status):
             status = ReadMetadataStep(f, fileSize, step)
             step = step + 1
+    return status
 
 
 if __name__ == "__main__":

--- a/source/utils/bp4dbg/bp4dbg_utils.py
+++ b/source/utils/bp4dbg/bp4dbg_utils.py
@@ -95,5 +95,60 @@ def GetCharacteristicDataLength(cID, typeID):
         return 0
 
 
+# Read Header info 64 bytes
+# fileType: Data, Metadata, Index Table
+def ReadHeader(f, fileSize, fileType):
+    status = True
+    if (fileSize < 64):
+        print("ERROR: Invalid " + fileType + ". File is smaller "
+              "than the header (64 bytes)")
+        return False
+    header = f.read(64)
+    hStr = header.decode('ascii')
+
+    versionStr = hStr[0:32].replace('\0', ' ')
+    major = hStr[32]
+    minor = hStr[33]
+    micro = hStr[34]
+#    unused = hStr[35]
+
+    endianValue = header[36]
+    if endianValue == 0:
+        endian = 'yes'
+    elif endianValue == 1:
+        endian = ' no'
+    else:
+        print("ERROR: byte 28 must be 0 or 1 to indicate endianness of "
+              "the data. It is however {0} in this file".format(
+                  endianValue))
+        status = False
+
+    bpversion = int(header[37])
+    active = int(header[38])
+    if active == 0:
+        activeStr = ' no'
+    else:
+        activeStr = 'yes'
+
+    #    unused = hStr[39]
+
+    # 40..63 unused
+
+    print("-----------------------------------------------------------"
+          "-----------------------------------------------------------")
+    print("|        Version string            | Major | Minor | Patch "
+          "| unused | Endian | BP version | Active |     unused      |")
+    print("|          32 bytes                |   1B  |   1B  |   1B  "
+          "|   1B   |   1B   |     1B     |   1B   |       33B       |")
+    print("+----------------------------------------------------------"
+          "----------------------------------------------------------+")
+    print("| {0} |   {1}   |   {2}   |   {3}   |        |  {4}   "
+          "|      {5}     |  {6}   |                 |".format(
+              versionStr, major, minor, micro, endian, bpversion, activeStr))
+    print("-----------------------------------------------------------"
+          "-----------------------------------------------------------")
+    return status
+
+
 if __name__ == "__main__":
     print("ERROR: Utility main program is bp4dbg.py")


### PR DESCRIPTION
- Modify header content:
  - 32 bytes Tag string e.g. "ADIOS-BP v2.3.1 Index Table     "
  - byte 36 endianness
  - byte 37 BP version
  - byte 38 Active flag (in Index table it indicates active writer)
- bp4dbg print header for all files