### PR TITLE
WIP: return fortran arrays in original order in python high-level interface

### DIFF
--- a/bindings/Python/py11File.cpp
+++ b/bindings/Python/py11File.cpp
@@ -215,14 +215,14 @@ std::vector<std::string> File::ReadString(const std::string &name,
 }
 
 pybind11::array File::Read(const std::string &name, const size_t blockID,
-                           const std::string &order)
+                           const std::string order)
 {
     return Read(name, {}, {}, blockID, order);
 }
 
 pybind11::array File::Read(const std::string &name, const Dims &start,
                            const Dims &count, const size_t blockID,
-                           const std::string &order)
+                           const std::string order)
 {
     const std::string type = m_Stream->m_IO->InquireVariableType(name);
 
@@ -241,7 +241,7 @@ pybind11::array File::Read(const std::string &name, const Dims &start,
 pybind11::array File::Read(const std::string &name, const Dims &start,
                            const Dims &count, const size_t stepStart,
                            const size_t stepCount, const size_t blockID,
-                           const std::string &order)
+                           const std::string order)
 {
     const std::string type = m_Stream->m_IO->InquireVariableType(name);
 

--- a/bindings/Python/py11File.h
+++ b/bindings/Python/py11File.h
@@ -24,6 +24,8 @@ namespace py11
 class File
 {
 public:
+    static std::string ReadOrder;
+
     const std::string m_Name;
     const std::string m_Mode;
 
@@ -92,14 +94,17 @@ public:
                                         const size_t stepCount,
                                         const size_t blockID = 0);
 
-    pybind11::array Read(const std::string &name, const size_t blockID = 0);
+    pybind11::array Read(const std::string &name, const size_t blockID,
+                         const std::string &order);
 
     pybind11::array Read(const std::string &name, const Dims &start,
-                         const Dims &count, const size_t blockID = 0);
+                         const Dims &count, const size_t blockID,
+                         const std::string &order);
 
     pybind11::array Read(const std::string &name, const Dims &start,
                          const Dims &count, const size_t stepStart,
-                         const size_t stepCount, const size_t blockID = 0);
+                         const size_t stepCount, const size_t blockID,
+                         const std::string &order);
 
     pybind11::array ReadAttribute(const std::string &name,
                                   const std::string &variableName = "",
@@ -121,11 +126,13 @@ public:
 private:
     std::shared_ptr<core::Stream> m_Stream;
     adios2::Mode ToMode(const std::string mode) const;
+    static Layout ToLayout(std::string order);
 
     template <class T>
     pybind11::array DoRead(const std::string &name, const Dims &start,
                            const Dims &count, const size_t stepStart,
-                           const size_t stepCount, const size_t blockID);
+                           const size_t stepCount, const size_t blockID,
+                           const std::string &order);
 };
 
 } // end namespace py11

--- a/bindings/Python/py11File.h
+++ b/bindings/Python/py11File.h
@@ -95,16 +95,16 @@ public:
                                         const size_t blockID = 0);
 
     pybind11::array Read(const std::string &name, const size_t blockID,
-                         const std::string &order);
+                         const std::string order);
 
     pybind11::array Read(const std::string &name, const Dims &start,
                          const Dims &count, const size_t blockID,
-                         const std::string &order);
+                         const std::string order);
 
     pybind11::array Read(const std::string &name, const Dims &start,
                          const Dims &count, const size_t stepStart,
                          const size_t stepCount, const size_t blockID,
-                         const std::string &order);
+                         const std::string order);
 
     pybind11::array ReadAttribute(const std::string &name,
                                   const std::string &variableName = "",
@@ -132,7 +132,7 @@ private:
     pybind11::array DoRead(const std::string &name, const Dims &start,
                            const Dims &count, const size_t stepStart,
                            const size_t stepCount, const size_t blockID,
-                           const std::string &order);
+                           const std::string order);
 };
 
 } // end namespace py11

--- a/bindings/Python/py11File.h
+++ b/bindings/Python/py11File.h
@@ -50,7 +50,8 @@ public:
     size_t AddTransport(const std::string type,
                         const Params &parameters = Params());
 
