### PR TITLE
Full Names Key option to IO::AvailableAttributes

### DIFF
--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -137,10 +137,10 @@ std::map<std::string, Params> IO::AvailableVariables()
 
 std::map<std::string, Params>
 IO::AvailableAttributes(const std::string &variableName,
-                        const std::string separator)
+                        const std::string separator, const bool fullNameKeys)
 {
     helper::CheckForNullptr(m_IO, "in call to IO::AvailableAttributes");
-    return m_IO->GetAvailableAttributes(variableName, separator);
+    return m_IO->GetAvailableAttributes(variableName, separator, fullNameKeys);
 }
 
 std::string IO::VariableType(const std::string &name) const

--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -296,6 +296,8 @@ public:
      * attributes, if empty (default) return all attributes
      * @param separator optional name hierarchy separator (/, ::, _, -, \\,
      * etc.)
+     * @param fullNameKeys true: return full attribute names in keys, false
+     * (default): return attribute names relative to variableName
      * @return map:
      * <pre>
      * key: unique attribute name
@@ -305,8 +307,9 @@ public:
      * </pre>
      */
     std::map<std::string, Params>
-    AvailableAttributes(const std::string &variableName = std::string(),
-                        const std::string separator = "/");
+    AvailableAttributes(const std::string &variableName = "",
+                        const std::string separator = "/",
+                        const bool fullNameKeys = false);
 
     /**
      * Inspects variable type. This function can be used in conjunction with

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -353,7 +353,8 @@ std::map<std::string, Params> IO::GetAvailableVariables() noexcept
 
 std::map<std::string, Params>
 IO::GetAvailableAttributes(const std::string &variableName,
-                           const std::string separator) noexcept
+                           const std::string separator,
+                           const bool fullNameKeys) noexcept
 {
     TAU_SCOPED_TIMER("IO::GetAvailableAttributes");
     std::map<std::string, Params> attributesInfo;
@@ -371,7 +372,8 @@ IO::GetAvailableAttributes(const std::string &variableName,
     {                                                                          \
         Variable<T> &variable =                                                \
             GetVariableMap<T>().at(itVariable->second.second);                 \
-        attributesInfo = variable.GetAttributesInfo(*this, separator);         \
+        attributesInfo =                                                       \
+            variable.GetAttributesInfo(*this, separator, fullNameKeys);        \
     }
         ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -354,7 +354,8 @@ public:
      */
     std::map<std::string, Params>
     GetAvailableAttributes(const std::string &variableName = std::string(),
-                           const std::string separator = "/") noexcept;
+                           const std::string separator = "/",
+                           const bool fullNamesKeys = false) noexcept;
 
     /**
      * @brief Check existence in config file passed to ADIOS class constructor

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -210,8 +210,8 @@ public:
      * @return attributes info
      */
     std::map<std::string, Params>
-    GetAttributesInfo(core::IO &io, const std::string separator = "/") const
-        noexcept;
+    GetAttributesInfo(core::IO &io, const std::string separator,
+                      const bool fullNameKeys) const noexcept;
 
 protected:
     const bool m_DebugMode = false;

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
@@ -841,35 +841,39 @@ TEST_F(BPWriteReadAttributes, WriteReadStreamVar)
     {
         auto lf_VerifyAttributes = [](const std::string &variableName,
                                       const std::string separator,
-                                      adios2::IO &io) {
+                                      adios2::IO &io, const bool fullNames) {
             const std::map<std::string, adios2::Params> attributesInfo =
-                io.AvailableAttributes(variableName, separator);
+                io.AvailableAttributes(variableName, separator, fullNames);
 
-            auto itSArray =
-                attributesInfo.find(variableName + separator + "sArray");
+            const std::string sArrayName =
+                fullNames ? variableName + separator + "sArray" : "sArray";
+            auto itSArray = attributesInfo.find(sArrayName);
             EXPECT_NE(itSArray, attributesInfo.end());
             EXPECT_EQ(itSArray->second.at("Type"), "string");
             EXPECT_EQ(itSArray->second.at("Elements"), "3");
             EXPECT_EQ(itSArray->second.at("Value"),
                       R"({ "one", "two", "three" })");
 
-            auto itU32Value =
-                attributesInfo.find(variableName + separator + "u32Value");
+            const std::string u32ValueName =
+                fullNames ? variableName + separator + "u32Value" : "u32Value";
+            auto itU32Value = attributesInfo.find(u32ValueName);
             EXPECT_NE(itU32Value, attributesInfo.end());
             EXPECT_EQ(itU32Value->second.at("Type"), "uint32_t");
             EXPECT_EQ(itU32Value->second.at("Elements"), "1");
             EXPECT_EQ(itU32Value->second.at("Value"), "1");
 
 #ifndef _WIN32
-            auto itSmile =
-                attributesInfo.find(variableName + separator + "smile");
+            const std::string smileName =
+                fullNames ? variableName + separator + "smile" : "smile";
+            auto itSmile = attributesInfo.find(smileName);
             EXPECT_NE(itSmile, attributesInfo.end());
             EXPECT_EQ(itSmile->second.at("Type"), "string");
             EXPECT_EQ(itSmile->second.at("Elements"), "1");
             EXPECT_EQ(itSmile->second.at("Value"), std::string("\"\u263A\""));
 
-            auto itUTF8 =
-                attributesInfo.find(variableName + separator + "utf8");
+            const std::string utf8Name =
+                fullNames ? variableName + separator + "utf8" : "utf8";
+            auto itUTF8 = attributesInfo.find(utf8Name);
             EXPECT_NE(itUTF8, attributesInfo.end());
             EXPECT_EQ(itUTF8->second.at("Type"), "string");
             EXPECT_EQ(itUTF8->second.at("Elements"), "1");
@@ -886,13 +890,15 @@ TEST_F(BPWriteReadAttributes, WriteReadStreamVar)
             auto var1 = io.InquireVariable<int32_t>("var1");
             if (var1)
             {
-                lf_VerifyAttributes("var1", separator, io);
+                lf_VerifyAttributes("var1", separator, io, false);
+                lf_VerifyAttributes("var1", separator, io, true);
             }
 
             auto var2 = io.InquireVariable<int32_t>("var2");
             if (var2)
             {
-                lf_VerifyAttributes("var2", separator, io);
+                lf_VerifyAttributes("var1", separator, io, false);
+                lf_VerifyAttributes("var2", separator, io, true);
             }
 
             bpReader.EndStep();


### PR DESCRIPTION
Added boolean flag to retrieve full or relative (default) attribute names
This prevents breaking the API from v2.5.0