### PR TITLE
Add Table engine for non-step based extremely large global arrays, and table based data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ adios_option(MPI       "Enable support for MPI" AUTO)
 adios_option(DataMan   "Enable support for DataMan" AUTO)
 adios_option(DataSpaces "Enable support for DATASPACES" AUTO)
 adios_option(SSC       "Enable support for SSC" AUTO)
+adios_option(Table     "Enable support for Table" AUTO)
 adios_option(SST       "Enable support for SST" AUTO)
 adios_option(ZeroMQ    "Enable support for ZeroMQ" AUTO)
 adios_option(HDF5      "Enable support for the HDF5 engine" AUTO)
@@ -139,7 +140,7 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 set(ADIOS2_CONFIG_OPTS
-    Blosc BZip2 ZFP SZ MGARD PNG MPI DataMan SSC SST DataSpaces ZeroMQ HDF5 Python Fortran SysVShMem Profiling Endian_Reverse
+    Blosc BZip2 ZFP SZ MGARD PNG MPI DataMan Table SSC SST DataSpaces ZeroMQ HDF5 Python Fortran SysVShMem Profiling Endian_Reverse
 )
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})
 configure_file(

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -131,6 +131,15 @@ if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "PGI") AND NOT MSVC)
     endif()
 endif()
 
+# Table
+if(ZeroMQ_FOUND)
+    if(ADIOS2_USE_Table STREQUAL AUTO)
+        set(ADIOS2_HAVE_Table TRUE)
+    elseif(ADIOS2_USE_Table)
+        set(ADIOS2_HAVE_Table TRUE)
+    endif()
+endif()
+
 # DataSpaces
 if(ADIOS2_USE_DataSpaces STREQUAL AUTO)
   find_package(DataSpaces 1.8)
@@ -139,7 +148,6 @@ elseif(ADIOS2_USE_DataSpaces)
 endif()
 if(DATASPACES_FOUND)
   set(ADIOS2_HAVE_DataSpaces TRUE)
-endif()
 
 # HDF5
 if(ADIOS2_USE_HDF5 STREQUAL AUTO)

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -148,6 +148,7 @@ elseif(ADIOS2_USE_DataSpaces)
 endif()
 if(DATASPACES_FOUND)
   set(ADIOS2_HAVE_DataSpaces TRUE)
+endif()
 
 # HDF5
 if(ADIOS2_USE_HDF5 STREQUAL AUTO)

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -133,7 +133,7 @@ endif()
 
 # Table
 if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "PGI") AND NOT MSVC)
-    if(ZeroMQ_FOUND)
+    if(ZeroMQ_FOUND AND ADIOS2_HAVE_MPI)
         if(ADIOS2_USE_Table STREQUAL AUTO)
             set(ADIOS2_HAVE_Table TRUE)
         elseif(ADIOS2_USE_Table)

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -132,11 +132,13 @@ if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "PGI") AND NOT MSVC)
 endif()
 
 # Table
-if(ZeroMQ_FOUND)
-    if(ADIOS2_USE_Table STREQUAL AUTO)
-        set(ADIOS2_HAVE_Table TRUE)
-    elseif(ADIOS2_USE_Table)
-        set(ADIOS2_HAVE_Table TRUE)
+if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "PGI") AND NOT MSVC)
+    if(ZeroMQ_FOUND)
+        if(ADIOS2_USE_Table STREQUAL AUTO)
+            set(ADIOS2_HAVE_Table TRUE)
+        elseif(ADIOS2_USE_Table)
+            set(ADIOS2_HAVE_Table TRUE)
+        endif()
     endif()
 endif()
 

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -121,17 +121,23 @@ if(ADIOS2_HAVE_ZeroMQ)
     target_link_libraries(adios2 PRIVATE ZeroMQ::ZMQ)
 endif()
 
-if(ADIOS2_HAVE_DataMan)
+if(ADIOS2_HAVE_DataMan OR ADIOS2_HAVE_WDM OR ADIOS2_HAVE_Table)
     target_sources(adios2 PRIVATE
         toolkit/format/dataman/DataManSerializer.cpp
         toolkit/format/dataman/DataManSerializer.tcc
+        )
+    target_link_libraries(adios2 PRIVATE nlohmann_json)
+endif()
+
+
+if(ADIOS2_HAVE_DataMan)
+    target_sources(adios2 PRIVATE
         engine/dataman/DataManCommon.cpp
         engine/dataman/DataManReader.cpp
         engine/dataman/DataManReader.tcc
         engine/dataman/DataManWriter.cpp
         engine/dataman/DataManWriter.tcc
         )
-    target_link_libraries(adios2 PRIVATE nlohmann_json)
 endif()
 
 if(ADIOS2_HAVE_SSC)
@@ -143,7 +149,13 @@ if(ADIOS2_HAVE_SSC)
         engine/ssc/SscWriter.cpp
         engine/ssc/SscWriter.tcc
         )
-    target_link_libraries(adios2 PRIVATE nlohmann_json)
+endif()
+
+if(ADIOS2_HAVE_Table)
+    target_sources(adios2 PRIVATE
+        engine/table/TableWriter.cpp
+        engine/table/TableWriter.tcc
+        )
 endif()
 
 if(ADIOS2_HAVE_SST)

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -41,6 +41,10 @@
 #include "adios2/engine/ssc/SscWriter.h"
 #endif
 
+#ifdef ADIOS2_HAVE_TABLE // external dependencies
+#include "adios2/engine/table/TableWriter.h"
+#endif
+
 #ifdef ADIOS2_HAVE_SST // external dependencies
 #include "adios2/engine/sst/SstReader.h"
 #include "adios2/engine/sst/SstWriter.h"
@@ -559,6 +563,17 @@ Engine &IO::Open(const std::string &name, const Mode mode,
 #else
         throw std::invalid_argument("ERROR: this version didn't compile with "
                                     "SSC library, can't use SSC engine\n");
+#endif
+    }
+    else if (engineTypeLC == "table")
+    {
+#ifdef ADIOS2_HAVE_TABLE
+        if (mode == Mode::Write)
+            engine = std::make_shared<engine::TableWriter>(*this, name, mode, mpiComm);
+        else
+            throw std::invalid_argument("ERROR: Table engine only supports Write. It uses other engines as backend. Please use corresponding engines for Read\n");
+#else
+        throw std::invalid_argument("ERROR: this version didn't compile with Table library, can't use Table engine\n");
 #endif
     }
     else if (engineTypeLC == "sst" || engineTypeLC == "effis")

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -569,11 +569,16 @@ Engine &IO::Open(const std::string &name, const Mode mode,
     {
 #ifdef ADIOS2_HAVE_TABLE
         if (mode == Mode::Write)
-            engine = std::make_shared<engine::TableWriter>(*this, name, mode, mpiComm);
+            engine = std::make_shared<engine::TableWriter>(*this, name, mode,
+                                                           mpiComm);
         else
-            throw std::invalid_argument("ERROR: Table engine only supports Write. It uses other engines as backend. Please use corresponding engines for Read\n");
+            throw std::invalid_argument(
+                "ERROR: Table engine only supports Write. It uses other "
+                "engines as backend. Please use corresponding engines for "
+                "Read\n");
 #else
-        throw std::invalid_argument("ERROR: this version didn't compile with Table library, can't use Table engine\n");
+        throw std::invalid_argument("ERROR: this version didn't compile with "
+                                    "Table library, can't use Table engine\n");
 #endif
     }
     else if (engineTypeLC == "sst" || engineTypeLC == "effis")

--- a/source/adios2/engine/dataman/DataManReader.cpp
+++ b/source/adios2/engine/dataman/DataManReader.cpp
@@ -25,8 +25,7 @@ namespace engine
 DataManReader::DataManReader(IO &io, const std::string &name, const Mode mode,
                              MPI_Comm mpiComm)
 : DataManCommon("DataManReader", io, name, mode, mpiComm),
-  m_DataManSerializer(m_IsRowMajor, m_ContiguousMajor, m_IsLittleEndian,
-                      mpiComm)
+  m_DataManSerializer(mpiComm, 0, m_IsRowMajor)
 {
     m_EndMessage = " in call to IO Open DataManReader " + m_Name + "\n";
     Init();

--- a/source/adios2/engine/dataman/DataManWriter.cpp
+++ b/source/adios2/engine/dataman/DataManWriter.cpp
@@ -42,7 +42,7 @@ StepStatus DataManWriter::BeginStep(StepMode mode, const float timeout_sec)
 
     for (size_t i = 0; i < m_Channels; ++i)
     {
-        m_DataManSerializer[i]->New(m_BufferSize);
+        m_DataManSerializer[i]->NewWriterBuffer(m_BufferSize);
     }
 
     if (m_Verbosity >= 5)
@@ -115,8 +115,8 @@ void DataManWriter::Init()
     for (size_t i = 0; i < m_Channels; ++i)
     {
         m_DataManSerializer.push_back(
-            std::make_shared<format::DataManSerializer>(
-                m_IsRowMajor, m_ContiguousMajor, m_IsLittleEndian, m_MPIComm));
+            std::make_shared<format::DataManSerializer>(m_MPIComm, m_BufferSize,
+                                                        m_IsRowMajor));
     }
 }
 

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -28,8 +28,7 @@ namespace engine
 SscReader::SscReader(IO &io, const std::string &name, const Mode mode,
                      MPI_Comm mpiComm)
 : Engine("SscReader", io, name, mode, mpiComm),
