### PR TITLE
WIP: Do not modify steps information in BeginStep if the status is not OK.

### DIFF
--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -56,32 +56,33 @@ StepStatus BP4Reader::BeginStep(StepMode mode, const float timeoutSeconds)
         }
     }
 
-    if (m_FirstStep)
-    {
-        m_FirstStep = false;
-    }
-    else
-    {
-        ++m_CurrentStep;
-    }
-
     // used to inquire for variables in streaming mode
     m_IO.m_ReadStreaming = true;
     StepStatus status = StepStatus::OK;
 
-    if (m_CurrentStep >= m_BP4Deserializer.m_MetadataSet.StepsCount)
+    if (m_CurrentStep + 1 >= m_BP4Deserializer.m_MetadataSet.StepsCount)
     {
         status = CheckForNewSteps(Seconds(timeoutSeconds));
     }
 
     // This should be after getting new steps
-    m_IO.m_EngineStep = m_CurrentStep;
 
     if (status == StepStatus::OK)
     {
+        if (m_FirstStep)
+        {
+            m_FirstStep = false;
+        }
+        else
+        {
+            ++m_CurrentStep;
+        }
+
+        m_IO.m_EngineStep = m_CurrentStep;
         m_IO.ResetVariablesStepSelection(false,
                                          "in call to BP4 Reader BeginStep");
     }
+
 
     return status;
 }

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -60,9 +60,19 @@ StepStatus BP4Reader::BeginStep(StepMode mode, const float timeoutSeconds)
     m_IO.m_ReadStreaming = true;
     StepStatus status = StepStatus::OK;
 
-    if (m_CurrentStep + 1 >= m_BP4Deserializer.m_MetadataSet.StepsCount)
+    if (m_FirstStep)
     {
-        status = CheckForNewSteps(Seconds(timeoutSeconds));
+        if (m_BP4Deserializer.m_MetadataSet.StepsCount == 0)
+        {
+            status = CheckForNewSteps(Seconds(timeoutSeconds));
+        }
+    }
+    else
+    {
+        if (m_CurrentStep + 1 >= m_BP4Deserializer.m_MetadataSet.StepsCount)
+        {
+            status = CheckForNewSteps(Seconds(timeoutSeconds));
+        }
     }
 
     // This should be after getting new steps

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -93,7 +93,6 @@ StepStatus BP4Reader::BeginStep(StepMode mode, const float timeoutSeconds)
                                          "in call to BP4 Reader BeginStep");
     }
 
-
     return status;
 }
 


### PR DESCRIPTION
BP4 BeginStep did not handle stepping properly in case of timeout, leading to invalid steps and failing InquireVariable() calls in applications. This PR alone may or may not solve the problem in #1745 