### PR TITLE
Fix Warning: Unsigned Never <0

### DIFF
--- a/source/adios2/toolkit/format/bp/BPBase.cpp
+++ b/source/adios2/toolkit/format/bp/BPBase.cpp
@@ -132,7 +132,7 @@ void BPBase::Init(const Params &parameters, const std::string hint)
                     value, m_DebugMode,
                     " in Parameter key=StatsLevel " + hint));
             if (m_DebugMode &&
-                (m_Parameters.StatsLevel < 0 || m_Parameters.StatsLevel > 5))
+                m_Parameters.StatsLevel > 5)
             {
                 throw std::invalid_argument(
                     "ERROR: value for Parameter key=StatsLevel must be "

--- a/source/adios2/toolkit/format/bp/BPBase.cpp
+++ b/source/adios2/toolkit/format/bp/BPBase.cpp
@@ -131,8 +131,7 @@ void BPBase::Init(const Params &parameters, const std::string hint)
                 static_cast<unsigned int>(helper::StringTo<uint32_t>(
                     value, m_DebugMode,
                     " in Parameter key=StatsLevel " + hint));
-            if (m_DebugMode &&
-                m_Parameters.StatsLevel > 5)
+            if (m_DebugMode && m_Parameters.StatsLevel > 5)
             {
                 throw std::invalid_argument(
                     "ERROR: value for Parameter key=StatsLevel must be "


### PR DESCRIPTION
Fix #1806: just a little `-Wtautological-compare` warning.