-  m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true,
-                      helper::IsLittleEndian(), mpiComm),
+  m_DataManSerializer(mpiComm, 0, helper::IsRowMajor(io.m_HostLanguage)),
   m_RepliedMetadata(std::make_shared<std::vector<char>>())
 {
     TAU_SCOPED_TIMER_FUNC();

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -28,8 +28,8 @@ namespace engine
 SscWriter::SscWriter(IO &io, const std::string &name, const Mode mode,
                      MPI_Comm mpiComm)
 : Engine("SscWriter", io, name, mode, mpiComm),
-  m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true,
-                      helper::IsLittleEndian(), mpiComm)
+  m_DataManSerializer(mpiComm, m_DefaultBufferSize,
+                      helper::IsRowMajor(io.m_HostLanguage))
 {
     TAU_SCOPED_TIMER_FUNC();
     Init();
@@ -48,7 +48,7 @@ StepStatus SscWriter::BeginStep(StepMode mode, const float timeoutSeconds)
     if (m_CurrentStep % m_StepsPerAggregation == 0)
     {
         m_CurrentStepActive = true;
-        m_DataManSerializer.New(m_DefaultBufferSize);
+        m_DataManSerializer.NewWriterBuffer(m_DefaultBufferSize);
         if (not m_AttributesSet)
         {
             m_DataManSerializer.PutAttributes(m_IO);

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -28,7 +28,8 @@ namespace engine
 SscWriter::SscWriter(IO &io, const std::string &name, const Mode mode,
                      MPI_Comm mpiComm)
 : Engine("SscWriter", io, name, mode, mpiComm),
-    m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true, helper::IsLittleEndian(), mpiComm)
+  m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true,
+                      helper::IsLittleEndian(), mpiComm)
 {
     TAU_SCOPED_TIMER_FUNC();
     Init();

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -28,7 +28,7 @@ namespace engine
 SscWriter::SscWriter(IO &io, const std::string &name, const Mode mode,
                      MPI_Comm mpiComm)
 : Engine("SscWriter", io, name, mode, mpiComm),
-  m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true, helper::IsLittleEndian(), mpiComm)
+    m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true, helper::IsLittleEndian(), mpiComm)
 {
     TAU_SCOPED_TIMER_FUNC();
     Init();

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -28,8 +28,7 @@ namespace engine
 SscWriter::SscWriter(IO &io, const std::string &name, const Mode mode,
                      MPI_Comm mpiComm)
 : Engine("SscWriter", io, name, mode, mpiComm),
-  m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true,
-                      helper::IsLittleEndian(), mpiComm)
+  m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true, helper::IsLittleEndian(), mpiComm)
 {
     TAU_SCOPED_TIMER_FUNC();
     Init();

--- a/source/adios2/engine/table/TableWriter.cpp
+++ b/source/adios2/engine/table/TableWriter.cpp
@@ -24,9 +24,12 @@ namespace engine
 
 TableWriter::TableWriter(IO &io, const std::string &name, const Mode mode,
                                MPI_Comm mpiComm)
-: Engine("TableWriter", io, name, mode, mpiComm)
+: Engine("TableWriter", io, name, mode, mpiComm),
+  m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true, helper::IsLittleEndian()),
+    m_SendStagingMan(mpiComm, Mode::Read, m_Timeout, 128)
 {
     MPI_Comm_rank(mpiComm, &m_MpiRank);
+    MPI_Comm_size(mpiComm, &m_MpiSize);
     Init();
 }
 
@@ -49,6 +52,7 @@ void TableWriter::EndStep()
 {
     PerformPuts();
 }
+
 void TableWriter::Flush(const int transportIndex)
 {
 }
@@ -96,14 +100,119 @@ void TableWriter::InitParameters()
             }
         }
     }
+
+    auto ips = helper::AvailableIpAddresses();
+    nlohmann::json j;
+    if(ips.empty())
+    {
+        throw(std::runtime_error("No available network interface."));
+    }
+    else
+    {
+        j[std::to_string(m_MpiRank)] = "tcp://" + ips[0] + ":" + std::to_string(m_Port + m_MpiRank % m_MaxRanksPerNode);
+    }
+    std::string a = j.dump();
+    std::vector<char> cv(128);
+    std::vector<char> cvAll(128*m_MpiSize);
+    std::memcpy(cv.data(), a.c_str(), a.size());
+    MPI_Allgather(cv.data(), cv.size(), MPI_CHAR, cvAll.data(), cv.size(), MPI_CHAR, m_MPIComm);
+    for(int i=0; i<m_MpiSize; ++i)
+    {
+        auto j = nlohmann::json::parse(cvAll.data() + i*128);
+        for(auto k = j.begin(); k!=j.end(); ++k)
+        {
+            m_AllAddresses[stoull(k.key())] = k.value();
+        }
+    }
+
+}
+
+void TableWriter::ReplyThread()
+{
+    transportman::StagingMan receiveStagingMan(m_MPIComm, Mode::Write, m_Timeout, 1e9);
+    receiveStagingMan.OpenTransport(m_AllAddresses[m_MpiRank]);
+    while (m_Listening)
+    {
+        auto request = receiveStagingMan.ReceiveRequest();
+        if (request == nullptr)
+        {
+            continue;
+        }
+        if (request->empty())
+        {
+            std::cout << "request->empty\n";
+            continue;
+        }
+        m_DataManSerializer.PutPack(request);
+        format::VecPtr reply = std::make_shared<std::vector<char>>();
+        reply->resize(1);
+        receiveStagingMan.SendReply(reply);
+
+        CheckFlush();
+    }
+}
+
+void TableWriter::CheckFlush()
+{
+    auto metadataMap = m_DataManSerializer.GetMetaData();
+
+    format::DmvVecPtr vars;
+
+    auto currentStepIt = metadataMap.find(m_CurrentStep);
+    if (currentStepIt == metadataMap.end())
+    {
+        throw("empty metadata map");
+    }
+    else
+    {
+        vars = currentStepIt->second;
+    }
+
+    for (const auto &i : *vars)
+    {
+
+    }
+
 }
 
 void TableWriter::InitTransports()
 {
+    m_Listening = true;
+    m_ReplyThread = std::thread(&TableWriter::ReplyThread, this);
 }
 
 void TableWriter::DoClose(const int transportIndex)
 {
+}
+
+std::vector<int> TableWriter::WhichRanks(const Dims &start, const Dims &count)
+{
+    std::vector<int> ranks;
+    if(start.size() > 0 and count.size() >0)
+    {
+        for(size_t i = start[0]; i<start[0]+count[0];  ++i)
+        {
+            int rank = WhichRank(i);
+            bool exist = false;
+            for(const auto &r: ranks)
+            {
+                if(rank == r)
+                {
+                    exist = true;
+                }
+            }
+            if(not exist)
+            {
+                ranks.push_back(rank);
+            }
+        }
+    }
+    return ranks;
+}
+
+int TableWriter::WhichRank(size_t row)
+{
+    return (row / m_RowsPerRank) % m_MpiSize;
 }
 
 } // end namespace engine

--- a/source/adios2/engine/table/TableWriter.cpp
+++ b/source/adios2/engine/table/TableWriter.cpp
@@ -27,7 +27,7 @@ TableWriter::TableWriter(IO &io, const std::string &name, const Mode mode,
                          MPI_Comm mpiComm)
 : Engine("TableWriter", io, name, mode, mpiComm),
   m_DataManSerializer(helper::IsRowMajor(io.m_HostLanguage), true,
-                      helper::IsLittleEndian()),
+                      helper::IsLittleEndian(), m_MPIComm),
   m_SendStagingMan(mpiComm, Mode::Read, m_Timeout, 128),
   m_SubAdios(MPI_COMM_WORLD, adios2::DebugOFF),
   m_SubIO(m_SubAdios.DeclareIO("SubIO")),

--- a/source/adios2/engine/table/TableWriter.cpp
+++ b/source/adios2/engine/table/TableWriter.cpp
@@ -69,6 +69,8 @@ void TableWriter::EndStep()
         m_SendStagingMan.Request(*localPack, s->GetDestination());
     }
 
