### PR TITLE
python hl

### DIFF
--- a/bindings/Python/py11File.cpp
+++ b/bindings/Python/py11File.cpp
@@ -214,6 +214,12 @@ std::vector<std::string> File::ReadString(const std::string &name,
 
 pybind11::array File::Read(const std::string &name, const size_t blockID)
 {
+    return Read(name, {}, {}, blockID);
+}
+
+pybind11::array File::Read(const std::string &name, const Dims &start,
+                           const Dims &count, const size_t blockID)
+{
     const std::string type = m_Stream->m_IO->InquireVariableType(name);
 
     if (type == helper::GetType<std::string>())
@@ -227,36 +233,7 @@ pybind11::array File::Read(const std::string &name, const size_t blockID)
 #define declare_type(T)                                                        \
     else if (type == helper::GetType<T>())                                     \
     {                                                                          \
-        core::Variable<T> &variable =                                          \
-            *m_Stream->m_IO->InquireVariable<T>(name);                         \
-        return DoRead(variable, blockID);                                      \
-    }
-    ADIOS2_FOREACH_NUMPY_TYPE_1ARG(declare_type)
-#undef declare_type
-    else
-    {
-        throw std::invalid_argument(
-            "ERROR: adios2 file read variable " + name +
-            ", type can't be mapped to a numpy type, in call to read\n");
-    }
-    return pybind11::array();
-}
-
-pybind11::array File::Read(const std::string &name, const Dims &start,
-                           const Dims &count, const size_t blockID)
-{
-    const std::string type = m_Stream->m_IO->InquireVariableType(name);
-
-    if (type.empty())
-    {
-    }
-#define declare_type(T)                                                        \
-    else if (type == helper::GetType<T>())                                     \
-    {                                                                          \
-        pybind11::array_t<T> pyArray(count);                                   \
-        m_Stream->Read<T>(name, pyArray.mutable_data(),                        \
-                          Box<Dims>(start, count), blockID);                   \
-        return pyArray;                                                        \
+        return DoRead<T>(name, start, count, blockID);                         \
     }
     ADIOS2_FOREACH_NUMPY_TYPE_1ARG(declare_type)
 #undef declare_type

--- a/bindings/Python/py11File.h
+++ b/bindings/Python/py11File.h
@@ -123,7 +123,8 @@ private:
     adios2::Mode ToMode(const std::string mode) const;
 
     template <class T>
-    pybind11::array DoRead(core::Variable<T> &variable, const size_t blockID);
+    pybind11::array DoRead(const std::string &name, const Dims &start,
+                           const Dims &count, const size_t blockID);
 };
 
 } // end namespace py11

--- a/bindings/Python/py11File.h
+++ b/bindings/Python/py11File.h
@@ -124,7 +124,8 @@ private:
 
     template <class T>
     pybind11::array DoRead(const std::string &name, const Dims &start,
-                           const Dims &count, const size_t blockID);
+                           const Dims &count, const size_t stepStart,
+                           const size_t stepCount, const size_t blockID);
 };
 
 } // end namespace py11

--- a/bindings/Python/py11File.tcc
+++ b/bindings/Python/py11File.tcc
@@ -42,11 +42,8 @@ pybind11::array File::DoRead(core::Variable<T> &variable, const size_t blockID)
         if (variable.m_SingleValue)
         {
             count = Dims{1};
-            pybind11::array pyArray(pybind11::dtype::of<T>(), count);
-            m_Stream->Read<T>(
-                variable.m_Name,
-                reinterpret_cast<T *>(const_cast<void *>(pyArray.data())),
-                blockID);
+            pybind11::array_t<T> pyArray(count);
+            m_Stream->Read<T>(variable.m_Name, pyArray.mutable_data(), blockID);
             return pyArray;
         }
     }

