### PR TITLE
BP4 span

### DIFF
--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -76,6 +76,7 @@ void BP3Writer::PerformPuts()
             variableName, "in call to PerformPuts, EndStep or Close");         \
         PerformPutCommon(variable);                                            \
     }
+
         ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -128,7 +128,7 @@ void BP3Writer::Init()
                           const size_t bufferID, const T &value)               \
     {                                                                          \
         TAU_SCOPED_TIMER("BP3Writer::Put");                                    \
-        return PutCommon(variable, span, bufferID, value);                     \
+        PutCommon(variable, span, bufferID, value);                            \
     }
 
 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)

--- a/source/adios2/engine/bp3/BP3Writer.tcc
+++ b/source/adios2/engine/bp3/BP3Writer.tcc
@@ -31,7 +31,7 @@ void BP3Writer::PutCommon(Variable<T> &variable,
             m_IO.m_Name, m_IO.m_HostLanguage,
             m_FileDataManager.GetTransportsTypes());
     }
-    const typename Variable<T>::Info blockInfo =
+    const typename Variable<T>::Info &blockInfo =
         variable.SetBlockInfo(nullptr, CurrentStep());
     m_BP3Serializer.m_DeferredVariables.insert(variable.m_Name);
 

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -81,7 +81,7 @@ void BP4Writer::PerformPuts()
         PerformPutCommon(variable);                                            \
     }
 
-        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
+        ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
     }
     m_BP4Serializer.m_DeferredVariables.clear();
@@ -638,6 +638,16 @@ void BP4Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
 
     m_BP4Serializer.m_Aggregator.ResetBuffers();
 }
+
+#define declare_type(T, L)                                                     \
+    T *BP4Writer::DoBufferData_##L(const size_t payloadPosition,               \
+                                   const size_t bufferID) noexcept             \
+    {                                                                          \
+        return BufferDataCommon<T>(payloadPosition, bufferID);                 \
+    }
+
+ADIOS2_FOREACH_PRIMITVE_STDTYPE_2ARGS(declare_type)
+#undef declare_type
 
 } // end namespace engine
 } // end namespace core

--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -72,23 +72,32 @@ private:
     void InitBPBuffer();
 
 #define declare_type(T)                                                        \
+    void DoPut(Variable<T> &variable, typename Variable<T>::Span &span,        \
+               const size_t bufferID, const T &value) final;
+
+    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+#define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &, const T *) final;                            \
     void DoPutDeferred(Variable<T> &, const T *) final;
 
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
-    /**
-     * Common function for primitive PutSync, puts variables in buffer
-     * @param variable
-     * @param values
-     */
+    template <class T>
+    void PutCommon(Variable<T> &variable, typename Variable<T>::Span &span,
+                   const size_t bufferID, const T &value);
+
     template <class T>
     void PutSyncCommon(Variable<T> &variable,
                        const typename Variable<T>::Info &blockInfo);
 
     template <class T>
     void PutDeferredCommon(Variable<T> &variable, const T *data);
+
+    template <class T>
+    void PerformPutCommon(Variable<T> &variable);
 
     void DoFlush(const bool isFinal = false, const int transportIndex = -1);
 

--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -96,9 +96,6 @@ private:
     template <class T>
     void PutDeferredCommon(Variable<T> &variable, const T *data);
 
-    template <class T>
-    void PerformPutCommon(Variable<T> &variable);
-
     void DoFlush(const bool isFinal = false, const int transportIndex = -1);
 
     void DoClose(const int transportIndex = -1) final;
@@ -128,6 +125,20 @@ private:
      * @param transportIndex
      */
     void AggregateWriteData(const bool isFinal, const int transportIndex = -1);
+
+#define declare_type(T, L)                                                     \
+    T *DoBufferData_##L(const size_t payloadPosition,                          \
+                        const size_t bufferID = 0) noexcept final;
+
+    ADIOS2_FOREACH_PRIMITVE_STDTYPE_2ARGS(declare_type)
+#undef declare_type
+
+    template <class T>
+    T *BufferDataCommon(const size_t payloadOffset,
+                        const size_t bufferID) noexcept;
+
+    template <class T>
+    void PerformPutCommon(Variable<T> &variable);
 };
 
 } // end namespace engine

--- a/source/adios2/engine/bp4/BP4Writer.tcc
+++ b/source/adios2/engine/bp4/BP4Writer.tcc
@@ -117,6 +117,15 @@ void BP4Writer::PutDeferredCommon(Variable<T> &variable, const T *data)
 }
 
 template <class T>
+T *BP4Writer::BufferDataCommon(const size_t payloadPosition,
+                               const size_t /*bufferID*/) noexcept
+{
+    T *data = reinterpret_cast<T *>(m_BP4Serializer.m_Data.m_Buffer.data() +
+                                    payloadPosition);
+    return data;
+}
+
+template <class T>
 void BP4Writer::PerformPutCommon(Variable<T> &variable)
 {
     for (size_t b = 0; b < variable.m_BlocksInfo.size(); ++b)

--- a/source/adios2/engine/bp4/BP4Writer.tcc
+++ b/source/adios2/engine/bp4/BP4Writer.tcc
@@ -137,7 +137,8 @@ void BP4Writer::PerformPutCommon(Variable<T> &variable)
         }
         else
         {
-            m_BP4Serializer.PutSpanMetadata(variable, itSpanBlock->second);
+            m_BP4Serializer.PutSpanMetadata(variable, variable.m_BlocksInfo[b],
+                                            itSpanBlock->second);
         }
     }
 

--- a/source/adios2/engine/bp4/BP4Writer.tcc
+++ b/source/adios2/engine/bp4/BP4Writer.tcc
@@ -20,6 +20,48 @@ namespace engine
 {
 
 template <class T>
+void BP4Writer::PutCommon(Variable<T> &variable,
+                          typename Variable<T>::Span &span,
+                          const size_t /*bufferID*/, const T &value)
+{
+    // if first timestep Write create a new pg index
+    if (!m_BP4Serializer.m_MetadataSet.DataPGIsOpen)
+    {
+        m_BP4Serializer.PutProcessGroupIndex(
+            m_IO.m_Name, m_IO.m_HostLanguage,
+            m_FileDataManager.GetTransportsTypes());
+    }
+    const typename Variable<T>::Info &blockInfo =
+        variable.SetBlockInfo(nullptr, CurrentStep());
+    m_BP4Serializer.m_DeferredVariables.insert(variable.m_Name);
+
+    const size_t dataSize =
+        helper::PayloadSize(blockInfo.Data, blockInfo.Count) +
+        m_BP4Serializer.GetBPIndexSizeInData(variable.m_Name, blockInfo.Count);
+
+    const format::BP4Serializer::ResizeResult resizeResult =
+        m_BP4Serializer.ResizeBuffer(dataSize, "in call to variable " +
+                                                   variable.m_Name + " Put");
+
+    if (m_DebugMode &&
+        resizeResult == format::BP4Serializer::ResizeResult::Flush)
+    {
+        throw std::invalid_argument(
+            "ERROR: returning a Span can't trigger "
+            "buffer reallocation in BP4 engine, remove "
+            "MaxBufferSize parameter, in call to Put\n");
+    }
+
+    // WRITE INDEX to data buffer and metadata structure (in memory)//
+    const bool sourceRowMajor = helper::IsRowMajor(m_IO.m_HostLanguage);
+    m_BP4Serializer.PutVariableMetadata(variable, blockInfo, sourceRowMajor,
+                                        &span);
+    span.m_Value = value;
+    m_BP4Serializer.PutVariablePayload(variable, blockInfo, sourceRowMajor,
+                                       &span);
+}
+
+template <class T>
 void BP4Writer::PutSyncCommon(Variable<T> &variable,
                               const typename Variable<T>::Info &blockInfo)
 {
@@ -72,6 +114,26 @@ void BP4Writer::PutDeferredCommon(Variable<T> &variable, const T *data)
         1.05 * helper::PayloadSize(blockInfo.Data, blockInfo.Count) +
         4 * m_BP4Serializer.GetBPIndexSizeInData(variable.m_Name,
                                                  blockInfo.Count));
+}
+
+template <class T>
+void BP4Writer::PerformPutCommon(Variable<T> &variable)
+{
+    for (size_t b = 0; b < variable.m_BlocksInfo.size(); ++b)
+    {
+        auto itSpanBlock = variable.m_BlocksSpan.find(b);
+        if (itSpanBlock == variable.m_BlocksSpan.end())
+        {
+            PutSyncCommon(variable, variable.m_BlocksInfo[b]);
+        }
+        else
+        {
+            m_BP4Serializer.PutSpanMetadata(variable, itSpanBlock->second);
+        }
+    }
+
+    variable.m_BlocksInfo.clear();
+    variable.m_BlocksSpan.clear();
 }
 
 } // end namespace engine

