### PR TITLE
fix HDF5Reader build with MSVC

### DIFF
--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -14,6 +14,8 @@
 #include "adios2/common/ADIOSMPI.h"
 #include "adios2/helper/adiosFunctions.h" //CSVToVector
 
+#include <vector>
+
 namespace adios2
 {
 namespace core
@@ -146,7 +148,7 @@ size_t HDF5ReaderP::ReadDataset(hid_t dataSetId, hid_t h5Type,
     }
     else
     {
-        hsize_t start[ndims], count[ndims], stride[ndims];
+        std::vector<hsize_t> start(ndims), count(ndims), stride(ndims);
         bool isOrderC = helper::IsRowMajor(m_IO.m_HostLanguage);
 
         for (int i = 0; i < ndims; i++)
@@ -164,12 +166,12 @@ size_t HDF5ReaderP::ReadDataset(hid_t dataSetId, hid_t h5Type,
             slabsize *= count[i];
             stride[i] = 1;
         }
-        hid_t ret = H5Sselect_hyperslab(fileSpace, H5S_SELECT_SET, start,
-                                        stride, count, NULL);
+        hid_t ret = H5Sselect_hyperslab(fileSpace, H5S_SELECT_SET, start.data(),
+                                        stride.data(), count.data(), NULL);
         if (ret < 0)
             return 0;
 
-        hid_t memDataSpace = H5Screate_simple(ndims, count, NULL);
+        hid_t memDataSpace = H5Screate_simple(ndims, count.data(), NULL);
         interop::HDF5TypeGuard g_mds(memDataSpace, interop::E_H5_SPACE);
 
         int elementsRead = 1;

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -15,6 +15,7 @@
 #include <ios>
 #include <iostream>
 #include <stdexcept>
+#include <vector>
 
 #include "adios2/common/ADIOSMPI.h"
 #include "adios2/helper/adiosFunctions.h" // IsRowMajor
@@ -419,8 +420,8 @@ void HDF5Common::AddVar(core::IO &io, std::string const &name, hid_t datasetId,
     {
         hid_t dspace = H5Dget_space(datasetId);
         const int ndims = H5Sget_simple_extent_ndims(dspace);
-        hsize_t dims[ndims];
-        H5Sget_simple_extent_dims(dspace, dims, NULL);
+        std::vector<hsize_t> dims(ndims);
+        H5Sget_simple_extent_dims(dspace, dims.data(), NULL);
         H5Sclose(dspace);
 
         Dims shape;

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -933,9 +933,9 @@ void HDF5Common::AddNonStringAttribute(core::IO &io,
     }
     else
     {
-        T val[arraySize];
-        H5Aread(attrId, h5Type, val);
-        io.DefineAttribute(attrName, val, arraySize);
+        std::vector<T> val(arraySize);
+        H5Aread(attrId, h5Type, val.data());
+        io.DefineAttribute(attrName, val.data(), arraySize);
     }
 }
 

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -190,7 +190,7 @@ void HDF5Common::WriteAdiosSteps()
     hid_t attr =
         H5Acreate(m_FileId, ATTRNAME_NUM_STEPS.c_str(),
                   /*"NumSteps",*/ H5T_NATIVE_UINT, s, H5P_DEFAULT, H5P_DEFAULT);
-    uint totalAdiosSteps = m_CurrentAdiosStep + 1;
+    unsigned int totalAdiosSteps = m_CurrentAdiosStep + 1;
 
     if (m_GroupId < 0)
     {
@@ -296,18 +296,16 @@ void HDF5Common::FindVarsFromH5(core::IO &io, hid_t top_id, const char *gname,
                         hid_t datasetId = H5Dopen(gid, name, H5P_DEFAULT);
                         HDF5TypeGuard d(datasetId, E_H5_DATASET);
 
-                        char longName[std::strlen(heritage) +
-                                      std::strlen(gname) + std::strlen(name) +
-                                      10];
+                        std::string longName;
 
                         if (strcmp(gname, "/") == 0)
                         {
-                            sprintf(longName, "/%s", name);
+                            longName = std::string("/") + name;
                         }
                         else
                         {
-                            sprintf(longName, "%s/%s/%s", heritage, gname,
-                                    name);
+                            longName = std::string(heritage) + "/" + gname +
+                                       "/" + name;
                         }
                         // CreateVar(io, datasetId, name);
                         ReadNativeAttrToIO(io, datasetId, longName);
@@ -1246,7 +1244,7 @@ void HDF5Common::ReadAttrToIO(core::IO &io)
     {
         numAttrs = oinfo.num_attrs;
         int k = 0;
-        int MAX_ATTR_NAME_SIZE = 100;
+        const int MAX_ATTR_NAME_SIZE = 100;
         for (k = 0; k < numAttrs; k++)
         {
             char attrName[MAX_ATTR_NAME_SIZE];
@@ -1304,7 +1302,7 @@ void HDF5Common::ReadNativeAttrToIO(core::IO &io, hid_t datasetId,
                     // consuimg
         }
         int k = 0;
-        int MAX_ATTR_NAME_SIZE = 100;
+        const int MAX_ATTR_NAME_SIZE = 100;
         for (k = 0; k < numAttrs; k++)
         {
             char attrName[MAX_ATTR_NAME_SIZE];

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
@@ -208,7 +208,7 @@ void HDF5Common::AddBlockInfo(const core::Variable<T> &variable, hid_t parentId)
         H5Dcreate(parentId, blockInfo_name.c_str(), H5T_NATIVE_HSIZE,
                   metaSpace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
-    size_t blocks[dimSize * 2];
+    std::vector<size_t> blocks(dimSize * 2);
     for (int i = 0; i < dimSize; i++)
     {
         blocks[i + dimSize] = variable.m_Count[i];
@@ -223,7 +223,7 @@ void HDF5Common::AddBlockInfo(const core::Variable<T> &variable, hid_t parentId)
                         metaCount, NULL);
 
     H5Dwrite(metaId, H5T_NATIVE_HSIZE, metaLocal_id, metaSpace_id,
-             m_PropertyTxfID, blocks);
+             m_PropertyTxfID, blocks.data());
 
     H5Sclose(metaLocal_id);
     H5Sclose(metaSpace_id);


### PR DESCRIPTION
Sadly, variable-sized stack arrays are only a feature of C99, but not C++11,
so this patch uses std::vector instead.

This fixes #1485, the second issue there, at least hopefully so -- @ax3l, could you test this one, too, as I don't think the adios2 CI covers this case. (I changed the place identified by the error message from your report, and one more place with the same issue, but there may be more).

@chuckatkins, I haven't checked, but my guess is that the MSVC CI doesn't build ADIOS2 with HDF5, otherwise I would have expected to see this problem earlier. So that may be something for the future todo list.