### PR TITLE
moving all readthedocs requirements to conda

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,3 +7,9 @@ channels:
 dependencies:
   - python
   - adios2-openmpi
+  - pip:
+    - sphinx==2.0.1
+    - blockdiag>=1.5.4
+    - sphinxcontrib-blockdiag>=1.5.5
+    - sphinx_rtd_theme>=0.4.1
+    - breathe==4.13

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,9 +3,7 @@ version: 2
 
 conda: 
   environment: docs/environment.yml
-
+    
 python:
-  version: 3.7
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
+   version: 3.7
+   system_packages: true


### PR DESCRIPTION
including pip sphinx packages
readthedocs can pick up the adios2 conda python module