--- a/bindings/Python/py11File.tcc
+++ b/bindings/Python/py11File.tcc
@@ -20,38 +20,14 @@ namespace py11
 
 template <class T>
 pybind11::array File::DoRead(const std::string &name, const Dims &_start,
-                             const Dims &_count, const size_t blockID)
+                             const Dims &_count, const size_t stepStart,
+                             const size_t stepCount, const size_t blockID)
 {
     core::Variable<T> &variable = *m_Stream->m_IO->InquireVariable<T>(name);
     Dims &shape = variable.m_Shape;
-
     Dims start = _start;
-    if (start.empty())
-    {
-        // default start to be (0, 0, ...)
-        start = Dims(shape.size());
-    }
-
     Dims count = _count;
-    if (count.empty())
-    {
-        if (variable.m_ShapeID == ShapeID::GlobalArray)
-        {
-            // default count is everything (shape of whole array)
-            count = shape;
-        }
-        else if (variable.m_ShapeID == ShapeID::LocalArray)
-        {
-            variable.SetBlockSelection(blockID);
-            count = variable.Count();
-        }
-    }
 
-    if (variable.m_ShapeID == ShapeID::GlobalValue)
-    {
-        count = Dims{1};
-    }
-    pybind11::array_t<T> pyArray(count);
     if (variable.m_ShapeID == ShapeID::GlobalValue)
     {
         if (!(_start.empty() && _count.empty()))
@@ -59,14 +35,63 @@ pybind11::array File::DoRead(const std::string &name, const Dims &_start,
             throw std::invalid_argument("when reading a scalar, start and "
                                         "count cannot be specified.\n");
         }
-        m_Stream->Read<T>(name, pyArray.mutable_data(), blockID);
+        if (stepCount == 0)
+        {
+            // for compatiblity, return 1-d arrays rather than 0-d
+            count = Dims{1};
+        }
+    }
+
+    if (variable.m_ShapeID == ShapeID::LocalArray)
+    {
+        variable.SetBlockSelection(blockID);
     }
     else
     {
-        m_Stream->Read<T>(name, pyArray.mutable_data(),
-                          Box<Dims>(std::move(start), std::move(count)),
-                          blockID);
+        if (blockID != 0)
+        {
+            throw std::invalid_argument(
+                "blockId can only be specified when reading LocalArrays.");
+        }
     }
+
+    if (start.empty())
+    {
+        // default start to be (0, 0, ...)
+        start = Dims(shape.size());
+    }
+
+    if (count.empty())
+    {
+        // does the right thing for global and local arrays
+        count = variable.Count();
+    }
+
+    // make numpy array, shape is count, possibly with extra dim for step added
+    Dims shapePy;
+    shapePy.reserve((stepCount > 0 ? 1 : 0) + count.size());
+    if (stepCount > 0)
+    {
+        shapePy.emplace_back(stepCount);
+    }
+    std::copy(count.begin(), count.end(), std::back_inserter(shapePy));
+
+    pybind11::array_t<T> pyArray(shapePy);
+
+    // set selection if requested
+    if (!start.empty() && !count.empty())
+    {
+        variable.SetSelection(Box<Dims>(std::move(start), std::move(count)));
+    }
+
+    // set step selection if requested
+    if (stepCount > 0)
+    {
+        variable.SetStepSelection({stepStart, stepCount});
+    }
+
+    m_Stream->Read(name, pyArray.mutable_data(), blockID);
+
     return pyArray;
 }
 

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -905,8 +905,9 @@ PYBIND11_MODULE(adios2, m)
                  const adios2::Dims &, const size_t)) &
                  adios2::py11::File::Read,
              pybind11::return_value_policy::take_ownership,
-             pybind11::arg("name"), pybind11::arg("start"),
-             pybind11::arg("count"), pybind11::arg("block_id") = 0,
+             pybind11::arg("name"), pybind11::arg("start") = adios2::Dims(),
+             pybind11::arg("count") = adios2::Dims(),
+             pybind11::arg("block_id") = 0,
              R"md(
              Reads a selection piece in dimension for current step 
              (streaming mode step by step)
@@ -916,10 +917,12 @@ PYBIND11_MODULE(adios2, m)
                      variable name
 
                  start
