### PR TITLE
Encapsulate multi-process communication (part 2)

### DIFF
--- a/bindings/C/adios2/c/adios2_c_adios.cpp
+++ b/bindings/C/adios2/c/adios2_c_adios.cpp
@@ -10,9 +10,12 @@
 
 #include "adios2_c_adios.h"
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/core/ADIOS.h"
 #include "adios2/helper/adiosFunctions.h"
+
+#ifdef ADIOS2_HAVE_MPI
+#include "adios2/helper/adiosCommMPI.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,7 +38,8 @@ adios2_adios *adios2_init_config_glue(const char *config_file, MPI_Comm comm,
         const bool debugBool =
             (debug_mode == adios2_debug_mode_on) ? true : false;
         adios = reinterpret_cast<adios2_adios *>(new adios2::core::ADIOS(
-            config_file, comm, debugBool, host_language));
+            config_file, adios2::helper::CommFromMPI(comm), debugBool,
+            host_language));
     }
     catch (...)
     {

--- a/bindings/C/adios2/c/adios2_c_io.cpp
+++ b/bindings/C/adios2/c/adios2_c_io.cpp
@@ -12,10 +12,13 @@
 
 #include <vector>
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosFunctions.h" //GetType<T>
 #include "adios2_c_internal.h"
+
+#ifdef ADIOS2_HAVE_MPI
+#include "adios2/helper/adiosCommMPI.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -729,7 +732,8 @@ adios2_engine *adios2_open_new_comm(adios2_io *io, const char *name,
             io, "for adios2_io, in call to adios2_open");
         engine = reinterpret_cast<adios2_engine *>(
             &reinterpret_cast<adios2::core::IO *>(io)->Open(
-                name, adios2_ToOpenMode(mode), comm));
+                name, adios2_ToOpenMode(mode),
+                adios2::helper::CommFromMPI(comm)));
     }
     catch (...)
     {

--- a/bindings/CXX11/adios2/cxx11/ADIOS.cpp
+++ b/bindings/CXX11/adios2/cxx11/ADIOS.cpp
@@ -8,16 +8,20 @@
 
 #include "ADIOS.h"
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/core/ADIOS.h"
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosFunctions.h" //CheckForNullptr
+
+#ifdef ADIOS2_HAVE_MPI
+#include "adios2/helper/adiosCommMPI.h"
+#endif
 
 namespace adios2
 {
 #ifdef ADIOS2_HAVE_MPI
 ADIOS::ADIOS(const std::string &configFile, MPI_Comm comm, const bool debugMode)
-: m_ADIOS(std::make_shared<core::ADIOS>(configFile, comm, debugMode, "C++"))
+: m_ADIOS(std::make_shared<core::ADIOS>(configFile, helper::CommFromMPI(comm),
+                                        debugMode, "C++"))
 {
 }
 

--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -11,8 +11,11 @@
 #include "IO.h"
 #include "IO.tcc"
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/core/IO.h"
+
+#ifdef ADIOS2_HAVE_MPI
+#include "adios2/helper/adiosCommMPI.h"
+#endif
 
 namespace adios2
 {
@@ -109,7 +112,7 @@ Engine IO::Open(const std::string &name, const Mode mode, MPI_Comm comm)
 {
     helper::CheckForNullptr(m_IO,
                             "for engine " + name + ", in call to IO::Open");
-    return Engine(&m_IO->Open(name, mode, comm));
+    return Engine(&m_IO->Open(name, mode, helper::CommFromMPI(comm)));
 }
 #endif
 

--- a/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstream.cpp
+++ b/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstream.cpp
@@ -11,7 +11,9 @@
 #include "ADIOS2fstream.h"
 #include "ADIOS2fstream.tcc"
 
-#include "adios2/common/ADIOSMPI.h"
+#ifdef ADIOS2_HAVE_MPI
+#include "adios2/helper/adiosCommMPI.h"
+#endif
 
 namespace adios2
 {
@@ -19,15 +21,16 @@ namespace adios2
 #ifdef ADIOS2_HAVE_MPI
 fstream::fstream(const std::string &name, const openmode mode, MPI_Comm comm,
                  const std::string engineType)
-: m_Stream(std::make_shared<core::Stream>(name, ToMode(mode), comm, engineType,
-                                          "C++"))
+: m_Stream(std::make_shared<core::Stream>(
+      name, ToMode(mode), helper::CommFromMPI(comm), engineType, "C++"))
 {
 }
 
 fstream::fstream(const std::string &name, const openmode mode, MPI_Comm comm,
                  const std::string &configFile,
                  const std::string ioInConfigFile)
-: m_Stream(std::make_shared<core::Stream>(name, ToMode(mode), comm, configFile,
+: m_Stream(std::make_shared<core::Stream>(name, ToMode(mode),
+                                          helper::CommFromMPI(comm), configFile,
                                           ioInConfigFile, "C++"))
 {
 }
@@ -54,8 +57,8 @@ void fstream::open(const std::string &name, const openmode mode, MPI_Comm comm,
                    const std::string engineType)
 {
     CheckOpen(name);
-    m_Stream = std::make_shared<core::Stream>(name, ToMode(mode), comm,
-                                              engineType, "C++");
+    m_Stream = std::make_shared<core::Stream>(
+        name, ToMode(mode), helper::CommFromMPI(comm), engineType, "C++");
 }
 
 void fstream::open(const std::string &name, const openmode mode, MPI_Comm comm,
@@ -64,7 +67,8 @@ void fstream::open(const std::string &name, const openmode mode, MPI_Comm comm,
 {
     CheckOpen(name);
     m_Stream = std::make_shared<core::Stream>(
-        name, ToMode(mode), comm, configFile, ioInConfigFile, "C++");
+        name, ToMode(mode), helper::CommFromMPI(comm), configFile,
+        ioInConfigFile, "C++");
 }
 #else
 void fstream::open(const std::string &name, const openmode mode,

--- a/bindings/Python/py11ADIOS.cpp
+++ b/bindings/Python/py11ADIOS.cpp
@@ -10,7 +10,9 @@
 
 #include "py11ADIOS.h"
 
-#include "adios2/common/ADIOSMPI.h"
+#ifdef ADIOS2_HAVE_MPI
+#include "adios2/helper/adiosCommMPI.h"
+#endif
 
 namespace adios2
 {
@@ -20,8 +22,8 @@ namespace py11
 #ifdef ADIOS2_HAVE_MPI
 ADIOS::ADIOS(const std::string &configFile, MPI4PY_Comm mpiComm,
              const bool debugMode)
-: m_ADIOS(std::make_shared<adios2::core::ADIOS>(configFile, mpiComm, debugMode,
-                                                "Python"))
+: m_ADIOS(std::make_shared<adios2::core::ADIOS>(
+      configFile, helper::CommFromMPI(mpiComm), debugMode, "Python"))
 {
 }
 

--- a/bindings/Python/py11File.cpp
+++ b/bindings/Python/py11File.cpp
@@ -14,9 +14,13 @@
 #include <algorithm>
 #include <iostream>
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSMacros.h"
+#include "adios2/helper/adiosCommDummy.h"
 #include "adios2/helper/adiosFunctions.h"
+
+#ifdef ADIOS2_HAVE_MPI
+#include "adios2/helper/adiosCommMPI.h"
+#endif
 
 #include "py11types.h"
 
@@ -25,31 +29,37 @@ namespace adios2
 namespace py11
 {
 
+#ifdef ADIOS2_HAVE_MPI
 File::File(const std::string &name, const std::string mode, MPI_Comm comm,
            const std::string engineType)
 : m_Name(name), m_Mode(mode),
-  m_Stream(std::make_shared<core::Stream>(name, ToMode(mode), comm, engineType,
-                                          "Python"))
+  m_Stream(std::make_shared<core::Stream>(
+      name, ToMode(mode), helper::CommFromMPI(comm), engineType, "Python"))
 {
 }
 
 File::File(const std::string &name, const std::string mode, MPI_Comm comm,
            const std::string &configFile, const std::string ioInConfigFile)
 : m_Name(name), m_Mode(mode),
-  m_Stream(std::make_shared<core::Stream>(name, ToMode(mode), comm, configFile,
+  m_Stream(std::make_shared<core::Stream>(name, ToMode(mode),
+                                          helper::CommFromMPI(comm), configFile,
                                           ioInConfigFile, "Python"))
 {
 }
+#endif
 
 File::File(const std::string &name, const std::string mode,
            const std::string engineType)
-: File(name, mode, MPI_COMM_NULL, engineType)
+: m_Name(name), m_Mode(mode), m_Stream(std::make_shared<core::Stream>(
+                                  name, ToMode(mode), engineType, "Python"))
 {
 }
 
 File::File(const std::string &name, const std::string mode,
            const std::string &configFile, const std::string ioInConfigFile)
-: File(name, mode, MPI_COMM_NULL, configFile, ioInConfigFile)
+: m_Name(name), m_Mode(mode),
+  m_Stream(std::make_shared<core::Stream>(name, ToMode(mode), configFile,
+                                          ioInConfigFile, "Python"))
 {
 }
 

--- a/bindings/Python/py11File.h
+++ b/bindings/Python/py11File.h
@@ -16,6 +16,10 @@
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/Stream.h"
 
+#ifdef ADIOS2_HAVE_MPI
+#include "adios2/common/ADIOSMPI.h"
+#endif
+
 namespace adios2
 {
 namespace py11
@@ -27,11 +31,13 @@ public:
     const std::string m_Name;
     const std::string m_Mode;
 
+#ifdef ADIOS2_HAVE_MPI
     File(const std::string &name, const std::string mode, MPI_Comm comm,
          const std::string engineType = "BPFile");
 
     File(const std::string &name, const std::string mode, MPI_Comm comm,
          const std::string &configFile, const std::string ioInConfigFile);
+#endif
 
     File(const std::string &name, const std::string mode,
          const std::string engineType = "BPFile");

--- a/bindings/Python/py11IO.cpp
+++ b/bindings/Python/py11IO.cpp
@@ -14,6 +14,7 @@
 #include "adios2/helper/adiosFunctions.h" //GetType<T>
 
 #ifdef ADIOS2_HAVE_MPI
+#include "adios2/helper/adiosCommMPI.h"
 #include <mpi4py/mpi4py.h>
 #endif
 
@@ -252,7 +253,8 @@ Engine IO::Open(const std::string &name, const int mode, MPI4PY_Comm comm)
     helper::CheckForNullptr(m_IO,
                             "for engine " + name + ", in call to IO::Open");
 
-    return Engine(&m_IO->Open(name, static_cast<adios2::Mode>(mode), comm));
+    return Engine(&m_IO->Open(name, static_cast<adios2::Mode>(mode),
+                              helper::CommFromMPI(comm)));
 }
 #endif
 

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(adios2
 
 #helper
   helper/adiosComm.h  helper/adiosComm.cpp
+  helper/adiosCommDummy.h  helper/adiosCommDummy.cpp
   helper/adiosCommMPI.h  helper/adiosCommMPI.cpp
   helper/adiosDynamicBinder.h  helper/adiosDynamicBinder.cpp
   helper/adiosMath.cpp

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(adios2
 
 #helper
   helper/adiosComm.h  helper/adiosComm.cpp
+  helper/adiosCommMPI.h  helper/adiosCommMPI.cpp
   helper/adiosDynamicBinder.h  helper/adiosDynamicBinder.cpp
   helper/adiosMath.cpp
   helper/adiosMemory.cpp

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -13,8 +13,8 @@
 #include <algorithm> // std::transform
 #include <ios>       //std::ios_base::failure
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/core/IO.h"
+#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" //InquireKey, BroadcastFile
 
 // OPERATORS
@@ -60,7 +60,7 @@ namespace core
 ADIOS::ADIOS(const std::string configFile, MPI_Comm mpiComm,
              const bool debugMode, const std::string hostLanguage)
 : m_ConfigFile(configFile), m_DebugMode(debugMode),
-  m_HostLanguage(hostLanguage), m_Comm(helper::Comm::Duplicate(mpiComm))
+  m_HostLanguage(hostLanguage), m_Comm(helper::CommFromMPI(mpiComm))
 {
     if (!configFile.empty())
     {

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -14,7 +14,7 @@
 #include <ios>       //std::ios_base::failure
 
 #include "adios2/core/IO.h"
-#include "adios2/helper/adiosCommMPI.h"
+#include "adios2/helper/adiosCommDummy.h"
 #include "adios2/helper/adiosFunctions.h" //InquireKey, BroadcastFile
 
 // OPERATORS
@@ -57,10 +57,10 @@ namespace adios2
 namespace core
 {
 
-ADIOS::ADIOS(const std::string configFile, MPI_Comm mpiComm,
+ADIOS::ADIOS(const std::string configFile, helper::Comm comm,
              const bool debugMode, const std::string hostLanguage)
 : m_ConfigFile(configFile), m_DebugMode(debugMode),
-  m_HostLanguage(hostLanguage), m_Comm(helper::CommFromMPI(mpiComm))
+  m_HostLanguage(hostLanguage), m_Comm(std::move(comm))
 {
     if (!configFile.empty())
     {
@@ -74,18 +74,18 @@ ADIOS::ADIOS(const std::string configFile, MPI_Comm mpiComm,
 
 ADIOS::ADIOS(const std::string configFile, const bool debugMode,
              const std::string hostLanguage)
-: ADIOS(configFile, MPI_COMM_NULL, debugMode, hostLanguage)
+: ADIOS(configFile, helper::CommDummy(), debugMode, hostLanguage)
 {
 }
 
-ADIOS::ADIOS(MPI_Comm mpiComm, const bool debugMode,
+ADIOS::ADIOS(helper::Comm comm, const bool debugMode,
              const std::string hostLanguage)
-: ADIOS("", mpiComm, debugMode, hostLanguage)
+: ADIOS("", std::move(comm), debugMode, hostLanguage)
 {
 }
 
 ADIOS::ADIOS(const bool debugMode, const std::string hostLanguage)
-: ADIOS("", MPI_COMM_NULL, debugMode, hostLanguage)
+: ADIOS("", helper::CommDummy(), debugMode, hostLanguage)
 {
 }
 

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -19,7 +19,6 @@
 /// \endcond
 
 #include "adios2/common/ADIOSConfig.h"
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/Operator.h"
 #include "adios2/helper/adiosComm.h"
@@ -55,7 +54,7 @@ public:
      * false: optional feature to turn off checks on user input data,
      * recommended in stable flows
      */
-    ADIOS(const std::string configFile, MPI_Comm mpiComm, const bool debugMode,
+    ADIOS(const std::string configFile, helper::Comm comm, const bool debugMode,
           const std::string hostLanguage);
 
     /**
@@ -77,7 +76,7 @@ public:
      * false: optional feature to turn off checks on user input data,
      * recommended in stable flows
      */
-    ADIOS(MPI_Comm mpiComm, const bool debugMode,
+    ADIOS(helper::Comm comm, const bool debugMode,
           const std::string hostLanguage);
 
     /**

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -29,6 +29,7 @@
 #include "adios2/engine/skeleton/SkeletonWriter.h"
 
 #include "adios2/helper/adiosComm.h"
+#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" //BuildParametersMap
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 #include <adios2sys/SystemTools.hxx> // FileIsDirectory()
@@ -504,7 +505,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, MPI_Comm mpiComm)
         }
     }
 
-    auto comm = helper::Comm::Duplicate(mpiComm);
+    auto comm = helper::CommFromMPI(mpiComm);
     std::shared_ptr<Engine> engine;
     const bool isDefaultEngine = m_EngineType.empty() ? true : false;
     std::string engineTypeLC = m_EngineType;
@@ -765,7 +766,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, MPI_Comm mpiComm)
 
 Engine &IO::Open(const std::string &name, const Mode mode)
 {
-    return Open(name, mode, m_ADIOS.GetComm().AsMPI());
+    return Open(name, mode, CommAsMPI(m_ADIOS.GetComm()));
 }
 
 Engine &IO::GetEngine(const std::string &name)

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -14,7 +14,6 @@
 #include <sstream>
 #include <utility> // std::pair
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSMacros.h"
 
 #include "adios2/engine/bp3/BP3Reader.h"
@@ -29,7 +28,6 @@
 #include "adios2/engine/skeleton/SkeletonWriter.h"
 
 #include "adios2/helper/adiosComm.h"
-#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" //BuildParametersMap
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 #include <adios2sys/SystemTools.hxx> // FileIsDirectory()
@@ -473,7 +471,7 @@ size_t IO::AddOperation(Operator &op, const Params &parameters) noexcept
     return m_Operations.size() - 1;
 }
 
-Engine &IO::Open(const std::string &name, const Mode mode, MPI_Comm mpiComm)
+Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
 {
     TAU_SCOPED_TIMER("IO::Open");
     auto itEngineFound = m_Engines.find(name);
@@ -505,7 +503,6 @@ Engine &IO::Open(const std::string &name, const Mode mode, MPI_Comm mpiComm)
         }
     }
 
-    auto comm = helper::CommFromMPI(mpiComm);
     std::shared_ptr<Engine> engine;
     const bool isDefaultEngine = m_EngineType.empty() ? true : false;
     std::string engineTypeLC = m_EngineType;
@@ -766,7 +763,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, MPI_Comm mpiComm)
 
 Engine &IO::Open(const std::string &name, const Mode mode)
 {
-    return Open(name, mode, CommAsMPI(m_ADIOS.GetComm()));
+    return Open(name, mode, m_ADIOS.GetComm().Duplicate());
 }
 
 Engine &IO::GetEngine(const std::string &name)

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -360,7 +360,7 @@ public:
      * @exception std::invalid_argument if Engine with unique name is already
      * created with another Open, in debug mode only
      */
-    Engine &Open(const std::string &name, const Mode mode, MPI_Comm mpiComm);
+    Engine &Open(const std::string &name, const Mode mode, helper::Comm comm);
 
     /**
      * Overloaded version that reuses the MPI_Comm object passed

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -18,7 +18,6 @@
 #include <stdexcept> //std::invalid_argument
 /// \endcond
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/helper/adiosFunctions.h" //helper::GetType<T>
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"

--- a/source/adios2/core/Stream.cpp
+++ b/source/adios2/core/Stream.cpp
@@ -11,16 +11,17 @@
 #include "Stream.h"
 #include "Stream.tcc"
 
-#include "adios2/common/ADIOSMPI.h"
+#include "adios2/helper/adiosCommDummy.h"
 
 namespace adios2
 {
 namespace core
 {
 
-Stream::Stream(const std::string &name, const Mode mode, MPI_Comm comm,
+Stream::Stream(const std::string &name, const Mode mode, helper::Comm comm,
                const std::string engineType, const std::string hostLanguage)
-: m_Name(name), m_ADIOS(std::make_shared<ADIOS>(comm, DebugON, hostLanguage)),
+: m_Name(name),
+  m_ADIOS(std::make_shared<ADIOS>(std::move(comm), DebugON, hostLanguage)),
   m_IO(&m_ADIOS->DeclareIO(name)), m_Mode(mode), m_EngineType(engineType)
 {
     if (mode == adios2::Mode::Read)
@@ -31,15 +32,15 @@ Stream::Stream(const std::string &name, const Mode mode, MPI_Comm comm,
 
 Stream::Stream(const std::string &name, const Mode mode,
                const std::string engineType, const std::string hostLanguage)
-: Stream(name, mode, MPI_COMM_NULL, engineType, hostLanguage)
+: Stream(name, mode, helper::CommDummy(), engineType, hostLanguage)
 {
 }
 
-Stream::Stream(const std::string &name, const Mode mode, MPI_Comm comm,
+Stream::Stream(const std::string &name, const Mode mode, helper::Comm comm,
                const std::string configFile, const std::string ioInConfigFile,
                const std::string hostLanguage)
-: m_Name(name),
-  m_ADIOS(std::make_shared<ADIOS>(configFile, comm, DebugON, hostLanguage)),
+: m_Name(name), m_ADIOS(std::make_shared<ADIOS>(configFile, std::move(comm),
+                                                DebugON, hostLanguage)),
   m_IO(&m_ADIOS->DeclareIO(ioInConfigFile)), m_Mode(mode)
 {
     if (mode == adios2::Mode::Read)
@@ -51,7 +52,8 @@ Stream::Stream(const std::string &name, const Mode mode, MPI_Comm comm,
 Stream::Stream(const std::string &name, const Mode mode,
                const std::string configFile, const std::string ioInConfigFile,
                const std::string hostLanguage)
-: Stream(name, mode, MPI_COMM_NULL, configFile, ioInConfigFile, hostLanguage)
+: Stream(name, mode, helper::CommDummy(), configFile, ioInConfigFile,
+         hostLanguage)
 {
 }
 

--- a/source/adios2/core/Stream.h
+++ b/source/adios2/core/Stream.h
@@ -13,12 +13,12 @@
 
 #include <memory> //std::shared_ptr
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/ADIOS.h"
 #include "adios2/core/Engine.h"
 #include "adios2/core/IO.h"
+#include "adios2/helper/adiosComm.h"
 
 namespace adios2
 {
@@ -47,13 +47,13 @@ public:
      */
     Engine *m_Engine = nullptr;
 
-    Stream(const std::string &name, const Mode mode, MPI_Comm comm,
+    Stream(const std::string &name, const Mode mode, helper::Comm comm,
            const std::string engineType, const std::string hostLanguage);
 
     Stream(const std::string &name, const Mode mode,
            const std::string engineType, const std::string hostLanguage);
 
-    Stream(const std::string &name, const Mode mode, MPI_Comm comm,
+    Stream(const std::string &name, const Mode mode, helper::Comm comm,
            const std::string configFile, const std::string ioInConfigFile,
            const std::string hostLanguage);
 

--- a/source/adios2/core/Stream.h
+++ b/source/adios2/core/Stream.h
@@ -13,6 +13,7 @@
 
 #include <memory> //std::shared_ptr
 
+#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/ADIOS.h"

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -11,7 +11,6 @@
 #include "BP3Writer.h"
 #include "BP3Writer.tcc"
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosFunctions.h" //CheckIndexRange

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -11,7 +11,6 @@
 #include "BP4Writer.h"
 #include "BP4Writer.tcc"
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosFunctions.h" //CheckIndexRange

--- a/source/adios2/engine/dataspaces/DataSpacesReader.cpp
+++ b/source/adios2/engine/dataspaces/DataSpacesReader.cpp
@@ -12,6 +12,7 @@
 
 #include "DataSpacesReader.h"
 #include "DataSpacesReader.tcc"
+#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" //CSVToVector
 #include "adios2/toolkit/dataspaces/ds_data.h"
 #include "dataspaces.h"
@@ -52,7 +53,7 @@ DataSpacesReader::DataSpacesReader(IO &io, const std::string &name,
     {
         m_ProvideLatest = false;
     }
-    MPI_Comm mpiComm = m_Comm.AsMPI();
+    MPI_Comm mpiComm = CommAsMPI(m_Comm);
     ret = adios_read_dataspaces_init(&mpiComm, &m_data);
     if (ret < 0)
     {

--- a/source/adios2/engine/dataspaces/DataSpacesWriter.cpp
+++ b/source/adios2/engine/dataspaces/DataSpacesWriter.cpp
@@ -13,6 +13,7 @@
 
 #include "DataSpacesWriter.h"
 #include "DataSpacesWriter.tcc"
+#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" //CSVToVector
 #include "adios2/toolkit/dataspaces/ds_data.h"
 #include "dataspaces.h"
@@ -40,7 +41,7 @@ DataSpacesWriter::DataSpacesWriter(IO &io, const std::string &name,
     {
         m_data.appid = 0;
     }
-    MPI_Comm mpiComm = m_Comm.AsMPI();
+    MPI_Comm mpiComm = CommAsMPI(m_Comm);
     ret = adios_dataspaces_init(&mpiComm, &m_data);
     if (ret < 0)
         fprintf(stderr, "Unable to connect to DataSpaces. Err: %d\n", ret);

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -11,7 +11,6 @@
 #include "HDF5ReaderP.h"
 #include "HDF5ReaderP.tcc"
 
-#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" //CSVToVector
 
 #include <vector>
@@ -62,7 +61,7 @@ void HDF5ReaderP::Init()
             ", in call to Open\n");
     }
 
-    m_H5File.Init(m_Name, CommAsMPI(m_Comm), false);
+    m_H5File.Init(m_Name, m_Comm, false);
     m_H5File.ParseParameters(m_IO);
 
     /*

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -11,7 +11,7 @@
 #include "HDF5ReaderP.h"
 #include "HDF5ReaderP.tcc"
 
-#include "adios2/common/ADIOSMPI.h"
+#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" //CSVToVector
 
 #include <vector>
@@ -62,7 +62,7 @@ void HDF5ReaderP::Init()
             ", in call to Open\n");
     }
 
-    m_H5File.Init(m_Name, m_Comm.AsMPI(), false);
+    m_H5File.Init(m_Name, CommAsMPI(m_Comm), false);
     m_H5File.ParseParameters(m_IO);
 
     /*

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -10,7 +10,6 @@
 
 #include "HDF5WriterP.h"
 
-#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" //CSVToVector
 
 namespace adios2
@@ -58,7 +57,7 @@ void HDF5WriterP::Init()
     }
 
 #ifdef NEVER
-    m_H5File.Init(m_Name, CommAsMPI(m_Comm), true);
+    m_H5File.Init(m_Name, m_Comm, true);
 #else
     // enforce .h5 ending
     std::string suffix = ".h5";
@@ -71,11 +70,11 @@ void HDF5WriterP::Init()
     {
         // is a file with .bp ending
         std::string updatedName = m_Name.substr(0, wpos) + suffix;
-        m_H5File.Init(updatedName, CommAsMPI(m_Comm), true);
+        m_H5File.Init(updatedName, m_Comm, true);
     }
     else
     {
-        m_H5File.Init(m_Name, CommAsMPI(m_Comm), true);
+        m_H5File.Init(m_Name, m_Comm, true);
     }
     m_H5File.ParseParameters(m_IO);
 #endif

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -10,7 +10,7 @@
 
 #include "HDF5WriterP.h"
 
-#include "adios2/common/ADIOSMPI.h"
+#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" //CSVToVector
 
 namespace adios2
@@ -58,7 +58,7 @@ void HDF5WriterP::Init()
     }
 
 #ifdef NEVER
-    m_H5File.Init(m_Name, m_Comm.AsMPI(), true);
+    m_H5File.Init(m_Name, CommAsMPI(m_Comm), true);
 #else
     // enforce .h5 ending
     std::string suffix = ".h5";
@@ -71,11 +71,11 @@ void HDF5WriterP::Init()
     {
         // is a file with .bp ending
         std::string updatedName = m_Name.substr(0, wpos) + suffix;
-        m_H5File.Init(updatedName, m_Comm.AsMPI(), true);
+        m_H5File.Init(updatedName, CommAsMPI(m_Comm), true);
     }
     else
     {
-        m_H5File.Init(m_Name, m_Comm.AsMPI(), true);
+        m_H5File.Init(m_Name, CommAsMPI(m_Comm), true);
     }
     m_H5File.ParseParameters(m_IO);
 #endif

--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -14,6 +14,7 @@
 
 #include "InSituMPIReader.tcc"
 
+#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h" // CSVToVector
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 
@@ -38,7 +39,7 @@ InSituMPIReader::InSituMPIReader(IO &io, const std::string &name,
     Init();
 
     m_RankAllPeers =
-        insitumpi::FindPeers(m_Comm.AsMPI(), m_Name, false, m_CommWorld);
+        insitumpi::FindPeers(CommAsMPI(m_Comm), m_Name, false, m_CommWorld);
     MPI_Comm_rank(m_CommWorld, &m_GlobalRank);
     MPI_Comm_size(m_CommWorld, &m_GlobalNproc);
     m_ReaderRank = m_Comm.Rank();

--- a/source/adios2/engine/insitumpi/InSituMPIReader.h
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.h
@@ -15,6 +15,7 @@
 #define ADIOS2_ENGINE_INSITUMPI_INSITUMPIREADER_H_
 
 #include "adios2/common/ADIOSConfig.h"
+#include "adios2/common/ADIOSMPI.h"
 #include "adios2/core/ADIOS.h"
 #include "adios2/core/Engine.h"
 #include "adios2/helper/adiosComm.h"

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
@@ -11,6 +11,7 @@
  *      Author: Norbert Podhorszki pnorbert@ornl.gov
  */
 
+#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosMath.h"
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 
@@ -39,7 +40,7 @@ InSituMPIWriter::InSituMPIWriter(IO &io, const std::string &name,
     m_BP3Serializer.Init(m_IO.m_Parameters, "in call to InSituMPI::Open write");
 
     m_RankAllPeers =
-        insitumpi::FindPeers(m_Comm.AsMPI(), m_Name, true, m_CommWorld);
+        insitumpi::FindPeers(CommAsMPI(m_Comm), m_Name, true, m_CommWorld);
     for (int i = 0; i < m_RankAllPeers.size(); i++)
     {
         m_RankToPeerID[m_RankAllPeers[i]] = i;

--- a/source/adios2/engine/mixer/HDFMixer.cpp
+++ b/source/adios2/engine/mixer/HDFMixer.cpp
@@ -11,7 +11,6 @@
 #include "HDFMixer.h"
 #include "HDFMixer.tcc"
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosFunctions.h" //CheckIndexRange
 #include "adios2/toolkit/transport/file/FileFStream.h"
@@ -27,7 +26,7 @@ HDFMixer::HDFMixer(IO &io, const std::string &name, const Mode openMode,
                    helper::Comm comm)
 : Engine("HDFMixer", io, name, openMode, std::move(comm)),
   m_HDFVDSWriter(m_Comm, m_DebugMode),
-  m_HDFSerialWriter(MPI_COMM_SELF, m_DebugMode),
+  m_HDFSerialWriter(helper::Comm(), m_DebugMode),
   m_TransportsManager(m_Comm, m_DebugMode)
 {
     m_EndMessage = " in call to IO Open HDFMixer " + m_Name + "\n";
@@ -102,9 +101,7 @@ void HDFMixer::InitTransports()
 */
 #else
 
-    int rank;
-    MPI_Comm_rank(m_Comm, &rank);
-    m_HDFSerialWriter.Init(m_Name, rank);
+    m_HDFSerialWriter.Init(m_Name, m_Comm.Rank());
     m_HDFVDSWriter.Init(m_Name);
 /*
 auto transportsNames = m_TransportsManager.GetFilesBaseNames(

--- a/source/adios2/engine/mixer/HDFMixerWriter.h
+++ b/source/adios2/engine/mixer/HDFMixerWriter.h
@@ -11,34 +11,9 @@
 #ifndef ADIOS2_ENGINE_BP_HDFSERIALWRITER_H_
 #define ADIOS2_ENGINE_BP_HDFSERIALWRITER_H_
 
+#include "adios2/helper/adiosComm.h"
 #include "adios2/toolkit/interop/hdf5/HDF5Common.h"
 
-/*
-inline MPI_Datatype mpi_typeof(char) { return MPI_CHAR; }
-inline MPI_Datatype mpi_typeof(signed short) { return MPI_SHORT; }
-inline MPI_Datatype mpi_typeof(signed int) { return MPI_INT; }
-inline MPI_Datatype mpi_typeof(signed long) { return MPI_LONG; }
-inline MPI_Datatype mpi_typeof(unsigned char) { return MPI_UNSIGNED_CHAR; }
-inline MPI_Datatype mpi_typeof(unsigned short) { return MPI_UNSIGNED_SHORT; }
-inline MPI_Datatype mpi_typeof(unsigned) { return MPI_UNSIGNED; }
-inline MPI_Datatype mpi_typeof(unsigned long) { return MPI_UNSIGNED_LONG; }
-inline MPI_Datatype mpi_typeof(signed long long) { return MPI_LONG_LONG_INT; }
-inline MPI_Datatype mpi_typeof(double) { return MPI_DOUBLE; }
-inline MPI_Datatype mpi_typeof(long double) { return MPI_LONG_DOUBLE; }
-inline MPI_Datatype mpi_typeof(std::pair<int, int>) { return MPI_2INT; }
-inline MPI_Datatype mpi_typeof(std::pair<float, int>) { return MPI_FLOAT_INT; }
-inline MPI_Datatype mpi_typeof(std::pair<double, int>)
-{
-    return MPI_DOUBLE_INT;
-}
-inline MPI_Datatype mpi_typeof(std::pair<long double, int>)
-{
-    return MPI_LONG_DOUBLE_INT;
-}
-inline MPI_Datatype mpi_typeof(std::pair<short, int>) { return MPI_SHORT_INT; }
-
-#define ADIOS_MPI_SIZE_T (mpi_typeof(size_t()))
-*/
 namespace adios2
 {
 namespace core
@@ -49,7 +24,7 @@ namespace engine
 class HDFVDSWriter
 {
 public:
-    HDFVDSWriter(MPI_Comm mpiComm, bool debugMode);
+    HDFVDSWriter(helper::Comm const &comm, bool debugMode);
     void Init(const std::string &name);
     void AddVar(const VariableBase &var, hid_t h5Type);
     void
@@ -66,13 +41,14 @@ private:
 
     int m_NumSubFiles;
     std::string m_FileName;
-    MPI_Comm m_MPISubfileComm; // only rank 0 in this comm can build VDS;
+    helper::Comm const
+        &m_SubfileComm; // only rank 0 in this comm can build VDS;
 };
 
 class HDFSerialWriter
 {
 public:
-    HDFSerialWriter(MPI_Comm mpiComm, bool debugMode);
+    HDFSerialWriter(helper::Comm const &comm, bool debugMode);
     void
     Advance(const float timeoutSeconds = std::numeric_limits<float>::max());
     void Close(const int transportIndex = -1);
@@ -84,12 +60,13 @@ public:
     /** contains data buffer and position */
     // capsule::STLVector m_HeapBuffer;
 
-    // int m_MPIRank;
+    // int m_Rank;
     interop::HDF5Common m_H5File;
     std::string m_FileName;
 
 private:
-    MPI_Comm m_MPILocalComm; // all ranks in this comm write to the same file
+    helper::Comm const
+        &m_LocalComm; // all ranks in this comm write to the same file
     const bool m_DebugMode = false;
     int m_Rank;
 };

--- a/source/adios2/engine/sst/SstParamParser.cpp
+++ b/source/adios2/engine/sst/SstParamParser.cpp
@@ -1,5 +1,4 @@
 
-#include <adios2/common/ADIOSMPI.h>
 #include <memory>
 
 #include "SstParamParser.h"

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <string>
 
+#include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosFunctions.h"
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 
@@ -34,7 +35,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
 
     Init();
 
-    m_Input = SstReaderOpen(cstr, &Params, m_Comm.AsMPI());
+    m_Input = SstReaderOpen(cstr, &Params, CommAsMPI(m_Comm));
     if (!m_Input)
     {
         throw std::runtime_error(

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -11,8 +11,6 @@
 #ifndef ADIOS2_ENGINE_SST_SSTREADER_H_
 #define ADIOS2_ENGINE_SST_SSTREADER_H_
 
-#include <adios2/common/ADIOSMPI.h>
-
 #include "adios2/toolkit/sst/sst.h"
 
 #include "adios2/core/Engine.h"

--- a/source/adios2/engine/sst/SstReader.tcc
+++ b/source/adios2/engine/sst/SstReader.tcc
@@ -13,7 +13,6 @@
 
 #include "SstReader.h"
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/helper/adiosFunctions.h" //GetType<T>
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -8,6 +8,7 @@
  *      Author: Greg Eisenhauer
  */
 
+#include "adios2/helper/adiosCommMPI.h"
 #include <memory>
 
 #include "SstParamParser.h"
@@ -108,7 +109,7 @@ SstWriter::SstWriter(IO &io, const std::string &name, const Mode mode,
 
     Init();
 
-    m_Output = SstWriterOpen(name.c_str(), &Params, m_Comm.AsMPI());
+    m_Output = SstWriterOpen(name.c_str(), &Params, CommAsMPI(m_Comm));
 
     if (m_MarshalMethod == SstMarshalBP)
     {

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -8,7 +8,6 @@
  *      Author: Greg Eisenhauer
  */
 
-#include <adios2/common/ADIOSMPI.h>
 #include <memory>
 
 #include "SstParamParser.h"

--- a/source/adios2/engine/sst/SstWriter.h
+++ b/source/adios2/engine/sst/SstWriter.h
@@ -11,8 +11,6 @@
 #ifndef ADIOS2_ENGINE_SST_SST_WRITER_H_
 #define ADIOS2_ENGINE_SST_SST_WRITER_H_
 
-#include <adios2/common/ADIOSMPI.h>
-
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/core/Engine.h"
 #include "adios2/helper/adiosComm.h"

--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -13,7 +13,6 @@
 
 #include "SstWriter.h"
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/helper/adiosFunctions.h" //GetType<T>
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -2,7 +2,7 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * Comm.cpp
+ * adiosComm.cpp
  */
 
 #include "adiosComm.h"
@@ -54,7 +54,7 @@ Comm &Comm::operator=(Comm &&comm)
 
 void Comm::swap(Comm &comm) { std::swap(this->m_MPIComm, comm.m_MPIComm); }
 
-Comm Comm::Duplicate(MPI_Comm mpiComm)
+Comm Comm::FromMPI(MPI_Comm mpiComm)
 {
     MPI_Comm newComm;
     SMPI_Comm_dup(mpiComm, &newComm);

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -58,6 +58,19 @@ std::string Comm::BroadcastFile(const std::string &fileName,
     return fileContents;
 }
 
+std::vector<size_t> Comm::GetGathervDisplacements(const size_t *counts,
+                                                  const size_t countsSize)
+{
+    std::vector<size_t> displacements(countsSize);
+    displacements[0] = 0;
+
+    for (size_t i = 1; i < countsSize; ++i)
+    {
+        displacements[i] = displacements[i - 1] + counts[i - 1];
+    }
+    return displacements;
+}
+
 Comm::Req::Req() = default;
 
 Comm::Req::Req(std::unique_ptr<CommReqImpl> impl) : m_Impl(std::move(impl)) {}

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -17,6 +17,32 @@ namespace adios2
 namespace helper
 {
 
+namespace
+{
+const size_t DatatypeToSize[] = {
+    sizeof(signed char),
+    sizeof(char),
+    sizeof(short),
+    sizeof(int),
+    sizeof(long),
+    sizeof(unsigned char),
+    sizeof(unsigned short),
+    sizeof(unsigned int),
+    sizeof(unsigned long),
+    sizeof(unsigned long long),
+    sizeof(long long),
+    sizeof(double),
+    sizeof(long double),
+    sizeof(std::pair<int, int>),
+    sizeof(std::pair<float, int>),
+    sizeof(std::pair<double, int>),
+    sizeof(std::pair<long double, int>),
+    sizeof(std::pair<short, int>),
+};
+
+size_t ToSize(CommImpl::Datatype dt) { return DatatypeToSize[int(dt)]; }
+}
+
 Comm::Comm() = default;
 
 Comm::Comm(std::unique_ptr<CommImpl> impl) : m_Impl(std::move(impl)) {}
@@ -93,6 +119,8 @@ Comm::Status Comm::Req::Wait(const std::string &hint)
 }
 
 CommImpl::~CommImpl() = default;
+
+size_t CommImpl::SizeOf(Datatype datatype) { return ToSize(datatype); }
 
 Comm CommImpl::MakeComm(std::unique_ptr<CommImpl> impl)
 {

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -123,8 +123,7 @@ std::string Comm::BroadcastFile(const std::string &fileName,
                                 const std::string hint,
                                 const int rankSource) const
 {
-    int rank;
-    MPI_Comm_rank(m_MPIComm, &rank);
+    int rank = this->Rank();
     std::string fileContents;
 
     // Read the file on rank 0 and broadcast it to everybody else

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -55,6 +55,11 @@ Comm &Comm::operator=(Comm &&comm) = default;
 
 void Comm::Free(const std::string &hint) { m_Impl->Free(hint); }
 
+Comm Comm::Duplicate(const std::string &hint) const
+{
+    return Comm(m_Impl->Duplicate(hint));
+}
+
 Comm Comm::Split(int color, int key, const std::string &hint) const
 {
     return Comm(m_Impl->Split(color, key, hint));

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -65,6 +65,11 @@ Comm Comm::Split(int color, int key, const std::string &hint) const
     return Comm(m_Impl->Split(color, key, hint));
 }
 
+Comm Comm::World(const std::string &hint) const
+{
+    return Comm(m_Impl->World(hint));
+}
+
 int Comm::Rank() const { return m_Impl->Rank(); }
 
 int Comm::Size() const { return m_Impl->Size(); }

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -119,24 +119,6 @@ void Comm::Barrier(const std::string &hint) const
     CheckMPIReturn(SMPI_Barrier(m_MPIComm), hint);
 }
 
-std::string Comm::BroadcastFile(const std::string &fileName,
-                                const std::string hint,
-                                const int rankSource) const
-{
-    int rank = this->Rank();
-    std::string fileContents;
-
-    // Read the file on rank 0 and broadcast it to everybody else
-    if (rank == rankSource)
-    {
-        // load file contents
-        fileContents = FileToString(fileName, hint);
-    }
-    fileContents = this->BroadcastValue(fileContents, rankSource);
-
-    return fileContents;
-}
-
 void Comm::AllgatherImpl(const void *sendbuf, size_t sendcount,
                          MPI_Datatype sendtype, void *recvbuf, size_t recvcount,
                          MPI_Datatype recvtype, const std::string &hint) const
@@ -365,6 +347,24 @@ Comm::Req Comm::IrecvImpl(void *buffer, size_t count, MPI_Datatype datatype,
     }
 
     return req;
+}
+
+std::string Comm::BroadcastFile(const std::string &fileName,
+                                const std::string hint,
+                                const int rankSource) const
+{
+    int rank = this->Rank();
+    std::string fileContents;
+
+    // Read the file on rank 0 and broadcast it to everybody else
+    if (rank == rankSource)
+    {
+        // load file contents
+        fileContents = FileToString(fileName, hint);
+    }
+    fileContents = this->BroadcastValue(fileContents, rankSource);
+
+    return fileContents;
 }
 
 Comm::Req::Req() = default;

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -8,12 +8,8 @@
 #include "adiosComm.h"
 #include "adiosComm.tcc"
 
-#include <algorithm>
-#include <ios> //std::ios_base::failure
-#include <iterator>
 #include <utility>
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/helper/adiosString.h"
 
 namespace adios2
@@ -23,331 +19,26 @@ namespace helper
 
 Comm::Comm() = default;
 
-Comm::Comm(MPI_Comm mpiComm) : m_MPIComm(mpiComm) {}
+Comm::Comm(std::unique_ptr<CommImpl> impl) : m_Impl(std::move(impl)) {}
 
-Comm::~Comm()
-{
-    // Handle the case where MPI is finalized before the ADIOS destructor is
-    // called, which happens, e.g., with global / static ADIOS objects
-    int flag;
-    MPI_Finalized(&flag);
-    if (!flag)
-    {
-        if (m_MPIComm != MPI_COMM_NULL && m_MPIComm != MPI_COMM_WORLD &&
-            m_MPIComm != MPI_COMM_SELF)
-        {
-            SMPI_Comm_free(&m_MPIComm);
-        }
-    }
-}
+Comm::~Comm() = default;
 
-Comm::Comm(Comm &&comm) : m_MPIComm(comm.m_MPIComm)
-{
-    comm.m_MPIComm = MPI_COMM_NULL;
-}
+Comm::Comm(Comm &&comm) = default;
 
-Comm &Comm::operator=(Comm &&comm)
-{
-    Comm(std::move(comm)).swap(*this);
-    return *this;
-}
+Comm &Comm::operator=(Comm &&comm) = default;
 
-void Comm::swap(Comm &comm) { std::swap(this->m_MPIComm, comm.m_MPIComm); }
-
-Comm Comm::FromMPI(MPI_Comm mpiComm)
-{
-    MPI_Comm newComm;
-    SMPI_Comm_dup(mpiComm, &newComm);
-    return Comm(newComm);
-}
-
-void Comm::CheckMPIReturn(const int value, const std::string &hint)
-{
-    if (value == MPI_SUCCESS)
-    {
-        return;
-    }
-
-    std::string error;
-    switch (value)
-    {
-    case MPI_ERR_COMM:
-        error = "MPI_ERR_COMM";
-        break;
-    case MPI_ERR_INTERN:
-        error = "MPI_ERR_INTERN";
-        break;
-    default:
-        error = "MPI_ERR number: " + std::to_string(value);
-    }
-
-    throw std::runtime_error("ERROR: ADIOS2 detected " + error + ", " + hint);
-}
-
-void Comm::Free(const std::string &hint)
-{
-    if (m_MPIComm != MPI_COMM_NULL && m_MPIComm != MPI_COMM_WORLD &&
-        m_MPIComm != MPI_COMM_SELF)
-    {
-        CheckMPIReturn(SMPI_Comm_free(&m_MPIComm), hint);
-    }
-}
+void Comm::Free(const std::string &hint) { m_Impl->Free(hint); }
 
 Comm Comm::Split(int color, int key, const std::string &hint) const
 {
-    MPI_Comm newComm;
-    CheckMPIReturn(MPI_Comm_split(m_MPIComm, color, key, &newComm), hint);
-    return Comm(newComm);
+    return Comm(m_Impl->Split(color, key, hint));
 }
 
-int Comm::Rank() const
-{
-    int rank;
-    CheckMPIReturn(SMPI_Comm_rank(m_MPIComm, &rank), {});
-    return rank;
-}
+int Comm::Rank() const { return m_Impl->Rank(); }
 
-int Comm::Size() const
-{
-    int size;
-    CheckMPIReturn(SMPI_Comm_size(m_MPIComm, &size), {});
-    return size;
-}
+int Comm::Size() const { return m_Impl->Size(); }
 
-void Comm::Barrier(const std::string &hint) const
-{
-    CheckMPIReturn(SMPI_Barrier(m_MPIComm), hint);
-}
-
-void Comm::AllgatherImpl(const void *sendbuf, size_t sendcount,
-                         MPI_Datatype sendtype, void *recvbuf, size_t recvcount,
-                         MPI_Datatype recvtype, const std::string &hint) const
-{
-    CheckMPIReturn(
-        SMPI_Allgather(sendbuf, static_cast<int>(sendcount), sendtype, recvbuf,
-                       static_cast<int>(recvcount), recvtype, m_MPIComm),
-        hint);
-}
-
-void Comm::AllreduceImpl(const void *sendbuf, void *recvbuf, size_t count,
-                         MPI_Datatype datatype, MPI_Op op,
-                         const std::string &hint) const
-{
-    CheckMPIReturn(SMPI_Allreduce(sendbuf, recvbuf, static_cast<int>(count),
-                                  datatype, op, m_MPIComm),
-                   hint);
-}
-
-void Comm::BcastImpl(void *buffer, size_t count, MPI_Datatype datatype,
-                     size_t datatypeSize, int root,
-                     const std::string &hint) const
-{
-    size_t inputSize = count;
-    const int MAXBCASTSIZE = 1073741824;
-    size_t blockSize = (inputSize > MAXBCASTSIZE ? MAXBCASTSIZE : inputSize);
-    unsigned char *blockBuf = static_cast<unsigned char *>(buffer);
-    while (inputSize > 0)
-    {
-        CheckMPIReturn(SMPI_Bcast(blockBuf, static_cast<int>(blockSize),
-                                  datatype, root, m_MPIComm),
-                       hint);
-        blockBuf += blockSize * datatypeSize;
-        inputSize -= blockSize;
-        blockSize = (inputSize > MAXBCASTSIZE ? MAXBCASTSIZE : inputSize);
-    }
-}
-
-void Comm::GatherImpl(const void *sendbuf, size_t sendcount,
-                      MPI_Datatype sendtype, void *recvbuf, size_t recvcount,
-                      MPI_Datatype recvtype, int root,
-                      const std::string &hint) const
-{
-    CheckMPIReturn(SMPI_Gather(sendbuf, static_cast<int>(sendcount), sendtype,
-                               recvbuf, static_cast<int>(recvcount), recvtype,
-                               root, m_MPIComm),
-                   hint);
-}
-
-void Comm::GathervImpl(const void *sendbuf, size_t sendcount,
-                       MPI_Datatype sendtype, void *recvbuf,
-                       const size_t *recvcounts, const size_t *displs,
-                       MPI_Datatype recvtype, int root,
-                       const std::string &hint) const
-{
-    std::vector<int> countsInt;
-    std::vector<int> displsInt;
-    if (root == this->Rank())
-    {
-        auto cast = [](size_t sz) -> int { return int(sz); };
-        const int size = this->Size();
-        countsInt.reserve(size);
-        std::transform(recvcounts, recvcounts + size,
-                       std::back_inserter(countsInt), cast);
-        displsInt.reserve(size);
-        std::transform(displs, displs + size, std::back_inserter(displsInt),
-                       cast);
-    }
-    CheckMPIReturn(SMPI_Gatherv(sendbuf, static_cast<int>(sendcount), sendtype,
-                                recvbuf, countsInt.data(), displsInt.data(),
-                                recvtype, root, m_MPIComm),
-                   hint);
-}
-
-void Comm::ReduceImpl(const void *sendbuf, void *recvbuf, size_t count,
-                      MPI_Datatype datatype, MPI_Op op, int root,
-                      const std::string &hint) const
-{
-    CheckMPIReturn(SMPI_Reduce(sendbuf, recvbuf, static_cast<int>(count),
-                               datatype, op, root, m_MPIComm),
-                   hint);
-}
-
-void Comm::ReduceInPlaceImpl(void *buf, size_t count, MPI_Datatype datatype,
-                             MPI_Op op, int root, const std::string &hint) const
-{
-    CheckMPIReturn(SMPI_Reduce(MPI_IN_PLACE, buf, static_cast<int>(count),
-                               datatype, op, root, m_MPIComm),
-                   hint);
-}
-
-void Comm::SendImpl(const void *buf, size_t count, MPI_Datatype datatype,
-                    int dest, int tag, const std::string &hint) const
-{
-    CheckMPIReturn(
-        MPI_Send(buf, static_cast<int>(count), datatype, dest, tag, m_MPIComm),
-        hint);
-}
-
-Comm::Status Comm::RecvImpl(void *buf, size_t count, MPI_Datatype datatype,
-                            int source, int tag, const std::string &hint) const
-{
-    MPI_Status mpiStatus;
-    CheckMPIReturn(MPI_Recv(buf, static_cast<int>(count), datatype, source, tag,
-                            m_MPIComm, &mpiStatus),
-                   hint);
-
-    Status status;
-#ifdef ADIOS2_HAVE_MPI
-    status.Source = mpiStatus.MPI_SOURCE;
-    status.Tag = mpiStatus.MPI_TAG;
-    {
-        int mpiCount = 0;
-        CheckMPIReturn(MPI_Get_count(&mpiStatus, datatype, &mpiCount), hint);
-        status.Count = mpiCount;
-    }
-#endif
-    return status;
-}
-
-void Comm::ScatterImpl(const void *sendbuf, size_t sendcount,
-                       MPI_Datatype sendtype, void *recvbuf, size_t recvcount,
-                       MPI_Datatype recvtype, int root,
-                       const std::string &hint) const
-{
-    CheckMPIReturn(MPI_Scatter(sendbuf, static_cast<int>(sendcount), sendtype,
-                               recvbuf, static_cast<int>(recvcount), recvtype,
-                               root, m_MPIComm),
-                   hint);
-}
-
-Comm::Req Comm::IsendImpl(const void *buffer, size_t count,
-                          MPI_Datatype datatype, int dest, int tag,
-                          const std::string &hint) const
-{
-    Comm::Req req(datatype);
-
-    if (count > DefaultMaxFileBatchSize)
-    {
-        const size_t batches = count / DefaultMaxFileBatchSize;
-
-        size_t position = 0;
-        for (size_t b = 0; b < batches; ++b)
-        {
-            int batchSize = static_cast<int>(DefaultMaxFileBatchSize);
-            MPI_Request mpiReq;
-            CheckMPIReturn(
-                MPI_Isend(static_cast<char *>(const_cast<void *>(buffer)) +
-                              position,
-                          batchSize, datatype, dest, tag, m_MPIComm, &mpiReq),
-                "in call to Isend batch " + std::to_string(b) + " " + hint +
-                    "\n");
-            req.m_MPIReqs.emplace_back(mpiReq);
-
-            position += DefaultMaxFileBatchSize;
-        }
-        const size_t remainder = count % DefaultMaxFileBatchSize;
-        if (remainder > 0)
-        {
-            int batchSize = static_cast<int>(remainder);
-            MPI_Request mpiReq;
-            CheckMPIReturn(
-                MPI_Isend(static_cast<char *>(const_cast<void *>(buffer)) +
-                              position,
-                          batchSize, datatype, dest, tag, m_MPIComm, &mpiReq),
-                "in call to Isend remainder batch " + hint + "\n");
-            req.m_MPIReqs.emplace_back(mpiReq);
-        }
-    }
-    else
-    {
-        int batchSize = static_cast<int>(count);
-        MPI_Request mpiReq;
-        CheckMPIReturn(
-            MPI_Isend(static_cast<char *>(const_cast<void *>(buffer)),
-                      batchSize, datatype, dest, tag, m_MPIComm, &mpiReq),
-            " in call to Isend with single batch " + hint + "\n");
-        req.m_MPIReqs.emplace_back(mpiReq);
-    }
-    return req;
-}
-
-Comm::Req Comm::IrecvImpl(void *buffer, size_t count, MPI_Datatype datatype,
-                          int source, int tag, const std::string &hint) const
-{
-    Comm::Req req(datatype);
-
-    if (count > DefaultMaxFileBatchSize)
-    {
-        const size_t batches = count / DefaultMaxFileBatchSize;
-        size_t position = 0;
-        for (size_t b = 0; b < batches; ++b)
-        {
-            int batchSize = static_cast<int>(DefaultMaxFileBatchSize);
-            MPI_Request mpiReq;
-            CheckMPIReturn(MPI_Irecv(static_cast<char *>(buffer) + position,
-                                     batchSize, datatype, source, tag,
-                                     m_MPIComm, &mpiReq),
-                           "in call to Irecv batch " + std::to_string(b) + " " +
-                               hint + "\n");
-            req.m_MPIReqs.emplace_back(mpiReq);
-
-            position += DefaultMaxFileBatchSize;
-        }
-
-        const size_t remainder = count % DefaultMaxFileBatchSize;
-        if (remainder > 0)
-        {
-            int batchSize = static_cast<int>(remainder);
-            MPI_Request mpiReq;
-            CheckMPIReturn(MPI_Irecv(static_cast<char *>(buffer) + position,
-                                     batchSize, datatype, source, tag,
-                                     m_MPIComm, &mpiReq),
-                           "in call to Irecv remainder batch " + hint + "\n");
-            req.m_MPIReqs.emplace_back(mpiReq);
-        }
-    }
-    else
-    {
-        int batchSize = static_cast<int>(count);
-        MPI_Request mpiReq;
-        CheckMPIReturn(MPI_Irecv(buffer, batchSize, datatype, source, tag,
-                                 m_MPIComm, &mpiReq),
-                       " in call to Isend with single batch " + hint + "\n");
-        req.m_MPIReqs.emplace_back(mpiReq);
-    }
-
-    return req;
-}
+void Comm::Barrier(const std::string &hint) const { m_Impl->Barrier(hint); }
 
 std::string Comm::BroadcastFile(const std::string &fileName,
                                 const std::string hint,
@@ -369,89 +60,40 @@ std::string Comm::BroadcastFile(const std::string &fileName,
 
 Comm::Req::Req() = default;
 
-Comm::Req::Req(MPI_Datatype datatype) : m_MPIDatatype(datatype) {}
+Comm::Req::Req(std::unique_ptr<CommReqImpl> impl) : m_Impl(std::move(impl)) {}
 
-Comm::Req::~Req() {}
+Comm::Req::~Req() = default;
 
-Comm::Req::Req(Req &&req)
-: m_MPIDatatype(req.m_MPIDatatype), m_MPIReqs(std::move(req.m_MPIReqs))
-{
-}
+Comm::Req::Req(Req &&req) = default;
 
-Comm::Req &Comm::Req::operator=(Req &&req)
-{
-    Req(std::move(req)).swap(*this);
-    return *this;
-}
-
-void Comm::Req::swap(Req &req)
-{
-    std::swap(this->m_MPIDatatype, req.m_MPIDatatype);
-    std::swap(this->m_MPIReqs, req.m_MPIReqs);
-}
+Comm::Req &Comm::Req::operator=(Req &&req) = default;
 
 Comm::Status Comm::Req::Wait(const std::string &hint)
 {
     Comm::Status status;
-    if (m_MPIReqs.empty())
+    if (m_Impl)
     {
-        return status;
+        status = m_Impl->Wait(hint);
+        m_Impl.reset();
     }
-
-#ifdef ADIOS2_HAVE_MPI
-    std::vector<MPI_Request> mpiRequests = std::move(m_MPIReqs);
-    std::vector<MPI_Status> mpiStatuses(mpiRequests.size());
-
-    if (mpiRequests.size() > 1)
-    {
-        int mpiReturn = MPI_Waitall(static_cast<int>(mpiRequests.size()),
-                                    mpiRequests.data(), mpiStatuses.data());
-        if (mpiReturn == MPI_ERR_IN_STATUS)
-        {
-            for (auto &mpiStatus : mpiStatuses)
-            {
-                if (mpiStatus.MPI_ERROR != MPI_SUCCESS)
-                {
-                    mpiReturn = mpiStatus.MPI_ERROR;
-                    break;
-                }
-            }
-        }
-        CheckMPIReturn(mpiReturn, hint);
-    }
-    else
-    {
-        CheckMPIReturn(MPI_Wait(mpiRequests.data(), mpiStatuses.data()), hint);
-    }
-
-    // Our batched operation should be from only one source and have one tag.
-    status.Source = mpiStatuses.front().MPI_SOURCE;
-    status.Tag = mpiStatuses.front().MPI_TAG;
-
-    // Accumulate the total count of our batched operation.
-    for (auto &mpiStatus : mpiStatuses)
-    {
-        int mpiCount = 0;
-        CheckMPIReturn(MPI_Get_count(&mpiStatus, m_MPIDatatype, &mpiCount),
-                       hint);
-        status.Count += mpiCount;
-    }
-
-    // Our batched operation was cancelled if any member was cancelled.
-    for (auto &mpiStatus : mpiStatuses)
-    {
-        int mpiCancelled = 0;
-        MPI_Test_cancelled(&mpiStatus, &mpiCancelled);
-        if (mpiCancelled)
-        {
-            status.Cancelled = true;
-            break;
-        }
-    }
-#endif
-
     return status;
 }
+
+CommImpl::~CommImpl() = default;
+
+Comm CommImpl::MakeComm(std::unique_ptr<CommImpl> impl)
+{
+    return Comm(std::move(impl));
+}
+
+Comm::Req CommImpl::MakeReq(std::unique_ptr<CommReqImpl> impl)
+{
+    return Comm::Req(std::move(impl));
+}
+
+CommImpl *CommImpl::Get(Comm const &comm) { return comm.m_Impl.get(); }
+
+CommReqImpl::~CommReqImpl() = default;
 
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -354,8 +354,7 @@ public:
                            Datatype datatype, Comm::Op op,
                            const std::string &hint) const = 0;
 
-    virtual void Bcast(void *buffer, size_t count, Datatype datatype,
-                       size_t datatypeSize, int root,
+    virtual void Bcast(void *buffer, size_t count, Datatype datatype, int root,
                        const std::string &hint) const = 0;
 
     virtual void Gather(const void *sendbuf, size_t sendcount,
@@ -396,6 +395,8 @@ public:
     virtual Comm::Req Irecv(void *buffer, size_t count, Datatype datatype,
                             int source, int tag,
                             const std::string &hint) const = 0;
+
+    static size_t SizeOf(Datatype datatype);
 
     static Comm MakeComm(std::unique_ptr<CommImpl> impl);
     static Comm::Req MakeReq(std::unique_ptr<CommReqImpl> impl);

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -66,16 +66,6 @@ public:
     void swap(Comm &comm);
 
     /**
-     * @brief Get the underlying raw MPI communicator.
-     */
-    MPI_Comm AsMPI() const { return m_MPIComm; }
-
-    /**
-     * @brief Create a communicator by duplicating a MPI communicator.
-     */
-    static Comm Duplicate(MPI_Comm mpiComm);
-
-    /**
      * @brief Free the communicator.
      * @param hint Description of std::runtime_error exception on error.
      *
@@ -291,6 +281,11 @@ private:
     /** Return MPI datatype id for type T.  */
     template <typename T>
     static MPI_Datatype Datatype();
+
+    friend Comm CommFromMPI(MPI_Comm mpiComm);
+    friend MPI_Comm CommAsMPI(Comm const &comm);
+    MPI_Comm AsMPI() const { return m_MPIComm; }
+    static Comm FromMPI(MPI_Comm mpiComm);
 };
 
 class Comm::Req

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -139,16 +139,6 @@ public:
     template <class T>
     std::vector<T> AllGatherValues(const T source) const;
 
-    /**
-     * Perform AllGather for equal size arrays
-     * @param source
-     * @param sourceCount
-     * @param destination
-     */
-    template <class T>
-    void AllGatherArrays(const T *source, const size_t sourceCount,
-                         T *destination) const;
-
     template <class T>
     T ReduceValues(const T source, MPI_Op operation = MPI_SUM,
                    const int rankDestination = 0) const;

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -112,8 +112,6 @@ public:
 
     /**
      * Gather arrays of the same type into a destination (must be pre-allocated)
-     * if countsSize == 1, calls MPI_Gather, otherwise calls MPI_Gatherv.
-     * This function must be specialized for each MPI_Type.
      * @param source  input from each rank
      * @param counts  counts for each source
      * @param countsSize number of counts

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -8,8 +8,6 @@
 #ifndef ADIOS2_HELPER_ADIOSCOMM_H_
 #define ADIOS2_HELPER_ADIOSCOMM_H_
 
-#include "adios2/common/ADIOSMPI.h"
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -233,10 +231,6 @@ private:
 
     std::unique_ptr<CommImpl> m_Impl;
 
-    /** Return MPI datatype id for type T.  */
-    template <typename T>
-    static MPI_Datatype Datatype();
-
     static std::vector<size_t> GetGathervDisplacements(const size_t *counts,
                                                        const size_t countsSize);
 };
@@ -319,6 +313,31 @@ public:
 class CommImpl
 {
 public:
+    enum class Datatype
+    {
+        SignedChar,
+        Char,
+        Short,
+        Int,
+        Long,
+        UnsignedChar,
+        UnsignedShort,
+        UnsignedInt,
+        UnsignedLong,
+        UnsignedLongLong,
+        LongLong,
+        Double,
+        LongDouble,
+        Int_Int,
+        Float_Int,
+        Double_Int,
+        LongDouble_Int,
+        Short_Int,
+    };
+
+    template <typename T>
+    static Datatype GetDatatype();
+
     virtual ~CommImpl() = 0;
     virtual void Free(const std::string &hint) = 0;
     virtual std::unique_ptr<CommImpl> Split(int color, int key,
@@ -327,54 +346,54 @@ public:
     virtual int Size() const = 0;
     virtual void Barrier(const std::string &hint) const = 0;
     virtual void Allgather(const void *sendbuf, size_t sendcount,
-                           MPI_Datatype sendtype, void *recvbuf,
-                           size_t recvcount, MPI_Datatype recvtype,
+                           Datatype sendtype, void *recvbuf, size_t recvcount,
+                           Datatype recvtype,
                            const std::string &hint) const = 0;
 
     virtual void Allreduce(const void *sendbuf, void *recvbuf, size_t count,
-                           MPI_Datatype datatype, Comm::Op op,
+                           Datatype datatype, Comm::Op op,
                            const std::string &hint) const = 0;
 
-    virtual void Bcast(void *buffer, size_t count, MPI_Datatype datatype,
+    virtual void Bcast(void *buffer, size_t count, Datatype datatype,
                        size_t datatypeSize, int root,
                        const std::string &hint) const = 0;
 
     virtual void Gather(const void *sendbuf, size_t sendcount,
-                        MPI_Datatype sendtype, void *recvbuf, size_t recvcount,
-                        MPI_Datatype recvtype, int root,
+                        Datatype sendtype, void *recvbuf, size_t recvcount,
+                        Datatype recvtype, int root,
                         const std::string &hint) const = 0;
 
     virtual void Gatherv(const void *sendbuf, size_t sendcount,
-                         MPI_Datatype sendtype, void *recvbuf,
+                         Datatype sendtype, void *recvbuf,
                          const size_t *recvcounts, const size_t *displs,
-                         MPI_Datatype recvtype, int root,
+                         Datatype recvtype, int root,
                          const std::string &hint) const = 0;
 
     virtual void Reduce(const void *sendbuf, void *recvbuf, size_t count,
-                        MPI_Datatype datatype, Comm::Op op, int root,
+                        Datatype datatype, Comm::Op op, int root,
                         const std::string &hint) const = 0;
 
-    virtual void ReduceInPlace(void *buf, size_t count, MPI_Datatype datatype,
+    virtual void ReduceInPlace(void *buf, size_t count, Datatype datatype,
                                Comm::Op op, int root,
                                const std::string &hint) const = 0;
 
-    virtual void Send(const void *buf, size_t count, MPI_Datatype datatype,
+    virtual void Send(const void *buf, size_t count, Datatype datatype,
                       int dest, int tag, const std::string &hint) const = 0;
 
-    virtual Comm::Status Recv(void *buf, size_t count, MPI_Datatype datatype,
+    virtual Comm::Status Recv(void *buf, size_t count, Datatype datatype,
                               int source, int tag,
                               const std::string &hint) const = 0;
 
     virtual void Scatter(const void *sendbuf, size_t sendcount,
-                         MPI_Datatype sendtype, void *recvbuf, size_t recvcount,
-                         MPI_Datatype recvtype, int root,
+                         Datatype sendtype, void *recvbuf, size_t recvcount,
+                         Datatype recvtype, int root,
                          const std::string &hint) const = 0;
 
-    virtual Comm::Req Isend(const void *buffer, size_t count,
-                            MPI_Datatype datatype, int dest, int tag,
+    virtual Comm::Req Isend(const void *buffer, size_t count, Datatype datatype,
+                            int dest, int tag,
                             const std::string &hint) const = 0;
 
-    virtual Comm::Req Irecv(void *buffer, size_t count, MPI_Datatype datatype,
+    virtual Comm::Req Irecv(void *buffer, size_t count, Datatype datatype,
                             int source, int tag,
                             const std::string &hint) const = 0;
 

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -249,7 +249,8 @@ private:
                        MPI_Datatype datatype, MPI_Op op,
                        const std::string &hint) const;
 
-    void BcastImpl(void *buffer, size_t count, MPI_Datatype datatype, int root,
+    void BcastImpl(void *buffer, size_t count, MPI_Datatype datatype,
+                   size_t datatypeSize, int root,
                    const std::string &hint) const;
 
     void GatherImpl(const void *sendbuf, size_t sendcount,

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -93,6 +93,14 @@ public:
     void Free(const std::string &hint = std::string());
 
     /**
+     * @brief Duplicate the communicator.
+     * @param hint Description of std::runtime_error exception on error.
+     *
+     * Creates a new communicator covering the same processes as the original.
+     */
+    Comm Duplicate(const std::string &hint = std::string()) const;
+
+    /**
      * @brief Split the communicator.
      * @param color Control of subset assignment (nonnegative integer).
      * @param key Control of rank assignment (integer).
@@ -340,6 +348,8 @@ public:
 
     virtual ~CommImpl() = 0;
     virtual void Free(const std::string &hint) = 0;
+    virtual std::unique_ptr<CommImpl>
+    Duplicate(const std::string &hint) const = 0;
     virtual std::unique_ptr<CommImpl> Split(int color, int key,
                                             const std::string &hint) const = 0;
     virtual int Rank() const = 0;

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -30,6 +30,28 @@ public:
     class Status;
 
     /**
+     * @brief Enumeration of element-wise accumulation operations.
+     */
+    enum class Op
+    {
+        Null,
+        Max,
+        Min,
+        Sum,
+        Product,
+        LogicalAnd,
+        BitwiseAnd,
+        LogicalOr,
+        BitwiseOr,
+        LogicalXor,
+        BitwiseXor,
+        MaxLoc,
+        MinLoc,
+        Replace,
+        None,
+    };
+
+    /**
      * @brief Default constructor.  Produces an empty communicator.
      *
      * An empty communicator may not be used for communcation.
@@ -138,7 +160,7 @@ public:
     std::vector<T> AllGatherValues(const T source) const;
 
     template <class T>
-    T ReduceValues(const T source, MPI_Op operation = MPI_SUM,
+    T ReduceValues(const T source, Op op = Op::Sum,
                    const int rankDestination = 0) const;
 
     template <class T>
@@ -158,7 +180,7 @@ public:
                    const std::string &hint = std::string()) const;
 
     template <typename T>
-    void Allreduce(const T *sendbuf, T *recvbuf, size_t count, MPI_Op op,
+    void Allreduce(const T *sendbuf, T *recvbuf, size_t count, Op op,
                    const std::string &hint = std::string()) const;
 
     template <typename T>
@@ -176,11 +198,11 @@ public:
                  const std::string &hint = std::string()) const;
 
     template <typename T>
-    void Reduce(const T *sendbuf, T *recvbuf, size_t count, MPI_Op op, int root,
+    void Reduce(const T *sendbuf, T *recvbuf, size_t count, Op op, int root,
                 const std::string &hint = std::string()) const;
 
     template <typename T>
-    void ReduceInPlace(T *buf, size_t count, MPI_Op op, int root,
+    void ReduceInPlace(T *buf, size_t count, Op op, int root,
                        const std::string &hint = std::string()) const;
 
     template <typename T>
@@ -310,7 +332,7 @@ public:
                            const std::string &hint) const = 0;
 
     virtual void Allreduce(const void *sendbuf, void *recvbuf, size_t count,
-                           MPI_Datatype datatype, MPI_Op op,
+                           MPI_Datatype datatype, Comm::Op op,
                            const std::string &hint) const = 0;
 
     virtual void Bcast(void *buffer, size_t count, MPI_Datatype datatype,
@@ -329,11 +351,11 @@ public:
                          const std::string &hint) const = 0;
 
     virtual void Reduce(const void *sendbuf, void *recvbuf, size_t count,
-                        MPI_Datatype datatype, MPI_Op op, int root,
+                        MPI_Datatype datatype, Comm::Op op, int root,
                         const std::string &hint) const = 0;
 
     virtual void ReduceInPlace(void *buf, size_t count, MPI_Datatype datatype,
-                               MPI_Op op, int root,
+                               Comm::Op op, int root,
                                const std::string &hint) const = 0;
 
     virtual void Send(const void *buf, size_t count, MPI_Datatype datatype,

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -216,6 +216,9 @@ private:
     /** Return MPI datatype id for type T.  */
     template <typename T>
     static MPI_Datatype Datatype();
+
+    static std::vector<size_t> GetGathervDisplacements(const size_t *counts,
+                                                       const size_t countsSize);
 };
 
 class Comm::Req

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -112,6 +112,12 @@ public:
     Comm Split(int color, int key,
                const std::string &hint = std::string()) const;
 
+    /**
+     * @brief Create a communicator covering all processes.
+     * @param hint Description of std::runtime_error exception on error.
+     */
+    Comm World(const std::string &hint = std::string()) const;
+
     int Rank() const;
     int Size() const;
 
@@ -352,6 +358,7 @@ public:
     Duplicate(const std::string &hint) const = 0;
     virtual std::unique_ptr<CommImpl> Split(int color, int key,
                                             const std::string &hint) const = 0;
+    virtual std::unique_ptr<CommImpl> World(const std::string &hint) const = 0;
     virtual int Rank() const = 0;
     virtual int Size() const = 0;
     virtual void Barrier(const std::string &hint) const = 0;

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -193,6 +193,11 @@ public:
                 size_t recvcount, int root,
                 const std::string &hint = std::string()) const;
 
+    template <typename TSend, typename TRecv>
+    void Gatherv(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
+                 const size_t *recvcounts, const size_t *displs, int root,
+                 const std::string &hint = std::string()) const;
+
     template <typename T>
     void Reduce(const T *sendbuf, T *recvbuf, size_t count, MPI_Op op, int root,
                 const std::string &hint = std::string()) const;
@@ -251,6 +256,12 @@ private:
                     MPI_Datatype sendtype, void *recvbuf, size_t recvcount,
                     MPI_Datatype recvtype, int root,
                     const std::string &hint) const;
+
+    void GathervImpl(const void *sendbuf, size_t sendcount,
+                     MPI_Datatype sendtype, void *recvbuf,
+                     const size_t *recvcounts, const size_t *displs,
+                     MPI_Datatype recvtype, int root,
+                     const std::string &hint) const;
 
     void ReduceImpl(const void *sendbuf, void *recvbuf, size_t count,
                     MPI_Datatype datatype, MPI_Op op, int root,

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -142,30 +142,30 @@ template <typename TSend, typename TRecv>
 void Comm::Allgather(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                      size_t recvcount, const std::string &hint) const
 {
-    return AllgatherImpl(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
-                         recvcount, Datatype<TRecv>(), hint);
+    return m_Impl->Allgather(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
+                             recvcount, Datatype<TRecv>(), hint);
 }
 
 template <typename T>
 void Comm::Allreduce(const T *sendbuf, T *recvbuf, size_t count, MPI_Op op,
                      const std::string &hint) const
 {
-    return AllreduceImpl(sendbuf, recvbuf, count, Datatype<T>(), op, hint);
+    return m_Impl->Allreduce(sendbuf, recvbuf, count, Datatype<T>(), op, hint);
 }
 
 template <typename T>
 void Comm::Bcast(T *buffer, const size_t count, int root,
                  const std::string &hint) const
 {
-    return BcastImpl(buffer, count, Datatype<T>(), sizeof(T), root, hint);
+    return m_Impl->Bcast(buffer, count, Datatype<T>(), sizeof(T), root, hint);
 }
 
 template <typename TSend, typename TRecv>
 void Comm::Gather(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                   size_t recvcount, int root, const std::string &hint) const
 {
-    return GatherImpl(sendbuf, sendcount, Datatype<TSend>(), recvbuf, recvcount,
-                      Datatype<TRecv>(), root, hint);
+    return m_Impl->Gather(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
+                          recvcount, Datatype<TRecv>(), root, hint);
 }
 
 template <typename TSend, typename TRecv>
@@ -173,58 +173,59 @@ void Comm::Gatherv(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                    const size_t *recvcounts, const size_t *displs, int root,
                    const std::string &hint) const
 {
-    return GathervImpl(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
-                       recvcounts, displs, Datatype<TRecv>(), root, hint);
+    return m_Impl->Gatherv(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
+                           recvcounts, displs, Datatype<TRecv>(), root, hint);
 }
 
 template <typename T>
 void Comm::Reduce(const T *sendbuf, T *recvbuf, size_t count, MPI_Op op,
                   int root, const std::string &hint) const
 {
-    return ReduceImpl(sendbuf, recvbuf, count, Datatype<T>(), op, root, hint);
+    return m_Impl->Reduce(sendbuf, recvbuf, count, Datatype<T>(), op, root,
+                          hint);
 }
 
 template <typename T>
 void Comm::ReduceInPlace(T *buf, size_t count, MPI_Op op, int root,
                          const std::string &hint) const
 {
-    return ReduceInPlaceImpl(buf, count, Datatype<T>(), op, root, hint);
+    return m_Impl->ReduceInPlace(buf, count, Datatype<T>(), op, root, hint);
 }
 
 template <typename T>
 void Comm::Send(const T *buf, size_t count, int dest, int tag,
                 const std::string &hint) const
 {
-    return SendImpl(buf, count, Datatype<T>(), dest, tag, hint);
+    return m_Impl->Send(buf, count, Datatype<T>(), dest, tag, hint);
 }
 
 template <typename T>
 Comm::Status Comm::Recv(T *buf, size_t count, int source, int tag,
                         const std::string &hint) const
 {
-    return RecvImpl(buf, count, Datatype<T>(), source, tag, hint);
+    return m_Impl->Recv(buf, count, Datatype<T>(), source, tag, hint);
 }
 
 template <typename TSend, typename TRecv>
 void Comm::Scatter(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                    size_t recvcount, int root, const std::string &hint) const
 {
-    return ScatterImpl(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
-                       recvcount, Datatype<TRecv>(), root, hint);
+    return m_Impl->Scatter(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
+                           recvcount, Datatype<TRecv>(), root, hint);
 }
 
 template <typename T>
 Comm::Req Comm::Isend(const T *buffer, const size_t count, int dest, int tag,
                       const std::string &hint) const
 {
-    return IsendImpl(buffer, count, Datatype<T>(), dest, tag, hint);
+    return m_Impl->Isend(buffer, count, Datatype<T>(), dest, tag, hint);
 }
 
 template <typename T>
 Comm::Req Comm::Irecv(T *buffer, const size_t count, int source, int tag,
                       const std::string &hint) const
 {
-    return IrecvImpl(buffer, count, Datatype<T>(), source, tag, hint);
+    return m_Impl->Irecv(buffer, count, Datatype<T>(), source, tag, hint);
 }
 
 // Datatype full specializations implemented in 'adiosComm.tcc'.

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -119,9 +119,21 @@ T Comm::ReduceValues(const T source, MPI_Op operation,
     return reduceValue;
 }
 
+template <class T>
+T Comm::BroadcastValue(const T &input, const int rankSource) const
+{
+    T output = 0;
+    if (rankSource == this->Rank())
+    {
+        output = input;
+    }
+
+    this->Bcast(&output, 1, rankSource);
+
+    return output;
+}
+
 // BroadcastValue full specializations implemented in 'adiosComm.tcc'.
-template <>
-size_t Comm::BroadcastValue(const size_t &input, const int rankSource) const;
 template <>
 std::string Comm::BroadcastValue(const std::string &input,
                                  const int rankSource) const;

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -20,13 +20,13 @@ namespace adios2
 namespace helper
 {
 
-// GatherArrays full specializations implemented in 'adiosComm.tcc'.
-template <>
-void Comm::GatherArrays(const char *source, size_t sourceCount,
-                        char *destination, int rankDestination) const;
-template <>
-void Comm::GatherArrays(const size_t *source, size_t sourceCount,
-                        size_t *destination, int rankDestination) const;
+template <class T>
+void Comm::GatherArrays(const T *source, size_t sourceCount, T *destination,
+                        int rankDestination) const
+{
+    this->Gather(source, sourceCount, destination, sourceCount,
+                 rankDestination);
+}
 
 template <class T>
 std::vector<T> Comm::GatherValues(T source, int rankDestination) const

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -110,12 +110,11 @@ std::vector<T> Comm::AllGatherValues(const T source) const
 }
 
 template <class T>
-T Comm::ReduceValues(const T source, MPI_Op operation,
-                     const int rankDestination) const
+T Comm::ReduceValues(const T source, Op op, const int rankDestination) const
 {
     T sourceLocal = source;
     T reduceValue = 0;
-    this->Reduce(&sourceLocal, &reduceValue, 1, operation, rankDestination);
+    this->Reduce(&sourceLocal, &reduceValue, 1, op, rankDestination);
     return reduceValue;
 }
 
@@ -166,7 +165,7 @@ void Comm::Allgather(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
 }
 
 template <typename T>
-void Comm::Allreduce(const T *sendbuf, T *recvbuf, size_t count, MPI_Op op,
+void Comm::Allreduce(const T *sendbuf, T *recvbuf, size_t count, Op op,
                      const std::string &hint) const
 {
     return m_Impl->Allreduce(sendbuf, recvbuf, count, Datatype<T>(), op, hint);
@@ -197,15 +196,15 @@ void Comm::Gatherv(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
 }
 
 template <typename T>
-void Comm::Reduce(const T *sendbuf, T *recvbuf, size_t count, MPI_Op op,
-                  int root, const std::string &hint) const
+void Comm::Reduce(const T *sendbuf, T *recvbuf, size_t count, Op op, int root,
+                  const std::string &hint) const
 {
     return m_Impl->Reduce(sendbuf, recvbuf, count, Datatype<T>(), op, root,
                           hint);
 }
 
 template <typename T>
-void Comm::ReduceInPlace(T *buf, size_t count, MPI_Op op, int root,
+void Comm::ReduceInPlace(T *buf, size_t count, Op op, int root,
                          const std::string &hint) const
 {
     return m_Impl->ReduceInPlace(buf, count, Datatype<T>(), op, root, hint);

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -177,8 +177,7 @@ template <typename T>
 void Comm::Bcast(T *buffer, const size_t count, int root,
                  const std::string &hint) const
 {
-    return m_Impl->Bcast(buffer, count, CommImpl::GetDatatype<T>(), sizeof(T),
-                         root, hint);
+    return m_Impl->Bcast(buffer, count, CommImpl::GetDatatype<T>(), root, hint);
 }
 
 template <typename TSend, typename TRecv>

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -97,8 +97,7 @@ void Comm::GathervVectors(const std::vector<T> &in, std::vector<T> &out,
 template <class T>
 std::vector<T> Comm::AllGatherValues(const T source) const
 {
-    int size;
-    SMPI_Comm_size(m_MPIComm, &size);
+    int size = this->Size();
     std::vector<T> output(size);
 
     T sourceCopy = source; // so we can have an address for rvalues

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -171,6 +171,15 @@ void Comm::Gather(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                       Datatype<TRecv>(), root, hint);
 }
 
+template <typename TSend, typename TRecv>
+void Comm::Gatherv(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
+                   const size_t *recvcounts, const size_t *displs, int root,
+                   const std::string &hint) const
+{
+    return GathervImpl(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
+                       recvcounts, displs, Datatype<TRecv>(), root, hint);
+}
+
 template <typename T>
 void Comm::Reduce(const T *sendbuf, T *recvbuf, size_t count, MPI_Op op,
                   int root, const std::string &hint) const

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -109,18 +109,15 @@ std::vector<T> Comm::AllGatherValues(const T source) const
     return output;
 }
 
-// ReduceValues full specializations implemented in 'adiosComm.tcc'.
-template <>
-unsigned int Comm::ReduceValues(const unsigned int source, MPI_Op operation,
-                                const int rankDestination) const;
-template <>
-unsigned long int Comm::ReduceValues(const unsigned long int source,
-                                     MPI_Op operation,
-                                     const int rankDestination) const;
-template <>
-unsigned long long int Comm::ReduceValues(const unsigned long long int source,
-                                          MPI_Op operation,
-                                          const int rankDestination) const;
+template <class T>
+T Comm::ReduceValues(const T source, MPI_Op operation,
+                     const int rankDestination) const
+{
+    T sourceLocal = source;
+    T reduceValue = 0;
+    this->Reduce(&sourceLocal, &reduceValue, 1, operation, rankDestination);
+    return reduceValue;
+}
 
 // BroadcastValue full specializations implemented in 'adiosComm.tcc'.
 template <>

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -47,15 +47,19 @@ std::vector<T> Comm::GatherValues(T source, int rankDestination) const
     return output;
 }
 
-// GathervArrays full specializations implemented in 'adiosComm.tcc'.
-template <>
-void Comm::GathervArrays(const char *source, size_t sourceCount,
+template <class T>
+void Comm::GathervArrays(const T *source, size_t sourceCount,
                          const size_t *counts, size_t countsSize,
-                         char *destination, int rankDestination) const;
-template <>
-void Comm::GathervArrays(const size_t *source, size_t sourceCount,
-                         const size_t *counts, size_t countsSize,
-                         size_t *destination, int rankDestination) const;
+                         T *destination, int rankDestination) const
+{
+    std::vector<size_t> displs;
+    if (rankDestination == this->Rank())
+    {
+        displs = GetGathervDisplacements(counts, countsSize);
+    }
+    this->Gatherv(source, sourceCount, destination, counts, displs.data(),
+                  rankDestination);
+}
 
 template <class T>
 void Comm::GathervVectors(const std::vector<T> &in, std::vector<T> &out,

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -68,8 +68,7 @@ void Comm::GathervVectors(const std::vector<T> &in, std::vector<T> &out,
 
     size_t gatheredSize = 0;
 
-    int rank;
-    SMPI_Comm_rank(m_MPIComm, &rank);
+    int rank = this->Rank();
 
     if (rank == rankDestination) // pre-allocate vector
     {

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -101,14 +101,9 @@ std::vector<T> Comm::AllGatherValues(const T source) const
     std::vector<T> output(size);
 
     T sourceCopy = source; // so we can have an address for rvalues
-    this->AllGatherArrays(&sourceCopy, 1, output.data());
+    this->Allgather(&sourceCopy, 1, output.data(), 1);
     return output;
 }
-
-// AllGatherArrays full specializations implemented in 'adiosComm.tcc'.
-template <>
-void Comm::AllGatherArrays(const size_t *source, const size_t sourceCount,
-                           size_t *destination) const;
 
 // ReduceValues full specializations implemented in 'adiosComm.tcc'.
 template <>

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -138,13 +138,24 @@ template <>
 std::string Comm::BroadcastValue(const std::string &input,
                                  const int rankSource) const;
 
-// BroadcastVector full specializations implemented in 'adiosComm.tcc'.
-template <>
-void Comm::BroadcastVector(std::vector<char> &vector,
-                           const int rankSource) const;
-template <>
-void Comm::BroadcastVector(std::vector<size_t> &vector,
-                           const int rankSource) const;
+template <class T>
+void Comm::BroadcastVector(std::vector<T> &vector, const int rankSource) const
+{
+    if (this->Size() == 1)
+    {
+        return;
+    }
+
+    // First Broadcast the size, then the contents
+    size_t inputSize = this->BroadcastValue(vector.size(), rankSource);
+
+    if (rankSource != this->Rank())
+    {
+        vector.resize(inputSize);
+    }
+
+    this->Bcast(vector.data(), inputSize, rankSource);
+}
 
 template <typename TSend, typename TRecv>
 void Comm::Allgather(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -157,7 +157,7 @@ template <typename T>
 void Comm::Bcast(T *buffer, const size_t count, int root,
                  const std::string &hint) const
 {
-    return BcastImpl(buffer, count, Datatype<T>(), root, hint);
+    return BcastImpl(buffer, count, Datatype<T>(), sizeof(T), root, hint);
 }
 
 template <typename TSend, typename TRecv>

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -160,30 +160,34 @@ template <typename TSend, typename TRecv>
 void Comm::Allgather(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                      size_t recvcount, const std::string &hint) const
 {
-    return m_Impl->Allgather(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
-                             recvcount, Datatype<TRecv>(), hint);
+    return m_Impl->Allgather(sendbuf, sendcount, CommImpl::GetDatatype<TSend>(),
+                             recvbuf, recvcount, CommImpl::GetDatatype<TRecv>(),
+                             hint);
 }
 
 template <typename T>
 void Comm::Allreduce(const T *sendbuf, T *recvbuf, size_t count, Op op,
                      const std::string &hint) const
 {
-    return m_Impl->Allreduce(sendbuf, recvbuf, count, Datatype<T>(), op, hint);
+    return m_Impl->Allreduce(sendbuf, recvbuf, count,
+                             CommImpl::GetDatatype<T>(), op, hint);
 }
 
 template <typename T>
 void Comm::Bcast(T *buffer, const size_t count, int root,
                  const std::string &hint) const
 {
-    return m_Impl->Bcast(buffer, count, Datatype<T>(), sizeof(T), root, hint);
+    return m_Impl->Bcast(buffer, count, CommImpl::GetDatatype<T>(), sizeof(T),
+                         root, hint);
 }
 
 template <typename TSend, typename TRecv>
 void Comm::Gather(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                   size_t recvcount, int root, const std::string &hint) const
 {
-    return m_Impl->Gather(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
-                          recvcount, Datatype<TRecv>(), root, hint);
+    return m_Impl->Gather(sendbuf, sendcount, CommImpl::GetDatatype<TSend>(),
+                          recvbuf, recvcount, CommImpl::GetDatatype<TRecv>(),
+                          root, hint);
 }
 
 template <typename TSend, typename TRecv>
@@ -191,98 +195,105 @@ void Comm::Gatherv(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                    const size_t *recvcounts, const size_t *displs, int root,
                    const std::string &hint) const
 {
-    return m_Impl->Gatherv(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
-                           recvcounts, displs, Datatype<TRecv>(), root, hint);
+    return m_Impl->Gatherv(sendbuf, sendcount, CommImpl::GetDatatype<TSend>(),
+                           recvbuf, recvcounts, displs,
+                           CommImpl::GetDatatype<TRecv>(), root, hint);
 }
 
 template <typename T>
 void Comm::Reduce(const T *sendbuf, T *recvbuf, size_t count, Op op, int root,
                   const std::string &hint) const
 {
-    return m_Impl->Reduce(sendbuf, recvbuf, count, Datatype<T>(), op, root,
-                          hint);
+    return m_Impl->Reduce(sendbuf, recvbuf, count, CommImpl::GetDatatype<T>(),
+                          op, root, hint);
 }
 
 template <typename T>
 void Comm::ReduceInPlace(T *buf, size_t count, Op op, int root,
                          const std::string &hint) const
 {
-    return m_Impl->ReduceInPlace(buf, count, Datatype<T>(), op, root, hint);
+    return m_Impl->ReduceInPlace(buf, count, CommImpl::GetDatatype<T>(), op,
+                                 root, hint);
 }
 
 template <typename T>
 void Comm::Send(const T *buf, size_t count, int dest, int tag,
                 const std::string &hint) const
 {
-    return m_Impl->Send(buf, count, Datatype<T>(), dest, tag, hint);
+    return m_Impl->Send(buf, count, CommImpl::GetDatatype<T>(), dest, tag,
+                        hint);
 }
 
 template <typename T>
 Comm::Status Comm::Recv(T *buf, size_t count, int source, int tag,
                         const std::string &hint) const
 {
-    return m_Impl->Recv(buf, count, Datatype<T>(), source, tag, hint);
+    return m_Impl->Recv(buf, count, CommImpl::GetDatatype<T>(), source, tag,
+                        hint);
 }
 
 template <typename TSend, typename TRecv>
 void Comm::Scatter(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                    size_t recvcount, int root, const std::string &hint) const
 {
-    return m_Impl->Scatter(sendbuf, sendcount, Datatype<TSend>(), recvbuf,
-                           recvcount, Datatype<TRecv>(), root, hint);
+    return m_Impl->Scatter(sendbuf, sendcount, CommImpl::GetDatatype<TSend>(),
+                           recvbuf, recvcount, CommImpl::GetDatatype<TRecv>(),
+                           root, hint);
 }
 
 template <typename T>
 Comm::Req Comm::Isend(const T *buffer, const size_t count, int dest, int tag,
                       const std::string &hint) const
 {
-    return m_Impl->Isend(buffer, count, Datatype<T>(), dest, tag, hint);
+    return m_Impl->Isend(buffer, count, CommImpl::GetDatatype<T>(), dest, tag,
+                         hint);
 }
 
 template <typename T>
 Comm::Req Comm::Irecv(T *buffer, const size_t count, int source, int tag,
                       const std::string &hint) const
 {
-    return m_Impl->Irecv(buffer, count, Datatype<T>(), source, tag, hint);
+    return m_Impl->Irecv(buffer, count, CommImpl::GetDatatype<T>(), source, tag,
+                         hint);
 }
 
-// Datatype full specializations implemented in 'adiosComm.tcc'.
+// CommImpl::GetDatatype full specializations implemented in 'adiosComm.tcc'.
 template <>
-MPI_Datatype Comm::Datatype<signed char>();
+CommImpl::Datatype CommImpl::GetDatatype<signed char>();
 template <>
-MPI_Datatype Comm::Datatype<char>();
+CommImpl::Datatype CommImpl::GetDatatype<char>();
 template <>
-MPI_Datatype Comm::Datatype<short>();
+CommImpl::Datatype CommImpl::GetDatatype<short>();
 template <>
-MPI_Datatype Comm::Datatype<int>();
+CommImpl::Datatype CommImpl::GetDatatype<int>();
 template <>
-MPI_Datatype Comm::Datatype<long>();
+CommImpl::Datatype CommImpl::GetDatatype<long>();
 template <>
-MPI_Datatype Comm::Datatype<unsigned char>();
+CommImpl::Datatype CommImpl::GetDatatype<unsigned char>();
 template <>
-MPI_Datatype Comm::Datatype<unsigned short>();
+CommImpl::Datatype CommImpl::GetDatatype<unsigned short>();
 template <>
-MPI_Datatype Comm::Datatype<unsigned int>();
+CommImpl::Datatype CommImpl::GetDatatype<unsigned int>();
 template <>
-MPI_Datatype Comm::Datatype<unsigned long>();
+CommImpl::Datatype CommImpl::GetDatatype<unsigned long>();
 template <>
-MPI_Datatype Comm::Datatype<unsigned long long>();
+CommImpl::Datatype CommImpl::GetDatatype<unsigned long long>();
 template <>
-MPI_Datatype Comm::Datatype<long long>();
+CommImpl::Datatype CommImpl::GetDatatype<long long>();
 template <>
-MPI_Datatype Comm::Datatype<double>();
+CommImpl::Datatype CommImpl::GetDatatype<double>();
 template <>
-MPI_Datatype Comm::Datatype<long double>();
+CommImpl::Datatype CommImpl::GetDatatype<long double>();
 template <>
-MPI_Datatype Comm::Datatype<std::pair<int, int>>();
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<int, int>>();
 template <>
-MPI_Datatype Comm::Datatype<std::pair<float, int>>();
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<float, int>>();
 template <>
-MPI_Datatype Comm::Datatype<std::pair<double, int>>();
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<double, int>>();
 template <>
-MPI_Datatype Comm::Datatype<std::pair<long double, int>>();
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<long double, int>>();
 template <>
-MPI_Datatype Comm::Datatype<std::pair<short, int>>();
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<short, int>>();
 
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -31,9 +31,8 @@ void Comm::GatherArrays(const size_t *source, size_t sourceCount,
 template <class T>
 std::vector<T> Comm::GatherValues(T source, int rankDestination) const
 {
-    int rank, size;
-    SMPI_Comm_rank(m_MPIComm, &rank);
-    SMPI_Comm_size(m_MPIComm, &size);
+    int rank = this->Rank();
+    int size = this->Size();
 
     std::vector<T> output;
 

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -97,8 +97,7 @@ unsigned int Comm::ReduceValues(const unsigned int source, MPI_Op operation,
 {
     unsigned int sourceLocal = source;
     unsigned int reduceValue = 0;
-    SMPI_Reduce(&sourceLocal, &reduceValue, 1, MPI_UNSIGNED, operation,
-                rankDestination, m_MPIComm);
+    this->Reduce(&sourceLocal, &reduceValue, 1, operation, rankDestination);
     return reduceValue;
 }
 
@@ -109,8 +108,7 @@ unsigned long int Comm::ReduceValues(const unsigned long int source,
 {
     unsigned long int sourceLocal = source;
     unsigned long int reduceValue = 0;
-    SMPI_Reduce(&sourceLocal, &reduceValue, 1, MPI_UNSIGNED_LONG, operation,
-                rankDestination, m_MPIComm);
+    this->Reduce(&sourceLocal, &reduceValue, 1, operation, rankDestination);
     return reduceValue;
 }
 
@@ -121,8 +119,7 @@ unsigned long long int Comm::ReduceValues(const unsigned long long int source,
 {
     unsigned long long int sourceLocal = source;
     unsigned long long int reduceValue = 0;
-    SMPI_Reduce(&sourceLocal, &reduceValue, 1, MPI_UNSIGNED_LONG_LONG,
-                operation, rankDestination, m_MPIComm);
+    this->Reduce(&sourceLocal, &reduceValue, 1, operation, rankDestination);
     return reduceValue;
 }
 

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -18,23 +18,6 @@ namespace adios2
 namespace helper
 {
 
-// GatherArrays full specializations forward-declared in 'adiosComm.inl'.
-template <>
-void Comm::GatherArrays(const char *source, size_t sourceCount,
-                        char *destination, int rankDestination) const
-{
-    this->Gather(source, sourceCount, destination, sourceCount,
-                 rankDestination);
-}
-
-template <>
-void Comm::GatherArrays(const size_t *source, size_t sourceCount,
-                        size_t *destination, int rankDestination) const
-{
-    this->Gather(source, sourceCount, destination, sourceCount,
-                 rankDestination);
-}
-
 // GathervArrays full specializations forward-declared in 'adiosComm.inl'.
 template <>
 void Comm::GathervArrays(const char *source, size_t sourceCount,

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -18,24 +18,6 @@ namespace adios2
 namespace helper
 {
 
-namespace
-{
-
-std::vector<size_t> GetGathervDisplacements(const size_t *counts,
-                                            const size_t countsSize)
-{
-    std::vector<size_t> displacements(countsSize);
-    displacements[0] = 0;
-
-    for (size_t i = 1; i < countsSize; ++i)
-    {
-        displacements[i] = displacements[i - 1] + counts[i - 1];
-    }
-    return displacements;
-}
-
-}
-
 // GatherArrays full specializations forward-declared in 'adiosComm.inl'.
 template <>
 void Comm::GatherArrays(const char *source, size_t sourceCount,

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -11,8 +11,6 @@
 
 #include "adiosComm.h"
 
-#include "adios2/common/ADIOSMPI.h"
-
 namespace adios2
 {
 namespace helper
@@ -41,113 +39,114 @@ std::string Comm::BroadcastValue(const std::string &input,
     return output;
 }
 
-// Datatype full specializations forward-declared in 'adiosComm.inl'.
+// Comm::Impl::GetDatatype full specializations forward-declared in
+// 'adiosComm.inl'.
 template <>
-MPI_Datatype Comm::Datatype<signed char>()
+CommImpl::Datatype CommImpl::GetDatatype<signed char>()
 {
-    return MPI_SIGNED_CHAR;
+    return CommImpl::Datatype::SignedChar;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<char>()
+CommImpl::Datatype CommImpl::GetDatatype<char>()
 {
-    return MPI_CHAR;
+    return CommImpl::Datatype::Char;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<short>()
+CommImpl::Datatype CommImpl::GetDatatype<short>()
 {
-    return MPI_SHORT;
+    return CommImpl::Datatype::Short;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<int>()
+CommImpl::Datatype CommImpl::GetDatatype<int>()
 {
-    return MPI_INT;
+    return CommImpl::Datatype::Int;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<long>()
+CommImpl::Datatype CommImpl::GetDatatype<long>()
 {
-    return MPI_LONG;
+    return CommImpl::Datatype::Long;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<unsigned char>()
+CommImpl::Datatype CommImpl::GetDatatype<unsigned char>()
 {
-    return MPI_UNSIGNED_CHAR;
+    return CommImpl::Datatype::UnsignedChar;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<unsigned short>()
+CommImpl::Datatype CommImpl::GetDatatype<unsigned short>()
 {
-    return MPI_UNSIGNED_SHORT;
+    return CommImpl::Datatype::UnsignedShort;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<unsigned int>()
+CommImpl::Datatype CommImpl::GetDatatype<unsigned int>()
 {
-    return MPI_UNSIGNED;
+    return CommImpl::Datatype::UnsignedInt;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<unsigned long>()
+CommImpl::Datatype CommImpl::GetDatatype<unsigned long>()
 {
-    return MPI_UNSIGNED_LONG;
+    return CommImpl::Datatype::UnsignedLong;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<unsigned long long>()
+CommImpl::Datatype CommImpl::GetDatatype<unsigned long long>()
 {
-    return MPI_UNSIGNED_LONG_LONG;
+    return CommImpl::Datatype::UnsignedLongLong;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<long long>()
+CommImpl::Datatype CommImpl::GetDatatype<long long>()
 {
-    return MPI_LONG_LONG_INT;
+    return CommImpl::Datatype::LongLong;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<double>()
+CommImpl::Datatype CommImpl::GetDatatype<double>()
 {
-    return MPI_DOUBLE;
+    return CommImpl::Datatype::Double;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<long double>()
+CommImpl::Datatype CommImpl::GetDatatype<long double>()
 {
-    return MPI_LONG_DOUBLE;
+    return CommImpl::Datatype::LongDouble;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<std::pair<int, int>>()
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<int, int>>()
 {
-    return MPI_2INT;
+    return CommImpl::Datatype::Int_Int;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<std::pair<float, int>>()
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<float, int>>()
 {
-    return MPI_FLOAT_INT;
+    return CommImpl::Datatype::Float_Int;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<std::pair<double, int>>()
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<double, int>>()
 {
-    return MPI_DOUBLE_INT;
+    return CommImpl::Datatype::Double_Int;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<std::pair<long double, int>>()
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<long double, int>>()
 {
-    return MPI_LONG_DOUBLE_INT;
+    return CommImpl::Datatype::LongDouble_Int;
 }
 
 template <>
-MPI_Datatype Comm::Datatype<std::pair<short, int>>()
+CommImpl::Datatype CommImpl::GetDatatype<std::pair<short, int>>()
 {
-    return MPI_SHORT_INT;
+    return CommImpl::Datatype::Short_Int;
 }
 
 } // end namespace helper

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -18,68 +18,6 @@ namespace adios2
 namespace helper
 {
 
-// GathervArrays full specializations forward-declared in 'adiosComm.inl'.
-template <>
-void Comm::GathervArrays(const char *source, size_t sourceCount,
-                         const size_t *counts, size_t countsSize,
-                         char *destination, int rankDestination) const
-{
-    std::vector<size_t> displs;
-    if (rankDestination == this->Rank())
-    {
-        displs = GetGathervDisplacements(counts, countsSize);
-    }
-    this->Gatherv(source, sourceCount, destination, counts, displs.data(),
-                  rankDestination);
-}
-
-template <>
-void Comm::GathervArrays(const size_t *source, size_t sourceCount,
-                         const size_t *counts, size_t countsSize,
-                         size_t *destination, int rankDestination) const
-{
-    std::vector<size_t> displs;
-    if (rankDestination == this->Rank())
-    {
-        displs = GetGathervDisplacements(counts, countsSize);
-    }
-    this->Gatherv(source, sourceCount, destination, counts, displs.data(),
-                  rankDestination);
-}
-
-// ReduceValues full specializations forward-declared in 'adiosComm.inl'.
-template <>
-unsigned int Comm::ReduceValues(const unsigned int source, MPI_Op operation,
-                                const int rankDestination) const
-{
-    unsigned int sourceLocal = source;
-    unsigned int reduceValue = 0;
-    this->Reduce(&sourceLocal, &reduceValue, 1, operation, rankDestination);
-    return reduceValue;
-}
-
-template <>
-unsigned long int Comm::ReduceValues(const unsigned long int source,
-                                     MPI_Op operation,
-                                     const int rankDestination) const
-{
-    unsigned long int sourceLocal = source;
-    unsigned long int reduceValue = 0;
-    this->Reduce(&sourceLocal, &reduceValue, 1, operation, rankDestination);
-    return reduceValue;
-}
-
-template <>
-unsigned long long int Comm::ReduceValues(const unsigned long long int source,
-                                          MPI_Op operation,
-                                          const int rankDestination) const
-{
-    unsigned long long int sourceLocal = source;
-    unsigned long long int reduceValue = 0;
-    this->Reduce(&sourceLocal, &reduceValue, 1, operation, rankDestination);
-    return reduceValue;
-}
-
 // BroadcastValue full specializations forward-declared in 'adiosComm.inl'.
 template <>
 size_t Comm::BroadcastValue(const size_t &input, const int rankSource) const

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -43,32 +43,16 @@ template <>
 void Comm::GatherArrays(const char *source, size_t sourceCount,
                         char *destination, int rankDestination) const
 {
-    int countsInt = static_cast<int>(sourceCount);
-    int result = SMPI_Gather(const_cast<char *>(source), countsInt, MPI_CHAR,
-                             destination, countsInt, MPI_CHAR, rankDestination,
-                             m_MPIComm);
-
-    if (result != MPI_SUCCESS)
-    {
-        throw std::runtime_error("ERROR: in ADIOS2 detected failure in MPI "
-                                 "Gather type MPI_CHAR function\n");
-    }
+    this->Gather(source, sourceCount, destination, sourceCount,
+                 rankDestination);
 }
 
 template <>
 void Comm::GatherArrays(const size_t *source, size_t sourceCount,
                         size_t *destination, int rankDestination) const
 {
-    int countsInt = static_cast<int>(sourceCount);
-    int result = SMPI_Gather(const_cast<size_t *>(source), countsInt,
-                             ADIOS2_MPI_SIZE_T, destination, countsInt,
-                             ADIOS2_MPI_SIZE_T, rankDestination, m_MPIComm);
-
-    if (result != MPI_SUCCESS)
-    {
-        throw std::runtime_error("ERROR: in ADIOS2 detected failure in MPI "
-                                 "Gather type size_t function\n");
-    }
+    this->Gather(source, sourceCount, destination, sourceCount,
+                 rankDestination);
 }
 
 // GathervArrays full specializations forward-declared in 'adiosComm.inl'.

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -41,47 +41,6 @@ std::string Comm::BroadcastValue(const std::string &input,
     return output;
 }
 
-// BroadcastVector full specializations forward-declared in 'adiosComm.inl'.
-template <>
-void Comm::BroadcastVector(std::vector<char> &vector,
-                           const int rankSource) const
-{
-    if (this->Size() == 1)
-    {
-        return;
-    }
-
-    // First Broadcast the size, then the contents
-    size_t inputSize = this->BroadcastValue(vector.size(), rankSource);
-
-    if (rankSource != this->Rank())
-    {
-        vector.resize(inputSize);
-    }
-
-    this->Bcast(vector.data(), inputSize, rankSource);
-}
-
-template <>
-void Comm::BroadcastVector(std::vector<size_t> &vector,
-                           const int rankSource) const
-{
-    if (this->Size() == 1)
-    {
-        return;
-    }
-
-    // First Broadcast the size, then the contents
-    size_t inputSize = this->BroadcastValue(vector.size(), rankSource);
-
-    if (rankSource != this->Rank())
-    {
-        vector.resize(inputSize);
-    }
-
-    this->Bcast(vector.data(), inputSize, rankSource);
-}
-
 // Datatype full specializations forward-declared in 'adiosComm.inl'.
 template <>
 MPI_Datatype Comm::Datatype<signed char>()

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -127,16 +127,13 @@ unsigned long long int Comm::ReduceValues(const unsigned long long int source,
 template <>
 size_t Comm::BroadcastValue(const size_t &input, const int rankSource) const
 {
-    int rank;
-    SMPI_Comm_rank(m_MPIComm, &rank);
     size_t output = 0;
-
-    if (rank == rankSource)
+    if (rankSource == this->Rank())
     {
         output = input;
     }
 
-    SMPI_Bcast(&output, 1, ADIOS2_MPI_SIZE_T, rankSource, m_MPIComm);
+    this->Bcast(&output, 1, rankSource);
 
     return output;
 }
@@ -145,13 +142,11 @@ template <>
 std::string Comm::BroadcastValue(const std::string &input,
                                  const int rankSource) const
 {
-    int rank;
-    SMPI_Comm_rank(m_MPIComm, &rank);
     const size_t inputSize = input.size();
     const size_t length = this->BroadcastValue(inputSize, rankSource);
     std::string output;
 
-    if (rank == rankSource)
+    if (rankSource == this->Rank())
     {
         output = input;
     }
@@ -160,8 +155,7 @@ std::string Comm::BroadcastValue(const std::string &input,
         output.resize(length);
     }
 
-    SMPI_Bcast(const_cast<char *>(output.data()), static_cast<int>(length),
-               MPI_CHAR, rankSource, m_MPIComm);
+    this->Bcast(const_cast<char *>(output.data()), length, rankSource);
 
     return output;
 }

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -165,70 +165,40 @@ template <>
 void Comm::BroadcastVector(std::vector<char> &vector,
                            const int rankSource) const
 {
-    int size;
-    SMPI_Comm_size(m_MPIComm, &size);
-
-    if (size == 1)
+    if (this->Size() == 1)
     {
         return;
     }
 
     // First Broadcast the size, then the contents
     size_t inputSize = this->BroadcastValue(vector.size(), rankSource);
-    int rank;
-    SMPI_Comm_rank(m_MPIComm, &rank);
 
-    if (rank != rankSource)
+    if (rankSource != this->Rank())
     {
         vector.resize(inputSize);
     }
 
-    const int MAXBCASTSIZE = 1073741824;
-    size_t blockSize = (inputSize > MAXBCASTSIZE ? MAXBCASTSIZE : inputSize);
-    char *buffer = vector.data();
-    while (inputSize > 0)
-    {
-        SMPI_Bcast(buffer, static_cast<int>(blockSize), MPI_CHAR, rankSource,
-                   m_MPIComm);
-        buffer += blockSize;
-        inputSize -= blockSize;
-        blockSize = (inputSize > MAXBCASTSIZE ? MAXBCASTSIZE : inputSize);
-    }
+    this->Bcast(vector.data(), inputSize, rankSource);
 }
 
 template <>
 void Comm::BroadcastVector(std::vector<size_t> &vector,
                            const int rankSource) const
 {
-    int size;
-    SMPI_Comm_size(m_MPIComm, &size);
-
-    if (size == 1)
+    if (this->Size() == 1)
     {
         return;
     }
 
     // First Broadcast the size, then the contents
     size_t inputSize = this->BroadcastValue(vector.size(), rankSource);
-    int rank;
-    SMPI_Comm_rank(m_MPIComm, &rank);
 
-    if (rank != rankSource)
+    if (rankSource != this->Rank())
     {
         vector.resize(inputSize);
     }
 
-    const int MAXBCASTSIZE = 1073741824 / sizeof(size_t);
-    size_t blockSize = (inputSize > MAXBCASTSIZE ? MAXBCASTSIZE : inputSize);
-    size_t *buffer = vector.data();
-    while (inputSize > 0)
-    {
-        SMPI_Bcast(buffer, static_cast<int>(blockSize), ADIOS2_MPI_SIZE_T,
-                   rankSource, m_MPIComm);
-        buffer += blockSize;
-        inputSize -= blockSize;
-        blockSize = (inputSize > MAXBCASTSIZE ? MAXBCASTSIZE : inputSize);
-    }
+    this->Bcast(vector.data(), inputSize, rankSource);
 }
 
 // Datatype full specializations forward-declared in 'adiosComm.inl'.

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -20,20 +20,6 @@ namespace helper
 
 // BroadcastValue full specializations forward-declared in 'adiosComm.inl'.
 template <>
-size_t Comm::BroadcastValue(const size_t &input, const int rankSource) const
-{
-    size_t output = 0;
-    if (rankSource == this->Rank())
-    {
-        output = input;
-    }
-
-    this->Bcast(&output, 1, rankSource);
-
-    return output;
-}
-
-template <>
 std::string Comm::BroadcastValue(const std::string &input,
                                  const int rankSource) const
 {

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -13,8 +13,6 @@
 
 #include "adios2/common/ADIOSMPI.h"
 
-#include <stdexcept> //std::runtime_error
-
 namespace adios2
 {
 namespace helper
@@ -89,16 +87,7 @@ template <>
 void Comm::AllGatherArrays(const size_t *source, const size_t sourceCount,
                            size_t *destination) const
 {
-    int countsInt = static_cast<int>(sourceCount);
-    int result = MPI_Allgather(const_cast<size_t *>(source), countsInt,
-                               ADIOS2_MPI_SIZE_T, destination, countsInt,
-                               ADIOS2_MPI_SIZE_T, m_MPIComm);
-
-    if (result != MPI_SUCCESS)
-    {
-        throw std::runtime_error("ERROR: in ADIOS2 detected failure in MPI "
-                                 "Allgather type size_t function\n");
-    }
+    this->Allgather(source, sourceCount, destination, sourceCount);
 }
 
 // ReduceValues full specializations forward-declared in 'adiosComm.inl'.

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -82,14 +82,6 @@ void Comm::GathervArrays(const size_t *source, size_t sourceCount,
                   rankDestination);
 }
 
-// AllGatherArrays full specializations forward-declared in 'adiosComm.inl'.
-template <>
-void Comm::AllGatherArrays(const size_t *source, const size_t sourceCount,
-                           size_t *destination) const
-{
-    this->Allgather(source, sourceCount, destination, sourceCount);
-}
-
 // ReduceValues full specializations forward-declared in 'adiosComm.inl'.
 template <>
 unsigned int Comm::ReduceValues(const unsigned int source, MPI_Op operation,

--- a/source/adios2/helper/adiosCommDummy.cpp
+++ b/source/adios2/helper/adiosCommDummy.cpp
@@ -1,0 +1,272 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosCommDummy.cpp
+ */
+
+#include "adiosCommDummy.h"
+
+#include <cstring>
+#include <iostream>
+
+#include "adiosComm.h"
+
+namespace adios2
+{
+namespace helper
+{
+
+namespace
+{
+void CommDummyError(const std::string &msg)
+{
+    std::cerr << "CommDummy: a function returned error code '" << msg
+              << "'. Aborting!" << std::endl;
+    std::abort();
+}
+}
+
+class CommReqImplDummy : public CommReqImpl
+{
+public:
+    CommReqImplDummy() {}
+    ~CommReqImplDummy() override;
+
+    Comm::Status Wait(const std::string &hint) override;
+};
+
+CommReqImplDummy::~CommReqImplDummy() = default;
+
+class CommImplDummy : public CommImpl
+{
+public:
+    CommImplDummy() = default;
+    ~CommImplDummy() override;
+
+    void Free(const std::string &hint) override;
+    std::unique_ptr<CommImpl> Duplicate(const std::string &hint) const override;
+    std::unique_ptr<CommImpl> Split(int color, int key,
+                                    const std::string &hint) const override;
+    std::unique_ptr<CommImpl> World(const std::string &hint) const override;
+
+    int Rank() const override;
+    int Size() const override;
+    void Barrier(const std::string &hint) const override;
+
+    void Allgather(const void *sendbuf, size_t sendcount, Datatype sendtype,
+                   void *recvbuf, size_t recvcount, Datatype recvtype,
+                   const std::string &hint) const override;
+
+    void Allreduce(const void *sendbuf, void *recvbuf, size_t count,
+                   Datatype datatype, Comm::Op op,
+                   const std::string &hint) const override;
+
+    void Bcast(void *buffer, size_t count, Datatype datatype, int root,
+               const std::string &hint) const override;
+
+    void Gather(const void *sendbuf, size_t sendcount, Datatype sendtype,
+                void *recvbuf, size_t recvcount, Datatype recvtype, int root,
+                const std::string &hint) const override;
+
+    void Gatherv(const void *sendbuf, size_t sendcount, Datatype sendtype,
+                 void *recvbuf, const size_t *recvcounts, const size_t *displs,
+                 Datatype recvtype, int root,
+                 const std::string &hint) const override;
+
+    void Reduce(const void *sendbuf, void *recvbuf, size_t count,
+                Datatype datatype, Comm::Op op, int root,
+                const std::string &hint) const override;
+
+    void ReduceInPlace(void *buf, size_t count, Datatype datatype, Comm::Op op,
+                       int root, const std::string &hint) const override;
+
+    void Send(const void *buf, size_t count, Datatype datatype, int dest,
+              int tag, const std::string &hint) const override;
+
+    Comm::Status Recv(void *buf, size_t count, Datatype datatype, int source,
+                      int tag, const std::string &hint) const override;
+
+    void Scatter(const void *sendbuf, size_t sendcount, Datatype sendtype,
+                 void *recvbuf, size_t recvcount, Datatype recvtype, int root,
+                 const std::string &hint) const override;
+
+    Comm::Req Isend(const void *buffer, size_t count, Datatype datatype,
+                    int dest, int tag, const std::string &hint) const override;
+
+    Comm::Req Irecv(void *buffer, size_t count, Datatype datatype, int source,
+                    int tag, const std::string &hint) const override;
+};
+
+CommImplDummy::~CommImplDummy() = default;
+
+void CommImplDummy::Free(const std::string &) {}
+
+std::unique_ptr<CommImpl> CommImplDummy::Duplicate(const std::string &) const
+{
+    return std::unique_ptr<CommImpl>(new CommImplDummy());
+}
+
+std::unique_ptr<CommImpl> CommImplDummy::Split(int, int,
+                                               const std::string &) const
+{
+    return std::unique_ptr<CommImpl>(new CommImplDummy());
+}
+
+std::unique_ptr<CommImpl> CommImplDummy::World(const std::string &) const
+{
+    return std::unique_ptr<CommImpl>(new CommImplDummy());
+}
+
+int CommImplDummy::Rank() const { return 0; }
+
+int CommImplDummy::Size() const { return 1; }
+
+void CommImplDummy::Barrier(const std::string &) const {}
+
+void CommImplDummy::Allgather(const void *sendbuf, size_t sendcount,
+                              Datatype sendtype, void *recvbuf,
+                              size_t recvcount, Datatype recvtype,
+                              const std::string &hint) const
+{
+    CommImplDummy::Gather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                          recvtype, 0, hint);
+}
+
+void CommImplDummy::Allreduce(const void *sendbuf, void *recvbuf, size_t count,
+                              Datatype datatype, Comm::Op op,
+                              const std::string &hint) const
+{
+    CommImplDummy::Reduce(sendbuf, recvbuf, count, datatype, op, 0, hint);
+}
+
+void CommImplDummy::Bcast(void *, size_t, Datatype, int,
+                          const std::string &) const
+{
+}
+
+void CommImplDummy::Gather(const void *sendbuf, size_t sendcount,
+                           Datatype sendtype, void *recvbuf, size_t recvcount,
+                           Datatype recvtype, int root,
+                           const std::string &) const
+{
+    if (sendcount > 0 && !sendbuf)
+    {
+        return CommDummyError("sendbuf is null");
+    }
+    if (recvcount > 0 && !recvbuf)
+    {
+        return CommDummyError("recvbuf is null");
+    }
+    if (root != 0)
+    {
+        return CommDummyError("root is not 0");
+    }
+
+    const size_t nsent = sendcount * CommImpl::SizeOf(sendtype);
+    const size_t nrecv = recvcount * CommImpl::SizeOf(recvtype);
+
+    if (nrecv != nsent)
+    {
+        return CommDummyError("send and recv sizes differ");
+    }
+
+    std::memcpy(recvbuf, sendbuf, nsent);
+}
+
+void CommImplDummy::Gatherv(const void *sendbuf, size_t sendcount,
+                            Datatype sendtype, void *recvbuf,
+                            const size_t *recvcounts, const size_t *displs,
+                            Datatype recvtype, int root,
+                            const std::string &hint) const
+{
+    const size_t recvcount = recvcounts[0];
+    if (recvcount != sendcount)
+    {
+        return CommDummyError("send and recv counts differ");
+    }
+    CommImplDummy::Gather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                          recvtype, root, hint);
+}
+
+void CommImplDummy::Reduce(const void *sendbuf, void *recvbuf, size_t count,
+                           Datatype datatype, Comm::Op, int,
+                           const std::string &) const
+{
+    std::memcpy(recvbuf, sendbuf, count * CommImpl::SizeOf(datatype));
+}
+
+void CommImplDummy::ReduceInPlace(void *, size_t, Datatype, Comm::Op, int,
+                                  const std::string &) const
+{
+}
+
+void CommImplDummy::Send(const void *, size_t, Datatype, int, int,
+                         const std::string &) const
+{
+}
+
+Comm::Status CommImplDummy::Recv(void *, size_t, Datatype, int, int,
+                                 const std::string &) const
+{
+    Comm::Status status;
+    return status;
+}
+
+void CommImplDummy::Scatter(const void *sendbuf, size_t sendcount,
+                            Datatype sendtype, void *recvbuf, size_t recvcount,
+                            Datatype recvtype, int root,
+                            const std::string &) const
+{
+    if (sendcount > 0 && !sendbuf)
+    {
+        return CommDummyError("sendbuf is null");
+    }
+    if (recvcount > 0 && !recvbuf)
+    {
+        return CommDummyError("recvbuf is null");
+    }
+    if (root != 0)
+    {
+        return CommDummyError("root is not 0");
+    }
+
+    const size_t nsent = sendcount * CommImpl::SizeOf(sendtype);
+    const size_t nrecv = recvcount * CommImpl::SizeOf(recvtype);
+
+    if (nrecv != nsent)
+    {
+        return CommDummyError("send and recv sizes differ");
+    }
+
+    std::memcpy(recvbuf, sendbuf, nsent);
+}
+
+Comm::Req CommImplDummy::Isend(const void *, size_t, Datatype, int, int,
+                               const std::string &) const
+{
+    auto req = std::unique_ptr<CommReqImplDummy>(new CommReqImplDummy());
+    return MakeReq(std::move(req));
+}
+
+Comm::Req CommImplDummy::Irecv(void *, size_t, Datatype, int, int,
+                               const std::string &) const
+{
+    auto req = std::unique_ptr<CommReqImplDummy>(new CommReqImplDummy());
+    return MakeReq(std::move(req));
+}
+
+Comm::Status CommReqImplDummy::Wait(const std::string &hint)
+{
+    Comm::Status status;
+    return status;
+}
+
+Comm CommDummy()
+{
+    auto comm = std::unique_ptr<CommImpl>(new CommImplDummy());
+    return CommImpl::MakeComm(std::move(comm));
+}
+
+} // end namespace helper
+} // end namespace adios2

--- a/source/adios2/helper/adiosCommDummy.h
+++ b/source/adios2/helper/adiosCommDummy.h
@@ -1,0 +1,26 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosCommDummy.h : A dummy Comm that does not actually communicate.
+ */
+
+#ifndef ADIOS2_HELPER_ADIOSCOMMDUMMY_H_
+#define ADIOS2_HELPER_ADIOSCOMMDUMMY_H_
+
+#include "adiosComm.h"
+
+namespace adios2
+{
+namespace helper
+{
+
+/**
+ * @brief Create a dummy communicator.
+ */
+Comm CommDummy();
+
+} // end namespace helper
+} // end namespace adios2
+
+#endif // ADIOS2_HELPER_ADIOSCOMMDUMMY_H_

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -111,6 +111,7 @@ public:
     std::unique_ptr<CommImpl> Duplicate(const std::string &hint) const override;
     std::unique_ptr<CommImpl> Split(int color, int key,
                                     const std::string &hint) const override;
+    std::unique_ptr<CommImpl> World(const std::string &hint) const override;
 
     int Rank() const override;
     int Size() const override;
@@ -198,6 +199,11 @@ std::unique_ptr<CommImpl> CommImplMPI::Split(int color, int key,
     MPI_Comm newComm;
     CheckMPIReturn(MPI_Comm_split(m_MPIComm, color, key, &newComm), hint);
     return std::unique_ptr<CommImpl>(new CommImplMPI(newComm));
+}
+
+std::unique_ptr<CommImpl> CommImplMPI::World(const std::string &) const
+{
+    return std::unique_ptr<CommImpl>(new CommImplMPI(MPI_COMM_WORLD));
 }
 
 int CommImplMPI::Rank() const

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -7,27 +7,494 @@
 
 #include "adiosCommMPI.h"
 
+#include <algorithm>
+#include <ios> //std::ios_base::failure
+#include <iterator>
 #include <utility>
 
 #include "adiosComm.h"
 
 #include "adios2/common/ADIOSMPI.h"
+#include "adios2/common/ADIOSTypes.h"
 
 namespace adios2
 {
 namespace helper
 {
 
+namespace
+{
+void CheckMPIReturn(const int value, const std::string &hint)
+{
+    if (value == MPI_SUCCESS)
+    {
+        return;
+    }
+
+    std::string error;
+    switch (value)
+    {
+    case MPI_ERR_COMM:
+        error = "MPI_ERR_COMM";
+        break;
+    case MPI_ERR_INTERN:
+        error = "MPI_ERR_INTERN";
+        break;
+    default:
+        error = "MPI_ERR number: " + std::to_string(value);
+    }
+
+    throw std::runtime_error("ERROR: ADIOS2 detected " + error + ", " + hint);
+}
+}
+
+class CommReqImplMPI : public CommReqImpl
+{
+public:
+    CommReqImplMPI(MPI_Datatype datatype) : m_MPIDatatype(datatype) {}
+    ~CommReqImplMPI() override;
+
+    Comm::Status Wait(const std::string &hint) override;
+
+    /** Encapsulated MPI datatype of the requested operation.  */
+    MPI_Datatype m_MPIDatatype = MPI_DATATYPE_NULL;
+
+    /** Encapsulated MPI request instances.  There may be more than
+     *  one when we batch requests too large for MPI interfaces.  */
+    std::vector<MPI_Request> m_MPIReqs;
+};
+
+CommReqImplMPI::~CommReqImplMPI() = default;
+
+class CommImplMPI : public CommImpl
+{
+public:
+    CommImplMPI(MPI_Comm mpiComm) : m_MPIComm(mpiComm) {}
+
+    MPI_Comm m_MPIComm;
+
+    ~CommImplMPI() override;
+
+    void Free(const std::string &hint) override;
+    std::unique_ptr<CommImpl> Split(int color, int key,
+                                    const std::string &hint) const override;
+
+    int Rank() const override;
+    int Size() const override;
+    void Barrier(const std::string &hint) const override;
+
+    void Allgather(const void *sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                   void *recvbuf, size_t recvcount, MPI_Datatype recvtype,
+                   const std::string &hint) const override;
+
+    void Allreduce(const void *sendbuf, void *recvbuf, size_t count,
+                   MPI_Datatype datatype, MPI_Op op,
+                   const std::string &hint) const override;
+
+    void Bcast(void *buffer, size_t count, MPI_Datatype datatype,
+               size_t datatypeSize, int root,
+               const std::string &hint) const override;
+
+    void Gather(const void *sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                void *recvbuf, size_t recvcount, MPI_Datatype recvtype,
+                int root, const std::string &hint) const override;
+
+    void Gatherv(const void *sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                 void *recvbuf, const size_t *recvcounts, const size_t *displs,
+                 MPI_Datatype recvtype, int root,
+                 const std::string &hint) const override;
+
+    void Reduce(const void *sendbuf, void *recvbuf, size_t count,
+                MPI_Datatype datatype, MPI_Op op, int root,
+                const std::string &hint) const override;
+
+    void ReduceInPlace(void *buf, size_t count, MPI_Datatype datatype,
+                       MPI_Op op, int root,
+                       const std::string &hint) const override;
+
+    void Send(const void *buf, size_t count, MPI_Datatype datatype, int dest,
+              int tag, const std::string &hint) const override;
+
+    Comm::Status Recv(void *buf, size_t count, MPI_Datatype datatype,
+                      int source, int tag,
+                      const std::string &hint) const override;
+
+    void Scatter(const void *sendbuf, size_t sendcount, MPI_Datatype sendtype,
+                 void *recvbuf, size_t recvcount, MPI_Datatype recvtype,
+                 int root, const std::string &hint) const override;
+
+    Comm::Req Isend(const void *buffer, size_t count, MPI_Datatype datatype,
+                    int dest, int tag, const std::string &hint) const override;
+
+    Comm::Req Irecv(void *buffer, size_t count, MPI_Datatype datatype,
+                    int source, int tag,
+                    const std::string &hint) const override;
+};
+
+CommImplMPI::~CommImplMPI()
+{
+    // Handle the case where MPI is finalized before the ADIOS destructor is
+    // called, which happens, e.g., with global / static ADIOS objects
+    int flag;
+    MPI_Finalized(&flag);
+    if (!flag)
+    {
+        if (m_MPIComm != MPI_COMM_NULL && m_MPIComm != MPI_COMM_WORLD &&
+            m_MPIComm != MPI_COMM_SELF)
+        {
+            SMPI_Comm_free(&m_MPIComm);
+        }
+    }
+}
+
+void CommImplMPI::Free(const std::string &hint)
+{
+    if (m_MPIComm != MPI_COMM_NULL && m_MPIComm != MPI_COMM_WORLD &&
+        m_MPIComm != MPI_COMM_SELF)
+    {
+        CheckMPIReturn(SMPI_Comm_free(&m_MPIComm), hint);
+    }
+}
+
+std::unique_ptr<CommImpl> CommImplMPI::Split(int color, int key,
+                                             const std::string &hint) const
+{
+    MPI_Comm newComm;
+    CheckMPIReturn(MPI_Comm_split(m_MPIComm, color, key, &newComm), hint);
+    return std::unique_ptr<CommImpl>(new CommImplMPI(newComm));
+}
+
+int CommImplMPI::Rank() const
+{
+    int rank;
+    CheckMPIReturn(SMPI_Comm_rank(m_MPIComm, &rank), {});
+    return rank;
+}
+
+int CommImplMPI::Size() const
+{
+    int size;
+    CheckMPIReturn(SMPI_Comm_size(m_MPIComm, &size), {});
+    return size;
+}
+
+void CommImplMPI::Barrier(const std::string &hint) const
+{
+    CheckMPIReturn(SMPI_Barrier(m_MPIComm), hint);
+}
+
+void CommImplMPI::Allgather(const void *sendbuf, size_t sendcount,
+                            MPI_Datatype sendtype, void *recvbuf,
+                            size_t recvcount, MPI_Datatype recvtype,
+                            const std::string &hint) const
+{
+    CheckMPIReturn(
+        SMPI_Allgather(sendbuf, static_cast<int>(sendcount), sendtype, recvbuf,
+                       static_cast<int>(recvcount), recvtype, m_MPIComm),
+        hint);
+}
+
+void CommImplMPI::Allreduce(const void *sendbuf, void *recvbuf, size_t count,
+                            MPI_Datatype datatype, MPI_Op op,
+                            const std::string &hint) const
+{
+    CheckMPIReturn(SMPI_Allreduce(sendbuf, recvbuf, static_cast<int>(count),
+                                  datatype, op, m_MPIComm),
+                   hint);
+}
+
+void CommImplMPI::Bcast(void *buffer, size_t count, MPI_Datatype datatype,
+                        size_t datatypeSize, int root,
+                        const std::string &hint) const
+{
+    size_t inputSize = count;
+    const int MAXBCASTSIZE = 1073741824;
+    size_t blockSize = (inputSize > MAXBCASTSIZE ? MAXBCASTSIZE : inputSize);
+    unsigned char *blockBuf = static_cast<unsigned char *>(buffer);
+    while (inputSize > 0)
+    {
+        CheckMPIReturn(SMPI_Bcast(blockBuf, static_cast<int>(blockSize),
+                                  datatype, root, m_MPIComm),
+                       hint);
+        blockBuf += blockSize * datatypeSize;
+        inputSize -= blockSize;
+        blockSize = (inputSize > MAXBCASTSIZE ? MAXBCASTSIZE : inputSize);
+    }
+}
+
+void CommImplMPI::Gather(const void *sendbuf, size_t sendcount,
+                         MPI_Datatype sendtype, void *recvbuf, size_t recvcount,
+                         MPI_Datatype recvtype, int root,
+                         const std::string &hint) const
+{
+    CheckMPIReturn(SMPI_Gather(sendbuf, static_cast<int>(sendcount), sendtype,
+                               recvbuf, static_cast<int>(recvcount), recvtype,
+                               root, m_MPIComm),
+                   hint);
+}
+
+void CommImplMPI::Gatherv(const void *sendbuf, size_t sendcount,
+                          MPI_Datatype sendtype, void *recvbuf,
+                          const size_t *recvcounts, const size_t *displs,
+                          MPI_Datatype recvtype, int root,
+                          const std::string &hint) const
+{
+    std::vector<int> countsInt;
+    std::vector<int> displsInt;
+    if (root == this->Rank())
+    {
+        auto cast = [](size_t sz) -> int { return int(sz); };
+        const int size = this->Size();
+        countsInt.reserve(size);
+        std::transform(recvcounts, recvcounts + size,
+                       std::back_inserter(countsInt), cast);
+        displsInt.reserve(size);
+        std::transform(displs, displs + size, std::back_inserter(displsInt),
+                       cast);
+    }
+    CheckMPIReturn(SMPI_Gatherv(sendbuf, static_cast<int>(sendcount), sendtype,
+                                recvbuf, countsInt.data(), displsInt.data(),
+                                recvtype, root, m_MPIComm),
+                   hint);
+}
+
+void CommImplMPI::Reduce(const void *sendbuf, void *recvbuf, size_t count,
+                         MPI_Datatype datatype, MPI_Op op, int root,
+                         const std::string &hint) const
+{
+    CheckMPIReturn(SMPI_Reduce(sendbuf, recvbuf, static_cast<int>(count),
+                               datatype, op, root, m_MPIComm),
+                   hint);
+}
+
+void CommImplMPI::ReduceInPlace(void *buf, size_t count, MPI_Datatype datatype,
+                                MPI_Op op, int root,
+                                const std::string &hint) const
+{
+    CheckMPIReturn(SMPI_Reduce(MPI_IN_PLACE, buf, static_cast<int>(count),
+                               datatype, op, root, m_MPIComm),
+                   hint);
+}
+
+void CommImplMPI::Send(const void *buf, size_t count, MPI_Datatype datatype,
+                       int dest, int tag, const std::string &hint) const
+{
+    CheckMPIReturn(
+        MPI_Send(buf, static_cast<int>(count), datatype, dest, tag, m_MPIComm),
+        hint);
+}
+
+Comm::Status CommImplMPI::Recv(void *buf, size_t count, MPI_Datatype datatype,
+                               int source, int tag,
+                               const std::string &hint) const
+{
+    MPI_Status mpiStatus;
+    CheckMPIReturn(MPI_Recv(buf, static_cast<int>(count), datatype, source, tag,
+                            m_MPIComm, &mpiStatus),
+                   hint);
+
+    Comm::Status status;
+#ifdef ADIOS2_HAVE_MPI
+    status.Source = mpiStatus.MPI_SOURCE;
+    status.Tag = mpiStatus.MPI_TAG;
+    {
+        int mpiCount = 0;
+        CheckMPIReturn(MPI_Get_count(&mpiStatus, datatype, &mpiCount), hint);
+        status.Count = mpiCount;
+    }
+#endif
+    return status;
+}
+
+void CommImplMPI::Scatter(const void *sendbuf, size_t sendcount,
+                          MPI_Datatype sendtype, void *recvbuf,
+                          size_t recvcount, MPI_Datatype recvtype, int root,
+                          const std::string &hint) const
+{
+    CheckMPIReturn(MPI_Scatter(sendbuf, static_cast<int>(sendcount), sendtype,
+                               recvbuf, static_cast<int>(recvcount), recvtype,
+                               root, m_MPIComm),
+                   hint);
+}
+
+Comm::Req CommImplMPI::Isend(const void *buffer, size_t count,
+                             MPI_Datatype datatype, int dest, int tag,
+                             const std::string &hint) const
+{
+    auto req = std::unique_ptr<CommReqImplMPI>(new CommReqImplMPI(datatype));
+
+    if (count > DefaultMaxFileBatchSize)
+    {
+        const size_t batches = count / DefaultMaxFileBatchSize;
+
+        size_t position = 0;
+        for (size_t b = 0; b < batches; ++b)
+        {
+            int batchSize = static_cast<int>(DefaultMaxFileBatchSize);
+            MPI_Request mpiReq;
+            CheckMPIReturn(
+                MPI_Isend(static_cast<char *>(const_cast<void *>(buffer)) +
+                              position,
+                          batchSize, datatype, dest, tag, m_MPIComm, &mpiReq),
+                "in call to Isend batch " + std::to_string(b) + " " + hint +
+                    "\n");
+            req->m_MPIReqs.emplace_back(mpiReq);
+
+            position += DefaultMaxFileBatchSize;
+        }
+        const size_t remainder = count % DefaultMaxFileBatchSize;
+        if (remainder > 0)
+        {
+            int batchSize = static_cast<int>(remainder);
+            MPI_Request mpiReq;
+            CheckMPIReturn(
+                MPI_Isend(static_cast<char *>(const_cast<void *>(buffer)) +
+                              position,
+                          batchSize, datatype, dest, tag, m_MPIComm, &mpiReq),
+                "in call to Isend remainder batch " + hint + "\n");
+            req->m_MPIReqs.emplace_back(mpiReq);
+        }
+    }
+    else
+    {
+        int batchSize = static_cast<int>(count);
+        MPI_Request mpiReq;
+        CheckMPIReturn(
+            MPI_Isend(static_cast<char *>(const_cast<void *>(buffer)),
+                      batchSize, datatype, dest, tag, m_MPIComm, &mpiReq),
+            " in call to Isend with single batch " + hint + "\n");
+        req->m_MPIReqs.emplace_back(mpiReq);
+    }
+
+    return MakeReq(std::move(req));
+}
+
+Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, MPI_Datatype datatype,
+                             int source, int tag, const std::string &hint) const
+{
+    auto req = std::unique_ptr<CommReqImplMPI>(new CommReqImplMPI(datatype));
+
+    if (count > DefaultMaxFileBatchSize)
+    {
+        const size_t batches = count / DefaultMaxFileBatchSize;
+        size_t position = 0;
+        for (size_t b = 0; b < batches; ++b)
+        {
+            int batchSize = static_cast<int>(DefaultMaxFileBatchSize);
+            MPI_Request mpiReq;
+            CheckMPIReturn(MPI_Irecv(static_cast<char *>(buffer) + position,
+                                     batchSize, datatype, source, tag,
+                                     m_MPIComm, &mpiReq),
+                           "in call to Irecv batch " + std::to_string(b) + " " +
+                               hint + "\n");
+            req->m_MPIReqs.emplace_back(mpiReq);
+
+            position += DefaultMaxFileBatchSize;
+        }
+
+        const size_t remainder = count % DefaultMaxFileBatchSize;
+        if (remainder > 0)
+        {
+            int batchSize = static_cast<int>(remainder);
+            MPI_Request mpiReq;
+            CheckMPIReturn(MPI_Irecv(static_cast<char *>(buffer) + position,
+                                     batchSize, datatype, source, tag,
+                                     m_MPIComm, &mpiReq),
+                           "in call to Irecv remainder batch " + hint + "\n");
+            req->m_MPIReqs.emplace_back(mpiReq);
+        }
+    }
+    else
+    {
+        int batchSize = static_cast<int>(count);
+        MPI_Request mpiReq;
+        CheckMPIReturn(MPI_Irecv(buffer, batchSize, datatype, source, tag,
+                                 m_MPIComm, &mpiReq),
+                       " in call to Isend with single batch " + hint + "\n");
+        req->m_MPIReqs.emplace_back(mpiReq);
+    }
+
+    return MakeReq(std::move(req));
+}
+
+Comm::Status CommReqImplMPI::Wait(const std::string &hint)
+{
+    Comm::Status status;
+    if (m_MPIReqs.empty())
+    {
+        return status;
+    }
+
+#ifdef ADIOS2_HAVE_MPI
+    std::vector<MPI_Request> mpiRequests = std::move(m_MPIReqs);
+    std::vector<MPI_Status> mpiStatuses(mpiRequests.size());
+
+    if (mpiRequests.size() > 1)
+    {
+        int mpiReturn = MPI_Waitall(static_cast<int>(mpiRequests.size()),
+                                    mpiRequests.data(), mpiStatuses.data());
+        if (mpiReturn == MPI_ERR_IN_STATUS)
+        {
+            for (auto &mpiStatus : mpiStatuses)
+            {
+                if (mpiStatus.MPI_ERROR != MPI_SUCCESS)
+                {
+                    mpiReturn = mpiStatus.MPI_ERROR;
+                    break;
+                }
+            }
+        }
+        CheckMPIReturn(mpiReturn, hint);
+    }
+    else
+    {
+        CheckMPIReturn(MPI_Wait(mpiRequests.data(), mpiStatuses.data()), hint);
+    }
+
+    // Our batched operation should be from only one source and have one tag.
+    status.Source = mpiStatuses.front().MPI_SOURCE;
+    status.Tag = mpiStatuses.front().MPI_TAG;
+
+    // Accumulate the total count of our batched operation.
+    for (auto &mpiStatus : mpiStatuses)
+    {
+        int mpiCount = 0;
+        CheckMPIReturn(MPI_Get_count(&mpiStatus, m_MPIDatatype, &mpiCount),
+                       hint);
+        status.Count += mpiCount;
+    }
+
+    // Our batched operation was cancelled if any member was cancelled.
+    for (auto &mpiStatus : mpiStatuses)
+    {
+        int mpiCancelled = 0;
+        MPI_Test_cancelled(&mpiStatus, &mpiCancelled);
+        if (mpiCancelled)
+        {
+            status.Cancelled = true;
+            break;
+        }
+    }
+#endif
+
+    return status;
+}
+
 Comm CommFromMPI(MPI_Comm mpiComm)
 {
-    // Forward to the private API.
-    return Comm::FromMPI(mpiComm);
+    MPI_Comm newComm;
+    SMPI_Comm_dup(mpiComm, &newComm);
+    auto comm = std::unique_ptr<CommImpl>(new CommImplMPI(newComm));
+    return CommImpl::MakeComm(std::move(comm));
 }
 
 MPI_Comm CommAsMPI(Comm const &comm)
 {
-    // Forward to the private API.
-    return comm.AsMPI();
+    if (CommImplMPI *mpi = dynamic_cast<CommImplMPI *>(CommImpl::Get(comm)))
+    {
+        return mpi->m_MPIComm;
+    }
+    return MPI_COMM_NULL;
 }
 
 } // end namespace helper

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -123,8 +123,7 @@ public:
                    Datatype datatype, Comm::Op op,
                    const std::string &hint) const override;
 
-    void Bcast(void *buffer, size_t count, Datatype datatype,
-               size_t datatypeSize, int root,
+    void Bcast(void *buffer, size_t count, Datatype datatype, int root,
                const std::string &hint) const override;
 
     void Gather(const void *sendbuf, size_t sendcount, Datatype sendtype,
@@ -232,8 +231,7 @@ void CommImplMPI::Allreduce(const void *sendbuf, void *recvbuf, size_t count,
                    hint);
 }
 
-void CommImplMPI::Bcast(void *buffer, size_t count, Datatype datatype,
-                        size_t datatypeSize, int root,
+void CommImplMPI::Bcast(void *buffer, size_t count, Datatype datatype, int root,
                         const std::string &hint) const
 {
     size_t inputSize = count;
@@ -245,7 +243,7 @@ void CommImplMPI::Bcast(void *buffer, size_t count, Datatype datatype,
         CheckMPIReturn(SMPI_Bcast(blockBuf, static_cast<int>(blockSize),
                                   ToMPI(datatype), root, m_MPIComm),
                        hint);
-        blockBuf += blockSize * datatypeSize;
+        blockBuf += blockSize * CommImpl::SizeOf(datatype);
         inputSize -= blockSize;
         blockSize = (inputSize > MAXBCASTSIZE ? MAXBCASTSIZE : inputSize);
     }

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "adiosComm.h"
+#include "adiosCommDummy.h"
 
 #include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSTypes.h"
@@ -172,7 +173,7 @@ CommImplMPI::~CommImplMPI()
         if (m_MPIComm != MPI_COMM_NULL && m_MPIComm != MPI_COMM_WORLD &&
             m_MPIComm != MPI_COMM_SELF)
         {
-            SMPI_Comm_free(&m_MPIComm);
+            MPI_Comm_free(&m_MPIComm);
         }
     }
 }
@@ -182,7 +183,7 @@ void CommImplMPI::Free(const std::string &hint)
     if (m_MPIComm != MPI_COMM_NULL && m_MPIComm != MPI_COMM_WORLD &&
         m_MPIComm != MPI_COMM_SELF)
     {
-        CheckMPIReturn(SMPI_Comm_free(&m_MPIComm), hint);
+        CheckMPIReturn(MPI_Comm_free(&m_MPIComm), hint);
     }
 }
 
@@ -209,30 +210,30 @@ std::unique_ptr<CommImpl> CommImplMPI::World(const std::string &) const
 int CommImplMPI::Rank() const
 {
     int rank;
-    CheckMPIReturn(SMPI_Comm_rank(m_MPIComm, &rank), {});
+    CheckMPIReturn(MPI_Comm_rank(m_MPIComm, &rank), {});
     return rank;
 }
 
 int CommImplMPI::Size() const
 {
     int size;
-    CheckMPIReturn(SMPI_Comm_size(m_MPIComm, &size), {});
+    CheckMPIReturn(MPI_Comm_size(m_MPIComm, &size), {});
     return size;
 }
 
 void CommImplMPI::Barrier(const std::string &hint) const
 {
-    CheckMPIReturn(SMPI_Barrier(m_MPIComm), hint);
+    CheckMPIReturn(MPI_Barrier(m_MPIComm), hint);
 }
 
 void CommImplMPI::Allgather(const void *sendbuf, size_t sendcount,
                             Datatype sendtype, void *recvbuf, size_t recvcount,
                             Datatype recvtype, const std::string &hint) const
 {
-    CheckMPIReturn(SMPI_Allgather(sendbuf, static_cast<int>(sendcount),
-                                  ToMPI(sendtype), recvbuf,
-                                  static_cast<int>(recvcount), ToMPI(recvtype),
-                                  m_MPIComm),
+    CheckMPIReturn(MPI_Allgather(sendbuf, static_cast<int>(sendcount),
+                                 ToMPI(sendtype), recvbuf,
+                                 static_cast<int>(recvcount), ToMPI(recvtype),
+                                 m_MPIComm),
                    hint);
 }
 
@@ -240,8 +241,8 @@ void CommImplMPI::Allreduce(const void *sendbuf, void *recvbuf, size_t count,
                             Datatype datatype, Comm::Op op,
                             const std::string &hint) const
 {
-    CheckMPIReturn(SMPI_Allreduce(sendbuf, recvbuf, static_cast<int>(count),
-                                  ToMPI(datatype), ToMPI(op), m_MPIComm),
+    CheckMPIReturn(MPI_Allreduce(sendbuf, recvbuf, static_cast<int>(count),
+                                 ToMPI(datatype), ToMPI(op), m_MPIComm),
                    hint);
 }
 
@@ -254,8 +255,8 @@ void CommImplMPI::Bcast(void *buffer, size_t count, Datatype datatype, int root,
     unsigned char *blockBuf = static_cast<unsigned char *>(buffer);
     while (inputSize > 0)
     {
-        CheckMPIReturn(SMPI_Bcast(blockBuf, static_cast<int>(blockSize),
-                                  ToMPI(datatype), root, m_MPIComm),
+        CheckMPIReturn(MPI_Bcast(blockBuf, static_cast<int>(blockSize),
+                                 ToMPI(datatype), root, m_MPIComm),
                        hint);
         blockBuf += blockSize * CommImpl::SizeOf(datatype);
         inputSize -= blockSize;
@@ -268,10 +269,10 @@ void CommImplMPI::Gather(const void *sendbuf, size_t sendcount,
                          Datatype recvtype, int root,
                          const std::string &hint) const
 {
-    CheckMPIReturn(SMPI_Gather(sendbuf, static_cast<int>(sendcount),
-                               ToMPI(sendtype), recvbuf,
-                               static_cast<int>(recvcount), ToMPI(recvtype),
-                               root, m_MPIComm),
+    CheckMPIReturn(MPI_Gather(sendbuf, static_cast<int>(sendcount),
+                              ToMPI(sendtype), recvbuf,
+                              static_cast<int>(recvcount), ToMPI(recvtype),
+                              root, m_MPIComm),
                    hint);
 }
 
@@ -294,10 +295,10 @@ void CommImplMPI::Gatherv(const void *sendbuf, size_t sendcount,
         std::transform(displs, displs + size, std::back_inserter(displsInt),
                        cast);
     }
-    CheckMPIReturn(SMPI_Gatherv(sendbuf, static_cast<int>(sendcount),
-                                ToMPI(sendtype), recvbuf, countsInt.data(),
-                                displsInt.data(), ToMPI(recvtype), root,
-                                m_MPIComm),
+    CheckMPIReturn(MPI_Gatherv(sendbuf, static_cast<int>(sendcount),
+                               ToMPI(sendtype), recvbuf, countsInt.data(),
+                               displsInt.data(), ToMPI(recvtype), root,
+                               m_MPIComm),
                    hint);
 }
 
@@ -305,8 +306,8 @@ void CommImplMPI::Reduce(const void *sendbuf, void *recvbuf, size_t count,
                          Datatype datatype, Comm::Op op, int root,
                          const std::string &hint) const
 {
-    CheckMPIReturn(SMPI_Reduce(sendbuf, recvbuf, static_cast<int>(count),
-                               ToMPI(datatype), ToMPI(op), root, m_MPIComm),
+    CheckMPIReturn(MPI_Reduce(sendbuf, recvbuf, static_cast<int>(count),
+                              ToMPI(datatype), ToMPI(op), root, m_MPIComm),
                    hint);
 }
 
@@ -314,8 +315,8 @@ void CommImplMPI::ReduceInPlace(void *buf, size_t count, Datatype datatype,
                                 Comm::Op op, int root,
                                 const std::string &hint) const
 {
-    CheckMPIReturn(SMPI_Reduce(MPI_IN_PLACE, buf, static_cast<int>(count),
-                               ToMPI(datatype), ToMPI(op), root, m_MPIComm),
+    CheckMPIReturn(MPI_Reduce(MPI_IN_PLACE, buf, static_cast<int>(count),
+                              ToMPI(datatype), ToMPI(op), root, m_MPIComm),
                    hint);
 }
 
@@ -530,8 +531,12 @@ Comm::Status CommReqImplMPI::Wait(const std::string &hint)
 
 Comm CommFromMPI(MPI_Comm mpiComm)
 {
+    if (mpiComm == MPI_COMM_NULL)
+    {
+        return CommDummy();
+    }
     MPI_Comm newComm;
-    SMPI_Comm_dup(mpiComm, &newComm);
+    MPI_Comm_dup(mpiComm, &newComm);
     auto comm = std::unique_ptr<CommImpl>(new CommImplMPI(newComm));
     return CommImpl::MakeComm(std::move(comm));
 }

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -108,6 +108,7 @@ public:
     ~CommImplMPI() override;
 
     void Free(const std::string &hint) override;
+    std::unique_ptr<CommImpl> Duplicate(const std::string &hint) const override;
     std::unique_ptr<CommImpl> Split(int color, int key,
                                     const std::string &hint) const override;
 
@@ -182,6 +183,13 @@ void CommImplMPI::Free(const std::string &hint)
     {
         CheckMPIReturn(SMPI_Comm_free(&m_MPIComm), hint);
     }
+}
+
+std::unique_ptr<CommImpl> CommImplMPI::Duplicate(const std::string &hint) const
+{
+    MPI_Comm newComm;
+    CheckMPIReturn(MPI_Comm_dup(m_MPIComm, &newComm), hint);
+    return std::unique_ptr<CommImpl>(new CommImplMPI(newComm));
 }
 
 std::unique_ptr<CommImpl> CommImplMPI::Split(int color, int key,

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -24,6 +24,15 @@ namespace helper
 
 namespace
 {
+
+const MPI_Op OpToMPI[] = {
+    MPI_OP_NULL, MPI_MAX,    MPI_MIN,    MPI_SUM,     MPI_PROD,
+    MPI_LAND,    MPI_BAND,   MPI_LOR,    MPI_BOR,     MPI_LXOR,
+    MPI_BXOR,    MPI_MAXLOC, MPI_MINLOC, MPI_REPLACE, MPI_NO_OP,
+};
+
+MPI_Op ToMPI(Comm::Op op) { return OpToMPI[int(op)]; }
+
 void CheckMPIReturn(const int value, const std::string &hint)
 {
     if (value == MPI_SUCCESS)
@@ -88,7 +97,7 @@ public:
                    const std::string &hint) const override;
 
     void Allreduce(const void *sendbuf, void *recvbuf, size_t count,
-                   MPI_Datatype datatype, MPI_Op op,
+                   MPI_Datatype datatype, Comm::Op op,
                    const std::string &hint) const override;
 
     void Bcast(void *buffer, size_t count, MPI_Datatype datatype,
@@ -105,11 +114,11 @@ public:
                  const std::string &hint) const override;
 
     void Reduce(const void *sendbuf, void *recvbuf, size_t count,
-                MPI_Datatype datatype, MPI_Op op, int root,
+                MPI_Datatype datatype, Comm::Op op, int root,
                 const std::string &hint) const override;
 
     void ReduceInPlace(void *buf, size_t count, MPI_Datatype datatype,
-                       MPI_Op op, int root,
+                       Comm::Op op, int root,
                        const std::string &hint) const override;
 
     void Send(const void *buf, size_t count, MPI_Datatype datatype, int dest,
@@ -195,11 +204,11 @@ void CommImplMPI::Allgather(const void *sendbuf, size_t sendcount,
 }
 
 void CommImplMPI::Allreduce(const void *sendbuf, void *recvbuf, size_t count,
-                            MPI_Datatype datatype, MPI_Op op,
+                            MPI_Datatype datatype, Comm::Op op,
                             const std::string &hint) const
 {
     CheckMPIReturn(SMPI_Allreduce(sendbuf, recvbuf, static_cast<int>(count),
-                                  datatype, op, m_MPIComm),
+                                  datatype, ToMPI(op), m_MPIComm),
                    hint);
 }
 
@@ -259,20 +268,20 @@ void CommImplMPI::Gatherv(const void *sendbuf, size_t sendcount,
 }
 
 void CommImplMPI::Reduce(const void *sendbuf, void *recvbuf, size_t count,
-                         MPI_Datatype datatype, MPI_Op op, int root,
+                         MPI_Datatype datatype, Comm::Op op, int root,
                          const std::string &hint) const
 {
     CheckMPIReturn(SMPI_Reduce(sendbuf, recvbuf, static_cast<int>(count),
-                               datatype, op, root, m_MPIComm),
+                               datatype, ToMPI(op), root, m_MPIComm),
                    hint);
 }
 
 void CommImplMPI::ReduceInPlace(void *buf, size_t count, MPI_Datatype datatype,
-                                MPI_Op op, int root,
+                                Comm::Op op, int root,
                                 const std::string &hint) const
 {
     CheckMPIReturn(SMPI_Reduce(MPI_IN_PLACE, buf, static_cast<int>(count),
-                               datatype, op, root, m_MPIComm),
+                               datatype, ToMPI(op), root, m_MPIComm),
                    hint);
 }
 

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -33,6 +33,29 @@ const MPI_Op OpToMPI[] = {
 
 MPI_Op ToMPI(Comm::Op op) { return OpToMPI[int(op)]; }
 
+const MPI_Datatype DatatypeToMPI[] = {
+    MPI_SIGNED_CHAR,
+    MPI_CHAR,
+    MPI_SHORT,
+    MPI_INT,
+    MPI_LONG,
+    MPI_UNSIGNED_CHAR,
+    MPI_UNSIGNED_SHORT,
+    MPI_UNSIGNED,
+    MPI_UNSIGNED_LONG,
+    MPI_UNSIGNED_LONG_LONG,
+    MPI_LONG_LONG_INT,
+    MPI_DOUBLE,
+    MPI_LONG_DOUBLE,
+    MPI_2INT,
+    MPI_FLOAT_INT,
+    MPI_DOUBLE_INT,
+    MPI_LONG_DOUBLE_INT,
+    MPI_SHORT_INT,
+};
+
+MPI_Datatype ToMPI(CommImpl::Datatype dt) { return DatatypeToMPI[int(dt)]; }
+
 void CheckMPIReturn(const int value, const std::string &hint)
 {
     if (value == MPI_SUCCESS)
@@ -92,52 +115,49 @@ public:
     int Size() const override;
     void Barrier(const std::string &hint) const override;
 
-    void Allgather(const void *sendbuf, size_t sendcount, MPI_Datatype sendtype,
-                   void *recvbuf, size_t recvcount, MPI_Datatype recvtype,
+    void Allgather(const void *sendbuf, size_t sendcount, Datatype sendtype,
+                   void *recvbuf, size_t recvcount, Datatype recvtype,
                    const std::string &hint) const override;
 
     void Allreduce(const void *sendbuf, void *recvbuf, size_t count,
-                   MPI_Datatype datatype, Comm::Op op,
+                   Datatype datatype, Comm::Op op,
                    const std::string &hint) const override;
 
-    void Bcast(void *buffer, size_t count, MPI_Datatype datatype,
+    void Bcast(void *buffer, size_t count, Datatype datatype,
                size_t datatypeSize, int root,
                const std::string &hint) const override;
 
-    void Gather(const void *sendbuf, size_t sendcount, MPI_Datatype sendtype,
-                void *recvbuf, size_t recvcount, MPI_Datatype recvtype,
-                int root, const std::string &hint) const override;
+    void Gather(const void *sendbuf, size_t sendcount, Datatype sendtype,
+                void *recvbuf, size_t recvcount, Datatype recvtype, int root,
+                const std::string &hint) const override;
 
-    void Gatherv(const void *sendbuf, size_t sendcount, MPI_Datatype sendtype,
+    void Gatherv(const void *sendbuf, size_t sendcount, Datatype sendtype,
                  void *recvbuf, const size_t *recvcounts, const size_t *displs,
-                 MPI_Datatype recvtype, int root,
+                 Datatype recvtype, int root,
                  const std::string &hint) const override;
 
     void Reduce(const void *sendbuf, void *recvbuf, size_t count,
-                MPI_Datatype datatype, Comm::Op op, int root,
+                Datatype datatype, Comm::Op op, int root,
                 const std::string &hint) const override;
 
-    void ReduceInPlace(void *buf, size_t count, MPI_Datatype datatype,
-                       Comm::Op op, int root,
-                       const std::string &hint) const override;
+    void ReduceInPlace(void *buf, size_t count, Datatype datatype, Comm::Op op,
+                       int root, const std::string &hint) const override;
 
-    void Send(const void *buf, size_t count, MPI_Datatype datatype, int dest,
+    void Send(const void *buf, size_t count, Datatype datatype, int dest,
               int tag, const std::string &hint) const override;
 
-    Comm::Status Recv(void *buf, size_t count, MPI_Datatype datatype,
-                      int source, int tag,
-                      const std::string &hint) const override;
+    Comm::Status Recv(void *buf, size_t count, Datatype datatype, int source,
+                      int tag, const std::string &hint) const override;
 
-    void Scatter(const void *sendbuf, size_t sendcount, MPI_Datatype sendtype,
-                 void *recvbuf, size_t recvcount, MPI_Datatype recvtype,
-                 int root, const std::string &hint) const override;
+    void Scatter(const void *sendbuf, size_t sendcount, Datatype sendtype,
+                 void *recvbuf, size_t recvcount, Datatype recvtype, int root,
+                 const std::string &hint) const override;
 
-    Comm::Req Isend(const void *buffer, size_t count, MPI_Datatype datatype,
+    Comm::Req Isend(const void *buffer, size_t count, Datatype datatype,
                     int dest, int tag, const std::string &hint) const override;
 
-    Comm::Req Irecv(void *buffer, size_t count, MPI_Datatype datatype,
-                    int source, int tag,
-                    const std::string &hint) const override;
+    Comm::Req Irecv(void *buffer, size_t count, Datatype datatype, int source,
+                    int tag, const std::string &hint) const override;
 };
 
 CommImplMPI::~CommImplMPI()
@@ -193,26 +213,26 @@ void CommImplMPI::Barrier(const std::string &hint) const
 }
 
 void CommImplMPI::Allgather(const void *sendbuf, size_t sendcount,
-                            MPI_Datatype sendtype, void *recvbuf,
-                            size_t recvcount, MPI_Datatype recvtype,
-                            const std::string &hint) const
+                            Datatype sendtype, void *recvbuf, size_t recvcount,
+                            Datatype recvtype, const std::string &hint) const
 {
-    CheckMPIReturn(
-        SMPI_Allgather(sendbuf, static_cast<int>(sendcount), sendtype, recvbuf,
-                       static_cast<int>(recvcount), recvtype, m_MPIComm),
-        hint);
-}
-
-void CommImplMPI::Allreduce(const void *sendbuf, void *recvbuf, size_t count,
-                            MPI_Datatype datatype, Comm::Op op,
-                            const std::string &hint) const
-{
-    CheckMPIReturn(SMPI_Allreduce(sendbuf, recvbuf, static_cast<int>(count),
-                                  datatype, ToMPI(op), m_MPIComm),
+    CheckMPIReturn(SMPI_Allgather(sendbuf, static_cast<int>(sendcount),
+                                  ToMPI(sendtype), recvbuf,
+                                  static_cast<int>(recvcount), ToMPI(recvtype),
+                                  m_MPIComm),
                    hint);
 }
 
-void CommImplMPI::Bcast(void *buffer, size_t count, MPI_Datatype datatype,
+void CommImplMPI::Allreduce(const void *sendbuf, void *recvbuf, size_t count,
+                            Datatype datatype, Comm::Op op,
+                            const std::string &hint) const
+{
+    CheckMPIReturn(SMPI_Allreduce(sendbuf, recvbuf, static_cast<int>(count),
+                                  ToMPI(datatype), ToMPI(op), m_MPIComm),
+                   hint);
+}
+
+void CommImplMPI::Bcast(void *buffer, size_t count, Datatype datatype,
                         size_t datatypeSize, int root,
                         const std::string &hint) const
 {
@@ -223,7 +243,7 @@ void CommImplMPI::Bcast(void *buffer, size_t count, MPI_Datatype datatype,
     while (inputSize > 0)
     {
         CheckMPIReturn(SMPI_Bcast(blockBuf, static_cast<int>(blockSize),
-                                  datatype, root, m_MPIComm),
+                                  ToMPI(datatype), root, m_MPIComm),
                        hint);
         blockBuf += blockSize * datatypeSize;
         inputSize -= blockSize;
@@ -232,20 +252,21 @@ void CommImplMPI::Bcast(void *buffer, size_t count, MPI_Datatype datatype,
 }
 
 void CommImplMPI::Gather(const void *sendbuf, size_t sendcount,
-                         MPI_Datatype sendtype, void *recvbuf, size_t recvcount,
-                         MPI_Datatype recvtype, int root,
+                         Datatype sendtype, void *recvbuf, size_t recvcount,
+                         Datatype recvtype, int root,
                          const std::string &hint) const
 {
-    CheckMPIReturn(SMPI_Gather(sendbuf, static_cast<int>(sendcount), sendtype,
-                               recvbuf, static_cast<int>(recvcount), recvtype,
+    CheckMPIReturn(SMPI_Gather(sendbuf, static_cast<int>(sendcount),
+                               ToMPI(sendtype), recvbuf,
+                               static_cast<int>(recvcount), ToMPI(recvtype),
                                root, m_MPIComm),
                    hint);
 }
 
 void CommImplMPI::Gatherv(const void *sendbuf, size_t sendcount,
-                          MPI_Datatype sendtype, void *recvbuf,
+                          Datatype sendtype, void *recvbuf,
                           const size_t *recvcounts, const size_t *displs,
-                          MPI_Datatype recvtype, int root,
+                          Datatype recvtype, int root,
                           const std::string &hint) const
 {
     std::vector<int> countsInt;
@@ -261,45 +282,46 @@ void CommImplMPI::Gatherv(const void *sendbuf, size_t sendcount,
         std::transform(displs, displs + size, std::back_inserter(displsInt),
                        cast);
     }
-    CheckMPIReturn(SMPI_Gatherv(sendbuf, static_cast<int>(sendcount), sendtype,
-                                recvbuf, countsInt.data(), displsInt.data(),
-                                recvtype, root, m_MPIComm),
+    CheckMPIReturn(SMPI_Gatherv(sendbuf, static_cast<int>(sendcount),
+                                ToMPI(sendtype), recvbuf, countsInt.data(),
+                                displsInt.data(), ToMPI(recvtype), root,
+                                m_MPIComm),
                    hint);
 }
 
 void CommImplMPI::Reduce(const void *sendbuf, void *recvbuf, size_t count,
-                         MPI_Datatype datatype, Comm::Op op, int root,
+                         Datatype datatype, Comm::Op op, int root,
                          const std::string &hint) const
 {
     CheckMPIReturn(SMPI_Reduce(sendbuf, recvbuf, static_cast<int>(count),
-                               datatype, ToMPI(op), root, m_MPIComm),
+                               ToMPI(datatype), ToMPI(op), root, m_MPIComm),
                    hint);
 }
 
-void CommImplMPI::ReduceInPlace(void *buf, size_t count, MPI_Datatype datatype,
+void CommImplMPI::ReduceInPlace(void *buf, size_t count, Datatype datatype,
                                 Comm::Op op, int root,
                                 const std::string &hint) const
 {
     CheckMPIReturn(SMPI_Reduce(MPI_IN_PLACE, buf, static_cast<int>(count),
-                               datatype, ToMPI(op), root, m_MPIComm),
+                               ToMPI(datatype), ToMPI(op), root, m_MPIComm),
                    hint);
 }
 
-void CommImplMPI::Send(const void *buf, size_t count, MPI_Datatype datatype,
+void CommImplMPI::Send(const void *buf, size_t count, Datatype datatype,
                        int dest, int tag, const std::string &hint) const
 {
-    CheckMPIReturn(
-        MPI_Send(buf, static_cast<int>(count), datatype, dest, tag, m_MPIComm),
-        hint);
+    CheckMPIReturn(MPI_Send(buf, static_cast<int>(count), ToMPI(datatype), dest,
+                            tag, m_MPIComm),
+                   hint);
 }
 
-Comm::Status CommImplMPI::Recv(void *buf, size_t count, MPI_Datatype datatype,
+Comm::Status CommImplMPI::Recv(void *buf, size_t count, Datatype datatype,
                                int source, int tag,
                                const std::string &hint) const
 {
     MPI_Status mpiStatus;
-    CheckMPIReturn(MPI_Recv(buf, static_cast<int>(count), datatype, source, tag,
-                            m_MPIComm, &mpiStatus),
+    CheckMPIReturn(MPI_Recv(buf, static_cast<int>(count), ToMPI(datatype),
+                            source, tag, m_MPIComm, &mpiStatus),
                    hint);
 
     Comm::Status status;
@@ -308,7 +330,8 @@ Comm::Status CommImplMPI::Recv(void *buf, size_t count, MPI_Datatype datatype,
     status.Tag = mpiStatus.MPI_TAG;
     {
         int mpiCount = 0;
-        CheckMPIReturn(MPI_Get_count(&mpiStatus, datatype, &mpiCount), hint);
+        CheckMPIReturn(MPI_Get_count(&mpiStatus, ToMPI(datatype), &mpiCount),
+                       hint);
         status.Count = mpiCount;
     }
 #endif
@@ -316,21 +339,23 @@ Comm::Status CommImplMPI::Recv(void *buf, size_t count, MPI_Datatype datatype,
 }
 
 void CommImplMPI::Scatter(const void *sendbuf, size_t sendcount,
-                          MPI_Datatype sendtype, void *recvbuf,
-                          size_t recvcount, MPI_Datatype recvtype, int root,
+                          Datatype sendtype, void *recvbuf, size_t recvcount,
+                          Datatype recvtype, int root,
                           const std::string &hint) const
 {
-    CheckMPIReturn(MPI_Scatter(sendbuf, static_cast<int>(sendcount), sendtype,
-                               recvbuf, static_cast<int>(recvcount), recvtype,
+    CheckMPIReturn(MPI_Scatter(sendbuf, static_cast<int>(sendcount),
+                               ToMPI(sendtype), recvbuf,
+                               static_cast<int>(recvcount), ToMPI(recvtype),
                                root, m_MPIComm),
                    hint);
 }
 
 Comm::Req CommImplMPI::Isend(const void *buffer, size_t count,
-                             MPI_Datatype datatype, int dest, int tag,
+                             Datatype datatype, int dest, int tag,
                              const std::string &hint) const
 {
-    auto req = std::unique_ptr<CommReqImplMPI>(new CommReqImplMPI(datatype));
+    auto req =
+        std::unique_ptr<CommReqImplMPI>(new CommReqImplMPI(ToMPI(datatype)));
 
     if (count > DefaultMaxFileBatchSize)
     {
@@ -342,9 +367,9 @@ Comm::Req CommImplMPI::Isend(const void *buffer, size_t count,
             int batchSize = static_cast<int>(DefaultMaxFileBatchSize);
             MPI_Request mpiReq;
             CheckMPIReturn(
-                MPI_Isend(static_cast<char *>(const_cast<void *>(buffer)) +
-                              position,
-                          batchSize, datatype, dest, tag, m_MPIComm, &mpiReq),
+                MPI_Isend(
+                    static_cast<char *>(const_cast<void *>(buffer)) + position,
+                    batchSize, ToMPI(datatype), dest, tag, m_MPIComm, &mpiReq),
                 "in call to Isend batch " + std::to_string(b) + " " + hint +
                     "\n");
             req->m_MPIReqs.emplace_back(mpiReq);
@@ -357,9 +382,9 @@ Comm::Req CommImplMPI::Isend(const void *buffer, size_t count,
             int batchSize = static_cast<int>(remainder);
             MPI_Request mpiReq;
             CheckMPIReturn(
-                MPI_Isend(static_cast<char *>(const_cast<void *>(buffer)) +
-                              position,
-                          batchSize, datatype, dest, tag, m_MPIComm, &mpiReq),
+                MPI_Isend(
+                    static_cast<char *>(const_cast<void *>(buffer)) + position,
+                    batchSize, ToMPI(datatype), dest, tag, m_MPIComm, &mpiReq),
                 "in call to Isend remainder batch " + hint + "\n");
             req->m_MPIReqs.emplace_back(mpiReq);
         }
@@ -370,7 +395,8 @@ Comm::Req CommImplMPI::Isend(const void *buffer, size_t count,
         MPI_Request mpiReq;
         CheckMPIReturn(
             MPI_Isend(static_cast<char *>(const_cast<void *>(buffer)),
-                      batchSize, datatype, dest, tag, m_MPIComm, &mpiReq),
+                      batchSize, ToMPI(datatype), dest, tag, m_MPIComm,
+                      &mpiReq),
             " in call to Isend with single batch " + hint + "\n");
         req->m_MPIReqs.emplace_back(mpiReq);
     }
@@ -378,10 +404,11 @@ Comm::Req CommImplMPI::Isend(const void *buffer, size_t count,
     return MakeReq(std::move(req));
 }
 
-Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, MPI_Datatype datatype,
+Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, Datatype datatype,
                              int source, int tag, const std::string &hint) const
 {
-    auto req = std::unique_ptr<CommReqImplMPI>(new CommReqImplMPI(datatype));
+    auto req =
+        std::unique_ptr<CommReqImplMPI>(new CommReqImplMPI(ToMPI(datatype)));
 
     if (count > DefaultMaxFileBatchSize)
     {
@@ -392,7 +419,7 @@ Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, MPI_Datatype datatype,
             int batchSize = static_cast<int>(DefaultMaxFileBatchSize);
             MPI_Request mpiReq;
             CheckMPIReturn(MPI_Irecv(static_cast<char *>(buffer) + position,
-                                     batchSize, datatype, source, tag,
+                                     batchSize, ToMPI(datatype), source, tag,
                                      m_MPIComm, &mpiReq),
                            "in call to Irecv batch " + std::to_string(b) + " " +
                                hint + "\n");
@@ -407,7 +434,7 @@ Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, MPI_Datatype datatype,
             int batchSize = static_cast<int>(remainder);
             MPI_Request mpiReq;
             CheckMPIReturn(MPI_Irecv(static_cast<char *>(buffer) + position,
-                                     batchSize, datatype, source, tag,
+                                     batchSize, ToMPI(datatype), source, tag,
                                      m_MPIComm, &mpiReq),
                            "in call to Irecv remainder batch " + hint + "\n");
             req->m_MPIReqs.emplace_back(mpiReq);
@@ -417,8 +444,8 @@ Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, MPI_Datatype datatype,
     {
         int batchSize = static_cast<int>(count);
         MPI_Request mpiReq;
-        CheckMPIReturn(MPI_Irecv(buffer, batchSize, datatype, source, tag,
-                                 m_MPIComm, &mpiReq),
+        CheckMPIReturn(MPI_Irecv(buffer, batchSize, ToMPI(datatype), source,
+                                 tag, m_MPIComm, &mpiReq),
                        " in call to Isend with single batch " + hint + "\n");
         req->m_MPIReqs.emplace_back(mpiReq);
     }

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -1,0 +1,34 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosCommMPI.cpp
+ */
+
+#include "adiosCommMPI.h"
+
+#include <utility>
+
+#include "adiosComm.h"
+
+#include "adios2/common/ADIOSMPI.h"
+
+namespace adios2
+{
+namespace helper
+{
+
+Comm CommFromMPI(MPI_Comm mpiComm)
+{
+    // Forward to the private API.
+    return Comm::FromMPI(mpiComm);
+}
+
+MPI_Comm CommAsMPI(Comm const &comm)
+{
+    // Forward to the private API.
+    return comm.AsMPI();
+}
+
+} // end namespace helper
+} // end namespace adios2

--- a/source/adios2/helper/adiosCommMPI.h
+++ b/source/adios2/helper/adiosCommMPI.h
@@ -1,0 +1,36 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosCommMPI.h : MPI-specific Comm APIs
+ */
+
+#ifndef ADIOS2_HELPER_ADIOSCOMMMPI_H_
+#define ADIOS2_HELPER_ADIOSCOMMMPI_H_
+
+#include "adiosComm.h"
+
+#include "adios2/common/ADIOSMPI.h"
+
+namespace adios2
+{
+namespace helper
+{
+
+/**
+ * @brief Create a communicator by duplicating a MPI communicator.
+ */
+Comm CommFromMPI(MPI_Comm mpiComm);
+
+/**
+ * @brief Get the underlying raw MPI communicator.
+ *
+ * Returns MPI_COMM_NULL if the communicator is empty or is not
+ * backed by MPI.
+ */
+MPI_Comm CommAsMPI(Comm const &comm);
+
+} // end namespace helper
+} // end namespace adios2
+
+#endif // ADIOS2_HELPER_ADIOSCOMMMPI_H_

--- a/source/adios2/helper/adiosSystem.cpp
+++ b/source/adios2/helper/adiosSystem.cpp
@@ -16,7 +16,6 @@
 
 #include <adios2sys/SystemTools.hxx>
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/helper/adiosString.h"

--- a/source/adios2/helper/adiosXML.cpp
+++ b/source/adios2/helper/adiosXML.cpp
@@ -17,7 +17,6 @@
 #include <stdexcept> //std::invalid_argument
 /// \endcond
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosString.h"

--- a/source/adios2/helper/mpidummy.h
+++ b/source/adios2/helper/mpidummy.h
@@ -82,20 +82,21 @@ typedef int MPI_Op;
 #define MPI_ANY_SOURCE 0
 #define MPI_ANY_TAG 0
 
-#define MPI_MAX 0
-#define MPI_MIN 1
-#define MPI_SUM 2
-#define MPI_PROD 3
-#define MPI_LAND 4
-#define MPI_BAND 5
-#define MPI_LOR 6
-#define MPI_BOR 7
-#define MPI_LXOR 8
-#define MPI_BXOR 9
-#define MPI_MAXLOC 10
-#define MPI_MINLOC 11
-#define MPI_REPLACE 12
-#define MPI_NO_OP 13
+#define MPI_OP_NULL 0
+#define MPI_MAX 1
+#define MPI_MIN 2
+#define MPI_SUM 3
+#define MPI_PROD 4
+#define MPI_LAND 5
+#define MPI_BAND 6
+#define MPI_LOR 7
+#define MPI_BOR 8
+#define MPI_LXOR 9
+#define MPI_BXOR 10
+#define MPI_MAXLOC 11
+#define MPI_MINLOC 12
+#define MPI_REPLACE 13
+#define MPI_NO_OP 14
 
 #define MPI_MAX_PROCESSOR_NAME 32
 

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
@@ -13,7 +13,6 @@
 
 #include <memory> //std::unique_ptr
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/toolkit/format/buffer/Buffer.h"

--- a/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
@@ -9,8 +9,6 @@
  */
 #include "MPIChain.h"
 
-#include "adios2/common/ADIOSMPI.h"
-
 #include "adios2/toolkit/format/buffer/heap/BufferSTL.h"
 
 namespace adios2

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -11,6 +11,8 @@
 #include "DataManSerializer.h"
 #include "DataManSerializer.tcc"
 
+#include "adios2/common/ADIOSMPI.h"
+
 #include <cstring>
 #include <iostream>
 

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -11,8 +11,6 @@
 #include "DataManSerializer.h"
 #include "DataManSerializer.tcc"
 
-#include "adios2/common/ADIOSMPI.h"
-
 #include <cstring>
 #include <iostream>
 
@@ -1195,8 +1193,7 @@ void DataManSerializer::Log(const int level, const std::string &message,
                             const bool mpi, const bool endline)
 {
     TAU_SCOPED_TIMER_FUNC();
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    const int rank = m_Comm.World().Rank();
 
     if (m_Verbosity >= level)
     {

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -72,7 +72,7 @@ void DataManSerializer::AggregateMetadata()
     auto localJsonPack = SerializeJson(m_MetadataJson);
     unsigned int size = localJsonPack->size();
     unsigned int maxSize;
-    m_Comm.Allreduce(&size, &maxSize, 1, MPI_MAX);
+    m_Comm.Allreduce(&size, &maxSize, 1, helper::Comm::Op::Max);
     maxSize += sizeof(uint64_t);
     localJsonPack->resize(maxSize, '\0');
     *(reinterpret_cast<uint64_t *>(localJsonPack->data() +

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -19,6 +19,7 @@
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/IO.h" // for CreateVar
 #include "adios2/core/Variable.h"
+#include "adios2/helper/adiosComm.h"
 
 #include <stdexcept> // for Intel Compiler
 
@@ -120,7 +121,7 @@ public:
     static const std::string PARAMETER_CHUNK_VARS;
 
     void ParseParameters(core::IO &io);
-    void Init(const std::string &name, MPI_Comm comm, bool toWrite);
+    void Init(const std::string &name, helper::Comm const &comm, bool toWrite);
 
     template <class T>
     void Write(core::Variable<T> &variable, const T *values);

--- a/source/adios2/toolkit/query/Worker.h
+++ b/source/adios2/toolkit/query/Worker.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSTypes.h"
 #include <fstream>
 

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -10,7 +10,6 @@
 
 #include "Transport.h"
 
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/helper/adiosFunctions.h" //CreateDirectory
 
 namespace adios2

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -17,7 +17,6 @@
 /// \endcond
 
 #include "adios2/common/ADIOSConfig.h"
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/toolkit/profiling/iochrono/IOChrono.h"

--- a/source/utils/adios_reorganize/Reorganize.cpp
+++ b/source/utils/adios_reorganize/Reorganize.cpp
@@ -44,9 +44,9 @@ namespace utils
 Reorganize::Reorganize(int argc, char *argv[])
 : Utils("adios_reorganize", argc, argv)
 {
-    MPI_Comm_split(MPI_COMM_WORLD, m_MPISplitColor, rank, &comm);
-    MPI_Comm_rank(comm, &rank);
-    MPI_Comm_size(comm, &numproc);
+    MPI_Comm_split(MPI_COMM_WORLD, m_MPISplitColor, 0, &m_Comm);
+    MPI_Comm_rank(m_Comm, &m_Rank);
+    MPI_Comm_size(m_Comm, &m_Size);
 
     if (argc < 5)
     {
@@ -92,14 +92,14 @@ Reorganize::Reorganize(int argc, char *argv[])
         prod *= decomp_values[i];
     }
 
-    if (prod > numproc)
+    if (prod > m_Size)
     {
         print0("ERROR: Product of decomposition numbers %d > number of "
                "processes %d\n",
-               prod, numproc);
+               prod, m_Size);
         std::string errmsg("ERROR: The product of decomposition numbers " +
                            std::to_string(prod) + " > number of processes " +
-                           std::to_string(numproc) + "\n");
+                           std::to_string(m_Size) + "\n");
         PrintUsage();
         throw std::invalid_argument(errmsg);
     }
@@ -119,7 +119,7 @@ void Reorganize::Run()
     print0("Write method parameters = ", wmethodparam_str);
 
 #ifdef ADIOS2_HAVE_MPI
-    core::ADIOS adios(comm, true, "C++");
+    core::ADIOS adios(m_Comm, true, "C++");
 #else
     core::ADIOS adios(true, "C++");
 #endif
@@ -145,7 +145,7 @@ void Reorganize::Run()
             rStream.BeginStep(adios2::StepMode::Read, 10.0);
         if (status == adios2::StepStatus::NotReady)
         {
-            if (!rank)
+            if (!m_Rank)
             {
                 std::cout << " No new steps arrived in a while " << std::endl;
             }
@@ -161,7 +161,7 @@ void Reorganize::Run()
         if (rStream.CurrentStep() != static_cast<size_t>(curr_step + 1))
         {
             // we missed some steps
-            std::cout << "rank " << rank << " WARNING: steps " << curr_step
+            std::cout << "rank " << m_Rank << " WARNING: steps " << curr_step
                       << ".." << rStream.CurrentStep() - 1
                       << "were missed when advancing." << std::endl;
         }
@@ -195,7 +195,7 @@ void Reorganize::Run()
 template <typename Arg, typename... Args>
 void Reorganize::osprint0(std::ostream &out, Arg &&arg, Args &&... args)
 {
-    if (!rank)
+    if (!m_Rank)
     {
         out << std::forward<Arg>(arg);
         using expander = int[];
@@ -207,7 +207,7 @@ void Reorganize::osprint0(std::ostream &out, Arg &&arg, Args &&... args)
 template <typename Arg, typename... Args>
 void Reorganize::print0(Arg &&arg, Args &&... args)
 {
-    if (!rank)
+    if (!m_Rank)
     {
         std::cout << std::forward<Arg>(arg);
         using expander = int[];
@@ -447,13 +447,13 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
 
         if (variable == nullptr)
         {
-            std::cerr << "rank " << rank << ": ERROR: Variable " << name
+            std::cerr << "rank " << m_Rank << ": ERROR: Variable " << name
                       << " inquiry failed" << std::endl;
             return 1;
         }
 
         // print variable type and dimensions
-        if (!rank)
+        if (!m_Rank)
         {
             std::cout << "    " << type << " " << name;
             if (variable->GetShape().size() > 0)
@@ -473,7 +473,7 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
 
         // determine subset we will write
         size_t sum_count =
-            Decompose(numproc, rank, varinfo[varidx], decomp_values);
+            Decompose(m_Size, m_Rank, varinfo[varidx], decomp_values);
         varinfo[varidx].writesize = sum_count * variable->m_ElementSize;
 
         if (varinfo[varidx].writesize != 0)
@@ -490,7 +490,7 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
         write_total + variables.size() * 200 + attributes.size() * 32 + 1024;
     if (bufsize > max_write_buffer_size)
     {
-        std::cerr << "ERROR: rank " << rank
+        std::cerr << "ERROR: rank " << m_Rank
                   << ": write buffer size needs to hold about " << bufsize
                   << "bytes but max is set to " << max_write_buffer_size
                   << std::endl;
@@ -499,7 +499,7 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
 
     if (bufsize > max_read_buffer_size)
     {
-        std::cerr << "ERROR: rank " << rank
+        std::cerr << "ERROR: rank " << m_Rank
                   << ": read buffer size needs to hold at least " << bufsize
                   << "bytes but max is set to " << max_read_buffer_size
                   << std::endl;
@@ -518,7 +518,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
     if (nvars != varinfo.size())
     {
         std::cerr
-            << "ERROR rank " << rank
+            << "ERROR rank " << m_Rank
             << ": Invalid program state, number "
                "of variables ("
             << nvars
@@ -536,7 +536,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
         if (varinfo[varidx].writesize != 0)
         {
             // read variable subset
-            std::cout << "rank " << rank << ": Read variable " << name
+            std::cout << "rank " << m_Rank << ": Read variable " << name
                       << std::endl;
             const std::string &type = variables.at(name).first;
             if (type == "compound")
@@ -577,7 +577,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
         if (varinfo[varidx].writesize != 0)
         {
             // Write variable subset
-            std::cout << "rank " << rank << ": Write variable " << name
+            std::cout << "rank " << m_Rank << ": Write variable " << name
                       << std::endl;
             const std::string &type = variables.at(name).first;
             if (type == "compound")

--- a/source/utils/adios_reorganize/Reorganize.h
+++ b/source/utils/adios_reorganize/Reorganize.h
@@ -13,6 +13,7 @@
 
 #include "adios2.h"
 #include "adios2/core/IO.h" // DataMap
+#include "adios2/helper/adiosComm.h"
 #include "utils/Utils.h"
 
 namespace adios2
@@ -40,7 +41,7 @@ public:
     void Run() final;
 
 private:
-    static const int m_MPISplitColor = 23731; // color in MPI_Split_comm() call
+    static const int m_CommSplitColor = 23731; // color in Comm::Split() call
     static const std::string m_HelpMessage;
     static const Params m_Options;
 
@@ -84,7 +85,7 @@ private:
     // Global variables
     int m_Rank = 0;
     int m_Size = 1;
-    MPI_Comm m_Comm;
+    helper::Comm m_Comm;
 
     // Read/write method parameters
     Params rmethodparams;

--- a/source/utils/adios_reorganize/Reorganize.h
+++ b/source/utils/adios_reorganize/Reorganize.h
@@ -82,9 +82,9 @@ private:
     static const int timeout_sec = 300;
 
     // Global variables
-    int rank = 0;
-    int numproc = 1;
-    MPI_Comm comm;
+    int m_Rank = 0;
+    int m_Size = 1;
+    MPI_Comm m_Comm;
 
     // Read/write method parameters
     Params rmethodparams;

--- a/source/utils/bpls/bpls.h
+++ b/source/utils/bpls/bpls.h
@@ -6,7 +6,6 @@
  */
 
 #include "adios2/common/ADIOSConfig.h"
-#include "adios2/common/ADIOSMPI.h"
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/core/ADIOS.h"
 #include "adios2/core/Engine.h"


### PR DESCRIPTION
Continue work started in #1691 to encapsulate multi-process communication behind a `helper::Comm` API:

* Encapsulate remaining MPI types and constants inside `helper::Comm` and offer equivalents publicly.
* Convert more code from direct MPI use over to `helper::Comm`.  Add APIs to the latter as needed.  * Abstract the `helper::Comm` implementation internally to work with either MPI or a dummy backend.
* Replace MPI with `helper::Comm` in core `ADIOS`, `IO`, and `Stream` interfaces.
* Minimize direct inclusion of `ADIOSMPI.h` to only places that still use MPI directly.