--- a/source/adios2/helper/adiosMath.h
+++ b/source/adios2/helper/adiosMath.h
@@ -264,12 +264,12 @@ enum class BlockDivisionMethod
  */
 struct BlockDivisionInfo
 {
-    uint16_t NBlocks;
-    size_t SubBlockSize;
-    BlockDivisionMethod DivisionMethod;
     std::vector<uint16_t> Div;
     std::vector<uint16_t> Rem;
     std::vector<uint16_t> ReverseDivProduct;
+    size_t SubBlockSize;
+    uint16_t NBlocks;
+    BlockDivisionMethod DivisionMethod;
 };
 
 /** Chop a block into smaller pieces by a size limit.
@@ -312,7 +312,7 @@ Box<Dims> GetSubBlock(const Dims &count, const BlockDivisionInfo &info,
  */
 template <class T>
 void GetMinMaxSubblocks(const T *values, const Dims &count,
-                        const BlockDivisionInfo info, std::vector<T> &MinMaxs,
+                        const BlockDivisionInfo &info, std::vector<T> &MinMaxs,
                         T &bmin, T &bmax, const unsigned int threads) noexcept;
 
 } // end namespace helper

--- a/source/adios2/helper/adiosMath.inl
+++ b/source/adios2/helper/adiosMath.inl
@@ -349,25 +349,36 @@ void GetMinMaxThreads(const std::complex<T> *values, const size_t size,
 
 template <class T>
 void GetMinMaxSubblocks(const T *values, const Dims &count,
-                        const BlockDivisionInfo info, std::vector<T> &MinMaxs,
+                        const BlockDivisionInfo &info, std::vector<T> &MinMaxs,
                         T &bmin, T &bmax, const unsigned int threads) noexcept
 {
     const int ndim = static_cast<int>(count.size());
     const size_t nElems = helper::GetTotalSize(count);
     if (info.NBlocks <= 1)
     {
-        GetMinMaxThreads(values, nElems, bmin, bmax, threads);
         MinMaxs.resize(2);
+        // account for span
+        if (values == nullptr)
+        {
+            return;
+        }
+        GetMinMaxThreads(values, nElems, bmin, bmax, threads);
         MinMaxs[0] = bmin;
         MinMaxs[1] = bmax;
     }
     else
     {
-        // Calculate min/max for each block separately
         MinMaxs.resize(2 * info.NBlocks);
+        // account for span
+        if (values == nullptr)
+        {
+            return;
+        }
+
+        // Calculate min/max for each block separately
         for (int b = 0; b < info.NBlocks; ++b)
         {
-            Box<Dims> box = GetSubBlock(count, info, b);
+            const Box<Dims> box = GetSubBlock(count, info, b);
             // calculate start position of this subblock in values array
             size_t pos = 0;
             size_t prod = 1;

--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -294,11 +294,6 @@ size_t PaddingToAlignPointer(const void *ptr)
     {
         padSize = 0;
     }
-    /*std::cout << " -- Pad pointer with " << std::to_string(padSize)
-              << " bytes. original pointer = " << std::to_string(memLocation)
-              << " aligned pointer = " << std::to_string(memLocation + padSize)
-              << " sizeof(max_align_t) = "
-              << std::to_string(sizeof(max_align_t)) << std::endl;*/
     return padSize;
 }
 

--- a/source/adios2/toolkit/format/bp/bp3/BP3Base.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Base.cpp
@@ -113,7 +113,9 @@ size_t BP3Base::GetBPIndexSizeInData(const std::string &variableName,
         indexSize += 28 * dimensions + 1;
     }
 
-    return indexSize + 12; // extra 12 bytes in case of attributes
+    indexSize += 32 + 5; // extra bytes for padding
+    indexSize += 12;     // extra 12 bytes in case of attributes
+    return indexSize;
 }
 
 // PROTECTED

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.cpp
@@ -656,18 +656,6 @@ BP3Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
     return indexPositions;
 }
 
-void BP3Serializer::SetDataOffset(uint64_t &offset) noexcept
-{
-    if (m_Aggregator.m_IsActive && !m_Aggregator.m_IsConsumer)
-    {
-        offset = static_cast<uint64_t>(m_Data.m_Position);
-    }
-    else
-    {
-        offset = static_cast<uint64_t>(m_Data.m_AbsolutePosition);
-    }
-}
-
 #define declare_template_instantiation(T)                                      \
     void BP3Serializer::DoPutAttributeInData(                                  \
         const core::Attribute<T> &attribute, Stats<T> &stats) noexcept         \

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.h
@@ -176,10 +176,11 @@ private:
                         const bool isRowMajor) noexcept;
 
     template <class T>
