### PR TITLE
fix use of "uint"

### DIFF
--- a/examples/heatTransfer/write/IO_ph5.cpp
+++ b/examples/heatTransfer/write/IO_ph5.cpp
@@ -112,7 +112,7 @@ void HDF5NativeWriter::Close()
     hid_t s = H5Screate(H5S_SCALAR);
     hid_t attr = H5Acreate(m_FileId, "NumSteps", H5T_NATIVE_UINT, s,
                            H5P_DEFAULT, H5P_DEFAULT);
-    uint totalTimeSteps = m_CurrentTimeStep + 1;
+    unsigned int totalTimeSteps = m_CurrentTimeStep + 1;
 
     if (m_GroupId < 0)
     {

--- a/source/adios2/operator/compress/CompressSZ.cpp
+++ b/source/adios2/operator/compress/CompressSZ.cpp
@@ -279,13 +279,12 @@ size_t CompressSZ::Compress(const void *dataIn, const Dims &dimensions,
     // In C, r[0] is the last dimension. In Fortran, r[0] is the first dimension
     for (int i = 0; i < ndims; i++)
     {
-        uint dsize = dimensions[i];
-        r[ndims - i - 1] = dsize;
+        r[ndims - i - 1] = dimensions[i];
         /*
         if (fd->group->adios_host_language_fortran == adios_flag_yes)
-            r[i] = dsize;
+            r[i] = dimensions[i];
         else
-            r[ndims-i-1] = dsize;
+            r[ndims-i-1] = dimensions[i];
         d = d->next;
          */
     }

--- a/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
+++ b/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
@@ -133,7 +133,7 @@ HDF5NativeWriter::~HDF5NativeWriter()
 
     hid_t attr = H5Acreate(m_FileId, "NumSteps", H5T_NATIVE_UINT, s,
                            H5P_DEFAULT, H5P_DEFAULT);
-    uint totalAdiosSteps = m_CurrentTimeStep + 1;
+    unsigned int totalAdiosSteps = m_CurrentTimeStep + 1;
 
     if (m_GroupId < 0)
     {


### PR DESCRIPTION
It's not a standard type, so can't be relied on. It gave me trouble in one
config on my Mac (gcc8 + address sanitizer), but also contributed to the
last minute MVSC issues before the 2.4.0 release.