+    MPI_Barrier(m_MPIComm);
+
     m_Listening = false;
     if (m_ReplyThread.joinable())
     {

--- a/source/adios2/engine/table/TableWriter.cpp
+++ b/source/adios2/engine/table/TableWriter.cpp
@@ -1,0 +1,111 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * TableWriter.cpp
+ *
+ *  Created on: Apr 6, 2019
+ *      Author: Jason Wang w4g@ornl.gov
+ */
+
+#include "TableWriter.h"
+#include "TableWriter.tcc"
+
+#include "adios2/helper/adiosFunctions.h"
+
+#include <iostream>
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+
+TableWriter::TableWriter(IO &io, const std::string &name, const Mode mode,
+                               MPI_Comm mpiComm)
+: Engine("TableWriter", io, name, mode, mpiComm)
+{
+    MPI_Comm_rank(mpiComm, &m_MpiRank);
+    Init();
+}
+
+StepStatus TableWriter::BeginStep(StepMode mode, const float timeoutSeconds)
+{
+    ++m_CurrentStep;
+    return StepStatus::OK;
+}
+
+size_t TableWriter::CurrentStep() const
+{
+    return m_CurrentStep;
+}
+
+void TableWriter::PerformPuts()
+{
+}
+
+void TableWriter::EndStep()
+{
+    PerformPuts();
+}
+void TableWriter::Flush(const int transportIndex)
+{
+}
+
+// PRIVATE
+
+#define declare_type(T)                                                        \
+    void TableWriter::DoPutSync(Variable<T> &variable, const T *data)       \
+    {                                                                          \
+        PutSyncCommon(variable, data);                                     \
+    }                                                                          \
+    void TableWriter::DoPutDeferred(Variable<T> &variable, const T *data)   \
+    {                                                                          \
+        PutDeferredCommon(variable, data);                                     \
+    }
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+void TableWriter::Init()
+{
+    InitParameters();
+    InitTransports();
+}
+
+void TableWriter::InitParameters()
+{
+    for (const auto &pair : m_IO.m_Parameters)
+    {
+        std::string key(pair.first);
+        std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+
+        std::string value(pair.second);
+        std::transform(value.begin(), value.end(), value.begin(), ::tolower);
+
+        if (key == "verbose")
+        {
+            m_Verbosity = std::stoi(value);
+            if (m_DebugMode)
+            {
+                if (m_Verbosity < 0 || m_Verbosity > 5)
+                    throw std::invalid_argument(
+                        "ERROR: Method verbose argument must be an "
+                        "integer in the range [0,5], in call to "
+                        "Open or Engine constructor\n");
+            }
+        }
+    }
+}
+
+void TableWriter::InitTransports()
+{
+}
+
+void TableWriter::DoClose(const int transportIndex)
+{
+}
+
+} // end namespace engine
+} // end namespace core
+} // end namespace adios2

--- a/source/adios2/engine/table/TableWriter.h
+++ b/source/adios2/engine/table/TableWriter.h
@@ -50,13 +50,13 @@ private:
         Dims shape;
         std::string type;
     };
-    int m_Verbosity = 5;
+    int m_Verbosity = 0;
     int m_Timeout = 5;
     int m_Port = 6789;
     int m_MaxRanksPerNode = 200;
     int m_PutSubEngineFrequency = 100;
     int m_Aggregators = 10;
-    size_t m_RowsPerAggregatorBuffer = 1000;
+    size_t m_RowsPerAggregatorBuffer = 400;
     std::unordered_map<size_t,
                        std::unordered_map<std::string, std::vector<char>>>
         m_AggregatorBuffers;
@@ -82,8 +82,8 @@ private:
     void PutSubEngine();
     void PutAggregatorBuffer();
 
-    std::vector<int> WhatRanks(const Dims &start, const Dims &count);
-    int WhatRank(const size_t row);
+    std::vector<std::string> WhatAggregators(const Dims &start, const Dims &count);
+    std::string WhatAggregator(const size_t row);
 
     std::vector<size_t> WhatBufferIndices(const Dims &start, const Dims &count);
     size_t WhatBufferIndex(const size_t row);

--- a/source/adios2/engine/table/TableWriter.h
+++ b/source/adios2/engine/table/TableWriter.h
@@ -13,6 +13,7 @@
 
 #include "adios2/ADIOSConfig.h"
 #include "adios2/core/Engine.h"
+#include "adios2/engine/bp4/BP4Writer.h"
 #include "adios2/toolkit/format/dataman/DataManSerializer.h"
 #include "adios2/toolkit/format/dataman/DataManSerializer.tcc"
 #include "adios2/toolkit/transportman/stagingman/StagingMan.h"
@@ -28,18 +29,10 @@ class TableWriter : public Engine
 {
 
 public:
-    /**
-     * Constructor for Writer
-     * @param name unique name given to the engine
-     * @param accessMode
-     * @param mpiComm
-     * @param method
-     * @param debugMode
-     */
     TableWriter(IO &adios, const std::string &name, const Mode mode,
-                   MPI_Comm mpiComm);
+                MPI_Comm mpiComm);
 
-    ~TableWriter() = default;
+    virtual ~TableWriter();
 
     StepStatus BeginStep(StepMode mode,
                          const float timeoutSeconds = -1.0) final;
@@ -49,30 +42,42 @@ public:
     void Flush(const int transportIndex = -1) final;
 
 private:
-    int m_Verbosity = 0;
+    int m_Verbosity = 5;
     int m_CurrentStep = -1;
     int m_MpiRank;
     int m_MpiSize;
     int m_Timeout = 5;
     size_t m_RowsPerRank = 128;
     size_t m_AppID;
-    std::unordered_map<std::string, std::unordered_map<size_t, std::vector<char>>> m_AggregatorBuffers;
-    std::unordered_map<std::string, std::pair<size_t, size_t>> m_AggregatorRecord;
+    std::unordered_map<std::string, Dims> m_CountMap;
+    std::unordered_map<size_t,
+                       std::unordered_map<std::string, std::vector<char>>>
+        m_AggregatorBuffers;
+    std::unordered_map<size_t,
+                       std::unordered_map<std::string, std::vector<bool>>>
+        m_AggregatorBufferFlags;
     std::unordered_map<int, std::string> m_AllAddresses;
     int m_Port = 6789;
     int m_MaxRanksPerNode = 200;
     bool m_Listening;
     std::thread m_ReplyThread;
-    bool m_FirstPut = true;
+    int m_PutSubEngineFrequency = 100;
+    BP4Writer m_SubEngine;
 
     void Init() final;
     void InitParameters() final;
     void InitTransports() final;
     void ReplyThread();
-    void CheckFlush();
+    void PutSubEngine();
 
-    std::vector<int> WhichRanks(const Dims &start, const Dims &count);
-    int WhichRank(size_t row);
+    // Get aggregator ranks from row numbers contained in start and count
+    std::vector<int> WhatRanks(const Dims &start, const Dims &count);
+
+    // Get aggregator rank from row number
+    int WhatRank(const size_t row);
+
+    std::vector<size_t> WhatBufferIndices(const Dims &start, const Dims &count);
+    size_t WhatBufferIndex(const size_t row);
 
     format::DataManSerializer m_DataManSerializer;
     transportman::StagingMan m_SendStagingMan;

--- a/source/adios2/engine/table/TableWriter.h
+++ b/source/adios2/engine/table/TableWriter.h
@@ -55,9 +55,8 @@ private:
     int m_Port = 6789;
     int m_MaxRanksPerNode = 200;
     int m_Aggregators = 10;
-    size_t m_BufferSize = 128 * 1024 * 1024;
+    size_t m_BufferSize = 1 * 1024 * 1024;
     size_t m_RowsPerAggregatorBuffer = 400;
-    bool m_AfterFinalSend = false;
     std::unordered_map<size_t,
                        std::unordered_map<std::string, std::vector<char>>>
         m_AggregatorBuffers;
@@ -81,7 +80,7 @@ private:
     void InitParameters() final;
     void InitTransports() final;
     void ReplyThread();