-    void
-    PutVariableMetadataInData(const core::Variable<T> &variable,
-                              const typename core::Variable<T>::Info &blockInfo,
-                              const Stats<T> &stats) noexcept;
+    void PutVariableMetadataInData(
+        const core::Variable<T> &variable,
+        const typename core::Variable<T>::Info &blockInfo,
+        const Stats<T> &stats,
+        const typename core::Variable<T>::Span *span = nullptr) noexcept;
 
     template <class T>
     void PutVariableMetadataInIndex(
@@ -234,8 +235,6 @@ private:
     std::vector<size_t>
     AggregateCollectiveMetadataIndices(helper::Comm const &comm,
                                        BufferSTL &bufferSTL);
-
-    void SetDataOffset(uint64_t &offset) noexcept;
 };
 
 #define declare_template_instantiation(T)                                      \

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.tcc
@@ -28,6 +28,18 @@ void BP3Serializer::PutVariableMetadata(
     const typename core::Variable<T>::Info &blockInfo,
     const bool sourceRowMajor, typename core::Variable<T>::Span *span) noexcept
 {
+    auto lf_SetOffset = [&](uint64_t &offset) {
+        if (m_Aggregator.m_IsActive && !m_Aggregator.m_IsConsumer)
+        {
+            offset = static_cast<uint64_t>(m_Data.m_Position);
+        }
+        else
+        {
+            offset = static_cast<uint64_t>(m_Data.m_AbsolutePosition +
+                                           m_PreDataFileLength);
+        }
+    };
+
     m_Profiler.Start("buffering");
 
     Stats<T> stats =
@@ -40,7 +52,7 @@ void BP3Serializer::PutVariableMetadata(
     stats.MemberID = variableIndex.MemberID;
 
     SetDataOffset(stats.Offset);
-    PutVariableMetadataInData(variable, blockInfo, stats);
+    PutVariableMetadataInData(variable, blockInfo, stats, span);
     SetDataOffset(stats.PayloadOffset);
     if (span != nullptr)
     {
@@ -71,10 +83,10 @@ inline void BP3Serializer::PutVariablePayload(
                                                m_Data.m_Position);
 
             // TODO: does std::fill_n have a bug in gcc or due to optimizations
-            // this is impossible? This seg faults in Release mode only . Even
-            // RelWithDebInfo works, replacing with explicit loop below using
-            // access operator []
-            // std::fill_n(itBegin, blockSize, span->m_Value);
+            // this is impossible due to memory alignment? This seg faults in
+            // Release mode only . Even RelWithDebInfo works, replacing with
+            // explicit loop below using access operator [] std::fill_n(itBegin,
+            // blockSize, span->m_Value);
 
             for (size_t i = 0; i < blockSize; ++i)
             {
@@ -318,8 +330,8 @@ BP3Serializer::GetBPStats(const bool singleValue,
 template <class T>
 void BP3Serializer::PutVariableMetadataInData(
     const core::Variable<T> &variable,
-    const typename core::Variable<T>::Info &blockInfo,
-    const Stats<T> &stats) noexcept
+    const typename core::Variable<T>::Info &blockInfo, const Stats<T> &stats,
+    const typename core::Variable<T>::Span *span) noexcept
 {
     auto &buffer = m_Data.m_Buffer;
     auto &position = m_Data.m_Position;
@@ -354,7 +366,26 @@ void BP3Serializer::PutVariableMetadataInData(
     // CHARACTERISTICS
     PutVariableCharacteristics(variable, blockInfo, stats, buffer, position);
 
-    // Back to varLength including payload size
+    // here align pointer for span
+    if (span != nullptr)
+    {
+        const size_t padLengthPosition = position;
+        uint8_t zero = 0;
+        // skip 1 for paddingLength and 4 for VMD] ending
+        helper::CopyToBuffer(buffer, position, &zero, 5);
+        // here check for the next aligned pointer
+        const size_t extraBytes = m_Data.Align<T>();
+        const std::string pad = std::string(extraBytes, '\0') + "VMD]";
+
+        size_t backPosition = padLengthPosition;
+        const uint8_t padLength = static_cast<uint8_t>(pad.size());
+        helper::CopyToBuffer(buffer, backPosition, &padLength);
+        helper::CopyToBuffer(buffer, backPosition, pad.c_str(), pad.size());
+
+        position += extraBytes;
+    }
+
+    // Back to varLength including payload size and pad
     // not need to remove its own size (8) from length from bpdump
     const uint64_t varLength = static_cast<uint64_t>(
         position - varLengthPosition +
@@ -370,7 +401,8 @@ template <>
 inline void BP3Serializer::PutVariableMetadataInData(
     const core::Variable<std::string> &variable,
     const typename core::Variable<std::string>::Info &blockInfo,
-    const Stats<std::string> &stats) noexcept
+    const Stats<std::string> &stats,
+    const typename core::Variable<std::string>::Span * /*span*/) noexcept
 {
     auto &buffer = m_Data.m_Buffer;
     auto &position = m_Data.m_Position;

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.tcc
@@ -51,9 +51,9 @@ void BP3Serializer::PutVariableMetadata(
         variable.m_Name, m_MetadataSet.VarsIndices, isNew);
     stats.MemberID = variableIndex.MemberID;
 
-    SetDataOffset(stats.Offset);
+    lf_SetOffset(stats.Offset);
     PutVariableMetadataInData(variable, blockInfo, stats, span);
-    SetDataOffset(stats.PayloadOffset);
+    lf_SetOffset(stats.PayloadOffset);
     if (span != nullptr)
     {
         span->m_PayloadPosition = m_Data.m_Position;

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
@@ -5,7 +5,9 @@
  * BP4Base.cpp
  *
  *  Created on: Aug 1, 2018
- *      Author: Lipeng Wan wanl@ornl.gov
+ *  Author: William F Godoy godoywf@ornl.gov
+ *          Lipeng Wan wanl@ornl.gov
+ *          Norbert Podhorszki pnb@ornl.gov
  */
 #include "BP4Base.h"
 

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.h
@@ -5,7 +5,9 @@
  * BP4Base.h  base class for BP4Serializer and BP4Deserializer
  *
  *  Created on: Aug 1, 2018
- *      Author: Lipeng Wan wanl@ornl.gov
+ *  Author: William F Godoy godoywf@ornl.gov
+ *          Lipeng Wan wanl@ornl.gov
+ *          Norbert Podhorszki pnb@ornl.gov
  */
 
 #ifndef ADIOS2_TOOLKIT_FORMAT_BP_BP4_BP4BASE_H_

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
@@ -5,7 +5,9 @@
  * BP4Deserializer.cpp
  *
  *  Created on: Aug 1, 2018
- *      Author: Lipeng Wan wanl@ornl.gov
+ *  Author: William F Godoy godoywf@ornl.gov
+ *          Lipeng Wan wanl@ornl.gov
+ *          Norbert Podhorszki pnb@ornl.gov
  */
 
 #include "BP4Deserializer.h"

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
@@ -5,7 +5,9 @@
  * BP4Deserializer.h
  *
  *  Created on: Aug 1, 2018
- *      Author: Lipeng Wan wanl@ornl.gov
+ *  Author: William F Godoy godoywf@ornl.gov
+ *          Lipeng Wan wanl@ornl.gov
+ *          Norbert Podhorszki pnb@ornl.gov
  */
 
 #ifndef ADIOS2_TOOLKIT_FORMAT_BP_BP4_BP4DESERIALIZER_H_

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -5,7 +5,9 @@
  * BP4Deserializer.tcc
  *
  *  Created on: Aug 1, 2018
- *      Author: Lipeng Wan wanl@ornl.gov
+ *  Author: William F Godoy godoywf@ornl.gov
+ *          Lipeng Wan wanl@ornl.gov
+ *          Norbert Podhorszki pnb@ornl.gov
  */
 
 #ifndef ADIOS2_TOOLKIT_FORMAT_BP1_BP4DESERIALIZER_TCC_

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
@@ -5,7 +5,9 @@
  * BP4Serializer.cpp
  *
  *  Created on: Aug 1, 2018
- *      Author: Lipeng Wan wanl@ornl.gov
+ *  Author: William F Godoy godoywf@ornl.gov
+ *          Lipeng Wan wanl@ornl.gov
+ *          Norbert Podhorszki pnb@ornl.gov
  */
 
 #include "BP4Serializer.h"
@@ -1796,16 +1798,24 @@ ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
 #define declare_template_instantiation(T)                                      \
     template void BP4Serializer::PutVariablePayload(                           \
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        const bool) noexcept;                                                  \
+        const bool, typename core::Variable<T>::Span *) noexcept;              \
                                                                                \
     template void BP4Serializer::PutVariableMetadata(                          \
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        const bool) noexcept;
+        const bool, typename core::Variable<T>::Span *) noexcept;
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 //------------------------------------------------------------------------------
+
+#define declare_template_instantiation(T)                                      \
+    template void BP4Serializer::PutSpanMetadata(                              \
+        const core::Variable<T> &,                                             \
+        const typename core::Variable<T>::Span &) noexcept;
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
 
 } // end namespace format
 } // end namespace adios2

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
@@ -1811,7 +1811,7 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 
 #define declare_template_instantiation(T)                                      \
     template void BP4Serializer::PutSpanMetadata(                              \
-        const core::Variable<T> &,                                             \
+        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
         const typename core::Variable<T>::Span &) noexcept;
 
 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.h
@@ -65,18 +65,26 @@ public:
      * @param variable
      */
     template <class T>
-    void PutVariableMetadata(const core::Variable<T> &variable,
-                             const typename core::Variable<T>::Info &blockInfo,
-                             const bool sourceRowMajor = true) noexcept;
+    void PutVariableMetadata(
+        const core::Variable<T> &variable,
+        const typename core::Variable<T>::Info &blockInfo,
+        const bool sourceRowMajor = true,
+        typename core::Variable<T>::Span *span = nullptr) noexcept;
 
     /**
      * Put in buffer variable payload. Expensive part.
      * @param variable payload input from m_PutValues
      */
     template <class T>
-    void PutVariablePayload(const core::Variable<T> &variable,
-                            const typename core::Variable<T>::Info &blockInfo,
-                            const bool sourceRowMajor = true) noexcept;
+    void PutVariablePayload(
+        const core::Variable<T> &variable,
+        const typename core::Variable<T>::Info &blockInfo,
+        const bool sourceRowMajor = true,
+        typename core::Variable<T>::Span *span = nullptr) noexcept;
+
+    template <class T>
+    void PutSpanMetadata(const core::Variable<T> &variable,
+                         const typename core::Variable<T>::Span &span) noexcept;
 
     /**
      * Serializes the metadata indices appending it into the data buffer inside
@@ -199,23 +207,25 @@ private:
      * PutVariablePayload()
      */
     template <class T>
-    size_t
-    PutVariableMetadataInData(const core::Variable<T> &variable,
-                              const typename core::Variable<T>::Info &blockInfo,
-                              const Stats<T> &stats) noexcept;
+    size_t PutVariableMetadataInData(
+        const core::Variable<T> &variable,
+        const typename core::Variable<T>::Info &blockInfo,
+        const Stats<T> &stats,
+        const typename core::Variable<T>::Span *span) noexcept;
 
     template <class T>
     void PutVariableMetadataInIndex(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::Info &blockInfo,
-        const Stats<T> &stats, const bool isNew,
-        SerialElementIndex &index) noexcept;
+        const Stats<T> &stats, const bool isNew, SerialElementIndex &index,
+        typename core::Variable<T>::Span *span) noexcept;
 
     template <class T>
     void PutVariableCharacteristics(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::Info &blockInfo,
-        const Stats<T> &stats, std::vector<char> &buffer) noexcept;
+        const Stats<T> &stats, std::vector<char> &buffer,
+        typename core::Variable<T>::Span *span) noexcept;
 
     template <class T>
     void PutVariableCharacteristicsInData(
@@ -321,13 +331,21 @@ private:
 #define declare_template_instantiation(T)                                      \
     extern template void BP4Serializer::PutVariablePayload(                    \
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        const bool) noexcept;                                                  \
+        const bool, typename core::Variable<T>::Span *) noexcept;              \
                                                                                \
     extern template void BP4Serializer::PutVariableMetadata(                   \
         const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
-        const bool) noexcept;
+        const bool, typename core::Variable<T>::Span *) noexcept;
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+
+#define declare_template_instantiation(T)                                      \
+    extern template void BP4Serializer::PutSpanMetadata(                       \
+        const core::Variable<T> &,                                             \
+        const typename core::Variable<T>::Span &) noexcept;
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.h
@@ -5,7 +5,9 @@
  * BP4Serializer.h
  *
  *  Created on: Aug 1, 2018
- *      Author: Lipeng Wan wanl@ornl.gov
+ *  Author: William F Godoy godoywf@ornl.gov
+ *          Lipeng Wan wanl@ornl.gov
+ *          Norbert Podhorszki pnb@ornl.gov
  */
 
 #ifndef ADIOS2_TOOLKIT_FORMAT_BP_BP4_BP4SERIALIZER_H_
@@ -84,6 +86,7 @@ public:
 
     template <class T>
     void PutSpanMetadata(const core::Variable<T> &variable,
+                         const typename core::Variable<T>::Info &blockInfo,
                          const typename core::Variable<T>::Span &span) noexcept;
 
     /**
@@ -342,7 +345,7 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 
 #define declare_template_instantiation(T)                                      \
     extern template void BP4Serializer::PutSpanMetadata(                       \
-        const core::Variable<T> &,                                             \
+        const core::Variable<T> &, const typename core::Variable<T>::Info &,   \
         const typename core::Variable<T>::Span &) noexcept;
 
 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
@@ -5,7 +5,10 @@
  * BP4Serializer.tcc
  *
  *  Created on: Aug 1, 2018
- *      Author: Lipeng Wan wanl@ornl.gov
+ *      Author: William F Godoy godoywf@ornl.gov
+ *              Lipeng Wan wanl@ornl.gov
+ *              Norbert Podhorszki pnb@ornl.gov
+ *
  */
 
 #ifndef ADIOS2_TOOLKIT_FORMAT_BP4_BP4SERIALIZER_TCC_
@@ -30,7 +33,7 @@ template <class T>
 inline void BP4Serializer::PutVariableMetadata(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::Info &blockInfo,
-    const bool sourceRowMajor) noexcept
+    const bool sourceRowMajor, typename core::Variable<T>::Span *span) noexcept
 {
     auto lf_SetOffset = [&](uint64_t &offset) {
         if (m_Aggregator.m_IsActive && !m_Aggregator.m_IsConsumer)
@@ -57,15 +60,18 @@ inline void BP4Serializer::PutVariableMetadata(
         true; // flag to indicate this variable is put at current step
     stats.MemberID = variableIndex.MemberID;
 
-    /*const size_t startingPos = m_Data.m_Position;*/
     lf_SetOffset(stats.Offset);
     m_LastVarLengthPosInBuffer =
-        PutVariableMetadataInData(variable, blockInfo, stats);
+        PutVariableMetadataInData(variable, blockInfo, stats, span);
     lf_SetOffset(stats.PayloadOffset);
+    if (span != nullptr)
+    {
+        span->m_PayloadPosition = m_Data.m_Position;
+    }
 
     // write to metadata  index
-    PutVariableMetadataInIndex(variable, blockInfo, stats, isNew,
-                               variableIndex);
+    PutVariableMetadataInIndex(variable, blockInfo, stats, isNew, variableIndex,
+                               span);
     ++m_MetadataSet.DataPGVarsCount;
 
     m_Profiler.Stop("buffering");
@@ -75,7 +81,7 @@ template <class T>
 inline void BP4Serializer::PutVariablePayload(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::Info &blockInfo,
-    const bool sourceRowMajor) noexcept
+    const bool sourceRowMajor, typename core::Variable<T>::Span *span) noexcept
 {
     m_Profiler.Start("buffering");
     if (blockInfo.Operations.empty())
@@ -96,6 +102,34 @@ inline void BP4Serializer::PutVariablePayload(
     helper::CopyToBuffer(m_Data.m_Buffer, backPosition, &varLength);
 
     m_Profiler.Stop("buffering");
+}
+
+template <class T>
+void BP4Serializer::PutSpanMetadata(
+    const core::Variable<T> &variable,
+    const typename core::Variable<T>::Span &span) noexcept
+{
+    if (m_Parameters.StatsLevel > 0)
+    {
+        // Get Min/Max from populated data
+        m_Profiler.Start("minmax");
+        T min, max;
+        helper::GetMinMaxThreads(span.Data(), span.Size(), min, max,
+                                 m_Parameters.Threads);
+        m_Profiler.Stop("minmax");
+
+        // Put min/max in variable index
+        SerialElementIndex &variableIndex =
+            m_MetadataSet.VarsIndices.at(variable.m_Name);
+        auto &buffer = variableIndex.Buffer;
+
+        const size_t minPosition = span.m_MinMaxMetadataPositions.first;
+        const size_t maxPosition = span.m_MinMaxMetadataPositions.second;
+        std::copy(&min, &min + 1,
+                  reinterpret_cast<T *>(buffer.data() + minPosition));
+        std::copy(&max, &max + 1,
+                  reinterpret_cast<T *>(buffer.data() + maxPosition));
+    }
 }
 
 // PRIVATE
@@ -268,6 +302,14 @@ BP4Serializer::GetBPStats(const bool singleValue,
     stats.Step = m_MetadataSet.TimeStep;
     stats.FileIndex = GetFileIndex();
 
+    // added to support span
+    if (blockInfo.Data == nullptr)
+    {
+        stats.Min = {};
+        stats.Max = {};
+        return stats;
+    }
+
     if (singleValue)
     {
         stats.Value = *blockInfo.Data;
@@ -279,14 +321,7 @@ BP4Serializer::GetBPStats(const bool singleValue,
     if (m_Parameters.StatsLevel > 0)
     {
         m_Profiler.Start("minmax");
-        if (!blockInfo.MemoryStart.empty())
-        {
-            // non-contiguous memory min/max
-            helper::GetMinMaxSelection(blockInfo.Data, blockInfo.MemoryCount,
-                                       blockInfo.MemoryStart, blockInfo.Count,
-                                       isRowMajor, stats.Min, stats.Max);
-        }
-        else
+        if (blockInfo.MemoryStart.empty())
         {
             stats.SubBlockInfo = helper::DivideBlock(
                 blockInfo.Count, m_Parameters.StatsBlockSize,
@@ -294,6 +329,13 @@ BP4Serializer::GetBPStats(const bool singleValue,
             helper::GetMinMaxSubblocks(
                 blockInfo.Data, blockInfo.Count, stats.SubBlockInfo,
                 stats.MinMaxs, stats.Min, stats.Max, m_Parameters.Threads);
+        }
+        else
+        {
+            // non-contiguous memory min/max
+            helper::GetMinMaxSelection(blockInfo.Data, blockInfo.MemoryCount,
+                                       blockInfo.MemoryStart, blockInfo.Count,
+                                       isRowMajor, stats.Min, stats.Max);
         }
         m_Profiler.Stop("minmax");
     }
@@ -304,8 +346,8 @@ BP4Serializer::GetBPStats(const bool singleValue,
 template <class T>
 size_t BP4Serializer::PutVariableMetadataInData(
     const core::Variable<T> &variable,
-    const typename core::Variable<T>::Info &blockInfo,
-    const Stats<T> &stats) noexcept
+    const typename core::Variable<T>::Info &blockInfo, const Stats<T> &stats,
+    const typename core::Variable<T>::Span *span) noexcept
 {
     auto &buffer = m_Data.m_Buffer;
     auto &position = m_Data.m_Position;
@@ -355,22 +397,25 @@ size_t BP4Serializer::PutVariableMetadataInData(
     PutVariableCharacteristicsInData(variable, blockInfo, stats, buffer,
                                      position);
 
-    // pad metadata so that data will fall on aligned position in memory
-    // write a padding plus block identifier VMD]
-    // format: length in 1 byte + padding characters + VMD]
-    // we would write at minimum 5 bytes, byte for length + "VMD]"
-    // hence the +5 in the calculation below
-    size_t padSize = rand() % 32;
-    // helper::PaddingToAlignPointer(buffer.data() + position + 5);
+    // here align pointer for span
+    // TODO: span only
+    if (span != nullptr)
+    {
+        const size_t padLengthPosition = position;
+        uint8_t zero = 0;
+        // skip 1 for paddingLength and 4 for VMD] ending
+        helper::CopyToBuffer(buffer, position, &zero, 5);
+        // here check for the next aligned pointer
+        const size_t extraBytes = m_Data.Align<T>();
+        const std::string pad = std::string(extraBytes, '\0') + "VMD]";
 
-    const char vmdEnd[] = "                                VMD]";
-    unsigned char vmdEndLen = static_cast<unsigned char>(padSize + 4);
-    // starting position in vmdEnd from where we copy to buffer
-    // we don't copy the \0 from vmdEnd !
-    const char *ptr = vmdEnd + (sizeof(vmdEnd) - 1 - vmdEndLen);
+        size_t backPosition = padLengthPosition;
+        const uint8_t padLength = static_cast<uint8_t>(pad.size());
+        helper::CopyToBuffer(buffer, backPosition, &padLength);
+        helper::CopyToBuffer(buffer, backPosition, pad.c_str(), pad.size());
 
-    helper::CopyToBuffer(buffer, position, &vmdEndLen, 1);
-    helper::CopyToBuffer(buffer, position, ptr, vmdEndLen);
+        position += extraBytes;
+    }
 
     absolutePosition += position - mdBeginPosition;
     return varLengthPosition;
@@ -380,7 +425,8 @@ template <>
 inline size_t BP4Serializer::PutVariableMetadataInData(
     const core::Variable<std::string> &variable,
     const typename core::Variable<std::string>::Info &blockInfo,
-    const Stats<std::string> &stats) noexcept
+    const Stats<std::string> &stats,
+    const typename core::Variable<std::string>::Span * /*span*/) noexcept
 {
     auto &buffer = m_Data.m_Buffer;
     auto &position = m_Data.m_Position;
@@ -431,7 +477,8 @@ template <class T>
 void BP4Serializer::PutVariableMetadataInIndex(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::Info &blockInfo, const Stats<T> &stats,
-    const bool isNew, SerialElementIndex &index) noexcept
+    const bool isNew, SerialElementIndex &index,
+    typename core::Variable<T>::Span *span) noexcept
 {
     auto &buffer = index.Buffer;
 
@@ -464,7 +511,7 @@ void BP4Serializer::PutVariableMetadataInIndex(
         // For updating absolute offsets in agreggation
         index.LastUpdatedPosition = buffer.size();
 
-        PutVariableCharacteristics(variable, blockInfo, stats, buffer);
+        PutVariableCharacteristics(variable, blockInfo, stats, buffer, span);
         const uint32_t indexLength =
             static_cast<uint32_t>(buffer.size() - indexLengthPosition - 4);
 
@@ -475,7 +522,7 @@ void BP4Serializer::PutVariableMetadataInIndex(
     else // update characteristics sets length and count
     {
         size_t currentIndexStartPosition = buffer.size();
-        PutVariableCharacteristics(variable, blockInfo, stats, buffer);
+        PutVariableCharacteristics(variable, blockInfo, stats, buffer, span);
         uint32_t currentIndexLength =
             static_cast<uint32_t>(buffer.size() - currentIndexStartPosition);
 
@@ -606,7 +653,8 @@ template <>
 inline void BP4Serializer::PutVariableCharacteristics(
     const core::Variable<std::string> &variable,
     const core::Variable<std::string>::Info &blockInfo,
-    const Stats<std::string> &stats, std::vector<char> &buffer) noexcept
+    const Stats<std::string> &stats, std::vector<char> &buffer,
+    typename core::Variable<std::string>::Span * /*span*/) noexcept
 {
     const size_t characteristicsCountPosition = buffer.size();
     // skip characteristics count(1) + length (4)
@@ -660,7 +708,7 @@ template <class T>
 void BP4Serializer::PutVariableCharacteristics(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::Info &blockInfo, const Stats<T> &stats,
-    std::vector<char> &buffer) noexcept
+    std::vector<char> &buffer, typename core::Variable<T>::Span *span) noexcept
 {
     // going back at the end
     const size_t characteristicsCountPosition = buffer.size();
@@ -685,10 +733,17 @@ void BP4Serializer::PutVariableCharacteristics(
                         buffer);
     ++characteristicsCounter;
 
-    if (blockInfo.Data != nullptr)
+    if (blockInfo.Data != nullptr || span != nullptr)
     {
         // minmax array depends on number of dimensions so this must
         // come after dimensions characteristics
+        if (m_Parameters.StatsLevel > 0 && span != nullptr)
+        {
+            span->m_MinMaxMetadataPositions.first = buffer.size() + 1;
+            span->m_MinMaxMetadataPositions.second =
+                buffer.size() + 2 + sizeof(T);
+        }
+
         PutBoundsRecord(variable.m_SingleValue, stats, characteristicsCounter,
                         buffer);
     }

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.cpp
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "BufferSTL.h"
+#include "BufferSTL.tcc"
 
 namespace adios2
 {
@@ -58,6 +59,12 @@ size_t BufferSTL::GetAvailableSize() const
 {
     return m_Buffer.size() - m_Position;
 }
+
+#define declare_template_instantiation(T)                                      \
+    template size_t BufferSTL::Align<T>() const noexcept;
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
 
 } // end namespace format
 } // end namespace adios2

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.h
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.h
@@ -13,6 +13,8 @@
 
 #include "adios2/toolkit/format/buffer/Buffer.h"
 
+#include "adios2/common/ADIOSMacros.h"
+
 namespace adios2
 {
 namespace format
@@ -39,6 +41,12 @@ public:
     template <class T>
     size_t Align() const noexcept;
 };
+
+#define declare_template_instantiation(T)                                      \
+    extern template size_t BufferSTL::Align<T>() const noexcept;
+
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
 
 } // end namespace format
 } // end namespace adios2

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.h
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.h
@@ -35,6 +35,9 @@ public:
                const bool zeroInitialize) final;
 
     size_t GetAvailableSize() const final;
+
+    template <class T>
+    size_t Align() const noexcept;
 };
 
 } // end namespace format

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
@@ -23,7 +23,8 @@ namespace format
 template <class T>
 size_t BufferSTL::Align() const noexcept
 {
-    void *currentAddress = m_Buffer.data() + m_Position;
+    void *currentAddress = reinterpret_cast<void *>(
+        const_cast<char *>(m_Buffer.data() + m_Position));
     size_t size = GetAvailableSize();
     std::align(alignof(T), sizeof(T), currentAddress, size);
     return GetAvailableSize() - size;

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
@@ -27,8 +27,8 @@ namespace format
 template <class T>
 size_t BufferSTL::Align() const noexcept
 {
-    // LLVM MIT license
-    // https://github.com/llvm-mirror/libcxx/blob/6952d1478ddd5a1870079d01f1a0e1eea5b09a1a/src/memory.cpp#L217
+    // std::align implementation from llvm libc++
+    // needed due to bug in gcc 4.8
     auto lf_align = [](const size_t alignment, const size_t size, void *&ptr,
                        size_t &space) {
         if (size <= space)

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
@@ -13,8 +13,6 @@
 
 #include "BufferSTL.h"
 
-#include <memory>
-
 namespace adios2
 {
 namespace format
@@ -23,10 +21,22 @@ namespace format
 template <class T>
 size_t BufferSTL::Align() const noexcept
 {
+    auto lf_align = [](const size_t align, const size_t size, void *&ptr,
+                       size_t &space) {
+        const uintptr_t largePtr = reinterpret_cast<uintptr_t>(ptr);
+        const uintptr_t aligned = (largePtr - 1u + align) & -align;
+        const uintptr_t diff = aligned - largePtr;
+        if ((size + diff) <= space)
+        {
+            space -= diff;
+        }
+    };
+
     void *currentAddress = reinterpret_cast<void *>(
         const_cast<char *>(m_Buffer.data() + m_Position));
     size_t size = GetAvailableSize();
-    std::align(alignof(T), sizeof(T), currentAddress, size);
+    lf_align(alignof(T), sizeof(T), currentAddress, size);
+
     return GetAvailableSize() - size;
 }
 

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
@@ -1,0 +1,35 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * BufferSTL.tcc
+ *
+ *  Created on: Sep 18, 2019
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#ifndef ADIOS2_TOOLKIT_FORMAT_BUFFER_HEAP_BUFFERSTL_TCC_
+#define ADIOS2_TOOLKIT_FORMAT_BUFFER_HEAP_BUFFERSTL_TCC_
+
+#include "BufferSTL.h"
+
+#include <memory>
+
+namespace adios2
+{
+namespace format
+{
+
+template <class T>
+size_t BufferSTL::Align() const noexcept
+{
+    void *currentAddress = m_Buffer.data() + m_Position;
+    size_t size = GetAvailableSize();
+    std::align(alignof(T), sizeof(T), currentAddress, size);
+    return GetAvailableSize() - size;
+}
+
+} // end namespace format
+} // end namespace adios2
+
+#endif /* ADIOS2_TOOLKIT_FORMAT_BUFFER_HEAP_BUFFERSTL_TCC_ */

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -19,36 +19,33 @@ endmacro()
 
 add_subdirectory(operations)
 
-bp3_bp4_gtest_add_tests_helper(BPWriteReadADIOS2)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadADIOS2fstream)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadADIOS2stdio)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadAsStreamADIOS2)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadAsStreamADIOS2_Threads)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadAttributesADIOS2)
-bp3_bp4_gtest_add_tests_helper(StreamWriteReadHighLevelAPI)
-bp3_bp4_gtest_add_tests_helper(BPWriteFlushRead)
-bp3_bp4_gtest_add_tests_helper(BPWriteMultiblockRead)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadMultiblock)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadVector)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadAttributesMultirank)
-bp3_bp4_gtest_add_tests_helper(BPLargeMetadata)
-bp3_bp4_gtest_add_tests_helper(BPWriteMemorySelectionRead)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadLocalVariables)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadLocalVariablesSel)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadLocalVariablesSelHighLevel)
-bp3_bp4_gtest_add_tests_helper(BPChangingShape)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadBlockInfo)
-bp3_bp4_gtest_add_tests_helper(BPWriteReadVariableSpan)
+bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2)
+bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2fstream)
+bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2stdio)
+bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2)
+bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2_Threads)
+bp3_bp4_gtest_add_tests_helper(WriteReadAttributesADIOS2)
+bp3_bp4_gtest_add_tests_helper(FStreamWriteReadHighLevelAPI)
+bp3_bp4_gtest_add_tests_helper(WriteFlushRead)
+bp3_bp4_gtest_add_tests_helper(WriteMultiblockRead)
+bp3_bp4_gtest_add_tests_helper(WriteReadMultiblock)
+bp3_bp4_gtest_add_tests_helper(WriteReadVector)
+bp3_bp4_gtest_add_tests_helper(WriteReadAttributesMultirank)
+bp3_bp4_gtest_add_tests_helper(LargeMetadata)
+bp3_bp4_gtest_add_tests_helper(WriteMemorySelectionRead)
+bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariables)
+bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariablesSel)
+bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariablesSelHighLevel)
+bp3_bp4_gtest_add_tests_helper(ChangingShape)
+bp3_bp4_gtest_add_tests_helper(WriteReadBlockInfo)
+bp3_bp4_gtest_add_tests_helper(WriteReadVariableSpan)
 
 if(ADIOS2_HAVE_MPI)
   bp3_bp4_gtest_add_tests_helper(WriteAggregateRead) 
 endif()
 
 # BP3 only for now