-                     variable local offset selection
+                     variable local offset selection (defaults to (0, 0, ...)
 
                  count
                      variable local dimension selection from start
+                     defaults to whole array for GlobalArrays, or selected Block size
+                     for LocalArrays
                  
                  block_id
                      required for local array variables

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -27,7 +27,7 @@ Engine::Engine(const std::string engineType, IO &io, const std::string &name,
 {
 }
 
-Engine::~Engine(){};
+Engine::~Engine() {}
 
 Engine::operator bool() const noexcept { return !m_IsClosed; }
 
@@ -83,11 +83,12 @@ size_t Engine::Steps() const { return DoSteps(); }
 void Engine::LockWriterDefinitions() noexcept
 {
     m_WriterDefinitionsLocked = true;
-};
+}
+
 void Engine::LockReaderSelections() noexcept
 {
     m_ReaderSelectionsLocked = true;
-};
+}
 
 // PROTECTED
 void Engine::Init() {}

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -86,7 +86,7 @@ void IO::SetEngine(const std::string engineType) noexcept
 {
     m_EngineType = engineType;
 }
-void IO::SetIOMode(const IOMode ioMode) { m_IOMode = ioMode; };
+void IO::SetIOMode(const IOMode ioMode) { m_IOMode = ioMode; }
 
 void IO::SetParameters(const Params &parameters) noexcept
 {
@@ -167,9 +167,9 @@ const DataMap &IO::GetAttributesDataMap() const noexcept
     return m_Attributes;
 }
 
-bool IO::InConfigFile() const noexcept { return m_InConfigFile; };
+bool IO::InConfigFile() const noexcept { return m_InConfigFile; }
 
-void IO::SetDeclared() noexcept { m_IsDeclared = true; };
+void IO::SetDeclared() noexcept { m_IsDeclared = true; }
 
 bool IO::IsDeclared() const noexcept { return m_IsDeclared; }
 

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -255,8 +255,8 @@ void VariableBase::CheckDimensions(const std::string hint) const
     CheckDimensionsCommon(hint);
 }
 
