### PR TITLE
python/hl: fix read() with selection of LocalArrays

### DIFF
--- a/bindings/Python/py11File.tcc
+++ b/bindings/Python/py11File.tcc
@@ -90,7 +90,11 @@ pybind11::array File::DoRead(const std::string &name, const Dims &_start,
         variable.SetStepSelection({stepStart, stepCount});
     }
 
-    m_Stream->Read(name, pyArray.mutable_data(), blockID);
+    if (!m_Stream->m_Engine)
+    {
+        throw std::logic_error("no engine available in DoRead()");
+    }
+    m_Stream->m_Engine->Get(variable, pyArray.mutable_data(), Mode::Sync);
 
     return pyArray;
 }

--- a/source/adios2/toolkit/format/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Deserializer.tcc
@@ -234,7 +234,7 @@ void BP3Deserializer::SetVariableBlockInfo(
                         helper::DimsToString(blockInfo.Count) +
                         " (requested) is out of bounds of (available) local"
                         " Count " +
-                        helper::DimsToString(blockCharacteristics.Shape) +
+                        helper::DimsToString(readInCount) +
                         " , when reading local array variable " + variableName +
                         ", in call to Get");
                 }
@@ -340,7 +340,7 @@ void BP3Deserializer::SetVariableBlockInfo(
                         helper::DimsToString(blockInfo.Count) +
                         " (requested) is out of bounds of (available) "
                         "Shape " +
-                        helper::DimsToString(blockCharacteristics.Shape) +
+                        helper::DimsToString(readInShape) +
                         " , when reading global array variable " +
                         variableName + ", in call to Get");
                 }

--- a/source/adios2/toolkit/format/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Deserializer.tcc
@@ -235,7 +235,7 @@ void BP4Deserializer::SetVariableBlockInfo(
                         helper::DimsToString(blockInfo.Count) +
                         " (requested) is out of bounds of (available) local"
                         " Count " +
-                        helper::DimsToString(blockCharacteristics.Shape) +
+                        helper::DimsToString(readInCount) +
                         " , when reading local array variable " + variableName +
                         ", in call to Get");
                 }
@@ -341,7 +341,7 @@ void BP4Deserializer::SetVariableBlockInfo(
                         helper::DimsToString(blockInfo.Count) +
                         " (requested) is out of bounds of (available) "
                         "Shape " +
-                        helper::DimsToString(blockCharacteristics.Shape) +
+                        helper::DimsToString(readInShape) +
                         " , when reading global array variable " +
                         variableName + ", in call to Get");
                 }

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -109,14 +109,14 @@ class TestReadSelection(unittest.TestCase):
                 val = fh.read("local_value", (), ())
                 self.assertTrue(np.array_equal(val, local_values[t]))
 
-    @unittest.expectedFailure
     def test_LocalArray(self):
         with adios2.open(filename, 'r') as fh:
             for fh_step in fh:
                 t = fh_step.current_step()
                 for b in range(n_blocks):
                     val = fh_step.read("local_array", (1, 1), (4, 2), b)
-                    self.assertTrue(np.array_equal(val, local_arrays[t][b]))
+                    self.assertTrue(np.array_equal(
+                        val, local_arrays[t][b][1:6, 1:3]))
 
     def test_LocalArrayDefault(self):
         with adios2.open(filename, 'r') as fh:
@@ -148,12 +148,12 @@ class TestReadStepSelection(unittest.TestCase):
             val = fh.read("local_value", (), (), 1, 2)
             self.assertTrue(np.array_equal(val, local_values[1:3]))
 
-    @unittest.expectedFailure
     def test_LocalArray(self):
         with adios2.open(filename, 'r') as fh:
             for b in range(n_blocks):
                 val = fh.read("local_array", (1, 1), (4, 2), 1, 2, b)
-                self.assertTrue(np.array_equal(val, local_arrays[1:3][b]))
+                self.assertTrue(np.array_equal(
+                    val, local_arrays[1:3, b, 1:5, 1:3]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes the two previously expectedFailure test cases, though only after
fixing the test cases (they previously broke not because of the incorrect
reference data, but because they threw exceptions).

The problem occurred because m_Stream->Read() called SetBlockSelection again,
which was already done previously, anyway, but doing it again reset `variable->m_Count`.
So we now call `Get()` directly, since we're already interfacing with core directly, anyway, 
and that also saves another lookup of the Variable by string.

Also fixes the error message that confused me into thinking the problem was
with core, and a couple of similar cases.