-#gtest_add_tests_helper(BPWriteReadVariableSpan ${test_mpi} Engine.BP. .BP3
-#  WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3"
-#)
-gtest_add_tests_helper(BPWriteNull ${test_mpi} Engine.BP. .BP3
+gtest_add_tests_helper(WriteNull ${test_mpi} BP Engine.BP. .BP3
   WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3"
 )
 

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -19,35 +19,36 @@ endmacro()
 
 add_subdirectory(operations)
 
-bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2)
-bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2fstream)
-bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2stdio)
-bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2)
-bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2_Threads)
-bp3_bp4_gtest_add_tests_helper(WriteReadAttributesADIOS2)
-bp3_bp4_gtest_add_tests_helper(FStreamWriteReadHighLevelAPI)
-bp3_bp4_gtest_add_tests_helper(WriteFlushRead)
-bp3_bp4_gtest_add_tests_helper(WriteMultiblockRead)
-bp3_bp4_gtest_add_tests_helper(WriteReadMultiblock)
-bp3_bp4_gtest_add_tests_helper(WriteReadVector)
-bp3_bp4_gtest_add_tests_helper(WriteReadAttributesMultirank)
-bp3_bp4_gtest_add_tests_helper(LargeMetadata)
-bp3_bp4_gtest_add_tests_helper(WriteMemorySelectionRead)
-bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariables)
-bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariablesSel)
-bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariablesSelHighLevel)
-bp3_bp4_gtest_add_tests_helper(ChangingShape)
-bp3_bp4_gtest_add_tests_helper(WriteReadBlockInfo)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadADIOS2)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadADIOS2fstream)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadADIOS2stdio)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadAsStreamADIOS2)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadAsStreamADIOS2_Threads)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadAttributesADIOS2)
+bp3_bp4_gtest_add_tests_helper(StreamWriteReadHighLevelAPI)
+bp3_bp4_gtest_add_tests_helper(BPWriteFlushRead)
+bp3_bp4_gtest_add_tests_helper(BPWriteMultiblockRead)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadMultiblock)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadVector)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadAttributesMultirank)
+bp3_bp4_gtest_add_tests_helper(BPLargeMetadata)
+bp3_bp4_gtest_add_tests_helper(BPWriteMemorySelectionRead)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadLocalVariables)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadLocalVariablesSel)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadLocalVariablesSelHighLevel)
+bp3_bp4_gtest_add_tests_helper(BPChangingShape)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadBlockInfo)
+bp3_bp4_gtest_add_tests_helper(BPWriteReadVariableSpan)
 
 if(ADIOS2_HAVE_MPI)
   bp3_bp4_gtest_add_tests_helper(WriteAggregateRead) 
 endif()
 
 # BP3 only for now
