### PR TITLE
Add a test for a global array with zero contribution from some rank

### DIFF
--- a/testing/adios2/engine/staging-common/CMakeLists.txt
+++ b/testing/adios2/engine/staging-common/CMakeLists.txt
@@ -132,7 +132,7 @@ endif()
 set (SIMPLE_MPI_TESTS "")
 set (SIMPLE_MPI_FORTRAN_TESTS "")
 if (ADIOS2_HAVE_MPI)
-  set (SIMPLE_MPI_TESTS "2x1;1x2;3x5;5x3;DelayedReader_3x5;2x1.Local;1x2.Local;3x5.Local;5x3.Local")
+  set (SIMPLE_MPI_TESTS "2x1;1x2;3x5;5x3;DelayedReader_3x5;2x1.Local;1x2.Local;3x5.Local;5x3.Local;2x1ZeroDataVar")
   if (ADIOS_HAVE_Fortran)
     set (SIMPLE_MPI_FORTRAN_TESTS "FtoC.3x5;CtoF.3x5;FtoF.3x5")
   endif()
@@ -170,6 +170,9 @@ list(FILTER SST_TESTS EXCLUDE REGEX "Fto.*FFS.*")
 # remove Fto anything tests that use CommMin because we can't spec it
 list(FILTER SST_TESTS EXCLUDE REGEX "Fto.*CommMin.*")
 
+# Zero Data tests are unreliable with SST and BP marshaling
+list (FILTER SST_TESTS EXCLUDE REGEX "2x1ZeroDataVar.*BP")
+
 foreach(test ${SST_TESTS})
     add_common_test(${test} SST)
 endforeach()
@@ -187,6 +190,8 @@ if(ADIOS2_HAVE_MPI)
     list (FILTER INSITU_TESTS EXCLUDE REGEX "x1.Shared")
     # Fortran Destination doesn't work for InSitu
     list (FILTER INSITU_TESTS EXCLUDE REGEX "toF")
+    # Zero size Data doesn't work for InSitu
+    list (FILTER INSITU_TESTS EXCLUDE REGEX "ZeroData")
     # DelayedReader doesn't make sense for InSitu
     list (FILTER INSITU_TESTS EXCLUDE REGEX "DelayedReader.*")
     # Fortran scalar reads don't work for InSitu

--- a/testing/adios2/engine/staging-common/ParseArgs.h
+++ b/testing/adios2/engine/staging-common/ParseArgs.h
@@ -16,6 +16,8 @@ int CompressZfp = 0;
 int TimeGapExpected = 0;
 int IgnoreTimeGap = 1;
 int ExpectOpenTimeout = 0;
+int ZeroDataVar = 0;
+int ZeroDataRank = 0;
 std::string shutdown_name = "DieTest";
 adios2::Mode GlobalWriteMode = adios2::Mode::Deferred;
 
@@ -147,6 +149,14 @@ static void ParseArgs(int argc, char **argv)
                 std::cerr << "Invalid number for ms_delay " << argv[1] << '\n';
             argv++;
             argc--;
