### PR TITLE
added exceptions in insitumpi

### DIFF
--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -48,7 +48,9 @@ InSituMPIReader::InSituMPIReader(IO &io, const std::string &name,
         insitumpi::AssignPeers(m_ReaderRank, m_ReaderNproc, m_RankAllPeers);
     if (m_RankAllPeers.empty())
     {
-        throw(std::runtime_error("no writers are found"));
+        throw(std::runtime_error(
+            "no writers are found. Make sure that the writer and reader "
+            "applications are launched as one application in MPMD mode."));
     }
     if (m_Verbosity == 5)
     {

--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -46,6 +46,10 @@ InSituMPIReader::InSituMPIReader(IO &io, const std::string &name,
     m_ReaderNproc = m_Comm.Size();
     m_RankDirectPeers =
         insitumpi::AssignPeers(m_ReaderRank, m_ReaderNproc, m_RankAllPeers);
+    if (m_RankAllPeers.empty())
+    {
+        throw(std::runtime_error("no writers are found"));
+    }
     if (m_Verbosity == 5)
     {
         std::cout << "InSituMPI Reader " << m_ReaderRank << " Open(" << m_Name

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
@@ -57,7 +57,9 @@ InSituMPIWriter::InSituMPIWriter(IO &io, const std::string &name,
     m_AmIPrimaryContact = static_cast<bool>(primaryContact);
     if (m_RankAllPeers.empty())
     {
-        throw(std::runtime_error("no readers are found"));
+        throw(std::runtime_error(
+            "No writers are found. Make sure that the writer and reader "
+            "applications are launched as one application in MPMD mode."));
     }
     if (m_Verbosity == 5)
     {

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
@@ -55,6 +55,10 @@ InSituMPIWriter::InSituMPIWriter(IO &io, const std::string &name,
         m_CommWorld, true, (m_BP3Serializer.m_RankMPI == 0), m_GlobalRank,
         m_RankDirectPeers);
     m_AmIPrimaryContact = static_cast<bool>(primaryContact);
+    if (m_RankAllPeers.empty())
+    {
+        throw(std::runtime_error("no readers are found"));
+    }
     if (m_Verbosity == 5)
     {
         std::cout << "InSituMPI Writer " << m_WriterRank << " Open(" << m_Name

--- a/testing/adios2/engine/insitumpi/CMakeLists.txt
+++ b/testing/adios2/engine/insitumpi/CMakeLists.txt
@@ -4,3 +4,4 @@
 #------------------------------------------------------------------------------#
 
 gtest_add_tests_helper(FunctionAssignPeers TRUE InSituMPI Engine.InSituMPI. "")
+gtest_add_tests_helper(MPMDExceptions TRUE InSituMPI Engine.InSituMPI. "")

--- a/testing/adios2/engine/insitumpi/TestInSituMPIMPMDExceptions.cpp
+++ b/testing/adios2/engine/insitumpi/TestInSituMPIMPMDExceptions.cpp
@@ -1,0 +1,58 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#ifdef ADIOS2_HAVE_MPI
+#include "mpi.h"
+#endif
+
+class InSituMPIMPMDExceptions : public ::testing::Test
+{
+public:
+    InSituMPIMPMDExceptions() = default;
+};
+
+TEST_F(InSituMPIMPMDExceptions, Writer)
+{
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+    adios2::IO dataManIO = adios.DeclareIO("Test");
+    dataManIO.SetEngine("insitumpi");
+    EXPECT_THROW(dataManIO.Open("filename", adios2::Mode::Write),
+                 std::runtime_error);
+}
+
+TEST_F(InSituMPIMPMDExceptions, Reader)
+{
+    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+    adios2::IO dataManIO = adios.DeclareIO("Test");
+    dataManIO.SetEngine("insitumpi");
+    EXPECT_THROW(dataManIO.Open("filename", adios2::Mode::Read),
+                 std::runtime_error);
+}
+
+//******************************************************************************
+// main
+//******************************************************************************
+
+int main(int argc, char **argv)
+{
+    MPI_Init(nullptr, nullptr);
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+    result = RUN_ALL_TESTS();
+
+    MPI_Finalize();
+    return result;
+}

--- a/testing/adios2/engine/staging-common/CMakeLists.txt
+++ b/testing/adios2/engine/staging-common/CMakeLists.txt
@@ -198,7 +198,8 @@ endforeach()
 #   Setup tests for InSituMPI engine
 #
 if(ADIOS2_HAVE_MPI)
-    set (INSITU_TESTS ${ALL_SIMPLE_TESTS})
+    set (SIMPLE_IMPI_TESTS "1x1;TimeoutOnOpen;1x1.Modes;1x1.Attrs;1x1.Local;1x1.SharedNothing;1x1.SharedIO;1x1.SharedVar;1x1.SharedNothingSync;1x1.SharedIOSync;1x1.SharedVarSync;2x1.SharedNothing;2x1.SharedIO;2x1.SharedVar;2x1.SharedNothingSync;2x1.SharedIOSync;2x1.SharedVarSync")
+    set (INSITU_TESTS ${SIMPLE_IMPI_TESTS} ${SIMPLE_FORTRAN_TESTS} ${SIMPLE_MPI_TESTS} ${SIMPLE_ZFP_TESTS})
     # Tests that don't work for InSitu
     list (REMOVE_ITEM INSITU_TESTS "TimeoutOnOpen" "1x1.Modes" "1x1.Attrs")
     # Local Vars don't work for InSitu


### PR DESCRIPTION
The insitumpi engine will return successfully when there is only writer (or reader) launched. This is a little confusing when the MPI environment is getting complicated, for example, running cheetah workflow on Summit. In this case it's very hard for users to directly tell whether the writers and readers are launched using correct split MPI communicators. So even if they are not launched correctly, both the writers and readers are still going to finish successfully, but of course in this case data is not going to be correct at all. So it's better to throw an exception when there is no writers or no readers launched. 