-gtest_add_tests_helper(WriteReadVariableSpan ${test_mpi} BP Engine.BP. .BP3
-  WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3"
-)
-gtest_add_tests_helper(WriteNull ${test_mpi} BP Engine.BP. .BP3
+#gtest_add_tests_helper(BPWriteReadVariableSpan ${test_mpi} Engine.BP. .BP3
+#  WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3"
+#)
+gtest_add_tests_helper(BPWriteNull ${test_mpi} Engine.BP. .BP3
   WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3"
 )
 

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -42,8 +42,6 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
 #endif
 
-    // Write test data using BP
-
 #ifdef ADIOS2_HAVE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
 #else
@@ -144,7 +142,6 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
                 cr64Span.at(i) = currentTestData.CR64[i];
             }
 
-            // TODO: update min/max for spans
             bpWriter.EndStep();
         }
 
@@ -210,56 +207,56 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
             auto var_cr32 = io.InquireVariable<std::complex<float>>("cr32");
             auto var_cr64 = io.InquireVariable<std::complex<double>>("cr64");
 
-            ASSERT_EQ(var_iStep.ShapeID(), adios2::ShapeID::GlobalValue);
-            ASSERT_EQ(var_iStep.Steps(), NSteps);
+            EXPECT_EQ(var_iStep.ShapeID(), adios2::ShapeID::GlobalValue);
+            EXPECT_EQ(var_iStep.Steps(), NSteps);
 
