### PR TITLE
Change some locations where checking DebugMode does more harm than good.

### DIFF
--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -497,7 +497,7 @@ void InSituMPIReader::AsyncRecvAllVariables()
     {                                                                          \
         core::Variable<T> *variable =                                          \
             m_IO.InquireVariable<T>(variablePair.first);                       \
-        if (m_DebugMode && variable == nullptr)                                \
+        if (variable == nullptr)                                               \
         {                                                                      \
             throw std::invalid_argument(                                       \
                 "ERROR: variable " + variablePair.first +                      \

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
@@ -291,7 +291,7 @@ void InSituMPIWriter::AsyncSendVariable(std::string variableName)
     else if (type == helper::GetType<T>())                                     \
     {                                                                          \
         Variable<T> *variable = m_IO.InquireVariable<T>(variableName);         \
-        if (m_DebugMode && variable == nullptr)                                \
+        if (variable == nullptr)                                               \
         {                                                                      \
             throw std::invalid_argument(                                       \
                 "ERROR: variable " + variableName +                            \

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
@@ -95,18 +95,14 @@ BP3Deserializer::InitVariableBlockInfo(core::Variable<T> &variable,
         const std::vector<typename core::Variable<T>::Info> blocksInfo =
             BlocksInfo(variable, stepsStart);
 
-        if (m_DebugMode)
+        if (variable.m_BlockID >= blocksInfo.size())
         {
-            if (variable.m_BlockID >= blocksInfo.size())
-            {
-                throw std::invalid_argument(
-                    "ERROR: invalid blockID " +
-                    std::to_string(variable.m_BlockID) + " from steps start " +
-                    std::to_string(stepsStart) + " in variable " +
-                    variable.m_Name +
-                    ", check argument to Variable<T>::SetBlockID, in call "
-                    "to Get\n");
-            }
+            throw std::invalid_argument(
+                "ERROR: invalid blockID " + std::to_string(variable.m_BlockID) +
+                " from steps start " + std::to_string(stepsStart) +
+                " in variable " + variable.m_Name +
+                ", check argument to Variable<T>::SetBlockID, in call "
+                "to Get\n");
         }
 
         // switch to bounding box for global array

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -98,18 +98,14 @@ BP4Deserializer::InitVariableBlockInfo(core::Variable<T> &variable,
         const std::vector<typename core::Variable<T>::Info> blocksInfo =
             BlocksInfo(variable, stepsStart);
 
-        if (m_DebugMode)
+        if (variable.m_BlockID >= blocksInfo.size())
         {
-            if (variable.m_BlockID >= blocksInfo.size())
-            {
-                throw std::invalid_argument(
-                    "ERROR: invalid blockID " +
-                    std::to_string(variable.m_BlockID) + " from steps start " +
-                    std::to_string(stepsStart) + " in variable " +
-                    variable.m_Name +
-                    ", check argument to Variable<T>::SetBlockID, in call "
-                    "to Get\n");
-            }
+            throw std::invalid_argument(
+                "ERROR: invalid blockID " + std::to_string(variable.m_BlockID) +
+                " from steps start " + std::to_string(stepsStart) +
+                " in variable " + variable.m_Name +
+                ", check argument to Variable<T>::SetBlockID, in call "
+                "to Get\n");
         }
 
         // switch to bounding box for global array


### PR DESCRIPTION
DebugMode's best use is to provide a way for users to avoid expensive checks in code thought to be fully-debugged.  It makes less sense when the check to be avoided is cheap, and the consequences are severe (e.g. seg faults or array out-of-bounds access, instead of a nice error).  This cleans up a couple of such uses.