### PR TITLE
python/hl: return single GlobalValue as scalar/0-d array

### DIFF
--- a/bindings/Python/py11File.cpp
+++ b/bindings/Python/py11File.cpp
@@ -274,6 +274,11 @@ pybind11::array File::ReadAttribute(const std::string &name,
     {                                                                          \
         core::Attribute<T> *attribute = m_Stream->m_IO->InquireAttribute<T>(   \
             name, variableName, separator);                                    \
+        if (attribute->m_IsSingleValue)                                        \
+        {                                                                      \
+            pybind11::array_t<T> pyArray({});                                  \
+            pyArray.mutable_data()[0] = attribute->m_DataSingleValue;          \
+        }                                                                      \
         pybind11::array_t<T> pyArray(attribute->m_Elements);                   \
         m_Stream->ReadAttribute<T>(name, pyArray.mutable_data(), variableName, \
                                    separator);                                 \

--- a/bindings/Python/py11File.tcc
+++ b/bindings/Python/py11File.tcc
@@ -35,11 +35,6 @@ pybind11::array File::DoRead(const std::string &name, const Dims &_start,
             throw std::invalid_argument("when reading a scalar, start and "
                                         "count cannot be specified.\n");
         }
-        if (stepCount == 0)
-        {
-            // for compatiblity, return 1-d arrays rather than 0-d
-            count = Dims{1};
-        }
     }
 
     if (variable.m_ShapeID == ShapeID::LocalArray)

--- a/testing/adios2/bindings/python/TestBPWriteTypesHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestBPWriteTypesHighLevelAPI.py
@@ -142,34 +142,34 @@ with adios2.open("types_np.bp", "r", comm) as fr:
                 print("InTag: " + str(inTag))
                 raise ValueError('tag variable read failed')
 
-            if(inI8[0] != data.I8[0]):
+            if(inI8 != data.I8[0]):
                 raise ValueError('gvarI8 read failed')
 
-            if(inI16[0] != data.I16[0]):
+            if(inI16 != data.I16[0]):
                 raise ValueError('gvarI16 read failed')
 
-            if(inI32[0] != data.I32[0]):
+            if(inI32 != data.I32[0]):
                 raise ValueError('gvarI32 read failed')
 
-            if(inI64[0] != data.I64[0]):
+            if(inI64 != data.I64[0]):
                 raise ValueError('gvarI64 read failed')
 
-            if(inU8[0] != data.U8[0]):
+            if(inU8 != data.U8[0]):
                 raise ValueError('gvarU8 read failed')
 
-            if(inU16[0] != data.U16[0]):
+            if(inU16 != data.U16[0]):
                 raise ValueError('gvarU16 read failed')
 
-            if(inU32[0] != data.U32[0]):
+            if(inU32 != data.U32[0]):
                 raise ValueError('gvarU32 read failed')
 
-            if(inU64[0] != data.U64[0]):
+            if(inU64 != data.U64[0]):
                 raise ValueError('gvarU64 read failed')
 
-            if(inR32[0] != data.R32[0]):
+            if(inR32 != data.R32[0]):
                 raise ValueError('gvarR32 read failed')
 
-            if(inR64[0] != data.R64[0]):
+            if(inR64 != data.R64[0]):
                 raise ValueError('gvarR64 read failed')
 
             # attributes

--- a/testing/adios2/bindings/python/TestBPWriteTypesHighLevelAPI_HDF5.py
+++ b/testing/adios2/bindings/python/TestBPWriteTypesHighLevelAPI_HDF5.py
@@ -138,34 +138,34 @@ with adios2.open("types_np.h5", "r", comm, "HDF5") as fr:
                 print("InTag: " + str(inTag))
                 raise ValueError('tag variable read failed')
 
-            if(inI8[0] != data.I8[0]):
+            if(inI8 != data.I8[0]):
                 raise ValueError('gvarI8 read failed')
 
-            if(inI16[0] != data.I16[0]):
+            if(inI16 != data.I16[0]):
                 raise ValueError('gvarI16 read failed')
 
-            if(inI32[0] != data.I32[0]):
+            if(inI32 != data.I32[0]):
                 raise ValueError('gvarI32 read failed')
 
-            if(inI64[0] != data.I64[0]):
+            if(inI64 != data.I64[0]):
                 raise ValueError('gvarI64 read failed')
 
-            if(inU8[0] != data.U8[0]):
+            if(inU8 != data.U8[0]):
                 raise ValueError('gvarU8 read failed')
 
-            if(inU16[0] != data.U16[0]):
+            if(inU16 != data.U16[0]):
                 raise ValueError('gvarU16 read failed')
 
-            if(inU32[0] != data.U32[0]):
+            if(inU32 != data.U32[0]):
                 raise ValueError('gvarU32 read failed')
 
-            if(inU64[0] != data.U64[0]):
+            if(inU64 != data.U64[0]):
                 raise ValueError('gvarU64 read failed')
 
-            if(inR32[0] != data.R32[0]):
+            if(inR32 != data.R32[0]):
                 raise ValueError('gvarR32 read failed')
 
-            if(inR64[0] != data.R64[0]):
+            if(inR64 != data.R64[0]):
                 raise ValueError('gvarR64 read failed')
 
             # attributes

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -84,8 +84,7 @@ class TestReadSelection(unittest.TestCase):
             for fh_step in fh:
                 t = fh_step.current_step()
                 val = fh_step.read("global_value", (), ())
-                self.assertTrue(np.array_equal(
-                    val, np.array([global_values[t]])))
+                self.assertTrue(val == global_values[t])
 
     def test_GlobalArray(self):
         with adios2.open(filename, 'r') as fh:


### PR DESCRIPTION
That's what one should expect for a single value, not a list / 1d array
with a single element. It is a change in behavior, though, though reading
global values was only partially supported previously, anyway.

Fixes #1671 