-            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i8.Steps(), NSteps);
-            ASSERT_EQ(var_i8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i8.Steps(), NSteps);
+            EXPECT_EQ(var_i8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i16.Steps(), NSteps);
-            ASSERT_EQ(var_i16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i16.Steps(), NSteps);
+            EXPECT_EQ(var_i16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i32.Steps(), NSteps);
-            ASSERT_EQ(var_i32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i32.Steps(), NSteps);
+            EXPECT_EQ(var_i32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i64.Steps(), NSteps);
-            ASSERT_EQ(var_i64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i64.Steps(), NSteps);
+            EXPECT_EQ(var_i64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u8.Steps(), NSteps);
-            ASSERT_EQ(var_u8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u8.Steps(), NSteps);
+            EXPECT_EQ(var_u8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u16.Steps(), NSteps);
-            ASSERT_EQ(var_u16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u16.Steps(), NSteps);
+            EXPECT_EQ(var_u16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u32.Steps(), NSteps);
-            ASSERT_EQ(var_u32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u32.Steps(), NSteps);
+            EXPECT_EQ(var_u32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u64.Steps(), NSteps);
-            ASSERT_EQ(var_u64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u64.Steps(), NSteps);
+            EXPECT_EQ(var_u64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r32.Steps(), NSteps);
-            ASSERT_EQ(var_r32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_r32.Steps(), NSteps);
+            EXPECT_EQ(var_r32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r64.Steps(), NSteps);
-            ASSERT_EQ(var_r64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_r64.Steps(), NSteps);
+            EXPECT_EQ(var_r64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_cr32.Steps(), NSteps);
-            ASSERT_EQ(var_cr32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_cr32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_cr32.Steps(), NSteps);
+            EXPECT_EQ(var_cr32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
-            ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_cr64.Steps(), NSteps);
-            ASSERT_EQ(var_cr64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_cr64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_cr64.Steps(), NSteps);
+            EXPECT_EQ(var_cr64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
 
             var_i8.SetSelection(sel);
             var_i16.SetSelection(sel);
@@ -480,87 +477,87 @@ TEST_F(BPWriteReadSpan, BPWriteRead2D2x4)
         {
             auto var_i8 = io.InquireVariable<int8_t>("i8");
             EXPECT_TRUE(var_i8);
-            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i8.Steps(), NSteps);
-            ASSERT_EQ(var_i8.Shape()[0], Ny);
-            ASSERT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i8.Steps(), NSteps);
+            EXPECT_EQ(var_i8.Shape()[0], Ny);
+            EXPECT_EQ(var_i8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i16 = io.InquireVariable<int16_t>("i16");
             EXPECT_TRUE(var_i16);
-            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i16.Steps(), NSteps);
-            ASSERT_EQ(var_i16.Shape()[0], Ny);
-            ASSERT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i16.Steps(), NSteps);
+            EXPECT_EQ(var_i16.Shape()[0], Ny);
+            EXPECT_EQ(var_i16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i32 = io.InquireVariable<int32_t>("i32");
             EXPECT_TRUE(var_i32);
-            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i32.Steps(), NSteps);
-            ASSERT_EQ(var_i32.Shape()[0], Ny);
-            ASSERT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i32.Steps(), NSteps);
+            EXPECT_EQ(var_i32.Shape()[0], Ny);
+            EXPECT_EQ(var_i32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_i64 = io.InquireVariable<int64_t>("i64");
             EXPECT_TRUE(var_i64);
-            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i64.Steps(), NSteps);
-            ASSERT_EQ(var_i64.Shape()[0], Ny);
-            ASSERT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i64.Steps(), NSteps);
+            EXPECT_EQ(var_i64.Shape()[0], Ny);
+            EXPECT_EQ(var_i64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u8 = io.InquireVariable<uint8_t>("u8");
             EXPECT_TRUE(var_u8);
-            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u8.Steps(), NSteps);
-            ASSERT_EQ(var_u8.Shape()[0], Ny);
-            ASSERT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u8.Steps(), NSteps);
+            EXPECT_EQ(var_u8.Shape()[0], Ny);
+            EXPECT_EQ(var_u8.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u16 = io.InquireVariable<uint16_t>("u16");
             EXPECT_TRUE(var_u16);
-            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u16.Steps(), NSteps);
-            ASSERT_EQ(var_u16.Shape()[0], Ny);
-            ASSERT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u16.Steps(), NSteps);
+            EXPECT_EQ(var_u16.Shape()[0], Ny);
+            EXPECT_EQ(var_u16.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u32 = io.InquireVariable<uint32_t>("u32");
             EXPECT_TRUE(var_u32);
-            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u32.Steps(), NSteps);
-            ASSERT_EQ(var_u32.Shape()[0], Ny);
-            ASSERT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u32.Steps(), NSteps);
+            EXPECT_EQ(var_u32.Shape()[0], Ny);
+            EXPECT_EQ(var_u32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_u64 = io.InquireVariable<uint64_t>("u64");
             EXPECT_TRUE(var_u64);
-            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u64.Steps(), NSteps);
-            ASSERT_EQ(var_u64.Shape()[0], Ny);
-            ASSERT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u64.Steps(), NSteps);
+            EXPECT_EQ(var_u64.Shape()[0], Ny);
+            EXPECT_EQ(var_u64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_r32 = io.InquireVariable<float>("r32");
             EXPECT_TRUE(var_r32);
-            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r32.Steps(), NSteps);
-            ASSERT_EQ(var_r32.Shape()[0], Ny);
-            ASSERT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_r32.Steps(), NSteps);
+            EXPECT_EQ(var_r32.Shape()[0], Ny);
+            EXPECT_EQ(var_r32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_r64 = io.InquireVariable<double>("r64");
             EXPECT_TRUE(var_r64);
-            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r64.Steps(), NSteps);
-            ASSERT_EQ(var_r64.Shape()[0], Ny);
-            ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_r64.Steps(), NSteps);
+            EXPECT_EQ(var_r64.Shape()[0], Ny);
+            EXPECT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_cr32 = io.InquireVariable<std::complex<float>>("cr32");
             EXPECT_TRUE(var_cr32);