-    void PutSubEngine();
+    void PutSubEngine(bool finalPut = false);
     void PutAggregatorBuffer();
 
     std::vector<int> WhatAggregatorIndices(const Dims &start,

--- a/source/adios2/engine/table/TableWriter.h
+++ b/source/adios2/engine/table/TableWriter.h
@@ -11,15 +11,14 @@
 #ifndef ADIOS2_ENGINE_TABLEWRITER_H_
 #define ADIOS2_ENGINE_TABLEWRITER_H_
 
-#include "../../bindings/CXX11/adios2.h"
-
-#include "adios2/ADIOSConfig.h"
 #include "adios2/core/Engine.h"
 #include "adios2/engine/bp3/BP3Writer.h"
 #include "adios2/engine/bp4/BP4Writer.h"
 #include "adios2/toolkit/format/dataman/DataManSerializer.h"
 #include "adios2/toolkit/format/dataman/DataManSerializer.tcc"
 #include "adios2/toolkit/transportman/stagingman/StagingMan.h"
+
+#include "../../bindings/CXX11/adios2.h"
 
 namespace adios2
 {

--- a/source/adios2/engine/table/TableWriter.h
+++ b/source/adios2/engine/table/TableWriter.h
@@ -57,6 +57,7 @@ private:
     int m_Aggregators = 10;
     size_t m_BufferSize = 128 * 1024 * 1024;
     size_t m_RowsPerAggregatorBuffer = 400;
+    bool m_AfterFinalSend = false;
     std::unordered_map<size_t,
                        std::unordered_map<std::string, std::vector<char>>>
         m_AggregatorBuffers;

--- a/source/adios2/engine/table/TableWriter.h
+++ b/source/adios2/engine/table/TableWriter.h
@@ -54,8 +54,8 @@ private:
     int m_Timeout = 5;
     int m_Port = 6789;
     int m_MaxRanksPerNode = 200;
-    int m_PutSubEngineFrequency = 100;
     int m_Aggregators = 10;
+    size_t m_BufferSize = 128 * 1024 * 1024;
     size_t m_RowsPerAggregatorBuffer = 400;
     std::unordered_map<size_t,
                        std::unordered_map<std::string, std::vector<char>>>
@@ -73,6 +73,7 @@ private:
     std::thread m_ReplyThread;
     adios2::ADIOS m_SubAdios;
     adios2::IO m_SubIO;
+    bool m_IsRowMajor;
     std::shared_ptr<adios2::Engine> m_SubEngine;
 
     void Init() final;
@@ -82,8 +83,12 @@ private:
     void PutSubEngine();
     void PutAggregatorBuffer();
 
-    std::vector<std::string> WhatAggregators(const Dims &start, const Dims &count);
-    std::string WhatAggregator(const size_t row);
+    std::vector<int> WhatAggregatorIndices(const Dims &start,
+                                           const Dims &count);
+    std::vector<std::string> WhatAggregatorAddresses(const Dims &start,
+                                                     const Dims &count);
+    std::vector<std::string>
+    WhatAggregatorAddresses(const std::vector<int> &indices);
 
     std::vector<size_t> WhatBufferIndices(const Dims &start, const Dims &count);
     size_t WhatBufferIndex(const size_t row);
@@ -91,8 +96,8 @@ private:
     Dims WhatStart(const Dims &shape, const size_t index);
     Dims WhatCount(const Dims &shape, const size_t index);
 
-    format::DataManSerializer m_DataManSerializer;
-    format::DataManSerializer m_DataManDeserializer;
+    std::vector<std::shared_ptr<format::DataManSerializer>> m_Serializers;
+    format::DataManSerializer m_Deserializer;
     transportman::StagingMan m_SendStagingMan;
 
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/table/TableWriter.h
+++ b/source/adios2/engine/table/TableWriter.h
@@ -54,7 +54,7 @@ private:
     int m_Timeout = 5;
     int m_Port = 6789;
     int m_MaxRanksPerNode = 200;
-    int m_PutSubEngineFrequency = 1000;
+    int m_PutSubEngineFrequency = 100;
     int m_Aggregators = 10;
     size_t m_RowsPerAggregatorBuffer = 1000;
     std::unordered_map<size_t,
@@ -73,13 +73,14 @@ private:
     std::thread m_ReplyThread;
     adios2::ADIOS m_SubAdios;
     adios2::IO m_SubIO;
-    adios2::Engine m_SubEngine;
+    std::shared_ptr<adios2::Engine> m_SubEngine;
 
     void Init() final;
     void InitParameters() final;
     void InitTransports() final;
     void ReplyThread();
     void PutSubEngine();
+    void PutAggregatorBuffer();
 
     std::vector<int> WhatRanks(const Dims &start, const Dims &count);
     int WhatRank(const size_t row);
@@ -91,6 +92,7 @@ private:
     Dims WhatCount(const Dims &shape, const size_t index);
 
     format::DataManSerializer m_DataManSerializer;
+    format::DataManSerializer m_DataManDeserializer;
     transportman::StagingMan m_SendStagingMan;
 
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/table/TableWriter.h
+++ b/source/adios2/engine/table/TableWriter.h
@@ -1,0 +1,87 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * TableWriter.h
+ *
+ *  Created on: Apr 6, 2019
+ *      Author: Jason Wang w4g@ornl.gov
+ */
+
+#ifndef ADIOS2_ENGINE_TABLEWRITER_H_
+#define ADIOS2_ENGINE_TABLEWRITER_H_
+
+#include "adios2/ADIOSConfig.h"
+#include "adios2/core/Engine.h"
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+
+class TableWriter : public Engine
+{
+
+public:
+    /**
+     * Constructor for Writer
+     * @param name unique name given to the engine
+     * @param accessMode
+     * @param mpiComm
+     * @param method
+     * @param debugMode
+     */
+    TableWriter(IO &adios, const std::string &name, const Mode mode,
+                   MPI_Comm mpiComm);
+
+    ~TableWriter() = default;
+
+    StepStatus BeginStep(StepMode mode,
+                         const float timeoutSeconds = -1.0) final;
+    size_t CurrentStep() const final;
+    void PerformPuts() final;
+    void EndStep() final;
+    void Flush(const int transportIndex = -1) final;
+
+private:
+    int m_Verbosity = 0;
+    int m_CurrentStep = -1;
+    int m_MpiRank;
+
+    void Init() final;
+    void InitParameters() final;
+    void InitTransports() final;
+
+#define declare_type(T)                                                        \
+    void DoPutSync(Variable<T> &, const T *) final;                            \
+    void DoPutDeferred(Variable<T> &, const T *) final;
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+    /**
+     * Closes a single transport or all transports
+     * @param transportIndex, if -1 (default) closes all transports,
+     * otherwise it closes a transport in m_Transport[transportIndex].
+     * In debug mode the latter is bounds-checked.
+     */
+    void DoClose(const int transportIndex = -1) final;
+
+    /**
+     * Common function for primitive PutSync, puts variables in buffer
+     * @param variable
+     * @param values
+     */
+    template <class T>
+    void PutSyncCommon(Variable<T> &variable, const T *values);
+
+    template <class T>
+    void PutDeferredCommon(Variable<T> &variable, const T *values);
+};
+
+} // end namespace engine
+} // end namespace core
+} // end namespace adios2
+
+#endif /* ADIOS2_ENGINE_TABLEWRITER_H_ */

--- a/source/adios2/engine/table/TableWriter.tcc
+++ b/source/adios2/engine/table/TableWriter.tcc
@@ -70,6 +70,10 @@ void TableWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
             auto localPack = serializer->GetLocalPack();
             m_SendStagingMan.Request(*localPack, serializer->GetDestination());
             serializer->NewWriterBuffer(m_BufferSize);
+            if (m_Verbosity >= 5)
+            {
+                std::cout << "TableWriter::PutDeferredCommon Rank " << m_MpiRank << " Sent a package" << std::endl;
+            }
         }
     }
 

--- a/source/adios2/engine/table/TableWriter.tcc
+++ b/source/adios2/engine/table/TableWriter.tcc
@@ -68,11 +68,16 @@ void TableWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
         if (serializer->LocalBufferSize() > m_BufferSize / 2)
         {
             auto localPack = serializer->GetLocalPack();
-            m_SendStagingMan.Request(*localPack, serializer->GetDestination());
+            auto reply = m_SendStagingMan.Request(*localPack,
+                                                  serializer->GetDestination());
             serializer->NewWriterBuffer(m_BufferSize);
-            if (m_Verbosity >= 5)
+            if (m_Verbosity >= 1)
             {
-                std::cout << "TableWriter::PutDeferredCommon Rank " << m_MpiRank << " Sent a package" << std::endl;
+                std::cout << "TableWriter::PutDeferredCommon Rank " << m_MpiRank
+                          << " Sent a package of size " << localPack->size()
+                          << " to " << serializer->GetDestination()
+                          << " and received reply " << reply->data()[0]
+                          << std::endl;
             }
         }
     }

--- a/source/adios2/engine/table/TableWriter.tcc
+++ b/source/adios2/engine/table/TableWriter.tcc
@@ -7,11 +7,11 @@
  *  Created on: Apr 6, 2019
  *      Author: Jason Wang w4g@ornl.gov
  */
+
 #ifndef ADIOS2_ENGINE_TABLEWRITER_TCC_
 #define ADIOS2_ENGINE_TABLEWRITER_TCC_
 
 #include "TableWriter.h"
-
 #include <iostream>
 
 namespace adios2

--- a/source/adios2/engine/table/TableWriter.tcc
+++ b/source/adios2/engine/table/TableWriter.tcc
@@ -1,0 +1,41 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * TableWriter.tcc implementation of template functions with known type
+ *
+ *  Created on: Apr 6, 2019
+ *      Author: Jason Wang w4g@ornl.gov
+ */
+#ifndef ADIOS2_ENGINE_TABLEWRITER_TCC_
+#define ADIOS2_ENGINE_TABLEWRITER_TCC_
+
+#include "TableWriter.h"
+
+#include <iostream>
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+
+template <class T>
+void TableWriter::PutSyncCommon(Variable<T> &variable, const T *data)
+{
+    PutDeferredCommon(variable, data);
+    PerformPuts();
+}
+
+template <class T>
+void TableWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
+{
+    std::cout << " =========== table engine put" << std::endl;
+}
+
+} // end namespace engine
+} // end namespace core
+} // end namespace adios2
+
+#endif /* ADIOS2_ENGINE_TABLEWRITER_TCC_ */

--- a/source/adios2/engine/table/TableWriter.tcc
+++ b/source/adios2/engine/table/TableWriter.tcc
@@ -31,7 +31,33 @@ void TableWriter::PutSyncCommon(Variable<T> &variable, const T *data)
 template <class T>
 void TableWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
 {
-    std::cout << " =========== table engine put" << std::endl;
+
+    if(m_FirstPut)
+    {
+        m_FirstPut=false;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    if (variable.m_SingleValue)
+    {
+        variable.m_Shape = Dims(1, 1);
+        variable.m_Start = Dims(1, 0);
+        variable.m_Count = Dims(1, 1);
+    }
+    variable.SetData(data);
+
+    size_t total_size = std::accumulate(variable.m_Count.begin(), variable.m_Count.end(), sizeof(T), std::multiplies<size_t>());
+    m_DataManSerializer.New(total_size + 1024);
+    m_DataManSerializer.PutVar(variable, m_Name, CurrentStep(), m_MpiRank, m_AllAddresses[m_MpiRank], Params());
+    auto localPack = m_DataManSerializer.GetLocalPack();
+
+    auto ranks = WhichRanks(variable.m_Start, variable.m_Count);
+
+    for(const auto r : ranks)
+    {
+        m_SendStagingMan.Request(*localPack, m_AllAddresses[r]);
+    }
+
 }
 
 } // end namespace engine

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -25,6 +25,7 @@ DataManSerializer::DataManSerializer(MPI_Comm mpiComm,
                                      const size_t writerBufferSize,
                                      const bool isRowMajor)
 : m_MpiComm(mpiComm), m_IsRowMajor(isRowMajor),
