### PR TITLE
CMake: SSC also uses JSON

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -141,7 +141,7 @@ if (ADIOS2_HAVE_DataMan)
     target_link_libraries(adios2 PRIVATE nlohmann_json)
 endif()
 
-if(ADIOS2_HAVE_DataMan OR ADIOS2_HAVE_WDM OR ADIOS2_HAVE_Table)
+if(ADIOS2_HAVE_DataMan OR ADIOS2_HAVE_WDM OR ADIOS2_HAVE_Table OR ADIOS2_HAVE_SSC)
     target_sources(adios2 PRIVATE
        	toolkit/format/dataman/DataManSerializer.cpp
         toolkit/format/dataman/DataManSerializer.tcc
@@ -162,8 +162,6 @@ endif()
 
 if(ADIOS2_HAVE_SSC)
     target_sources(adios2 PRIVATE
-        toolkit/format/dataman/DataManSerializer.cpp
-        toolkit/format/dataman/DataManSerializer.tcc
         engine/ssc/SscReader.cpp
         engine/ssc/SscReader.tcc
         engine/ssc/SscWriter.cpp

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -143,9 +143,9 @@ endif()
 
 if(ADIOS2_HAVE_DataMan OR ADIOS2_HAVE_WDM OR ADIOS2_HAVE_Table OR ADIOS2_HAVE_SSC)
     target_sources(adios2 PRIVATE
-       	toolkit/format/dataman/DataManSerializer.cpp
+        toolkit/format/dataman/DataManSerializer.cpp
         toolkit/format/dataman/DataManSerializer.tcc
-        )
+    )
     target_link_libraries(adios2 PRIVATE nlohmann_json)
 endif()
 
@@ -166,14 +166,14 @@ if(ADIOS2_HAVE_SSC)
         engine/ssc/SscReader.tcc
         engine/ssc/SscWriter.cpp
         engine/ssc/SscWriter.tcc
-        )
+    )
 endif()
 
 if(ADIOS2_HAVE_Table)
     target_sources(adios2 PRIVATE
         engine/table/TableWriter.cpp
         engine/table/TableWriter.tcc
-        )
+    )
 endif()
 
 if(ADIOS2_HAVE_SST)


### PR DESCRIPTION
Fix compile errors with missing `nlohmann/json.hpp` include.

Fix #1830