### PR TITLE
Disable install test on macOS + Fortran + MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,24 +159,24 @@ install(FILES ${PROJECT_BINARY_DIR}/source/adios2/common/ADIOSConfig.h
 #------------------------------------------------------------------------------#
 # Some specialized shared library and RPATH handling
 #------------------------------------------------------------------------------#
+set(ADIOS2_RUN_INSTALL_TEST TRUE)
 if(BUILD_SHARED_LIBS)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  string(REGEX REPLACE "[^/]+" ".." relative_base "${CMAKE_INSTALL_LIBDIR}")
 
   if(APPLE)
-    # On Mac OS X, set the dir included as part of the installed library's path:
-    if(NOT DEFINED CMAKE_INSTALL_NAME_DIR)
-      set(CMAKE_INSTALL_NAME_DIR
-        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-    endif ()
-
     # Various homebrew MPI fortran installations break rpath usage on OSX
     if(APPLE AND ADIOS2_HAVE_Fortran AND ADIOS2_HAVE_MPI)
+      set(CMAKE_INSTALL_NAME_DIR
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
       set(CMAKE_MACOSX_RPATH OFF)
+      set(ADIOS2_RUN_INSTALL_TEST FALSE)
+    else()
+      set(CMAKE_INSTALL_RPATH "@loader_path/${relative_base}/${CMAKE_INSTALL_LIBDIR}")
     endif()
 
   elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
     # Linux needs some specialized RPATH handling
-    string(REGEX REPLACE "[^/]+" ".." relative_base "${CMAKE_INSTALL_LIBDIR}")
     set(CMAKE_INSTALL_RPATH "$ORIGIN/${relative_base}/${CMAKE_INSTALL_LIBDIR}")
   endif()
 endif()

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -68,7 +68,9 @@ endfunction()
 
 add_subdirectory(adios2)
 add_subdirectory(utils)
-add_subdirectory(install)
+if(ADIOS2_RUN_INSTALL_TEST)
+  add_subdirectory(install)
+endif()
 
 if(ADIOS2_BUILD_EXAMPLES)
   add_subdirectory(examples)


### PR DESCRIPTION
mpifort adds a -Wl,-flat_namespace flag, which, in conjunction with
an ugly Xcode bug (http://www.openradar.me/25313838), prohibits the
use of rpaths to locate the libraries. Therefore, in commit a80afca,
the configure-time value of ${CMAKE_INSTALL_PREFIX} was used as the
install name directory instead of @rpath, and CMAKE_MACOSX_RPATH was
also set to OFF if macOS + Fortran + MPI was detected.

Unfortunately, the install test changes ${CMAKE_INSTALL_PREFIX} at
install time, which results in the test failing due to the executable
searching in the wrong directory for the libraries. It may be possible
to dynamically set the correct install name directory at install time,
using some combination of install(SCRIPT), file(GENERATE), and
install_name_tool. However, for the sake of simplicity, we have chosen
to simply disable the test under these circumstances.

Disable the install test if macOS + Fortran + MPI is detected. Enable
it otherwise. In addition, allow rpath to work if this combination is
not detected, by not setting CMAKE_INSTALL_NAME_DIR and setting
CMAKE_INSTALL_RPATH to @loader_path, which is the macOS equivalent of
Linux's ${ORIGIN}.