### PR TITLE
- Handle situation of concurrency where index table may have less ste…

### DIFF
--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -72,18 +72,14 @@ private:
 
     /** Read in more metadata if exist (throwing away old).
      *  For streaming only.
-     *  @return pair of sizes if new metadata was read in
-     *  sizes.first = size of new content from Index Table
-     *  sizes.second = size of new content from Metadata File
+     *  @return size of new content from Index Table
      */
-    std::pair<size_t, size_t> UpdateBuffer();
+    size_t UpdateBuffer();
 
     /** Process the new metadata coming in (in UpdateBuffer)
      *  @param newIdxSize: the size of the new content from Index Table
-     *  @param neMDSize: the size of new content from Metadata File
      */
-    void ProcessMetadataForNewSteps(const size_t newIdxSize,
-                                    const size_t newMDSize);
+    void ProcessMetadataForNewSteps(const size_t newIdxSize);
 
     /** Check the active status flag in index file.
      *  @return true if writer is still active

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -205,12 +205,24 @@ void BP4Writer::InitTransports()
                                         m_IO.m_TransportsParameters,
                                         m_BP4Serializer.m_Profiler.IsActive);
 
+        /* Prepare header and write now to Index Table indicating
+         * the start of streaming
+         */
+        m_BP4Serializer.MakeHeader(m_BP4Serializer.m_MetadataIndex,
+                                   "Index Table", true);
+
         std::vector<std::string> metadataIndexFileNames =
             m_BP4Serializer.GetBPMetadataIndexFileNames(transportsNames);
 
         m_FileMetadataIndexManager.OpenFiles(
             metadataIndexFileNames, m_OpenMode, m_IO.m_TransportsParameters,
             m_BP4Serializer.m_Profiler.IsActive);
+        m_FileMetadataIndexManager.WriteFiles(
+            m_BP4Serializer.m_MetadataIndex.m_Buffer.data(),
+            m_BP4Serializer.m_MetadataIndex.m_Position);
+        m_FileMetadataIndexManager.FlushFiles();
+        /* clear the metadata index buffer*/
+        m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_MetadataIndex, true);
     }
 }
 
@@ -486,11 +498,11 @@ void BP4Writer::WriteCollectiveMetadataFile(const bool isFinal)
                                                "BP4 Index Table");
         for (auto const &t : timeSteps)
         {
-            if (t == 1)
+            /*if (t == 1)
             {
                 m_BP4Serializer.MakeHeader(m_BP4Serializer.m_MetadataIndex,
                                            "Index Table", true);
-            }
+            }*/
             const uint64_t pgIndexStartMetadataFile =
                 m_BP4Serializer
                     .m_MetadataIndexTable[m_BP4Serializer.m_RankMPI][t][0] +

--- a/source/adios2/toolkit/format/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp4/BP4Deserializer.h
@@ -52,10 +52,17 @@ public:
     ~BP4Deserializer() = default;
 
     void ParseMetadataIndex(const BufferSTL &bufferSTL,
-                            const size_t absoluteStartPos = 0);
+                            const size_t absoluteStartPos = 0,
+                            const bool hasHeader = true);
 
-    void ParseMetadata(const BufferSTL &bufferSTL, core::Engine &engine,
-                       const bool firstStep = true);
+    /* Return the position in the buffer where processing ends. The processing
+     * is controlled by the number of records in the Index, which may be less
+     * than the actual entries in the metadata in a streaming situation (where
+     * writer has just written metadata for step K+1,...,K+L while the index
+     * contains K steps when the reader looks at it).
+     */
+    size_t ParseMetadata(const BufferSTL &bufferSTL, core::Engine &engine,
+                         const bool firstStep = true);
 
     /**
      * Used to get the variable payload data for the current selection (dims and


### PR DESCRIPTION
…ps than the metadata file: makes sure that those extra steps will be processed in the next round.

- Writer drops header record into index table at Open() to indicate start of streaming like the connection files do in other staging engines.