-            ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_cr32.Steps(), NSteps);
-            ASSERT_EQ(var_cr32.Shape()[0], Ny);
-            ASSERT_EQ(var_cr32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_cr32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_cr32.Steps(), NSteps);
+            EXPECT_EQ(var_cr32.Shape()[0], Ny);
+            EXPECT_EQ(var_cr32.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             auto var_cr64 = io.InquireVariable<std::complex<double>>("cr64");
             EXPECT_TRUE(var_cr64);
-            ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_cr64.Steps(), NSteps);
-            ASSERT_EQ(var_cr64.Shape()[0], Ny);
-            ASSERT_EQ(var_cr64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_cr64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_cr64.Steps(), NSteps);
+            EXPECT_EQ(var_cr64.Shape()[0], Ny);
+            EXPECT_EQ(var_cr64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
 
             std::array<int8_t, Nx * Ny> I8;
             std::array<int16_t, Nx * Ny> I16;
@@ -661,7 +658,6 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8Local)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
 #endif
-
     // Write test data using BP
 
 #ifdef ADIOS2_HAVE_MPI
@@ -761,7 +757,6 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8Local)
                 cr64Span.at(i) = currentTestData.CR64[i];
             }
 
-            // TODO: update min/max for spans
             bpWriter.EndStep();
         }
 
@@ -820,41 +815,41 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8Local)
             auto var_cr32 = io.InquireVariable<std::complex<float>>("cr32");
             auto var_cr64 = io.InquireVariable<std::complex<double>>("cr64");
 
-            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_i8.Steps(), NSteps);
+            EXPECT_EQ(var_i8.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_i8.Steps(), NSteps);
 
-            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_i16.Steps(), NSteps);
+            EXPECT_EQ(var_i16.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_i16.Steps(), NSteps);
 
-            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_i32.Steps(), NSteps);
+            EXPECT_EQ(var_i32.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_i32.Steps(), NSteps);
 
-            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_i64.Steps(), NSteps);
+            EXPECT_EQ(var_i64.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_i64.Steps(), NSteps);
 
-            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_u8.Steps(), NSteps);
+            EXPECT_EQ(var_u8.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_u8.Steps(), NSteps);
 
-            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_u16.Steps(), NSteps);
+            EXPECT_EQ(var_u16.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_u16.Steps(), NSteps);
 
-            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_u32.Steps(), NSteps);
+            EXPECT_EQ(var_u32.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_u32.Steps(), NSteps);
 
-            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_u64.Steps(), NSteps);
+            EXPECT_EQ(var_u64.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_u64.Steps(), NSteps);
 
-            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_r32.Steps(), NSteps);
+            EXPECT_EQ(var_r32.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_r32.Steps(), NSteps);
 
-            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_r64.Steps(), NSteps);
+            EXPECT_EQ(var_r64.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_r64.Steps(), NSteps);
 
-            ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_cr32.Steps(), NSteps);
+            EXPECT_EQ(var_cr32.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_cr32.Steps(), NSteps);
 
-            ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_cr64.Steps(), NSteps);
+            EXPECT_EQ(var_cr64.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_cr64.Steps(), NSteps);
 
             const size_t rankBlock = static_cast<size_t>(mpiRank);
             var_i8.SetBlockSelection(rankBlock);
