### PR TITLE
Blosc: Fix Static Builds

### DIFF
--- a/cmake/adios2-config-common.cmake.in
+++ b/cmake/adios2-config-common.cmake.in
@@ -22,6 +22,11 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 if(NOT @BUILD_SHARED_LIBS@)
+  set(ADIOS2_HAVE_Blosc @ADIOS2_HAVE_Blosc@)
+  if(ADIOS2_HAVE_Blosc)
+    find_dependency(Blosc)
+  endif()
+
   set(ADIOS2_HAVE_BZip2 @ADIOS2_HAVE_BZip2@)
   if(ADIOS2_HAVE_BZip2)
     find_dependency(BZip2)


### PR DESCRIPTION
Adds search functionality for transitive blosc dependency in static builds.

Fix #1810

- [x] verified this solves the reported problem