-bool VariableBase::IsConstantDims() const noexcept { return m_ConstantDims; };
-void VariableBase::SetConstantDims() noexcept { m_ConstantDims = true; };
+bool VariableBase::IsConstantDims() const noexcept { return m_ConstantDims; }
+void VariableBase::SetConstantDims() noexcept { m_ConstantDims = true; }
 
 bool VariableBase::IsValidStep(const size_t step) const noexcept
 {

--- a/source/adios2/helper/adiosString.cpp
+++ b/source/adios2/helper/adiosString.cpp
@@ -196,7 +196,7 @@ bool EndsWith(const std::string &str, const std::string &ending,
     {
         return false;
     }
-};
+}
 
 std::vector<std::string>
 GetParametersValues(const std::string &key,

--- a/source/utils/adios_iotest/adiosStream.cpp
+++ b/source/utils/adios_iotest/adiosStream.cpp
@@ -52,7 +52,7 @@ adiosStream::adiosStream(const std::string &streamName, adios2::IO &io,
     // }
 }
 
-adiosStream::~adiosStream(){};
+adiosStream::~adiosStream() {}
 
 void adiosStream::defineADIOSArray(const std::shared_ptr<VariableInfo> ov)
 {

--- a/source/utils/adios_iotest/hdf5Stream.cpp
+++ b/source/utils/adios_iotest/hdf5Stream.cpp
@@ -58,7 +58,7 @@ hdf5Stream::hdf5Stream(const std::string &streamName, const adios2::Mode mode,
     ret = H5Pclose(acc_tpl);
 }
 
-hdf5Stream::~hdf5Stream(){};
+hdf5Stream::~hdf5Stream() {}
 
 hid_t hdf5Stream::hdf5Type(std::string &type)
 {

--- a/source/utils/adios_iotest/processConfig.cpp
+++ b/source/utils/adios_iotest/processConfig.cpp
@@ -17,26 +17,34 @@
 #include "decomp.h"
 #include "processConfig.h"
 
-Command::Command(Operation operation) : op(operation){};
-Command::~Command(){};
+Command::Command(Operation operation) : op(operation) {}
+Command::~Command() {}
 
 CommandSleep::CommandSleep(size_t time)
-: Command(Operation::Sleep), sleepTime_us(time){};
-CommandSleep::~CommandSleep(){};
+: Command(Operation::Sleep), sleepTime_us(time)
+{
+}
+CommandSleep::~CommandSleep() {}
 
 CommandBusy::CommandBusy(size_t time)
-: Command(Operation::Busy), busyTime_us(time){};
-CommandBusy::~CommandBusy(){};
+: Command(Operation::Busy), busyTime_us(time)
+{
+}
+CommandBusy::~CommandBusy() {}
 
 CommandWrite::CommandWrite(std::string stream, std::string group)
-: Command(Operation::Write), streamName(stream), groupName(group){};
-CommandWrite::~CommandWrite(){};
+: Command(Operation::Write), streamName(stream), groupName(group)
+{
+}
+CommandWrite::~CommandWrite() {}
 
 CommandRead::CommandRead(std::string stream, std::string group,
                          const float timeoutSec)
 : Command(Operation::Read), stepMode(adios2::StepMode::Read),
-  streamName(stream), groupName(group), timeout_sec(timeoutSec){};
-CommandRead::~CommandRead(){};
+  streamName(stream), groupName(group), timeout_sec(timeoutSec)
+{
+}
+CommandRead::~CommandRead() {}
 
 std::vector<std::string> FileToLines(std::ifstream &configfile)
 {

--- a/source/utils/adios_iotest/stream.cpp
+++ b/source/utils/adios_iotest/stream.cpp
@@ -14,12 +14,12 @@
 #include "hdf5Stream.h"
 #endif
 
-ioGroup::~ioGroup(){};
+ioGroup::~ioGroup() {}
 Stream::Stream(const std::string &streamName, const adios2::Mode mode)
 : streamName(streamName), mode(mode)
 {
 }
-Stream::~Stream(){};
+Stream::~Stream() {}
 
 void Stream::fillArray(std::shared_ptr<VariableInfo> ov, double value)
 {

--- a/testing/adios2/bindings/python/CMakeLists.txt
+++ b/testing/adios2/bindings/python/CMakeLists.txt
@@ -3,6 +3,8 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
+python_add_test(NAME PythonTestHighLevelAPI SCRIPT TestHighLevelAPI.py)
+
 if(NOT ADIOS2_HAVE_MPI)
     python_add_test(NAME PythonBPWriteReadTypes SCRIPT TestBPWriteReadTypes_nompi.py)
 endif()

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -17,7 +17,8 @@ n_times = 3
 n_blocks = 4
 filename = 'TestHighLevelAPI.bp'
 
-# The following are the test data, with an additional dimension for timestep prepended
+# The following are the test data, with an additional dimension for timestep
+# prepended
 
 global_values = np.arange(n_times)
 global_arrays = np.arange(n_times * 2 * 16).reshape(n_times, 2, 16)
@@ -30,15 +31,17 @@ def setUpModule():
     with adios2.open(filename, 'w') as fh:
         for t in range(n_times):
             fh.write('global_value', np.array(global_values[t]))
-            fh.write('global_array', global_arrays[t], global_arrays[t].shape, (
-                0, 0), global_arrays[t].shape)
-            # We're kinda faking a local array, since the blocks all written from one proc
+            fh.write('global_array', global_arrays[t], global_arrays[t].shape,
+                     (0, 0), global_arrays[t].shape)
+            # We're kinda faking a local array, since the blocks all written
+            # from one proc
             for b in range(n_blocks):
                 fh.write('local_value', np.array(
                     local_values[t][b]), True)
             for b in range(n_blocks):
                 fh.write(
-                    'local_array', local_arrays[t][b], (), (), local_arrays[t][b].shape)
+                    'local_array', local_arrays[t][b], (), (),
+                    local_arrays[t][b].shape)
             fh.end_step()
 
 
@@ -49,8 +52,7 @@ class TestReadBasic(unittest.TestCase):
             for fh_step in fh:
                 t = fh_step.current_step()
                 val = fh_step.read('global_value')
-                self.assertTrue(np.array_equal(
-                    val, np.array([global_values[t]])))
+                self.assertTrue(val == global_values[t])
 
     def test_GlobalArray(self):
         with adios2.open(filename, 'r') as fh:
@@ -126,7 +128,6 @@ class TestReadSelection(unittest.TestCase):
 
 
 class TestReadStepSelection(unittest.TestCase):
-    @unittest.expectedFailure
     def test_GlobalValue(self):
         with adios2.open(filename, 'r') as fh:
             val = fh.read("global_value", (), (), 1, 2)
@@ -142,7 +143,6 @@ class TestReadStepSelection(unittest.TestCase):
             val = fh.read("local_value", (1,), (3,), 1, 2)
             self.assertTrue(np.array_equal(val, local_values[1:3, 1:4]))
 
-    @unittest.expectedFailure
     def test_LocalValueDefault(self):
         with adios2.open(filename, 'r') as fh:
             val = fh.read("local_value", (), (), 1, 2)

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+
+#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#
+# TestBPWriteTypes.py: test Python numpy types in ADIOS2 File
+#                      Write/Read High-Level API
+#  Created on: Aug 11, 2019
+#      Author: Kai Germaschewski <kai.germaschewski@unh.edu>
+
+import unittest
+import adios2
+import numpy as np
+
+n_times = 3
+n_blocks = 4
+filename = 'TestHighLevelAPI.bp'
+
+# The following are the test data, with an additional dimension for timestep prepended
+
+global_values = np.arange(n_times)
+global_arrays = np.arange(n_times * 2 * 16).reshape(n_times, 2, 16)
+local_values = np.arange(n_times * n_blocks).reshape(n_times, n_blocks)
+local_arrays = np.arange(n_times * n_blocks * 5 *
+                         3).reshape(n_times, n_blocks, 5, 3)
+
+
+def setUpModule():
+    with adios2.open(filename, 'w') as fh:
+        for t in range(n_times):
+            fh.write('global_value', np.array(global_values[t]))
+            fh.write('global_array', global_arrays[t], global_arrays[t].shape, (
+                0, 0), global_arrays[t].shape)
+            # We're kinda faking a local array, since the blocks all written from one proc
+            for b in range(n_blocks):
+                fh.write('local_value', np.array(
+                    local_values[t][b]), True)
+            for b in range(n_blocks):
+                fh.write(
+                    'local_array', local_arrays[t][b], (), (), local_arrays[t][b].shape)
+            fh.end_step()
+
+
+class TestReadBasic(unittest.TestCase):
+    # FIXME, would be nicer to return scalar (0-d array), as above
+    def test_GlobalValue1d(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh_step.read('global_value')
+                self.assertTrue(np.array_equal(
+                    val, np.array([global_values[t]])))
+
+    def test_GlobalArray(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh_step.read('global_array')
+                self.assertTrue(np.array_equal(val, global_arrays[t]))
+
+    def test_LocalValue(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh.read('local_value')
+                self.assertTrue(np.array_equal(val, local_values[t]))
+
+    def test_LocalArray(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                for b in range(n_blocks):
+                    val = fh_step.read('local_array', b)
+                    self.assertTrue(np.array_equal(
+                        val, local_arrays[t][b]))
+
+
+class TestReadSelection(unittest.TestCase):
+    @unittest.expectedFailure
+    def test_GlobalValue(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh_step.read("global_value", (), ())
+                self.assertTrue(np.array_equal(
+                    val, np.array([global_values[t]])))
+
+    def test_GlobalArray(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh_step.read("global_array", (0, 1), (2, 3))
+                self.assertTrue(np.array_equal(
+                    val, global_arrays[t][0:2, 1:4]))
+
+    def test_LocalValue(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh.read("local_value", (1,), (2,))
+                self.assertTrue(np.array_equal(val, local_values[t][1:3]))
+
+    @unittest.expectedFailure
+    def test_LocalValueDefault(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh.read("local_value", (), ())
+                self.assertTrue(np.array_equal(val, local_values[t]))
+
+    @unittest.expectedFailure
+    def test_LocalArray(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                for b in range(n_blocks):
+                    val = fh_step.read("local_array", (1, 1), (4, 2), b)
+                    self.assertTrue(np.array_equal(val, local_arrays[t][b]))
+
+    @unittest.expectedFailure
+    def test_LocalArrayDefault(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                for b in range(n_blocks):
+                    val = fh_step.read("local_array", (), (), b)
+                    self.assertTrue(np.array_equal(val, local_arrays[t][b]))
+
+
+class TestReadStepSelection(unittest.TestCase):
+    @unittest.expectedFailure
+    def test_GlobalValue(self):
+        with adios2.open(filename, 'r') as fh:
+            val = fh.read("global_value", (), (), 1, 2)
+            self.assertTrue(np.array_equal(val, global_values[1:3]))
+
+    def test_GlobalArray(self):
+        with adios2.open(filename, 'r') as fh:
+            val = fh.read("global_array", (1, 0), (1, 3), 1, 2)
+            self.assertTrue(np.array_equal(val, global_arrays[1:3, 1:2, 0:3]))
+
+    def test_LocalValue(self):
+        with adios2.open(filename, 'r') as fh:
+            val = fh.read("local_value", (1,), (3,), 1, 2)
+            self.assertTrue(np.array_equal(val, local_values[1:3, 1:4]))
+
+    @unittest.expectedFailure
+    def test_LocalValueDefault(self):
+        with adios2.open(filename, 'r') as fh:
+            val = fh.read("local_value", (), (), 1, 2)
+            self.assertTrue(np.array_equal(val, local_values[1:3]))
+
+    @unittest.expectedFailure
+    def test_LocalArray(self):
+        with adios2.open(filename, 'r') as fh:
+            for b in range(n_blocks):
+                val = fh.read("local_array", (1, 1), (4, 2), 1, 2, b)
+                self.assertTrue(np.array_equal(val, local_arrays[1:3][b]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -77,7 +77,6 @@ class TestReadBasic(unittest.TestCase):
 
 
 class TestReadSelection(unittest.TestCase):
-    @unittest.expectedFailure
     def test_GlobalValue(self):
         with adios2.open(filename, 'r') as fh:
             for fh_step in fh:
@@ -101,7 +100,6 @@ class TestReadSelection(unittest.TestCase):
                 val = fh.read("local_value", (1,), (2,))
                 self.assertTrue(np.array_equal(val, local_values[t][1:3]))
 
-    @unittest.expectedFailure
     def test_LocalValueDefault(self):
         with adios2.open(filename, 'r') as fh:
             for fh_step in fh:
@@ -118,7 +116,6 @@ class TestReadSelection(unittest.TestCase):
                     val = fh_step.read("local_array", (1, 1), (4, 2), b)
                     self.assertTrue(np.array_equal(val, local_arrays[t][b]))
 
-    @unittest.expectedFailure
     def test_LocalArrayDefault(self):
         with adios2.open(filename, 'r') as fh:
             for fh_step in fh:

--- a/testing/adios2/engine/common/TestEngineCommon.cpp
+++ b/testing/adios2/engine/common/TestEngineCommon.cpp
@@ -273,7 +273,7 @@ TEST_F(EngineCommon, NewAttributeEveryStep)
 
     // Separate each individual test with a big gap in time
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-};
+}
 
 void threadTimeoutRun(size_t t)
 {


### PR DESCRIPTION
This is prep work for supporting column-major data in its original order in the python high-level interface, but I think it's useful even by itself.

This PR includes a minor unrelated cleanup removing superfluous semicolons.

It then adds a bunch of tests covering all the variants of the python HL read() functionality, in particular: (1) read whole array / block (2) read a provided selection and (3) read a provided selection and step selection. All 3 overloads are tested against GlobalValue, GlobalArray, LocalValue, LocalArray datasets. Not everything is supported in the current code, so those tests are marked expected failures.

The main part of the PR merges the actual implementation of the various read() overloads into on `DoRead()` function, which takes a Selection and a StepSelection, those being optional:
- An empty `start` means: Start at the origin (0, 0, ...)
- An empty `count` means: Cover whole array (ie, shape) or whole block (ie, count) for GlobalArrays and LocalArrays respectively.
- stepCount = 0 means: Read data from current step.

These changes are internal, ie, the python-facing HL API doesn't change.

This consolidation add support for a few cases, like reading a step selection of GlobalValues. It also makes possible to read a step selection of, say, a whole global array, without having to specify a selection, too:
```python
     read("var', stepStart=1, stepCount=2)
```
Specifying a selection on a LocalArray reads does not work, neither before nor after this PR -- this seems to be an issue of core not supporting it.

This PR squashes (part of) #1668, so if one wants to follow the actual evolution of the code, the former might be easier.





