### PR TITLE
Replace PATH 2 bytes length info for 1 byte ORDER + 1 byte UNUSED in …

### DIFF
--- a/source/adios2/toolkit/format/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp4/BP4Base.cpp
@@ -802,7 +802,12 @@ BP4Base::ReadElementIndexHeader(const std::vector<char> &buffer,
         helper::ReadValue<uint32_t>(buffer, position, isLittleEndian);
     header.GroupName = ReadBP4String(buffer, position, isLittleEndian);
     header.Name = ReadBP4String(buffer, position, isLittleEndian);
-    header.Path = ReadBP4String(buffer, position, isLittleEndian);
+    // header.Path = ReadBP4String(buffer, position, isLittleEndian);
+    header.Path = "";
+    header.Order = helper::ReadValue<char>(buffer, position, isLittleEndian);
+    // uint8_t unused =
+    helper::ReadValue<uint8_t>(buffer, position, isLittleEndian);
+
     header.DataType =
         helper::ReadValue<int8_t>(buffer, position, isLittleEndian);
     header.CharacteristicsSetsCount =

--- a/source/adios2/toolkit/format/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp4/BP4Base.h
@@ -585,6 +585,7 @@ protected:
         std::string GroupName;
         std::string Name;
         std::string Path;
+        char Order;
         uint8_t DataType = std::numeric_limits<uint8_t>::max() - 1;
     };
 

--- a/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp4/BP4Serializer.tcc
@@ -488,9 +488,15 @@ size_t BP4Serializer::PutVariableMetadataInData(
     helper::CopyToBuffer(buffer, position, &stats.MemberID);
 
     PutNameRecord(variable.m_Name, buffer, position);
-    // path is empty now, write a 0 length to skip it
-    const uint16_t zero16 = 0;
-    helper::CopyToBuffer(buffer, position, &zero16);
+
+    // Layout can be 'K' = same as the language default, 'C' for row major and
+    // 'F' for column major -- these are Numpy-like flags
+    const char layout = 'K';
+    helper::CopyToBuffer(buffer, position, &layout);
+
+    // unused byte, write a 0 length to skip it
+    const uint8_t zero8 = 0;
+    helper::CopyToBuffer(buffer, position, &zero8);
 
     const uint8_t dataType = TypeTraits<T>::type_enum;
     helper::CopyToBuffer(buffer, position, &dataType);
@@ -573,7 +579,7 @@ inline size_t BP4Serializer::PutVariableMetadataInData(
     helper::CopyToBuffer(buffer, position, &stats.MemberID);
 
     PutNameRecord(variable.m_Name, buffer, position);
-    position += 2; // skip path
+    position += 2; // skip layout and unused byte
 
     const uint8_t dataType = TypeTraits<std::string>::type_enum;
     helper::CopyToBuffer(buffer, position, &dataType);
@@ -630,7 +636,14 @@ void BP4Serializer::PutVariableMetadataInIndex(
         helper::InsertToBuffer(buffer, &stats.MemberID);
         buffer.insert(buffer.end(), 2, '\0'); // skip group name
         PutNameRecord(variable.m_Name, buffer);
-        buffer.insert(buffer.end(), 2, '\0'); // skip path
+
+        // Layout can be 'K' = same as the language default, 'C' for row major
+        // and 'F' for column major -- these are Numpy-like flags
+        const char layout = 'K';
+        buffer.insert(buffer.end(), 1, layout);
+
+        // unused byte, write a 0 length to skip it
+        buffer.insert(buffer.end(), 1, '\0'); // unused byte
 
         const uint8_t dataType = TypeTraits<T>::type_enum;
         helper::InsertToBuffer(buffer, &dataType);

--- a/source/utils/bp4dbg/bp4dbg_data.py
+++ b/source/utils/bp4dbg/bp4dbg_data.py
@@ -82,7 +82,7 @@ def readDataToNumpyArray(f, typeName, nElements):
         return np.zeros(1, dtype=np.uint32)
 
 
-def ReadCharacteristicsFromData(f, limit, typeID):
+def ReadCharacteristicsFromData(f, limit, typeID, ndim):
     cStartPosition = f.tell()
     dataTypeName = bp4dbg_utils.GetTypeName(typeID)
     # 1 byte NCharacteristics
@@ -346,7 +346,7 @@ def ReadVMD(f, varidx, varsStartPosition, varsTotalLength):
         print("           offset dim : {0}".format(offset))
 
     sizeLimit = expectedVarBlockLength - (f.tell() - startPosition)
-    status = ReadCharacteristicsFromData(f, sizeLimit, typeID)
+    status = ReadCharacteristicsFromData(f, sizeLimit, typeID, ndims)
     if not status:
         return False
 

--- a/source/utils/bp4dbg/bp4dbg_metadata.py
+++ b/source/utils/bp4dbg/bp4dbg_metadata.py
@@ -396,13 +396,29 @@ def ReadVarMD(buf, idx, pos, limit, varStartOffset):
           "' ({0} bytes)".format(varNameLen))
 
     # print("        Current offset : {0}".format(varStartOffset + pos))
-    namelimit = limit - (pos - varStartPosition)
-    status, varPath, varPathLen, pos = ReadEncodedStringFromBuffer(
-        buf, pos, "Var Path", namelimit)
-    if not status:
-        return False, pos
-    print("        Var Path        : '" + varPath +
-          "' ({0} bytes)".format(varPathLen))
+    # namelimit = limit - (pos - varStartPosition)
+    # status, varPath, varPathLen, pos = ReadEncodedStringFromBuffer(
+    #     buf, pos, "Var Path", namelimit)
+    # if not status:
+    #     return False, pos
+    # print("        Var Path        : '" + varPath +
+    #       "' ({0} bytes)".format(varPathLen))
+
+    # 1 byte ORDER (K, C, F)
+    order = buf[pos]  # this is an integer value
+    pos = pos + 1
+    if (order != ord('K') and order != ord('C') and order != ord('F')):
+        print(
+            "ERROR: Next byte for Order must be 'K', 'C', or 'F' "
+            "but it isn't = {0} (={1})".format(
+                chr(order), order))
+        return False
+    print("        Order           : " + chr(order))
+
+    # 1 byte UNUSED
+    unused = buf[pos]  # this is an integer value
+    pos = pos + 1
+    print("        Unused byte     : {0}".format(unused))
 
     # 1 byte TYPE
     typeID = buf[pos]


### PR DESCRIPTION
…BP4 variable metadata header both in metadata buffer and data buffer.

This PR changes the BP4 format slightly to make room for a per-variable flag about ordering. There is no code to set this flag, right now it is a fixed 'K' character to indicate the variable has the "original" order, i.e. whatever the language default is. Also allowed characters are 'C' and 'F' after the numpy convention. This may have to be extended if numpy actually has more options as mentioned in #1705.

Change: the variable Path is always empty now and there is a 2-byte {0,0} place in the variable metadata header both in the data buffer (data.N) and metadata buffer (md.0). The first byte is now used for this flag, the second is an "UNUSED" byte. 

