### PR TITLE
EVPath upstream

### DIFF
--- a/testing/adios2/engine/staging-common/run_test.in
+++ b/testing/adios2/engine/staging-common/run_test.in
@@ -53,6 +53,7 @@ def clean_server_kill(writer):
     
     print("TestDriver:  Waiting for writer after touching file")
     writer.wait()
+    print("TestDriver:  Writer complete")
     os.remove('DieTest')
 
 

--- a/testing/adios2/engine/staging-common/run_test.in
+++ b/testing/adios2/engine/staging-common/run_test.in
@@ -50,6 +50,8 @@ def touch(path):
 
 def clean_server_kill(writer):
     touch('DieTest')
+    
+    print("TestDriver:  Waiting for writer after touching file")
     writer.wait()
     os.remove('DieTest')
 
@@ -211,6 +213,7 @@ def do_kill_readers_test(writer_cmd, reader_cmd, duration, interval):
             print("TestDriver: Killing surviving Reader")
             reader.terminate()
             reader.wait()
+            print("TestDriver: Wait on Reader Succeeded")
             sys.stdout.flush()
     clean_server_kill(writer)
     print("TestDriver: Writer exit status was " + str(writer.returncode))

--- a/thirdparty/EVPath/EVPath/cm_internal.h
+++ b/thirdparty/EVPath/EVPath/cm_internal.h
@@ -539,7 +539,7 @@ extern void INT_CMTrace_file_id(int ID);
 #else
 #define TRACE_TIME_DECL	struct timeval tv
 #define TRACE_TIME_GET gettimeofday(&tv, NULL)
-#define TRACE_TIME_PRINTDETAILS "%lld.%.6ld - ", (long long)tv.tv_sec, tv.tv_usec
+#define TRACE_TIME_PRINTDETAILS "%lld.%.6ld - ", (long long)tv.tv_sec, (long)tv.tv_usec
 #endif
 #define CMtrace_out(cm, trace_type, ...) {TRACE_TIME_DECL ; (CMtrace_on(cm,trace_type) ? (CMtrace_PID ? fprintf(cm->CMTrace_file, "P%lxT%lx - ", (long) getpid(), (long)thr_thread_self()) : 0) , CMtrace_timing? TRACE_TIME_GET,fprintf(cm->CMTrace_file, TRACE_TIME_PRINTDETAILS):0, fprintf(cm->CMTrace_file, __VA_ARGS__) : 0);fflush(cm->CMTrace_file);}
 extern void CMdo_performance_response(CMConnection conn, long length, int func,


### PR DESCRIPTION
This PR pulls in a minor EVPath upstream mod that kills a warning that only seems to appear on Conda OSX builds.  It also adds a little bit more output in staging-common/run_test so that it's clearer what the script might be waiting on if it hangs.  This was added to diagnose one of our rare CI fails, I've left it here because it's useful but seems not be worth a separate PR.