+        }
+        else if (std::string(argv[1]) == "--zero_data_var")
+        {
+            ZeroDataVar++;
+        }
+        else if (std::string(argv[1]) == "--zero_data_rank")
+        {
+            ZeroDataRank++;
         }
         else
         {

--- a/testing/adios2/engine/staging-common/TestCommonClient.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonClient.cpp
@@ -261,7 +261,7 @@ TEST_F(SstReadTest, ADIOS2SstRead)
 
         if (myStart + myLength > writerSize * Nx)
         {
-            myLength = (long unsigned int)writerSize * Nx - myStart;
+            myLength = (long unsigned int)writerSize * (int)Nx - myStart;
         }
         const adios2::Dims start{myStart};
         const adios2::Dims count{myLength};

--- a/testing/adios2/engine/staging-common/TestCommonRead.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonRead.cpp
@@ -155,7 +155,7 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
 
         if (myStart + myLength > writerSize * Nx)
         {
-            myLength = (long unsigned int)writerSize * Nx - myStart;
+            myLength = (long unsigned int)writerSize * (int)Nx - myStart;
         }
         const adios2::Dims start{myStart};
         const adios2::Dims count{myLength};

--- a/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
@@ -80,17 +80,13 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
 
         size_t writerSize;
 
+        generateCommonTestData((int)0, mpiRank, mpiSize, (int)Nx, (int)Nx);
         auto attr_s1 = io.InquireAttribute<std::string>(s1_Single);
         auto attr_s1a = io.InquireAttribute<std::string>(s1_Array);
         auto attr_i8 = io.InquireAttribute<int8_t>(i8_Single);
         auto attr_i16 = io.InquireAttribute<int16_t>(i16_Single);
         auto attr_i32 = io.InquireAttribute<int32_t>(i32_Single);
         auto attr_i64 = io.InquireAttribute<int64_t>(i64_Single);
-
-        auto attr_u8 = io.InquireAttribute<uint8_t>(u8_Single);
-        auto attr_u16 = io.InquireAttribute<uint16_t>(u16_Single);
-        auto attr_u32 = io.InquireAttribute<uint32_t>(u32_Single);
-        auto attr_u64 = io.InquireAttribute<uint64_t>(u64_Single);
 
         auto attr_r32 = io.InquireAttribute<float>(r32_Single);
         auto attr_r64 = io.InquireAttribute<double>(r64_Single);
@@ -130,30 +126,6 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
         ASSERT_EQ(attr_i64.Data().size() == 1, true);
         ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
         ASSERT_EQ(attr_i64.Data().front(), data_I64.front());
-
-        EXPECT_TRUE(attr_u8);
-        ASSERT_EQ(attr_u8.Name(), u8_Single);
-        ASSERT_EQ(attr_u8.Data().size() == 1, true);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
-        ASSERT_EQ(attr_u8.Data().front(), data_U8.front());
-
-        EXPECT_TRUE(attr_u16);
-        ASSERT_EQ(attr_u16.Name(), u16_Single);
-        ASSERT_EQ(attr_u16.Data().size() == 1, true);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
-        ASSERT_EQ(attr_u16.Data().front(), data_U16.front());
-
-        EXPECT_TRUE(attr_u32);
-        ASSERT_EQ(attr_u32.Name(), u32_Single);
-        ASSERT_EQ(attr_u32.Data().size() == 1, true);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
-        ASSERT_EQ(attr_u32.Data().front(), data_U32.front());
-
-        EXPECT_TRUE(attr_u64);
-        ASSERT_EQ(attr_u64.Name(), u64_Single);
-        ASSERT_EQ(attr_u64.Data().size() == 1, true);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
-        ASSERT_EQ(attr_u64.Data().front(), data_U64.front());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), r32_Single);
@@ -247,7 +219,7 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
 
         if (myStart + myLength > writerSize * Nx)
         {
-            myLength = (long unsigned int)writerSize * Nx - myStart;
+            myLength = (long unsigned int)writerSize * (int)Nx - myStart;
         }
         const adios2::Dims start{myStart};
         const adios2::Dims count{myLength};

--- a/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
@@ -138,7 +138,7 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
             EXPECT_FALSE(var_r64_2d_rev);
         }
 
-        long unsigned int hisStart = rankToRead * Nx;
+        long unsigned int hisStart = rankToRead * (int)Nx;
         long unsigned int hisLength = (long unsigned int)Nx;
 
         var_i8.SetBlockSelection(rankToRead);

