### PR TITLE
Pass build configuration in install test

### DIFF
--- a/testing/install/CMakeLists.txt
+++ b/testing/install/CMakeLists.txt
@@ -12,6 +12,7 @@ function(add_install_cmake_test name)
     "-DTEST_CASE=${name}"
     "-DCMAKE_INSTALL_BINDIR=${CMAKE_INSTALL_BINDIR}"
     "-DCMAKE_INSTALL_CMAKEDIR=${CMAKE_INSTALL_CMAKEDIR}"
+    "-DBUILD_TYPE=$<CONFIG>"
     -P "${CMAKE_CURRENT_SOURCE_DIR}/run_cmake.cmake"
     )
   set_tests_properties(Install.CMake.${name} PROPERTIES
@@ -54,6 +55,7 @@ endfunction()
 add_test(NAME Install.Setup COMMAND "${CMAKE_COMMAND}"
   "-DADIOS2_SOURCE_DIR=${CMAKE_SOURCE_DIR}"
   "-DADIOS2_BINARY_DIR=${CMAKE_BINARY_DIR}"
+  "-DBUILD_TYPE=$<CONFIG>"
   -P "${CMAKE_CURRENT_SOURCE_DIR}/run_install.cmake"
   )
 set_tests_properties(Install.Setup PROPERTIES

--- a/testing/install/run_cmake.cmake
+++ b/testing/install/run_cmake.cmake
@@ -16,6 +16,7 @@ execute_process(COMMAND "${CMAKE_CTEST_COMMAND}"
   --build-options
     "-Dadios2_DIR=${ADIOS2_BINARY_DIR}/testing/install/install/${CMAKE_INSTALL_CMAKEDIR}"
   --test-command "${CMAKE_CTEST_COMMAND}" -V
+  -C "${BUILD_TYPE}"
   RESULT_VARIABLE result
   )
 if(result)

--- a/testing/install/run_install.cmake
+++ b/testing/install/run_install.cmake
@@ -7,6 +7,7 @@ unset(ENV{DESTDIR})
 file(REMOVE_RECURSE "${ADIOS2_BINARY_DIR}/testing/install/install")
 execute_process(COMMAND "${CMAKE_COMMAND}"
   "-DCMAKE_INSTALL_PREFIX=${ADIOS2_BINARY_DIR}/testing/install/install"
+  "-DBUILD_TYPE=${BUILD_TYPE}"
   -P "${ADIOS2_BINARY_DIR}/cmake_install.cmake"
   RESULT_VARIABLE result
   )


### PR DESCRIPTION
In order to work with multi-config generators, the install test needs
to know the current working configuration. Pass this information using
the `$<CONFIG>` generator expression.