### PR TITLE
Fix incorrect error message in SST

### DIFF
--- a/source/adios2/engine/sst/SstParamParser.cpp
+++ b/source/adios2/engine/sst/SstParamParser.cpp
@@ -158,7 +158,7 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
             else
             {
                 throw std::invalid_argument(
-                    "ERROR: Unknown Sst MarshalMethod parameter \"" + method +
+                    "ERROR: Unknown Sst CPCommPattern parameter \"" + method +
                     "\"");
             }
             return true;
@@ -185,7 +185,7 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
             else
             {
                 throw std::invalid_argument(
-                    "ERROR: Unknown Sst MarshalMethod parameter \"" + method +
+                    "ERROR: Unknown Sst QueueFullPolicy parameter \"" + method +
                     "\"");
             }
             return true;


### PR DESCRIPTION
SST throws incorrect error messages when invalid values are given to CPCommPattern or QueueFullPolicy. Small issue but probably confusing for the user.