-    std::map<std::string, adios2::Params> AvailableVariables() noexcept;
+    std::map<std::string, adios2::Params>
+    AvailableVariables(const std::string order) noexcept;
 
     std::map<std::string, adios2::Params> AvailableAttributes() noexcept;
 

--- a/bindings/Python/py11File.tcc
+++ b/bindings/Python/py11File.tcc
@@ -18,11 +18,13 @@ namespace adios2
 namespace py11
 {
 
-static Dims py_strides(const Dims &shape, ssize_t itemsize, bool has_step_dim)
+namespace
+{
+Dims py_strides(const Dims &shape, ssize_t itemsize, bool hasStepDim)
 {
     auto ndim = shape.size();
     Dims strides(ndim, itemsize);
-    if (!has_step_dim)
+    if (!hasStepDim)
     {
         // regular column-major
         for (size_t i = 1; i < ndim; ++i)
@@ -41,12 +43,13 @@ static Dims py_strides(const Dims &shape, ssize_t itemsize, bool has_step_dim)
     }
     return strides;
 }
+} // end anonymous namespace
 
 template <class T>
 pybind11::array File::DoRead(const std::string &name, const Dims &_start,
                              const Dims &_count, const size_t stepStart,
                              const size_t stepCount, const size_t blockID,
-                             const std::string &order)
+                             const std::string order)
 {
     Layout layout = ToLayout(order);
     core::Variable<T> &variable = *m_Stream->m_IO->InquireVariable<T>(name);

--- a/bindings/Python/py11File.tcc
+++ b/bindings/Python/py11File.tcc
@@ -18,6 +18,30 @@ namespace adios2
 namespace py11
 {
 
+static Dims py_strides(const Dims &shape, ssize_t itemsize, bool has_step_dim)
+{
+    auto ndim = shape.size();
+    Dims strides(ndim, itemsize);
+    if (!has_step_dim)
+    {
+        // regular column-major
+        for (size_t i = 1; i < ndim; ++i)
+        {
+            strides[i] = strides[i - 1] * shape[i - 1];
+        }
+    }
+    else
+    {
+        // rotate so that slowest dim will be in front
+        for (size_t i = 2; i < ndim; ++i)
+        {
+            strides[i] = strides[i - 1] * shape[i - 1];
+        }
+        strides[0] = strides[ndim - 1] * shape[ndim - 1];
+    }
+    return strides;
+}
+
 template <class T>
 pybind11::array File::DoRead(const std::string &name, const Dims &_start,
                              const Dims &_count, const size_t stepStart,
@@ -83,7 +107,8 @@ pybind11::array File::DoRead(const std::string &name, const Dims &_start,
         }
     }
 
-    // make numpy array, shape is count, possibly with extra dim for step added
+    // make numpy array, shape is count, possibly with extra dim for step
+    // added
     Dims shapePy;
     if (stepCount == 0)
     {
@@ -91,23 +116,17 @@ pybind11::array File::DoRead(const std::string &name, const Dims &_start,
         std::copy(count.begin(), count.end(), std::back_inserter(shapePy));
     }
     else
-    { // add step dimension
-        if (!reverse_dims)
-        {
-            shapePy.emplace_back(stepCount);
-            std::copy(count.begin(), count.end(), std::back_inserter(shapePy));
-        }
-        else
-        {
-            std::copy(count.begin(), count.end(), std::back_inserter(shapePy));
-            shapePy.emplace_back(stepCount);
-        }
+    { // prepend step dimension
+        shapePy.reserve(count.size() + 1);
+        shapePy.emplace_back(stepCount);
+        std::copy(count.begin(), count.end(), std::back_inserter(shapePy));
     }
 
     pybind11::array_t<T> pyArray;
     if (layout == Layout::ColumnMajor)
     {
-        pyArray = pybind11::array_t<T, pybind11::array::f_style>(shapePy);
+        pyArray = pybind11::array_t<T>(
+            shapePy, py_strides(shapePy, pyArray.itemsize(), stepCount > 0));
     }
     else
     {

--- a/bindings/Python/py11File.tcc
+++ b/bindings/Python/py11File.tcc
@@ -21,10 +21,27 @@ namespace py11
 template <class T>
 pybind11::array File::DoRead(const std::string &name, const Dims &_start,
                              const Dims &_count, const size_t stepStart,
-                             const size_t stepCount, const size_t blockID)
+                             const size_t stepCount, const size_t blockID,
+                             const std::string &order)
 {
+    Layout layout = ToLayout(order);
     core::Variable<T> &variable = *m_Stream->m_IO->InquireVariable<T>(name);
-    Dims &shape = variable.m_Shape;
+
+    if (layout == Layout::Original)
+    {
+        layout = variable.GetOriginalLayout();
+    }
+    bool reverse_dims = layout == Layout::ColumnMajor;
+
+    // Do everything in original dims first, ie, we need to
+    // un-reverse shape and count we get from the core
+
+    Dims shape = variable.m_Shape;
+    if (reverse_dims)
+    {
+        std::reverse(shape.begin(), shape.end());
+    }
+
     Dims start = _start;
     Dims count = _count;
 
@@ -60,22 +77,51 @@ pybind11::array File::DoRead(const std::string &name, const Dims &_start,
     {
         // does the right thing for global and local arrays
         count = variable.Count();
+        if (reverse_dims)
+        {
+            std::reverse(count.begin(), count.end());
+        }
     }
 
     // make numpy array, shape is count, possibly with extra dim for step added
     Dims shapePy;
-    shapePy.reserve((stepCount > 0 ? 1 : 0) + count.size());
-    if (stepCount > 0)
+    if (stepCount == 0)
     {
-        shapePy.emplace_back(stepCount);
+        shapePy.reserve(count.size());
+        std::copy(count.begin(), count.end(), std::back_inserter(shapePy));
     }
-    std::copy(count.begin(), count.end(), std::back_inserter(shapePy));
+    else
+    { // add step dimension
+        if (!reverse_dims)
+        {
+            shapePy.emplace_back(stepCount);
+            std::copy(count.begin(), count.end(), std::back_inserter(shapePy));
+        }
+        else
+        {
+            std::copy(count.begin(), count.end(), std::back_inserter(shapePy));
+            shapePy.emplace_back(stepCount);
+        }
+    }
 
-    pybind11::array_t<T> pyArray(shapePy);
+    pybind11::array_t<T> pyArray;
+    if (layout == Layout::ColumnMajor)
+    {
+        pyArray = pybind11::array_t<T, pybind11::array::f_style>(shapePy);
+    }
+    else
+    {
+        pyArray = pybind11::array_t<T, pybind11::array::c_style>(shapePy);
+    }
 
     // set selection if requested
     if (!start.empty() && !count.empty())
     {
+        if (reverse_dims)
+        {
+            std::reverse(start.begin(), start.end());
+            std::reverse(count.begin(), count.end());
+        }
         variable.SetSelection(Box<Dims>(std::move(start), std::move(count)));
     }
 

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -533,6 +533,8 @@ PYBIND11_MODULE(adios2, m)
                  return stream;
              })
 
+        .def_readwrite_static("read_order", &adios2::py11::File::ReadOrder)
+
         .def("set_parameter", &adios2::py11::File::SetParameter,
              pybind11::arg("key"), pybind11::arg("value"), R"md(
              Sets a single parameter. Overwrites value if key exists.
@@ -877,11 +879,12 @@ PYBIND11_MODULE(adios2, m)
         )md")
 
         .def("read",
-             (pybind11::array(adios2::py11::File::*)(const std::string &,
-                                                     const size_t)) &
+             (pybind11::array(adios2::py11::File::*)(
+                 const std::string &, const size_t, const std::string &)) &
                  adios2::py11::File::Read,
              pybind11::return_value_policy::take_ownership,
              pybind11::arg("name"), pybind11::arg("block_id") = 0,
+             pybind11::arg("order") = "",
              R"md(
              Reads entire variable for current step 
              (streaming mode step by step)
@@ -899,16 +902,17 @@ PYBIND11_MODULE(adios2, m)
                      Single values will have a shape={1} numpy array
         )md")
 
-        .def("read",
-             (pybind11::array(adios2::py11::File::*)(
-                 const std::string &, const adios2::Dims &,
-                 const adios2::Dims &, const size_t)) &
-                 adios2::py11::File::Read,
-             pybind11::return_value_policy::take_ownership,
-             pybind11::arg("name"), pybind11::arg("start") = adios2::Dims(),
-             pybind11::arg("count") = adios2::Dims(),
-             pybind11::arg("block_id") = 0,
-             R"md(
+        .def(
+            "read",
+            (pybind11::array(adios2::py11::File::*)(
+                const std::string &, const adios2::Dims &, const adios2::Dims &,
+                const size_t, const std::string &order)) &
+                adios2::py11::File::Read,
+            pybind11::return_value_policy::take_ownership,
+            pybind11::arg("name"), pybind11::arg("start") = adios2::Dims(),
+            pybind11::arg("count") = adios2::Dims(),
+            pybind11::arg("block_id") = 0, pybind11::arg("order") = "",
+            R"md(
              Reads a selection piece in dimension for current step 
              (streaming mode step by step)
 
@@ -933,16 +937,17 @@ PYBIND11_MODULE(adios2, m)
                      empty if exception is thrown
         )md")
 
-        .def(
-            "read",
-            (pybind11::array(adios2::py11::File::*)(
-                const std::string &, const adios2::Dims &, const adios2::Dims &,
-                const size_t, const size_t, const size_t)) &
-                adios2::py11::File::Read,
-            pybind11::return_value_policy::take_ownership,
-            pybind11::arg("name"), pybind11::arg("start"),
-            pybind11::arg("count"), pybind11::arg("step_start"),
-            pybind11::arg("step_count"), pybind11::arg("block_id") = 0, R"md(
+        .def("read",
+             (pybind11::array(adios2::py11::File::*)(
+                 const std::string &, const adios2::Dims &,
+                 const adios2::Dims &, const size_t, const size_t, const size_t,
+                 const std::string &order)) &
+                 adios2::py11::File::Read,
+             pybind11::return_value_policy::take_ownership,
+             pybind11::arg("name"), pybind11::arg("start"),
+             pybind11::arg("count"), pybind11::arg("step_start"),
+             pybind11::arg("step_count"), pybind11::arg("block_id") = 0,
+             pybind11::arg("order") = "", R"md(
             Random access read allowed to select steps, 
             only valid with File Engines
 

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -588,10 +588,17 @@ PYBIND11_MODULE(adios2, m)
         )md")
 
         .def("available_variables", &adios2::py11::File::AvailableVariables,
-             pybind11::return_value_policy::move, R"md(
+             pybind11::arg("order") = "", pybind11::return_value_policy::move,
+             R"md(
              Returns a 2-level dictionary with variable information. 
              Read mode only.
              
+             Parameters
+                 order
+                     choice of 'C', 'F', or 'K' for row-major, column major
+                     or original layout, respectively. If not provided,
+                     File.read_order is used (which defaults to 'K')
+
              Returns
                  variables dictionary
                      key 

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -888,7 +888,7 @@ PYBIND11_MODULE(adios2, m)
 
         .def("read",
              (pybind11::array(adios2::py11::File::*)(
-                 const std::string &, const size_t, const std::string &)) &
+                 const std::string &, const size_t, const std::string)) &
                  adios2::py11::File::Read,
              pybind11::return_value_policy::take_ownership,
              pybind11::arg("name"), pybind11::arg("block_id") = 0,
@@ -915,17 +915,16 @@ PYBIND11_MODULE(adios2, m)
                      Single values will have a shape={1} numpy array
         )md")
 
-        .def(
-            "read",
-            (pybind11::array(adios2::py11::File::*)(
-                const std::string &, const adios2::Dims &, const adios2::Dims &,
-                const size_t, const std::string &order)) &
-                adios2::py11::File::Read,
-            pybind11::return_value_policy::take_ownership,
-            pybind11::arg("name"), pybind11::arg("start") = adios2::Dims(),
-            pybind11::arg("count") = adios2::Dims(),
-            pybind11::arg("block_id") = 0, pybind11::arg("order") = "",
-            R"md(
+        .def("read",
+             (pybind11::array(adios2::py11::File::*)(
+                 const std::string &, const adios2::Dims &,
+                 const adios2::Dims &, const size_t, const std::string order)) &
+                 adios2::py11::File::Read,
+             pybind11::return_value_policy::take_ownership,
+             pybind11::arg("name"), pybind11::arg("start") = adios2::Dims(),
+             pybind11::arg("count") = adios2::Dims(),
+             pybind11::arg("block_id") = 0, pybind11::arg("order") = "",
+             R"md(
              Reads a selection piece in dimension for current step 
              (streaming mode step by step)
 
@@ -959,7 +958,7 @@ PYBIND11_MODULE(adios2, m)
              (pybind11::array(adios2::py11::File::*)(
                  const std::string &, const adios2::Dims &,
                  const adios2::Dims &, const size_t, const size_t, const size_t,
-                 const std::string &order)) &
+                 const std::string order)) &
                  adios2::py11::File::Read,
              pybind11::return_value_policy::take_ownership,
              pybind11::arg("name"), pybind11::arg("start"),

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -509,7 +509,10 @@ PYBIND11_MODULE(adios2, m)
         .def("SetParameter", &adios2::py11::Operator::SetParameter)
         .def("Parameters", &adios2::py11::Operator::Parameters);
 
-    pybind11::class_<adios2::py11::File>(m, "File")
+    pybind11::class_<adios2::py11::File>(m, "File", R"md(
+       The ``File`` class provides a high-level interface for reading and writing
+       adios data.
+        )md")
         .def("__repr__",
              [](const adios2::py11::File &stream) {
                  return "<adios2.file named '" + stream.m_Name +
@@ -533,7 +536,12 @@ PYBIND11_MODULE(adios2, m)
                  return stream;
              })
 
-        .def_readwrite_static("read_order", &adios2::py11::File::ReadOrder)
+        .def_readwrite_static("read_order", &adios2::py11::File::ReadOrder,
+                              R"md(
+            ```read_order``` is the default for the ``order`` parameter when
+            reading data from a Variable. Supported choices are 'C', 'F', 'K' meaning
+            row-major, column-major and original layout, respectively.
+        )md")
 
         .def("set_parameter", &adios2::py11::File::SetParameter,
              pybind11::arg("key"), pybind11::arg("value"), R"md(
@@ -896,6 +904,11 @@ PYBIND11_MODULE(adios2, m)
                  block_id
                      required for local array variables
 
+                 order
+                     choice of 'C', 'F', or 'K' for row-major, column major
+                     or original layout, respectively. If not provided,
+                     File.read_order is used (which defaults to 'K')
+
              Returns
                  array
                      values of variable name for current step.
@@ -930,6 +943,11 @@ PYBIND11_MODULE(adios2, m)
                  
                  block_id
                      required for local array variables
+
+                 order
+                     choice of 'C', 'F', or 'K' for row-major, column major
+                     or original layout, respectively. If not provided,
+                     File.read_order is used (which defaults to 'K')
 
              Returns
                  array
@@ -969,6 +987,11 @@ PYBIND11_MODULE(adios2, m)
 
                 block_id
                     required for local array variables
+
+                order
+                    choice of 'C', 'F', or 'K' for row-major, column major
+                    or original layout, respectively. If not provided,
+                    File.read_order is used (which defaults to 'K')
 
             Returns
                 array

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -119,6 +119,15 @@ enum class SelectionType
     Auto         ///< Let the engine decide what to return
 };
 
+/** Data layouts */
+enum class Layout
+{
+    Unknown,
+    RowMajor,
+    ColumnMajor,
+    Original,
+};
+
 // Types
 using std::size_t;
 

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -300,6 +300,8 @@ void VariableBase::ResetStepsSelection(const bool zeroStart) noexcept
     }
 }
 
+Layout VariableBase::GetOriginalLayout() const { return m_OriginalLayout; }
+
 // PRIVATE
 void VariableBase::InitShapeType()
 {

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -70,6 +70,9 @@ public:
      * already encountered in previous step */
     bool m_FirstStreamingStep = true;
 
+    /** The data layout that is/was used when serializing this variable */
+    Layout m_OriginalLayout = Layout::Unknown;
+
     /** Operators metadata info */
     struct Operation
     {
@@ -196,6 +199,8 @@ public:
     void CheckRandomAccessConflict(const std::string hint) const;
 
     Dims GetShape(const size_t step = adios2::EngineCurrentStep);
+
+    Layout GetOriginalLayout() const;
 
 protected:
     const bool m_DebugMode = false;

--- a/source/adios2/toolkit/format/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp3/BP3Deserializer.tcc
@@ -846,6 +846,9 @@ void BP3Deserializer::DefineVariableInEngineIO(const ElementIndexHeader &header,
         }
     } // end mutex lock
 
+    variable->m_OriginalLayout =
+        m_IsRowMajor ? Layout::RowMajor : Layout::ColumnMajor;
+
     // going back to get variable index position
     variable->m_IndexStart =
         initialPosition - (header.Name.size() + header.GroupName.size() +

--- a/source/adios2/toolkit/format/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Deserializer.tcc
@@ -930,6 +930,9 @@ void BP4Deserializer::DefineVariableInEngineIOPerStep(
         }
     } // end mutex lock
 
+    variable->m_OriginalLayout =
+        m_IsRowMajor ? Layout::RowMajor : Layout::ColumnMajor;
+
     // going back to get variable index position
     variable->m_IndexStart =
         initialPosition - (header.Name.size() + header.GroupName.size() +

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -39,9 +39,8 @@ def setUpModule():
                 fh.write('local_value', np.array(
                     local_values[t][b]), True)
             for b in range(n_blocks):
-                fh.write(
-                    'local_array', local_arrays[t][b], (), (),
-                    local_arrays[t][b].shape)
+                fh.write('local_array',
+                         local_arrays[t][b], (), (), local_arrays[t][b].shape)
             fh.end_step()
 
 
@@ -156,9 +155,9 @@ class TestReadStepSelection(unittest.TestCase):
 
 
 class TestReadOrder(unittest.TestCase):
-    # we can't generate any col-major data test file (unless we're running Fortran),
-    # but we can force data to be read in column major order, in which case it should
-    # match the transpose of the original data
+    # we can't generate any col-major data test file (unless we're running
+    # Fortran), but we can force data to be read in column major order, in
+    # which case it should match the transpose of the original data
 
     def test_GlobalArrayBasic(self):
         with adios2.open(filename, 'r') as fh:
@@ -179,12 +178,9 @@ class TestReadOrder(unittest.TestCase):
         with adios2.open(filename, 'r') as fh:
             val = fh.read("global_array", (0, 1), (3, 1), 1, 2, order='F')
             # don't transpose step axis
-            global_arrays_T = np.transpose(global_arrays)  # , (0, 2, 1))
-            print("val", val)
-            #print("ref", global_arrays_T[1:3, 0:3, 1:2])
-            print("ref", global_arrays_T[0:3, 1:2, 1:3])
+            global_arrays_T = np.transpose(global_arrays, (0, 2, 1))
             self.assertTrue(np.array_equal(
-                val, global_arrays_T[0:3, 1:2, 1:3]))
+                val, global_arrays_T[1:3, 0:3, 1:2]))
 
 
 if __name__ == '__main__':

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -155,5 +155,37 @@ class TestReadStepSelection(unittest.TestCase):
                     val, local_arrays[1:3, b, 1:5, 1:3]))
 
 
+class TestReadOrder(unittest.TestCase):
+    # we can't generate any col-major data test file (unless we're running Fortran),
+    # but we can force data to be read in column major order, in which case it should
+    # match the transpose of the original data
+
+    def test_GlobalArrayBasic(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh_step.read('global_array', order='F')
+                self.assertTrue(np.array_equal(val, global_arrays[t].T))
+
+    def test_GlobalArraySelection(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh_step.read("global_array", (1, 0), (3, 2), order='F')
+                self.assertTrue(np.array_equal(
+                    val, global_arrays[t].T[1:4, 0:2]))
+
+    def test_GlobalArrayStepSelection(self):
+        with adios2.open(filename, 'r') as fh:
+            val = fh.read("global_array", (0, 1), (3, 1), 1, 2, order='F')
+            # don't transpose step axis
+            global_arrays_T = np.transpose(global_arrays)  # , (0, 2, 1))
+            print("val", val)
+            #print("ref", global_arrays_T[1:3, 0:3, 1:2])
+            print("ref", global_arrays_T[0:3, 1:2, 1:3])
+            self.assertTrue(np.array_equal(
+                val, global_arrays_T[0:3, 1:2, 1:3]))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -182,6 +182,27 @@ class TestReadOrder(unittest.TestCase):
             self.assertTrue(np.array_equal(
                 val, global_arrays_T[1:3, 0:3, 1:2]))
 
+    def test_ReadOrderDefault(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh_step.read('global_array')
+                self.assertTrue(np.array_equal(val, global_arrays[t]))
+
+        # change default to 'F' (column-major), which will transpose the data
+        # as it was written as row-major
+
+        adios2.File.read_order = 'F'
+
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                t = fh_step.current_step()
+                val = fh_step.read('global_array')
+                self.assertTrue(np.array_equal(val, global_arrays[t].T))
+
+        # restore default so tests run after this one don't fail
+        adios2.File.read_order = 'K'
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -204,5 +204,19 @@ class TestReadOrder(unittest.TestCase):
         adios2.File.read_order = 'K'
 
 
+class TestAvailableVariables(unittest.TestCase):
+    # FIXME, would be nicer to return scalar (0-d array), as above
+    def test_GlobalArray(self):
+        with adios2.open(filename, 'r') as fh:
+            vars = fh.available_variables()
+            self.assertTrue(vars["global_array"]["Shape"] == "2, 16")
+            # test reversing of shape
+            vars = fh.available_variables(order='F')
+            self.assertTrue(vars["global_array"]["Shape"] == "16, 2")
+
+        # restore default so tests run after this one don't fail
+        adios2.File.read_order = 'K'
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
So this is what I originally set out to do:

* adds a `m_OriginalLayout` member to `core::Variable`, which defaults to `Unknown`, but BP3 and BP4 engines will set it to the original layout the data was written with it.
* `bpls` behavior is changed slightly (only): If the data was originally written from Fortran, it'll add the note `(transposed)` to the shape, but other than that, it still shows the dimensions reversed / dumps the data transposed. (This could be changed in the future to present the data how it was originally written, if that's considered more useful than current behavior)
* The Fortran HL interface is changed to return arrays in their original index order. Nothing changes for arrays written in row-major, but arrays written as column-major will be read back in their original order. No transposing / rearranging of the data occurs, one just needs to tell numpy what the layout is.

More specifically, the `read` methods gain an additional `order` parameter. `'F'` means ,interpret the data as column-major (so if it was written by Fortran, it'll show up in its original order. If it was originally row-major, this makes it show up transposed. `'C'` means, interpret the data as row-major, which is what current behavior is always. `'K'` means, interpret the data as the layout that it was saved as (if known, default row-major).

If no order parameter is provided, it defaults to `'K'`, which means both data written by C and Fortran will show up in their original order, which is what most people would want. However, it is a change in behavior. The default order, if not provided as an argument, can be easily changed using
```python
import adios2
adios2.file.read_order = 'C'
```
will make restore current behavior. So while this PR changes behavior, it's at least easy to restore the original behavior if anyone turns out to be affected. I chose this way because the default behavior will avoid confusion, at the cost of potentially causing issues to someone relying on the old behavior. One could prioritize the opposite way, ie., keep old behavior by default and everyone who would like to see their Fortran arrays presented in original order would need to explicitly set `read_order` to `'K'`.

Fixes #1665