@@ -1071,63 +1066,63 @@ TEST_F(BPWriteReadSpan, BPWriteRead2D2x4Local)
         {
             auto var_i8 = io.InquireVariable<int8_t>("i8");
             EXPECT_TRUE(var_i8);
-            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_i8.Steps(), NSteps);
+            EXPECT_EQ(var_i8.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_i8.Steps(), NSteps);
 
             auto var_i16 = io.InquireVariable<int16_t>("i16");
             EXPECT_TRUE(var_i16);
-            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_i16.Steps(), NSteps);
+            EXPECT_EQ(var_i16.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_i16.Steps(), NSteps);
 
             auto var_i32 = io.InquireVariable<int32_t>("i32");
             EXPECT_TRUE(var_i32);
-            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_i32.Steps(), NSteps);
+            EXPECT_EQ(var_i32.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_i32.Steps(), NSteps);
 
             auto var_i64 = io.InquireVariable<int64_t>("i64");
             EXPECT_TRUE(var_i64);
-            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_i64.Steps(), NSteps);
+            EXPECT_EQ(var_i64.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_i64.Steps(), NSteps);
 
             auto var_u8 = io.InquireVariable<uint8_t>("u8");
             EXPECT_TRUE(var_u8);
-            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_u8.Steps(), NSteps);
+            EXPECT_EQ(var_u8.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_u8.Steps(), NSteps);
 
             auto var_u16 = io.InquireVariable<uint16_t>("u16");
             EXPECT_TRUE(var_u16);
-            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_u16.Steps(), NSteps);
+            EXPECT_EQ(var_u16.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_u16.Steps(), NSteps);
 
             auto var_u32 = io.InquireVariable<uint32_t>("u32");
             EXPECT_TRUE(var_u32);
-            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_u32.Steps(), NSteps);
+            EXPECT_EQ(var_u32.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_u32.Steps(), NSteps);
 
             auto var_u64 = io.InquireVariable<uint64_t>("u64");
             EXPECT_TRUE(var_u64);
-            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_u64.Steps(), NSteps);
+            EXPECT_EQ(var_u64.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_u64.Steps(), NSteps);
 
             auto var_r32 = io.InquireVariable<float>("r32");
             EXPECT_TRUE(var_r32);
-            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_r32.Steps(), NSteps);
+            EXPECT_EQ(var_r32.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_r32.Steps(), NSteps);
 
             auto var_r64 = io.InquireVariable<double>("r64");
             EXPECT_TRUE(var_r64);
-            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_r64.Steps(), NSteps);
+            EXPECT_EQ(var_r64.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_r64.Steps(), NSteps);
 
             auto var_cr32 = io.InquireVariable<std::complex<float>>("cr32");
             EXPECT_TRUE(var_cr32);
-            ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_cr32.Steps(), NSteps);
+            EXPECT_EQ(var_cr32.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_cr32.Steps(), NSteps);
 
             auto var_cr64 = io.InquireVariable<std::complex<double>>("cr64");
             EXPECT_TRUE(var_cr64);
-            ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::LocalArray);
-            ASSERT_EQ(var_cr64.Steps(), NSteps);
+            EXPECT_EQ(var_cr64.ShapeID(), adios2::ShapeID::LocalArray);
+            EXPECT_EQ(var_cr64.Steps(), NSteps);
 
             std::array<int8_t, Nx * Ny> I8;
             std::array<int16_t, Nx * Ny> I16;
@@ -1373,53 +1368,85 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8FillValue)
             auto var_cr32 = io.InquireVariable<std::complex<float>>("cr32");
             auto var_cr64 = io.InquireVariable<std::complex<double>>("cr64");
 
-            ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i8.Steps(), NSteps);
-            ASSERT_EQ(var_i8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i8.Steps(), NSteps);
+            EXPECT_EQ(var_i8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i8.Min(), static_cast<int8_t>(currentStep));
+            EXPECT_EQ(var_i8.Max(), static_cast<int8_t>(currentStep));
 
-            ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i16.Steps(), NSteps);
-            ASSERT_EQ(var_i16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i16.Steps(), NSteps);
+            EXPECT_EQ(var_i16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i16.Min(), static_cast<int16_t>(currentStep));
+            EXPECT_EQ(var_i16.Max(), static_cast<int16_t>(currentStep));
 
-            ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i32.Steps(), NSteps);
-            ASSERT_EQ(var_i32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i32.Steps(), NSteps);
+            EXPECT_EQ(var_i32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i32.Min(), static_cast<int32_t>(currentStep));
+            EXPECT_EQ(var_i32.Max(), static_cast<int32_t>(currentStep));
 
-            ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_i64.Steps(), NSteps);
-            ASSERT_EQ(var_i64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_i64.Steps(), NSteps);
+            EXPECT_EQ(var_i64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_i64.Min(), static_cast<int64_t>(currentStep));
+            EXPECT_EQ(var_i64.Max(), static_cast<int64_t>(currentStep));
 
-            ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u8.Steps(), NSteps);
-            ASSERT_EQ(var_u8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u8.Steps(), NSteps);
+            EXPECT_EQ(var_u8.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u8.Min(), static_cast<uint8_t>(currentStep));
+            EXPECT_EQ(var_u8.Max(), static_cast<uint8_t>(currentStep));
 
-            ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u16.Steps(), NSteps);
-            ASSERT_EQ(var_u16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u16.Steps(), NSteps);
+            EXPECT_EQ(var_u16.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u16.Min(), static_cast<uint16_t>(currentStep));
+            EXPECT_EQ(var_u16.Max(), static_cast<uint16_t>(currentStep));
 
-            ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u32.Steps(), NSteps);
-            ASSERT_EQ(var_u32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u32.Steps(), NSteps);
+            EXPECT_EQ(var_u32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u32.Min(), static_cast<uint32_t>(currentStep));
+            EXPECT_EQ(var_u32.Max(), static_cast<uint32_t>(currentStep));
 
-            ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_u64.Steps(), NSteps);
-            ASSERT_EQ(var_u64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_u64.Steps(), NSteps);
+            EXPECT_EQ(var_u64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_u64.Min(), static_cast<uint64_t>(currentStep));
+            EXPECT_EQ(var_u64.Max(), static_cast<uint64_t>(currentStep));
 
-            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r32.Steps(), NSteps);
-            ASSERT_EQ(var_r32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_r32.Steps(), NSteps);
+            EXPECT_EQ(var_r32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_r32.Min(), static_cast<float>(currentStep));
+            EXPECT_EQ(var_r32.Max(), static_cast<float>(currentStep));
 
-            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_r64.Steps(), NSteps);
-            ASSERT_EQ(var_r64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_r64.Steps(), NSteps);
+            EXPECT_EQ(var_r64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_r64.Min(), static_cast<double>(currentStep));
+            EXPECT_EQ(var_r64.Max(), static_cast<double>(currentStep));
 
-            ASSERT_EQ(var_cr32.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_cr32.Steps(), NSteps);
-            ASSERT_EQ(var_cr32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_cr32.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_cr32.Steps(), NSteps);
+            EXPECT_EQ(var_cr32.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_cr32.Min(),
+                      std::complex<float>(static_cast<float>(currentStep),
+                                          static_cast<float>(currentStep)));
+            EXPECT_EQ(var_cr32.Max(),
+                      std::complex<float>(static_cast<float>(currentStep),
+                                          static_cast<float>(currentStep)));
 
-            ASSERT_EQ(var_cr64.ShapeID(), adios2::ShapeID::GlobalArray);
-            ASSERT_EQ(var_cr64.Steps(), NSteps);
-            ASSERT_EQ(var_cr64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_cr64.ShapeID(), adios2::ShapeID::GlobalArray);
+            EXPECT_EQ(var_cr64.Steps(), NSteps);
+            EXPECT_EQ(var_cr64.Shape()[0], static_cast<size_t>(mpiSize * Nx));
+            EXPECT_EQ(var_cr64.Min(),
+                      std::complex<double>(static_cast<double>(currentStep),
+                                           static_cast<double>(currentStep)));
+            EXPECT_EQ(var_cr64.Max(),
+                      std::complex<double>(static_cast<double>(currentStep),
+                                           static_cast<double>(currentStep)));
 
             var_i8.SetSelection(sel);
             var_i16.SetSelection(sel);


### PR DESCRIPTION
Support for zero-copy access to BP4 buffer at write
Added padding for pointer alignment in BP3/BP4 buffers addressing #1314 
Replacing `std::align` with internal function due to [gcc 4.8 bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57350)
