### PR TITLE
OSX: Fix JSON Compile Issue

### DIFF
--- a/source/adios2/toolkit/query/JsonWorker.cpp
+++ b/source/adios2/toolkit/query/JsonWorker.cpp
@@ -124,7 +124,7 @@ void JsonWorker::ParseJson()
     }
 
     auto ioO = jsonObj.find("io");
-    auto ioName = (*ioO)["name"];
+    std::string const ioName = (*ioO)["name"];
     if (m_SourceReader->m_IO.m_Name.compare(ioName) != 0)
         throw std::ios_base::failure("invalid query io. Expecting io name = " +
                                      m_SourceReader->m_IO.m_Name);


### PR DESCRIPTION
Cast to `std::string` to avoid ambiguity in `std::string::compare`.
Fix #1804 

Seen in https://github.com/conda-forge/adios2-feedstock/pull/8