### PR TITLE
- Handle LocalValueDim (local values turned into 1D global array) in …

### DIFF
--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -349,8 +349,10 @@ void VariableBase::InitShapeType()
             if (m_Shape.size() == 1 && m_Shape.front() == LocalValueDim)
             {
                 m_ShapeID = ShapeID::LocalValue;
-                m_Start.resize(1);
-                m_Count.resize(1); // real count = 1
+                m_Start.resize(1, 0); // start[0] == 0
+                m_Count.resize(1, 1); // count[0] == 1
+                // Count[0] == 1 makes sure the value will be written
+                // into the data file (PutVariablePayload())
                 m_SingleValue = true;
             }
             else

--- a/source/adios2/toolkit/format/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Deserializer.tcc
@@ -1134,6 +1134,7 @@ std::vector<typename core::Variable<T>::Info> BP4Deserializer::BlocksInfoCommon(
     std::vector<typename core::Variable<T>::Info> blocksInfo;
     blocksInfo.reserve(blocksIndexOffsets.size());
 
+    size_t n = 0;
     for (const size_t blockIndexOffset : blocksIndexOffsets)
     {
         size_t position = blockIndexOffset;
@@ -1166,7 +1167,23 @@ std::vector<typename core::Variable<T>::Info> BP4Deserializer::BlocksInfoCommon(
             blockInfo.Min = blockCharacteristics.Statistics.Min;
             blockInfo.Max = blockCharacteristics.Statistics.Max;
         }
+        if (blockInfo.Shape.size() == 1 &&
+            blockInfo.Shape.front() == LocalValueDim)
+        {
+            blockInfo.Shape = Dims{blocksIndexOffsets.size()};
+            blockInfo.Count = Dims{1};
+            blockInfo.Start = Dims{n};
+            blockInfo.Min = blockCharacteristics.Statistics.Value;
+            blockInfo.Max = blockCharacteristics.Statistics.Value;
+        }
+        // bp index starts at 1
+        blockInfo.Step =
+            static_cast<size_t>(blockCharacteristics.Statistics.Step - 1);
+        blockInfo.BlockID = n;
+
         blocksInfo.push_back(blockInfo);
+
+        ++n;
     }
     return blocksInfo;
 }

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.h
@@ -254,11 +254,11 @@ private:
         const Stats<T> &stats, std::vector<char> &buffer) noexcept;
 
     template <class T>
-    void PutVariableCharacteristics(
+    void PutVariableCharacteristicsInData(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::Info &blockInfo,
-        const Stats<T> &stats, std::vector<char> &buffer, size_t &position,
-        const bool putDimensions = true) noexcept;
+        const Stats<T> &stats, std::vector<char> &buffer,
+        size_t &position) noexcept;
 
     /**
      * Writes from &buffer[position]:  [2

--- a/source/utils/bp4dbg/bp4dbg.py
+++ b/source/utils/bp4dbg/bp4dbg.py
@@ -22,8 +22,8 @@ def SetupArgs():
                         action="store_true")
     parser.add_argument("--no-metadata", "-m",
                         help="Do not print metadata md.0", action="store_true")
-    parser.add_argument(
-        "--no-data", "-d", help="Do not print data data.*", action="store_true")
+    parser.add_argument("--no-data", "-d",
+                        help="Do not print data data.*", action="store_true")
     args = parser.parse_args()
 
     # default values

--- a/source/utils/bp4dbg/bp4dbg_metadata.py
+++ b/source/utils/bp4dbg/bp4dbg_metadata.py
@@ -209,8 +209,10 @@ def ReadPGMD(buf, idx, pos, limit, pgStartOffset):
     # 2 bytes PG Length + Name length
     pgLength = np.frombuffer(buf, dtype=np.uint16, count=1, offset=pos)[0]
     pos = pos + 2
-    print("        PG length       : {0} bytes".format(pgLength))
-    if (pgStartPosition + pgLength > limit):
+    print(
+        "        PG length       : {0} bytes (+2 for length)".format(
+            pgLength))
+    if (pgStartPosition + pgLength + 2 > limit):
         print("ERROR: There is not enough bytes {0} left in PG index block "
               "to read this single PG index ({1} bytes)").format(
                   limit - pgStartPosition, pgLength)
@@ -277,8 +279,9 @@ def ReadVarMD(buf, idx, pos, limit, varStartOffset):
     # 4 bytes VAR Index Length
     varLength = np.frombuffer(buf, dtype=np.uint32, count=1, offset=pos)[0]
     pos = pos + 4
-    print("        Var idx length  : {0} bytes".format(varLength))
-    if (varStartPosition + varLength > limit):
+    print("        Var idx length  : {0} bytes (+4 for idx length)".format(
+        varLength))
+    if (varStartPosition + varLength + 4 > limit):
         print("ERROR: There is not enough bytes in Var index block "
               "to read this single Var index")
         return False, pos
@@ -344,8 +347,9 @@ def ReadAttrMD(buf, idx, pos, limit, attrStartOffset):
     # 4 bytes ATTR Index Length
     attrLength = np.frombuffer(buf, dtype=np.uint32, count=1, offset=pos)[0]
     pos = pos + 4
-    print("        Attr idx length : {0} bytes".format(attrLength))
-    if (attrStartPosition + attrLength > limit):
+    print("        Attr idx length : {0} bytes (+4 for idx length)".format(
+        attrLength))
+    if (attrStartPosition + attrLength + 4 > limit):
         print("ERROR: There is not enough bytes in Attr index block "
               "to read this single Attr index")
         return False, pos

--- a/source/utils/bp4dbg/bp4dbg_utils.py
+++ b/source/utils/bp4dbg/bp4dbg_utils.py
@@ -1,6 +1,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+LocalValueDim = 18446744073709551613
+
 dataTypes = {
     -1: 'unknown',
     0: 'byte',


### PR DESCRIPTION
…BP4 (parity with BP3)

- Do not write values in characteristics in the Data buffer (like it was in adios 1.x BP3)
- Do write LocalValueDim (local value at writing) variable value after metadata (like other values)
- Print payload of single value variables in data