--- a/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
@@ -79,7 +79,6 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
     {
         size_t writerSize;
 
-
         auto var1 = io1.InquireVariable<double>(varname1);
         auto var2 = io2.InquireVariable<double>(varname2);
 

--- a/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
@@ -100,7 +100,7 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
 
         if (myStart + myLength > writerSize * Nx)
         {
-            myLength = (long unsigned int)(writerSize + 1) * Nx - myStart;
+            myLength = (long unsigned int)(writerSize + 1) * (int)Nx - myStart;
         }
         const adios2::Dims start{myStart};
         const adios2::Dims count{myLength};

--- a/testing/adios2/engine/staging-common/TestCommonServer.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonServer.cpp
@@ -101,7 +101,7 @@ TEST_F(CommonServerTest, ADIOS2CommonServer)
     while ((std::time(NULL) < EndTime) && !GlobalCloseNow)
     {
         // Generate test data for each process uniquely
-        generateCommonTestData((int)step, mpiRank, mpiSize);
+        generateCommonTestData((int)step, mpiRank, mpiSize, (int)Nx, (int)Nx);
 
         engine.BeginStep();
         // Retrieve the variables that previously went out of scope

--- a/testing/adios2/engine/staging-common/TestCommonWriteAttrs.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteAttrs.cpp
@@ -119,15 +119,11 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
     //                                        data_S1array.data(),
     //                                        data_S1array.size());
 
+    generateCommonTestData((int)0, mpiRank, mpiSize, (int)Nx, (int)Nx);
     io.DefineAttribute<int8_t>(i8_Single, data_I8.front());
     io.DefineAttribute<int16_t>(i16_Single, data_I16.front());
     io.DefineAttribute<int32_t>(i32_Single, data_I32.front());
     io.DefineAttribute<int64_t>(i64_Single, data_I64.front());
-
-    io.DefineAttribute<uint8_t>(u8_Single, data_U8.front());
-    io.DefineAttribute<uint16_t>(u16_Single, data_U16.front());
-    io.DefineAttribute<uint32_t>(u32_Single, data_U32.front());
-    io.DefineAttribute<uint64_t>(u64_Single, data_U64.front());
 
     io.DefineAttribute<float>(r32_Single, data_R32.front());
     io.DefineAttribute<double>(r64_Single, data_R64.front());
@@ -141,7 +137,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
     for (size_t step = 0; step < NSteps; ++step)
     {
         // Generate test data for each process uniquely
-        generateCommonTestData((int)step, mpiRank, mpiSize);
+        generateCommonTestData((int)step, mpiRank, mpiSize, (int)Nx, (int)Nx);
 
         engine.BeginStep();
         // Retrieve the variables that previously went out of scope

--- a/testing/adios2/engine/staging-common/TestCommonWriteLocal.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteLocal.cpp
@@ -109,7 +109,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
     for (size_t step = 0; step < NSteps; ++step)
     {
         // Generate test data for each process uniquely
-        generateCommonTestData((int)step, mpiRank, mpiSize);
+        generateCommonTestData((int)step, mpiRank, mpiSize, (int)Nx, (int)Nx);
 
         engine.BeginStep();
         // Retrieve the variables that previously went out of scope

--- a/testing/adios2/engine/staging-common/TestCommonWriteModes.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteModes.cpp
@@ -110,7 +110,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
     {
         adios2::Mode WriteMode;
         // Generate test data for each process uniquely
-        generateCommonTestData((int)step, mpiRank, mpiSize);
+        generateCommonTestData((int)step, mpiRank, mpiSize, (int)Nx, (int)Nx);
 
         engine.BeginStep();
         // Retrieve the variables that previously went out of scope
@@ -166,7 +166,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         if (WriteMode == adios2::Mode::Sync)
         {
             // trash the data since it's a Sync, this should be OK.
-            data_I8.fill(0);
+            std::fill(data_I8.begin(), data_I8.end(), 0);
         }
         engine.Put(var_i16, data_I16.data(), adios2::Mode::Sync);
         engine.Put(var_i32, data_I32.data(), WriteMode);

--- a/testing/adios2/engine/staging-common/TestCommonWriteShared.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteShared.cpp
@@ -70,22 +70,22 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
     // Declare 1D variables (NumOfProcesses * Nx)
     // The local process' part (start, count) can be defined now or later
     // before Write().
-    unsigned int myStart1 = Nx * mpiRank, myStart2 = Nx * mpiRank;
-    unsigned int myCount1 = Nx, myCount2 = Nx;
+    unsigned int myStart1 = (int)Nx * mpiRank, myStart2 = (int)Nx * mpiRank;
+    unsigned int myCount1 = (int)Nx, myCount2 = (int)Nx;
     if (mpiRank == 0)
     {
         /* first guy gets twice allotment var 1 */
-        myCount1 = 2 * Nx;
+        myCount1 = 2 * (int)Nx;
     }
     else
     {
         /* everyone else shifts up */
-        myStart1 += Nx;
+        myStart1 += (int)Nx;
     }
     if (mpiRank == (mpiSize - 1))
     {
         /* last guy  gets twice allotment var 2 */
-        myCount2 = 2 * Nx;
+        myCount2 = 2 * (int)Nx;
     }
     {
         adios2::Dims shape1{static_cast<unsigned int>(Nx * (mpiSize + 1))};
@@ -122,9 +122,9 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         std::vector<double> data_reverse;
 
         generateSimpleForwardData(data_forward, (int)step, myStart1, myCount1,
-                                  Nx * (mpiSize + 1));
+                                  (int)Nx * (mpiSize + 1));
         generateSimpleReverseData(data_reverse, (int)step, myStart2, myCount2,
-                                  Nx * (mpiSize + 1));
+                                  (int)Nx * (mpiSize + 1));
 
         engine1.BeginStep();
         engine2.BeginStep();

--- a/testing/adios2/engine/staging-common/TestData.h
+++ b/testing/adios2/engine/staging-common/TestData.h
@@ -17,24 +17,24 @@
 
 // Number of rows
 
-const std::size_t Nx = 10;
+std::size_t Nx = 10;
 
 std::string data_S1 = "Testing ADIOS2 String type";
 std::array<std::string, 1> data_S1array = {{"one"}};
 std::array<std::string, 3> data_S3 = {{"one", "two", "three"}};
 
-std::array<int8_t, 10> data_I8;
-std::array<int16_t, 10> data_I16;
-std::array<int32_t, 10> data_I32;
-std::array<int64_t, 10> data_I64;
+std::vector<int8_t> data_I8;
+std::vector<int16_t> data_I16;
+std::vector<int32_t> data_I32;
+std::vector<int64_t> data_I64;
 std::array<int8_t, 10> data_U8;
 std::array<int16_t, 10> data_U16;
 std::array<int32_t, 10> data_U32;
 std::array<int64_t, 10> data_U64;
-std::array<float, 10> data_R32;
-std::array<double, 10> data_R64;
-std::array<std::complex<float>, 10> data_C32;
-std::array<std::complex<double>, 10> data_C64;
+std::vector<float> data_R32;
+std::vector<double> data_R64;
+std::vector<std::complex<float>> data_C32;
+std::vector<std::complex<double>> data_C64;
 double data_R64_2d[10][2];
 double data_R64_2d_rev[2][10];
 
@@ -124,19 +124,36 @@ int validateSimpleReverseData(std::vector<double> &data_reverse, int step,
     return ret;
 }
 
-void generateCommonTestData(int step, int rank, int size)
+void generateCommonTestData(int step, int rank, int size, int Nx, int r64_Nx)
 {
     int64_t j = rank * Nx * 10 + step;
+    int64_t r64_j = j;
 
+    data_I8.reserve(Nx);
+    data_I16.reserve(Nx);
+    data_I32.reserve(Nx);
+    data_I64.reserve(Nx);
+    data_R32.reserve(Nx);
+    data_R64.reserve(r64_Nx);
+    data_C32.reserve(Nx);
+    data_C64.reserve(Nx);
+
+    if (r64_Nx != Nx)
+    {
+        /* for rank 1 (which has the data of rank 0 in this case, use a
+         * different j */
+        r64_j = (rank - 1) * Nx * 10 + step;
+    }
     data_scalar_R64 = (step + 1) * 1.5;
-    for (int i = 0; i < sizeof(data_I8); i++)
+    for (int i = 0; i < Nx; i++)
     {
         data_I8[i] = (int8_t)(j + 10 * i);
         data_I16[i] = (int16_t)(j + 10 * i);
         data_I32[i] = (int32_t)(j + 10 * i);
         data_I64[i] = (int64_t)(j + 10 * i);
         data_R32[i] = (float)j + 10 * i;
-        data_R64[i] = (double)j + 10 * i;
+        if (r64_Nx > i)
+            data_R64[i] = (double)r64_j + 10 * i;
         data_C32[i].imag((float)j + 10 * i);
         data_C32[i].real((float)-(j + 10 * i));
         data_C64[i].imag((double)j + 10 * i);
@@ -145,6 +162,10 @@ void generateCommonTestData(int step, int rank, int size)
         data_R64_2d[i][1] = (double)10000 + j + 10 * i;
         data_R64_2d_rev[0][i] = (double)j + 10 * i;
         data_R64_2d_rev[1][i] = (double)10000 + j + 10 * i;
+    }
+    for (int i = Nx; i < r64_Nx; i++)
+    {
+        data_R64[i] = (double)r64_j + 10 * i;
     }
 }
 

--- a/testing/adios2/engine/staging-common/TestSupp.cmake
+++ b/testing/adios2/engine/staging-common/TestSupp.cmake
@@ -61,6 +61,7 @@ set (STAGING_COMMON_TEST_SUPP_VERBOSE OFF)
 
 set (1x1_CMD "run_test.py -nw 1 -nr 1 --warg=ENGINE_PARAMS")
 set (2x1_CMD "run_test.py -nw 2 -nr 1 --warg=ENGINE_PARAMS")
+set (2x1ZeroDataVar_CMD "run_test.py -nw 2 -nr 1 --warg=--zero_data_var --warg=ENGINE_PARAMS")
 set (1x2_CMD "run_test.py -nw 1 -nr 2 --warg=ENGINE_PARAMS")
 set (3x5_CMD "run_test.py -nw 3 -nr 5 --warg=ENGINE_PARAMS")
 set (5x3_CMD "run_test.py -nw 5 -nr 3 --warg=ENGINE_PARAMS")


### PR DESCRIPTION
Currently this test is unstable with SST's default BP marshaling, so that variant is excluded.