+  m_IsLittleEndian(helper::IsLittleEndian()),
   m_DeferredRequestsToSend(std::make_shared<DeferredRequestMap>())
 {
     MPI_Comm_size(m_MpiComm, &m_MpiSize);

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -153,6 +153,10 @@ public:
                            const Dims &start, const Dims &count, void *data);
     DeferredRequestMapPtr GetDeferredRequest();
 
+    bool CalculateOverlap(const Dims &inStart, const Dims &inCount,
+                          const Dims &outStart, const Dims &outCount,
+                          Dims &ovlpStart, Dims &ovlpCount);
+
     size_t MinStep();
     size_t Steps();
 
@@ -179,9 +183,6 @@ private:
 
     void JsonToDataManVarMap(nlohmann::json &metaJ, VecPtr pack);
 
-    bool CalculateOverlap(const Dims &inStart, const Dims &inCount,
-                          const Dims &outStart, const Dims &outCount,
-                          Dims &ovlpStart, Dims &ovlpCount);
 
     VecPtr SerializeJson(const nlohmann::json &message);
     nlohmann::json DeserializeJson(const char *start, size_t size);

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -83,7 +83,8 @@ using DeferredRequestMapPtr = std::shared_ptr<DeferredRequestMap>;
 class DataManSerializer
 {
 public:
-    DataManSerializer(bool isRowMajor, const bool contiguousMajor, bool isLittleEndian, MPI_Comm mpiComm);
+    DataManSerializer(bool isRowMajor, const bool contiguousMajor,
+                      bool isLittleEndian, MPI_Comm mpiComm);
 
     // clear and allocate new buffer for writer
     void New(size_t size);

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -83,11 +83,11 @@ using DeferredRequestMapPtr = std::shared_ptr<DeferredRequestMap>;
 class DataManSerializer
 {
 public:
-    DataManSerializer(bool isRowMajor, const bool contiguousMajor,
-                      bool isLittleEndian, MPI_Comm mpiComm);
+    DataManSerializer(MPI_Comm mpiComm, const size_t writerBufferSize,
+                      const bool isRowMajor);
 
     // clear and allocate new buffer for writer
-    void New(size_t size);
+    void NewWriterBuffer(size_t size);
 
     // put a variable for writer
     template <class T>
@@ -113,6 +113,8 @@ public:
 
     // attach m_StaticDataJson to m_MetadataJson
     void AttachAttributes();
+
+    void SetReverseMajor();
 
     // get the metadata incorporated local buffer for writer, usually called in
     // EndStep
@@ -157,8 +159,12 @@ public:
                           const Dims &outStart, const Dims &outCount,
                           Dims &ovlpStart, Dims &ovlpCount);
 
+    void SetDestination(const std::string &dest);
+    std::string GetDestination();
+
     size_t MinStep();
     size_t Steps();
+    size_t LocalBufferSize();
 
 private:
     template <class T>
@@ -224,14 +230,14 @@ private:
     std::mutex m_StaticDataJsonMutex;
     bool m_StaticDataFinished = false;
 
-    // for generating deferred requests, only accessed from reader app thread,
+    // for generating deferred requests, only accessed from reader main thread,
     // does not need mutex
-
     DeferredRequestMapPtr m_DeferredRequestsToSend;
 
     // string, msgpack, cbor, ubjson
     std::string m_UseJsonSerialization = "string";
 
+    std::string m_Destination;
     bool m_IsRowMajor;
     bool m_IsLittleEndian;
     bool m_ContiguousMajor;

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -83,8 +83,7 @@ using DeferredRequestMapPtr = std::shared_ptr<DeferredRequestMap>;
 class DataManSerializer
 {
 public:
-    DataManSerializer(bool isRowMajor, const bool contiguousMajor,
-                      bool isLittleEndian, MPI_Comm mpiComm);
+    DataManSerializer(bool isRowMajor, const bool contiguousMajor, bool isLittleEndian, MPI_Comm mpiComm);
 
     // clear and allocate new buffer for writer
     void New(size_t size);
@@ -182,7 +181,6 @@ private:
                                 const std::string &type, const Dims &count);
 
     void JsonToDataManVarMap(nlohmann::json &metaJ, VecPtr pack);
-
 
     VecPtr SerializeJson(const nlohmann::json &message);
     nlohmann::json DeserializeJson(const char *start, size_t size);

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
@@ -112,13 +112,17 @@ void DataManSerializer::PutVar(const T *inputData, const std::string &varName,
 
     nlohmann::json metaj;
 
-    metaj["A"] = address;
     metaj["N"] = varName;
     metaj["O"] = varStart;
     metaj["C"] = varCount;
     metaj["S"] = varShape;
     metaj["Y"] = helper::GetType<T>();
     metaj["P"] = localBuffer->size();
+
+    if (not address.empty())
+    {
+        metaj["A"] = address;
+    }
 
     if (m_EnableStat)
     {

--- a/source/adios2/toolkit/transport/socket/SocketZmqReqRep.cpp
+++ b/source/adios2/toolkit/transport/socket/SocketZmqReqRep.cpp
@@ -43,7 +43,7 @@ SocketZmqReqRep::~SocketZmqReqRep()
 int SocketZmqReqRep::Open(const std::string &fullAddress, const Mode openMode)
 {
     std::string openModeStr;
-    int error = -1;
+    int error = -100;
     if (openMode == Mode::Write)
     {
         openModeStr = "Write/ZMQ_REP";

--- a/source/adios2/toolkit/transportman/stagingman/StagingMan.cpp
+++ b/source/adios2/toolkit/transportman/stagingman/StagingMan.cpp
@@ -56,6 +56,7 @@ StagingMan::Request(const std::vector<char> &request,
     }
 
     ret = m_Transport.Write(request.data(), request.size());
+
     start_time = std::chrono::system_clock::now();
     while (ret < 1)
     {
@@ -71,6 +72,7 @@ StagingMan::Request(const std::vector<char> &request,
     }
 
     ret = m_Transport.Read(m_Buffer.data(), m_MaxBufferSize);
+
     start_time = std::chrono::system_clock::now();
     while (ret < 1)
     {

--- a/testing/adios2/engine/CMakeLists.txt
+++ b/testing/adios2/engine/CMakeLists.txt
@@ -17,6 +17,10 @@ if(ADIOS2_HAVE_DataMan)
   add_subdirectory(dataman)
 endif()
 
+if(ADIOS2_HAVE_Table)
+  add_subdirectory(table)
+endif()
+
 if(ADIOS2_HAVE_SSC)
   add_subdirectory(ssc)
 endif()

--- a/testing/adios2/engine/table/CMakeLists.txt
+++ b/testing/adios2/engine/table/CMakeLists.txt
@@ -1,0 +1,11 @@
+#------------------------------------------------------------------------------#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#------------------------------------------------------------------------------#
+
+if(ADIOS2_HAVE_MPI AND ADIOS2_HAVE_ZeroMQ)
+    add_executable(TestTableBase TableBase.cpp)
+    target_link_libraries(TestTableBase adios2 gtest MPI::MPI_C)
+    add_test(NAME TableBase COMMAND "mpirun" "-n" "4" $<TARGET_FILE:TestTableBase>)
+endif()
+

--- a/testing/adios2/engine/table/TableBase.cpp
+++ b/testing/adios2/engine/table/TableBase.cpp
@@ -1,0 +1,305 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+
+#include <adios2.h>
+#include <gtest/gtest.h>
+#ifdef ADIOS2_HAVE_MPI
+#include <mpi.h>
+#endif
+#include <numeric>
+#include <thread>
+
+using namespace adios2;
+int mpiRank = 0;
+int mpiSize = 1;
+size_t print_lines = 0;
+
+char runMode;
+
+class TableEngineTest : public ::testing::Test
+{
+public:
+    TableEngineTest() = default;
+};
+
+template <class T>
+void PrintData(const T *data, const size_t step, const Dims &start,
+               const Dims &count)
+{
+    size_t size = std::accumulate(count.begin(), count.end(), 1,
+                                  std::multiplies<size_t>());
+    std::cout << "Rank: " << mpiRank << " Step: " << step << " Size:" << size
+              << "\n";
+    size_t printsize = 128;
+
+    if (size < printsize)
+    {
+        printsize = size;
+    }
+    int s = 0;
+    for (size_t i = 0; i < printsize; ++i)
+    {
+        ++s;
+        std::cout << data[i] << " ";
+        if (s == count[1])
+        {
+            std::cout << std::endl;
+            s = 0;
+        }
+    }
+
+    std::cout << "]" << std::endl;
+}
+
+template <class T>
+void GenData(std::vector<T> &data, const size_t step, const Dims &start, const Dims &count, const Dims &shape)
+{
+    for (size_t i = 0; i < count[1]; ++i)
+    {
+        for (size_t j = 0; j < count[2]; ++j)
+        {
+            data[i * count[2] + j] = i * count[2] + j;
+        }
+    }
+}
+
+template <class T>
+void VerifyData(const std::complex<T> *data, size_t step, const Dims &start,
+                const Dims &count, const Dims &shape)
+{
+    size_t size = std::accumulate(count.begin(), count.end(), 1,
+                                  std::multiplies<size_t>());
+    std::vector<std::complex<T>> tmpdata(size);
+    GenData(tmpdata, step, start, count, shape);
+    for (size_t i = 0; i < size; ++i)
+    {
+        ASSERT_EQ(data[i], tmpdata[i]);
+    }
+    if (print_lines < 100)
+    {
+        PrintData(data, step, start, count);
+        ++print_lines;
+    }
+}
+
+template <class T>
+void VerifyData(const T *data, size_t step, const Dims &start,
+                const Dims &count, const Dims &shape)
+{
+    size_t size = std::accumulate(count.begin(), count.end(), 1,
+                                  std::multiplies<size_t>());
+    bool compressed = false;
+    std::vector<T> tmpdata(size);
+    if (print_lines < 100)
+    {
+        PrintData(data, step, start, count);
+        ++print_lines;
+    }
+    GenData(tmpdata, step, start, count, shape);
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (!compressed)
+        {
+            ASSERT_EQ(data[i], tmpdata[i]);
+        }
+    }
+}
+
+void Reader(const Dims &shape, const Dims &start, const Dims &count,
+            const size_t steps, const adios2::Params &engineParams,
+            const std::string &name)
+{
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+    adios2::IO dataManIO = adios.DeclareIO("Test");
+    dataManIO.SetEngine("BPFile");
+    dataManIO.SetParameters(engineParams);
+    adios2::Engine dataManReader = dataManIO.Open(name, adios2::Mode::Read);
+    size_t datasize = std::accumulate(count.begin(), count.end(), 1, std::multiplies<size_t>());
+    std::vector<char> myChars(datasize);
+    std::vector<unsigned char> myUChars(datasize);
+    std::vector<short> myShorts(datasize);
+    std::vector<unsigned short> myUShorts(datasize);
+    std::vector<int> myInts(datasize);
+    std::vector<unsigned int> myUInts(datasize);
+    std::vector<float> myFloats(datasize);
+    std::vector<double> myDoubles(datasize);
+    std::vector<std::complex<float>> myComplexes(datasize);
+    std::vector<std::complex<double>> myDComplexes(datasize);
+
+    bool received_steps = false;
+    size_t i;
+    for (i = 0; i < steps; ++i)
+    {
+
+        adios2::StepStatus status = dataManReader.BeginStep(StepMode::Read, 5);
+
+        received_steps = true;
+        const auto &vars = dataManIO.AvailableVariables();
+        if (print_lines == 0)
+        {
+            std::cout << "All available variables : ";
+            for (const auto &var : vars)
+            {
+                std::cout << var.first << ", ";
+            }
+            std::cout << std::endl;
+        }
+        ASSERT_EQ(vars.size(), 10);
+        size_t currentStep = dataManReader.CurrentStep();
+        adios2::Variable<char> bpChars =
+            dataManIO.InquireVariable<char>("bpChars");
+        adios2::Variable<unsigned char> bpUChars =
+            dataManIO.InquireVariable<unsigned char>("bpUChars");
+        adios2::Variable<short> bpShorts =
+            dataManIO.InquireVariable<short>("bpShorts");
+        adios2::Variable<unsigned short> bpUShorts =
+            dataManIO.InquireVariable<unsigned short>("bpUShorts");
+        adios2::Variable<int> bpInts =
+            dataManIO.InquireVariable<int>("bpInts");
+        adios2::Variable<unsigned int> bpUInts =
+            dataManIO.InquireVariable<unsigned int>("bpUInts");
+        adios2::Variable<float> bpFloats =
+            dataManIO.InquireVariable<float>("bpFloats");
+        adios2::Variable<double> bpDoubles =
+            dataManIO.InquireVariable<double>("bpDoubles");
+        adios2::Variable<std::complex<float>> bpComplexes =
+            dataManIO.InquireVariable<std::complex<float>>("bpComplexes");
+        adios2::Variable<std::complex<double>> bpDComplexes =
+            dataManIO.InquireVariable<std::complex<double>>("bpDComplexes");
+        auto charsBlocksInfo = dataManReader.AllStepsBlocksInfo(bpChars);
+
+        bpChars.SetSelection({start, count});
+        bpUChars.SetSelection({start, count});
+        bpShorts.SetSelection({start, count});
+        bpUShorts.SetSelection({start, count});
+        bpInts.SetSelection({start, count});
+        bpUInts.SetSelection({start, count});
+        bpFloats.SetSelection({start, count});
+        bpDoubles.SetSelection({start, count});
+        bpComplexes.SetSelection({start, count});
+        bpDComplexes.SetSelection({start, count});
+
+        dataManReader.Get(bpChars, myChars.data(), adios2::Mode::Sync);
+        dataManReader.Get(bpUChars, myUChars.data(), adios2::Mode::Sync);
+        dataManReader.Get(bpShorts, myShorts.data(), adios2::Mode::Sync);
+        dataManReader.Get(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
+        dataManReader.Get(bpInts, myInts.data(), adios2::Mode::Sync);
+        dataManReader.Get(bpUInts, myUInts.data(), adios2::Mode::Sync);
+        dataManReader.Get(bpFloats, myFloats.data(), adios2::Mode::Sync);
+        dataManReader.Get(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
+        dataManReader.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
+        dataManReader.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
+        VerifyData(myChars.data(), currentStep, start, count, shape);
+        VerifyData(myUChars.data(), currentStep, start, count, shape);
+        VerifyData(myShorts.data(), currentStep, start, count, shape);
+        VerifyData(myUShorts.data(), currentStep, start, count, shape);
+        VerifyData(myInts.data(), currentStep, start, count, shape);
+        VerifyData(myUInts.data(), currentStep, start, count, shape);
+        VerifyData(myFloats.data(), currentStep, start, count, shape);
+        VerifyData(myDoubles.data(), currentStep, start, count, shape);
+        VerifyData(myComplexes.data(), currentStep, start, count, shape);
+        VerifyData(myDComplexes.data(), currentStep, start, count, shape);
+        dataManReader.EndStep();
+    }
+    dataManReader.Close();
+    print_lines = 0;
+}
+
+void Writer(const Dims &shape, const Dims &start, const Dims &count, const size_t rows, const adios2::Params &engineParams, const std::string &name)
+{
+    size_t datasize = std::accumulate(count.begin(), count.end(), 1, std::multiplies<size_t>());
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+    adios2::IO dataManIO = adios.DeclareIO("ms");
+    dataManIO.SetEngine("table");
+    dataManIO.SetParameters(engineParams);
+    std::vector<char> myChars(datasize);
+    std::vector<unsigned char> myUChars(datasize);
+    std::vector<short> myShorts(datasize);
+    std::vector<unsigned short> myUShorts(datasize);
+    std::vector<int> myInts(datasize);
+    std::vector<unsigned int> myUInts(datasize);
+    std::vector<float> myFloats(datasize);
+    std::vector<double> myDoubles(datasize);
+    std::vector<std::complex<float>> myComplexes(datasize);
+    std::vector<std::complex<double>> myDComplexes(datasize);
+    auto bpChars = dataManIO.DefineVariable<char>("bpChars", shape, start, count);
+    auto bpUChars = dataManIO.DefineVariable<unsigned char>("bpUChars", shape, start, count);
+    auto bpShorts = dataManIO.DefineVariable<short>("bpShorts", shape, start, count);
+    auto bpUShorts = dataManIO.DefineVariable<unsigned short>( "bpUShorts", shape, start, count);
+    auto bpInts = dataManIO.DefineVariable<int>("bpInts", shape, start, count);
+    auto bpUInts = dataManIO.DefineVariable<unsigned int>("bpUInts", shape, start, count);
+    auto bpFloats = dataManIO.DefineVariable<float>("bpFloats", shape, start, count);
+    auto bpDoubles = dataManIO.DefineVariable<double>("bpDoubles", shape, start, count);
+    auto bpComplexes = dataManIO.DefineVariable<std::complex<float>>( "bpComplexes", shape, start, count);
+    auto bpDComplexes = dataManIO.DefineVariable<std::complex<double>>( "bpDComplexes", shape, start, count);
+    adios2::Engine tableWriter = dataManIO.Open(name, adios2::Mode::Write);
+    tableWriter.BeginStep();
+    for (int i = 0; i < rows; ++i)
+    {
+        Dims startRow = start;
+        startRow[0] = i;
+        bpChars.SetSelection({startRow, count});
+        bpUChars.SetSelection({startRow, count});
+        bpShorts.SetSelection({startRow, count});
+        bpUShorts.SetSelection({startRow, count});
+        bpInts.SetSelection({startRow, count});
+        bpUInts.SetSelection({startRow, count});
+        bpFloats.SetSelection({startRow, count});
+        bpDoubles.SetSelection({startRow, count});
+        bpComplexes.SetSelection({startRow, count});
+        bpDComplexes.SetSelection({startRow, count});
+        GenData(myChars, i, startRow, count, shape);
+        GenData(myUChars, i, startRow, count, shape);
+        GenData(myShorts, i, startRow, count, shape);
+        GenData(myUShorts, i, startRow, count, shape);
+        GenData(myInts, i, startRow, count, shape);
+        GenData(myUInts, i, startRow, count, shape);
+        GenData(myFloats, i, startRow, count, shape);
+        GenData(myDoubles, i, startRow, count, shape);
+        GenData(myComplexes, i, startRow, count, shape);
+        GenData(myDComplexes, i, startRow, count, shape);
+        tableWriter.Put(bpChars, myChars.data(), adios2::Mode::Sync);
+        tableWriter.Put(bpUChars, myUChars.data(), adios2::Mode::Sync);
+        tableWriter.Put(bpShorts, myShorts.data(), adios2::Mode::Sync);
+        tableWriter.Put(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
+        tableWriter.Put(bpInts, myInts.data(), adios2::Mode::Sync);
+        tableWriter.Put(bpUInts, myUInts.data(), adios2::Mode::Sync);
+        tableWriter.Put(bpFloats, myFloats.data(), adios2::Mode::Sync);
+        tableWriter.Put(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
+        tableWriter.Put(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
+        tableWriter.Put(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
+    }
+    tableWriter.EndStep();
+    tableWriter.Close();
+}
+
+TEST_F(TableEngineTest, TableBase)
+{
+    std::string filename = "TableBase";
+    adios2::Params engineParams = {{"Verbose", "11"}};
+
+    size_t rows = 1000;
+    Dims shape = {rows, 1, 128};
+    Dims start = {0, 0, 0};
+    Dims count = {1, 1, 128};
+
+    Writer(shape, start, count, rows, engineParams, filename);
+
+//        Reader(shape, start, count, 10, engineParams, filename);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+    result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
+}

--- a/testing/adios2/engine/table/TableBase.cpp
+++ b/testing/adios2/engine/table/TableBase.cpp
@@ -14,7 +14,6 @@
 using namespace adios2;
 int mpiRank = 0;
 int mpiSize = 1;
-size_t print_lines = 0;
 
 char runMode;
 
@@ -25,98 +24,54 @@ public:
 };
 
 template <class T>
-void PrintData(const T *data, const size_t step, const Dims &start,
-               const Dims &count)
-{
-    size_t size = std::accumulate(count.begin(), count.end(), 1,
-                                  std::multiplies<size_t>());
-    std::cout << "Rank: " << mpiRank << " Step: " << step << " Size:" << size
-              << "\n";
-    size_t printsize = 128;
-
-    if (size < printsize)
-    {
-        printsize = size;
-    }
-    int s = 0;
-    for (size_t i = 0; i < printsize; ++i)
-    {
-        ++s;
-        std::cout << data[i] << " ";
-        if (s == count[1])
-        {
-            std::cout << std::endl;
-            s = 0;
-        }
-    }
-
-    std::cout << "]" << std::endl;
-}
-
-template <class T>
-void GenData(std::vector<T> &data, const size_t step, const Dims &start, const Dims &count, const Dims &shape)
+void GenData(T *data, const size_t row, const Dims &count)
 {
     for (size_t i = 0; i < count[1]; ++i)
     {
         for (size_t j = 0; j < count[2]; ++j)
         {
-            data[i * count[2] + j] = i * count[2] + j;
+            data[i * count[2] + j] = i * count[2] + j + row;
         }
     }
 }
 
 template <class T>
-void VerifyData(const std::complex<T> *data, size_t step, const Dims &start,
-                const Dims &count, const Dims &shape)
+void GenData(std::vector<T> &data, const size_t row, const Dims &count)
 {
-    size_t size = std::accumulate(count.begin(), count.end(), 1,
-                                  std::multiplies<size_t>());
-    std::vector<std::complex<T>> tmpdata(size);
-    GenData(tmpdata, step, start, count, shape);
-    for (size_t i = 0; i < size; ++i)
+    GenData(data.data(), row, count);
+}
+
+template <class T>
+void VerifyData(const T *data, const size_t rows, const Dims &shape)
+{
+    size_t columnSize = std::accumulate(shape.begin(), shape.end(), 1,
+                                        std::multiplies<size_t>());
+    size_t rowSize = std::accumulate(shape.begin() + 1, shape.end(), 1,
+                                     std::multiplies<size_t>());
+    std::vector<T> tmpdata(columnSize);
+    size_t position = 0;
+    for (size_t i = 0; i < rows; ++i)
+    {
+        GenData(tmpdata.data() + position, i, shape);
+        position += rowSize;
+    }
+    for (size_t i = 0; i < columnSize; ++i)
     {
         ASSERT_EQ(data[i], tmpdata[i]);
-    }
-    if (print_lines < 100)
-    {
-        PrintData(data, step, start, count);
-        ++print_lines;
-    }
-}
-
-template <class T>
-void VerifyData(const T *data, size_t step, const Dims &start,
-                const Dims &count, const Dims &shape)
-{
-    size_t size = std::accumulate(count.begin(), count.end(), 1,
-                                  std::multiplies<size_t>());
-    bool compressed = false;
-    std::vector<T> tmpdata(size);
-    if (print_lines < 100)
-    {
-        PrintData(data, step, start, count);
-        ++print_lines;
-    }
-    GenData(tmpdata, step, start, count, shape);
-    for (size_t i = 0; i < size; ++i)
-    {
-        if (!compressed)
-        {
-            ASSERT_EQ(data[i], tmpdata[i]);
-        }
     }
 }
 
 void Reader(const Dims &shape, const Dims &start, const Dims &count,
-            const size_t steps, const adios2::Params &engineParams,
+            const size_t rows, const adios2::Params &engineParams,
             const std::string &name)
 {
     adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
     adios2::IO dataManIO = adios.DeclareIO("Test");
-    dataManIO.SetEngine("BPFile");
+    dataManIO.SetEngine("BP4");
     dataManIO.SetParameters(engineParams);
     adios2::Engine dataManReader = dataManIO.Open(name, adios2::Mode::Read);
-    size_t datasize = std::accumulate(count.begin(), count.end(), 1, std::multiplies<size_t>());
+    size_t datasize = std::accumulate(shape.begin(), shape.end(), 1,
+                                      std::multiplies<size_t>());
     std::vector<char> myChars(datasize);
     std::vector<unsigned char> myUChars(datasize);
     std::vector<short> myShorts(datasize);
@@ -128,88 +83,77 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
     std::vector<std::complex<float>> myComplexes(datasize);
     std::vector<std::complex<double>> myDComplexes(datasize);
 
-    bool received_steps = false;
-    size_t i;
-    for (i = 0; i < steps; ++i)
+    adios2::StepStatus status = dataManReader.BeginStep(StepMode::Read, 5);
+    const auto &vars = dataManIO.AvailableVariables();
+    std::cout << "All available variables : ";
+    for (const auto &var : vars)
     {
-
-        adios2::StepStatus status = dataManReader.BeginStep(StepMode::Read, 5);
-
-        received_steps = true;
-        const auto &vars = dataManIO.AvailableVariables();
-        if (print_lines == 0)
-        {
-            std::cout << "All available variables : ";
-            for (const auto &var : vars)
-            {
-                std::cout << var.first << ", ";
-            }
-            std::cout << std::endl;
-        }
-        ASSERT_EQ(vars.size(), 10);
-        size_t currentStep = dataManReader.CurrentStep();
-        adios2::Variable<char> bpChars =
-            dataManIO.InquireVariable<char>("bpChars");
-        adios2::Variable<unsigned char> bpUChars =
-            dataManIO.InquireVariable<unsigned char>("bpUChars");
-        adios2::Variable<short> bpShorts =
-            dataManIO.InquireVariable<short>("bpShorts");
-        adios2::Variable<unsigned short> bpUShorts =
-            dataManIO.InquireVariable<unsigned short>("bpUShorts");
-        adios2::Variable<int> bpInts =
-            dataManIO.InquireVariable<int>("bpInts");
-        adios2::Variable<unsigned int> bpUInts =
-            dataManIO.InquireVariable<unsigned int>("bpUInts");
-        adios2::Variable<float> bpFloats =
-            dataManIO.InquireVariable<float>("bpFloats");
-        adios2::Variable<double> bpDoubles =
-            dataManIO.InquireVariable<double>("bpDoubles");
-        adios2::Variable<std::complex<float>> bpComplexes =
-            dataManIO.InquireVariable<std::complex<float>>("bpComplexes");
-        adios2::Variable<std::complex<double>> bpDComplexes =
-            dataManIO.InquireVariable<std::complex<double>>("bpDComplexes");
-        auto charsBlocksInfo = dataManReader.AllStepsBlocksInfo(bpChars);
-
-        bpChars.SetSelection({start, count});
-        bpUChars.SetSelection({start, count});
-        bpShorts.SetSelection({start, count});
-        bpUShorts.SetSelection({start, count});
-        bpInts.SetSelection({start, count});
-        bpUInts.SetSelection({start, count});
-        bpFloats.SetSelection({start, count});
-        bpDoubles.SetSelection({start, count});
-        bpComplexes.SetSelection({start, count});
-        bpDComplexes.SetSelection({start, count});
-
-        dataManReader.Get(bpChars, myChars.data(), adios2::Mode::Sync);
-        dataManReader.Get(bpUChars, myUChars.data(), adios2::Mode::Sync);
-        dataManReader.Get(bpShorts, myShorts.data(), adios2::Mode::Sync);
-        dataManReader.Get(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
-        dataManReader.Get(bpInts, myInts.data(), adios2::Mode::Sync);
-        dataManReader.Get(bpUInts, myUInts.data(), adios2::Mode::Sync);
-        dataManReader.Get(bpFloats, myFloats.data(), adios2::Mode::Sync);
-        dataManReader.Get(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
-        dataManReader.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
-        dataManReader.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
-        VerifyData(myChars.data(), currentStep, start, count, shape);
-        VerifyData(myUChars.data(), currentStep, start, count, shape);
-        VerifyData(myShorts.data(), currentStep, start, count, shape);
-        VerifyData(myUShorts.data(), currentStep, start, count, shape);
-        VerifyData(myInts.data(), currentStep, start, count, shape);
-        VerifyData(myUInts.data(), currentStep, start, count, shape);
-        VerifyData(myFloats.data(), currentStep, start, count, shape);
-        VerifyData(myDoubles.data(), currentStep, start, count, shape);
-        VerifyData(myComplexes.data(), currentStep, start, count, shape);
-        VerifyData(myDComplexes.data(), currentStep, start, count, shape);
-        dataManReader.EndStep();
+        std::cout << var.first << ", ";
     }
+    std::cout << std::endl;
+    ASSERT_EQ(vars.size(), 10);
+
+    adios2::Variable<char> bpChars = dataManIO.InquireVariable<char>("bpChars");
+    adios2::Variable<unsigned char> bpUChars =
+        dataManIO.InquireVariable<unsigned char>("bpUChars");
+    adios2::Variable<short> bpShorts =
+        dataManIO.InquireVariable<short>("bpShorts");
+    adios2::Variable<unsigned short> bpUShorts =
+        dataManIO.InquireVariable<unsigned short>("bpUShorts");
+    adios2::Variable<int> bpInts = dataManIO.InquireVariable<int>("bpInts");
+    adios2::Variable<unsigned int> bpUInts =
+        dataManIO.InquireVariable<unsigned int>("bpUInts");
+    adios2::Variable<float> bpFloats =
+        dataManIO.InquireVariable<float>("bpFloats");
+    adios2::Variable<double> bpDoubles =
+        dataManIO.InquireVariable<double>("bpDoubles");
+    adios2::Variable<std::complex<float>> bpComplexes =
+        dataManIO.InquireVariable<std::complex<float>>("bpComplexes");
+    adios2::Variable<std::complex<double>> bpDComplexes =
+        dataManIO.InquireVariable<std::complex<double>>("bpDComplexes");
+
+    bpChars.SetSelection({start, shape});
+    bpUChars.SetSelection({start, shape});
+    bpShorts.SetSelection({start, shape});
+    bpUShorts.SetSelection({start, shape});
+    bpInts.SetSelection({start, shape});
+    bpUInts.SetSelection({start, shape});
+    bpFloats.SetSelection({start, shape});
+    bpDoubles.SetSelection({start, shape});
+    bpComplexes.SetSelection({start, shape});
+    bpDComplexes.SetSelection({start, shape});
+
+    dataManReader.Get(bpChars, myChars.data(), adios2::Mode::Sync);
+    dataManReader.Get(bpUChars, myUChars.data(), adios2::Mode::Sync);
+    dataManReader.Get(bpShorts, myShorts.data(), adios2::Mode::Sync);
+    dataManReader.Get(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
+    dataManReader.Get(bpInts, myInts.data(), adios2::Mode::Sync);
+    dataManReader.Get(bpUInts, myUInts.data(), adios2::Mode::Sync);
+    dataManReader.Get(bpFloats, myFloats.data(), adios2::Mode::Sync);
+    dataManReader.Get(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
+    dataManReader.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
+    dataManReader.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
+
+    VerifyData(myChars.data(), rows, shape);
+    VerifyData(myUChars.data(), rows, shape);
+    VerifyData(myShorts.data(), rows, shape);
+    VerifyData(myUShorts.data(), rows, shape);
+    VerifyData(myInts.data(), rows, shape);
+    VerifyData(myUInts.data(), rows, shape);
+    VerifyData(myFloats.data(), rows, shape);
+    VerifyData(myDoubles.data(), rows, shape);
+    VerifyData(myComplexes.data(), rows, shape);
+    VerifyData(myDComplexes.data(), rows, shape);
+    dataManReader.EndStep();
     dataManReader.Close();
-    print_lines = 0;
 }
 
-void Writer(const Dims &shape, const Dims &start, const Dims &count, const size_t rows, const adios2::Params &engineParams, const std::string &name)
+void Writer(const Dims &shape, const Dims &start, const Dims &count,
+            const size_t rows, const adios2::Params &engineParams,
+            const std::string &name)
 {
-    size_t datasize = std::accumulate(count.begin(), count.end(), 1, std::multiplies<size_t>());
+    size_t datasize = std::accumulate(count.begin(), count.end(), 1,
+                                      std::multiplies<size_t>());
     adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
     adios2::IO dataManIO = adios.DeclareIO("ms");
     dataManIO.SetEngine("table");
@@ -224,19 +168,28 @@ void Writer(const Dims &shape, const Dims &start, const Dims &count, const size_
     std::vector<double> myDoubles(datasize);
     std::vector<std::complex<float>> myComplexes(datasize);
     std::vector<std::complex<double>> myDComplexes(datasize);
-    auto bpChars = dataManIO.DefineVariable<char>("bpChars", shape, start, count);
-    auto bpUChars = dataManIO.DefineVariable<unsigned char>("bpUChars", shape, start, count);
-    auto bpShorts = dataManIO.DefineVariable<short>("bpShorts", shape, start, count);
-    auto bpUShorts = dataManIO.DefineVariable<unsigned short>( "bpUShorts", shape, start, count);
+    auto bpChars =
+        dataManIO.DefineVariable<char>("bpChars", shape, start, count);
+    auto bpUChars = dataManIO.DefineVariable<unsigned char>("bpUChars", shape,
+                                                            start, count);
+    auto bpShorts =
+        dataManIO.DefineVariable<short>("bpShorts", shape, start, count);
+    auto bpUShorts = dataManIO.DefineVariable<unsigned short>(
+        "bpUShorts", shape, start, count);
     auto bpInts = dataManIO.DefineVariable<int>("bpInts", shape, start, count);
-    auto bpUInts = dataManIO.DefineVariable<unsigned int>("bpUInts", shape, start, count);
-    auto bpFloats = dataManIO.DefineVariable<float>("bpFloats", shape, start, count);
-    auto bpDoubles = dataManIO.DefineVariable<double>("bpDoubles", shape, start, count);
-    auto bpComplexes = dataManIO.DefineVariable<std::complex<float>>( "bpComplexes", shape, start, count);
-    auto bpDComplexes = dataManIO.DefineVariable<std::complex<double>>( "bpDComplexes", shape, start, count);
+    auto bpUInts =
+        dataManIO.DefineVariable<unsigned int>("bpUInts", shape, start, count);
+    auto bpFloats =
+        dataManIO.DefineVariable<float>("bpFloats", shape, start, count);
+    auto bpDoubles =
+        dataManIO.DefineVariable<double>("bpDoubles", shape, start, count);
+    auto bpComplexes = dataManIO.DefineVariable<std::complex<float>>(
+        "bpComplexes", shape, start, count);
+    auto bpDComplexes = dataManIO.DefineVariable<std::complex<double>>(
+        "bpDComplexes", shape, start, count);
     adios2::Engine tableWriter = dataManIO.Open(name, adios2::Mode::Write);
     tableWriter.BeginStep();
-    for (int i = 0; i < rows; ++i)
+    for (int i = mpiRank; i < rows; i += mpiSize)
     {
         Dims startRow = start;
         startRow[0] = i;
@@ -250,16 +203,16 @@ void Writer(const Dims &shape, const Dims &start, const Dims &count, const size_
         bpDoubles.SetSelection({startRow, count});
         bpComplexes.SetSelection({startRow, count});
         bpDComplexes.SetSelection({startRow, count});
-        GenData(myChars, i, startRow, count, shape);
-        GenData(myUChars, i, startRow, count, shape);
-        GenData(myShorts, i, startRow, count, shape);
-        GenData(myUShorts, i, startRow, count, shape);
-        GenData(myInts, i, startRow, count, shape);
-        GenData(myUInts, i, startRow, count, shape);
-        GenData(myFloats, i, startRow, count, shape);
-        GenData(myDoubles, i, startRow, count, shape);
-        GenData(myComplexes, i, startRow, count, shape);
-        GenData(myDComplexes, i, startRow, count, shape);
+        GenData(myChars, i, count);
+        GenData(myUChars, i, count);
+        GenData(myShorts, i, count);
+        GenData(myUShorts, i, count);
+        GenData(myInts, i, count);
+        GenData(myUInts, i, count);
+        GenData(myFloats, i, count);
+        GenData(myDoubles, i, count);
+        GenData(myComplexes, i, count);
+        GenData(myDComplexes, i, count);
         tableWriter.Put(bpChars, myChars.data(), adios2::Mode::Sync);
         tableWriter.Put(bpUChars, myUChars.data(), adios2::Mode::Sync);
         tableWriter.Put(bpShorts, myShorts.data(), adios2::Mode::Sync);
@@ -278,16 +231,17 @@ void Writer(const Dims &shape, const Dims &start, const Dims &count, const size_
 TEST_F(TableEngineTest, TableBase)
 {
     std::string filename = "TableBase";
-    adios2::Params engineParams = {{"Verbose", "11"}};
+    adios2::Params engineParams = {{"Verbose", "0"},
+                                   {"RowsPerAggregatorBuffer", "40"}};
 
-    size_t rows = 1000;
+    size_t rows = 10000;
     Dims shape = {rows, 1, 128};
     Dims start = {0, 0, 0};
     Dims count = {1, 1, 128};
 
     Writer(shape, start, count, rows, engineParams, filename);
 
-//        Reader(shape, start, count, 10, engineParams, filename);
+    Reader(shape, start, count, rows, engineParams, filename);
 
     MPI_Barrier(MPI_COMM_WORLD);
 }


### PR DESCRIPTION
The table engine is a meta-engine that uses BP4 underneath. Before offloading IO operations to the BP4 engine, it merges small puts into larger blocks to reduce the metadata size. The aggregation is done using the ZeroMQ transport.