### PR TITLE
Revert bp3 version changes

### DIFF
--- a/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp3/BP3Serializer.cpp
@@ -721,7 +721,12 @@ void BP3Serializer::PutMinifooter(const uint64_t pgIndexStart,
         helper::CopyToBuffer(buffer, position, version.c_str());
     };
 
-    const std::string versionLongTag("ADIOS-BP v" ADIOS2_VERSION_STR);
+    const std::string majorVersion(std::to_string(ADIOS2_VERSION_MAJOR));
+    const std::string minorVersion(std::to_string(ADIOS2_VERSION_MINOR));
+    const std::string patchVersion(std::to_string(ADIOS2_VERSION_PATCH));
+
+    const std::string versionLongTag("ADIOS-BP v" + majorVersion + "." +
+                                     minorVersion + "." + patchVersion);
     const size_t versionLongTagSize = versionLongTag.size();
     if (versionLongTagSize < 24)
     {
@@ -734,12 +739,9 @@ void BP3Serializer::PutMinifooter(const uint64_t pgIndexStart,
         helper::CopyToBuffer(buffer, position, versionLongTag.c_str(), 24);
     }
 
-    lf_CopyVersionChar(std::to_string(ADIOS2_VERSION_MAJOR), buffer, position);
-    lf_CopyVersionChar(std::to_string(ADIOS2_VERSION_MINOR), buffer, position);
-    lf_CopyVersionChar(std::to_string(ADIOS2_VERSION_PATCH), buffer, position);
-#ifdef ADIOS2_VERSION_TWEAK
-    lf_CopyVersionChar(std::to_string(ADIOS2_VERSION_TWEAK), buffer, position);
-#endif
+    lf_CopyVersionChar(majorVersion, buffer, position);
+    lf_CopyVersionChar(minorVersion, buffer, position);
+    lf_CopyVersionChar(patchVersion, buffer, position);
     ++position;
 
     helper::CopyToBuffer(buffer, position, &pgIndexStart);


### PR DESCRIPTION
This reverts the version changes in #1646 to the bp3 format as it can break existing compatibility.  Note that the 4 part version string is retained, this only reverts the way the version gets encoded into the BP byte stream.