### PR TITLE
fix MSVC/conda build

### DIFF
--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -111,14 +111,14 @@ T ReadValue(const std::vector<char> &buffer, size_t &position,
  * @param srcMemCount
  */
 template <class T, class U>
-void CopyMemory(T *dest, const Dims &destStart, const Dims &destCount,
-                const bool destRowMajor, const U *src, const Dims &srcStart,
-                const Dims &srcCount, const bool srcRowMajor,
-                const bool endianReverse = false,
-                const Dims &destMemStart = Dims(),
-                const Dims &destMemCount = Dims(),
-                const Dims &srcMemStart = Dims(),
-                const Dims &srcMemCount = Dims()) noexcept;
+void CopyMemoryBlock(T *dest, const Dims &destStart, const Dims &destCount,
+                     const bool destRowMajor, const U *src,
+                     const Dims &srcStart, const Dims &srcCount,
+                     const bool srcRowMajor, const bool endianReverse = false,
+                     const Dims &destMemStart = Dims(),
+                     const Dims &destMemCount = Dims(),
+                     const Dims &srcMemStart = Dims(),
+                     const Dims &srcMemCount = Dims()) noexcept;
 
 void CopyPayload(char *dest, const Dims &destStart, const Dims &destCount,
                  const bool destRowMajor, const char *src, const Dims &srcStart,

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -252,12 +252,12 @@ void ClipVector(std::vector<T> &vec, const size_t start,
 }
 
 template <class T, class U>
-void CopyMemory(T *dest, const Dims &destStart, const Dims &destCount,
-                const bool destRowMajor, const U *src, const Dims &srcStart,
-                const Dims &srcCount, const bool srcRowMajor,
-                const bool endianReverse, const Dims &destMemStart,
-                const Dims &destMemCount, const Dims &srcMemStart,
-                const Dims &srcMemCount) noexcept
+void CopyMemoryBlock(T *dest, const Dims &destStart, const Dims &destCount,
+                     const bool destRowMajor, const U *src,
+                     const Dims &srcStart, const Dims &srcCount,
+                     const bool srcRowMajor, const bool endianReverse,
+                     const Dims &destMemStart, const Dims &destMemCount,
+                     const Dims &srcMemStart, const Dims &srcMemCount) noexcept
 {
     // transform everything to payload dims
     const Dims destStartPayload = PayloadDims<T>(destStart, destRowMajor);

--- a/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.tcc
@@ -862,7 +862,7 @@ void BP3Serializer::PutPayloadInBuffer(
     ProfilerStart("memcpy");
     if (!blockInfo.MemoryStart.empty())
     {
-        helper::CopyMemory(
+        helper::CopyMemoryBlock(
             reinterpret_cast<T *>(m_Data.m_Buffer.data() + m_Data.m_Position),
             blockInfo.Start, blockInfo.Count, sourceRowMajor, blockInfo.Data,
             blockInfo.Start, blockInfo.Count, sourceRowMajor, false, Dims(),

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
@@ -903,7 +903,7 @@ void BP4Serializer::PutPayloadInBuffer(
     if (!blockInfo.MemoryStart.empty())
     {
         // TODO make it a BP4Serializer function
-        helper::CopyMemory(
+        helper::CopyMemoryBlock(
             reinterpret_cast<T *>(m_Data.m_Buffer.data() + m_Data.m_Position),
             blockInfo.Start, blockInfo.Count, sourceRowMajor, blockInfo.Data,
             blockInfo.Start, blockInfo.Count, sourceRowMajor, false, Dims(),


### PR DESCRIPTION
This simply renames `helper::CopyMemory` to `helper::CopyMemoryBlock` to
avoid a name clash with the `CopyMemory` defined in the MSVC build in #1485.

@ax3l, it'd be great if you could check whether this fixes your problem, since it apparently doesn't happen with the MSVC builds that part of the ADIOS2 CI.