### PR TITLE
Attributes: Allow Complex Types

### DIFF
--- a/source/adios2/common/ADIOSMacros.h
+++ b/source/adios2/common/ADIOSMacros.h
@@ -52,7 +52,7 @@
 
 #define ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(MACRO)                           \
     MACRO(std::string)                                                         \
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(MACRO)
+    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)
 
 #define ADIOS2_FOREACH_STDTYPE_1ARG(MACRO)                                     \
     MACRO(std::string)                                                         \
@@ -147,7 +147,9 @@
     MACRO(unsigned long long int)                                              \
     MACRO(float)                                                               \
     MACRO(double)                                                              \
-    MACRO(long double)
+    MACRO(long double)                                                         \
+    MACRO(std::complex<float>)                                                 \
+    MACRO(std::complex<double>)
 
 #define ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)                    \
     MACRO(char)                                                                \
@@ -163,7 +165,9 @@
     MACRO(unsigned long long int)                                              \
     MACRO(float)                                                               \
     MACRO(double)                                                              \
-    MACRO(long double)
+    MACRO(long double)                                                         \
+    MACRO(std::complex<float>)                                                 \
+    MACRO(std::complex<double>)
 
 #define ADIOS2_FOREACH_NUMERIC_ATTRIBUTE_TYPE_1ARG(MACRO)                      \
     MACRO(short)                                                               \
@@ -176,7 +180,9 @@
     MACRO(unsigned long long int)                                              \
     MACRO(float)                                                               \
     MACRO(double)                                                              \
-    MACRO(long double)
+    MACRO(long double)                                                         \
+    MACRO(std::complex<float>)                                                 \
+    MACRO(std::complex<double>)
 
 /**
  <pre>
@@ -214,7 +220,9 @@
     MACRO(uint64_t, uint64)                                                    \
     MACRO(float, float)                                                        \
     MACRO(double, double)                                                      \
-    MACRO(long double, ldouble)
+    MACRO(long double, ldouble)                                                \
+    MACRO(std::complex<float>, cfloat)                                         \
+    MACRO(std::complex<double>, cdouble)
 
 #define ADIOS2_FOREACH_PRIMITVE_STDTYPE_2ARGS(MACRO)                           \
     MACRO(int8_t, int8)                                                        \
@@ -232,9 +240,7 @@
     MACRO(std::complex<double>, cdouble)
 
 #define ADIOS2_FOREACH_STDTYPE_2ARGS(MACRO)                                    \
-    ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)                              \
-    MACRO(std::complex<float>, cfloat)                                         \
-    MACRO(std::complex<double>, cdouble)
+    ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)
 
 #define ADIOS2_FOREACH_COMPLEX_TYPE_2ARGS(MACRO)                               \
     MACRO(std::complex<float>, CFloat)                                         \

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -11,6 +11,7 @@
 #include "SscReader.tcc"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2/helper/adiosJSONcomplex.h"
 #include "nlohmann/json.hpp"
 
 namespace adios2

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -10,6 +10,7 @@
 
 #include "SscWriter.tcc"
 #include "adios2/helper/adiosComm.h"
+#include "adios2/helper/adiosJSONcomplex.h"
 #include "nlohmann/json.hpp"
 
 namespace adios2

--- a/source/adios2/helper/adiosJSONcomplex.h
+++ b/source/adios2/helper/adiosJSONcomplex.h
@@ -1,0 +1,34 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosYAML.h basic YAML parsing functionality for ADIOS config file schema
+ *
+ *  Created on: Dec 19, 2019
+ *      Author: Axel Huebl <axelhuebl@lbl.gov>
+ */
+
+#ifndef ADIOS2_HELPER_ADIOSJSONCOMPLEX_H_
+#define ADIOS2_HELPER_ADIOSJSONCOMPLEX_H_
+
+#include "nlohmann/json.hpp"
+#include <complex>
+
+// JSON std::complex handling
+namespace std
+{
+template <class T>
+inline void to_json(nlohmann::json &j, const std::complex<T> &p)
+{
+    j = nlohmann::json{p.real(), p.imag()};
+}
+
+template <class T>
+inline void from_json(const nlohmann::json &j, std::complex<T> &p)
+{
+    p.real(j.at(0));
+    p.imag(j.at(1));
+}
+} // end namespace std
+
+#endif /* ADIOS2_HELPER_ADIOSJSONCOMPLEX_H_ */

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -14,6 +14,7 @@
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosComm.h"
+#include "adios2/helper/adiosJSONcomplex.h"
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 
 #include <mutex>

--- a/testing/adios2/engine/SmallTestData.h
+++ b/testing/adios2/engine/SmallTestData.h
@@ -47,6 +47,8 @@ struct SmallTestData
         {0.1f, 1.1f, 2.1f, 3.1f, 4.1f, 5.1f, 6.1f, 7.1f, 8.1f, 9.1f}};
     std::array<double, 10> R64 = {
         {10.2, 11.2, 12.2, 13.2, 14.2, 15.2, 16.2, 17.2, 18.2, 19.2}};
+    std::array<long double, 10> R128 = {
+        {410.2, 411.2, 412.2, 413.2, 414.2, 415.2, 416.2, 417.2, 418.2, 419.2}};
 
     std::array<std::complex<float>, 10> CR32 = {
         {std::complex<float>(0.1f, 1.1f), std::complex<float>(1.1f, 2.1f),
@@ -77,6 +79,8 @@ SmallTestData generateNewSmallTestData(SmallTestData in, int step, int rank,
     std::for_each(in.U64.begin(), in.U64.end(), [&](uint64_t &v) { v += j; });
     std::for_each(in.R32.begin(), in.R32.end(), [&](float &v) { v += j; });
     std::for_each(in.R64.begin(), in.R64.end(), [&](double &v) { v += j; });
+    std::for_each(in.R128.begin(), in.R128.end(),
+                  [&](long double &v) { v += j; });
 
     std::for_each(in.CR32.begin(), in.CR32.end(), [&](std::complex<float> &v) {
         v.real(v.real() + static_cast<float>(j));
@@ -103,6 +107,8 @@ void UpdateSmallTestData(SmallTestData &in, int step, int rank, int size)
     std::for_each(in.U64.begin(), in.U64.end(), [&](uint64_t &v) { v += j; });
     std::for_each(in.R32.begin(), in.R32.end(), [&](float &v) { v += j; });
     std::for_each(in.R64.begin(), in.R64.end(), [&](double &v) { v += j; });
+    std::for_each(in.R128.begin(), in.R128.end(),
+                  [&](long double &v) { v += j; });
 
     std::for_each(in.CR32.begin(), in.CR32.end(), [&](std::complex<float> &v) {
         v.real(v.real() + static_cast<float>(j));

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
@@ -2,6 +2,7 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */
+#include <complex>
 #include <cstdint>
 #include <string>
 
@@ -43,6 +44,9 @@ TEST_F(BPWriteReadAttributes, WriteReadSingleTypes)
     const std::string u64_Single = std::string("u64_Single_") + zero;
     const std::string r32_Single = std::string("r32_Single_") + zero;
     const std::string r64_Single = std::string("r64_Single_") + zero;
+    const std::string r128_Single = std::string("r128_Single_") + zero;
+    const std::string cr32_Single = std::string("cr32_Single_") + zero;
+    const std::string cr64_Single = std::string("cr64_Single_") + zero;
 
     // When collective meta generation has landed, use
     // generateNewSmallTestData(m_TestData, 0, mpiRank, mpiSize);
@@ -77,6 +81,13 @@ TEST_F(BPWriteReadAttributes, WriteReadSingleTypes)
 
         io.DefineAttribute<float>(r32_Single, currentTestData.R32.front());
         io.DefineAttribute<double>(r64_Single, currentTestData.R64.front());
+        io.DefineAttribute<long double>(r128_Single,
+                                        currentTestData.R128.front());
+
+        io.DefineAttribute<std::complex<float>>(cr32_Single,
+                                                currentTestData.CR32.front());
+        io.DefineAttribute<std::complex<double>>(cr64_Single,
+                                                 currentTestData.CR64.front());
 
         if (!engineName.empty())
         {
@@ -119,6 +130,12 @@ TEST_F(BPWriteReadAttributes, WriteReadSingleTypes)
 
         auto attr_r32 = ioRead.InquireAttribute<float>(r32_Single);
         auto attr_r64 = ioRead.InquireAttribute<double>(r64_Single);
+        auto attr_r128 = ioRead.InquireAttribute<long double>(r128_Single);
+
+        auto attr_cr32 =
+            ioRead.InquireAttribute<std::complex<float>>(cr32_Single);
+        auto attr_cr64 =
+            ioRead.InquireAttribute<std::complex<double>>(cr64_Single);
 
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), s1_Single);
@@ -192,6 +209,24 @@ TEST_F(BPWriteReadAttributes, WriteReadSingleTypes)
         ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
         ASSERT_EQ(attr_r64.Data().front(), currentTestData.R64.front());
 
+        EXPECT_TRUE(attr_r128);
+        ASSERT_EQ(attr_r128.Name(), r128_Single);
+        ASSERT_EQ(attr_r128.Data().size() == 1, true);
+        ASSERT_EQ(attr_r128.Type(), adios2::GetType<long double>());
+        ASSERT_EQ(attr_r128.Data().front(), currentTestData.R128.front());
+
+        EXPECT_TRUE(attr_cr32);
+        ASSERT_EQ(attr_cr32.Name(), cr32_Single);
+        ASSERT_EQ(attr_cr32.Data().size() == 1, true);
+        ASSERT_EQ(attr_cr32.Type(), adios2::GetType<std::complex<float>>());
+        ASSERT_EQ(attr_cr32.Data().front(), currentTestData.CR32.front());
+
+        EXPECT_TRUE(attr_cr64);
+        ASSERT_EQ(attr_cr64.Name(), cr64_Single);
+        ASSERT_EQ(attr_cr64.Data().size() == 1, true);
+        ASSERT_EQ(attr_cr64.Type(), adios2::GetType<std::complex<double>>());
+        ASSERT_EQ(attr_cr64.Data().front(), currentTestData.CR64.front());
+
         bpRead.Close();
     }
 }
@@ -220,6 +255,9 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypes)
     const std::string u64_Array = std::string("u64_Array_") + zero;
     const std::string r32_Array = std::string("r32_Array_") + zero;
     const std::string r64_Array = std::string("r64_Array_") + zero;
+    const std::string r128_Array = std::string("r128_Array_") + zero;
+    const std::string cr32_Array = std::string("cr32_Array_") + zero;
+    const std::string cr64_Array = std::string("cr64_Array_") + zero;
 
     // When collective meta generation has landed, use
     // generateNewSmallTestData(m_TestData, 0, mpiRank, mpiSize);
@@ -262,6 +300,15 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypes)
                                   currentTestData.R32.size());
         io.DefineAttribute<double>(r64_Array, currentTestData.R64.data(),
                                    currentTestData.R64.size());
+        io.DefineAttribute<long double>(r128_Array, currentTestData.R128.data(),
+                                        currentTestData.R128.size());
+
+        io.DefineAttribute<std::complex<float>>(cr32_Array,
+                                                currentTestData.CR32.data(),
+                                                currentTestData.CR32.size());
+        io.DefineAttribute<std::complex<double>>(cr64_Array,
+                                                 currentTestData.CR64.data(),
+                                                 currentTestData.CR64.size());
 
         if (!engineName.empty())
         {
@@ -303,6 +350,12 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypes)
 
         auto attr_r32 = ioRead.InquireAttribute<float>(r32_Array);
         auto attr_r64 = ioRead.InquireAttribute<double>(r64_Array);
+        auto attr_r128 = ioRead.InquireAttribute<long double>(r128_Array);
+
+        auto attr_cr32 =
+            ioRead.InquireAttribute<std::complex<float>>(cr32_Array);
+        auto attr_cr64 =
+            ioRead.InquireAttribute<std::complex<double>>(cr64_Array);
 
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), s1_Array);
@@ -359,6 +412,21 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypes)
         ASSERT_EQ(attr_r64.Data().size() == 1, false);
         ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
 
+        EXPECT_TRUE(attr_r128);
+        ASSERT_EQ(attr_r128.Name(), r128_Array);
+        ASSERT_EQ(attr_r128.Data().size() == 1, false);
+        ASSERT_EQ(attr_r128.Type(), adios2::GetType<long double>());
+
+        EXPECT_TRUE(attr_cr32);
+        ASSERT_EQ(attr_cr32.Name(), cr32_Array);
+        ASSERT_EQ(attr_cr32.Data().size() == 1, false);
+        ASSERT_EQ(attr_cr32.Type(), adios2::GetType<std::complex<float>>());
+
+        EXPECT_TRUE(attr_cr64);
+        ASSERT_EQ(attr_cr64.Name(), cr64_Array);
+        ASSERT_EQ(attr_cr64.Data().size() == 1, false);
+        ASSERT_EQ(attr_cr64.Type(), adios2::GetType<std::complex<double>>());
+
         auto I8 = attr_i8.Data();
         auto I16 = attr_i16.Data();
         auto I32 = attr_i32.Data();
@@ -404,6 +472,9 @@ TEST_F(BPWriteReadAttributes, BPWriteReadSingleTypesVar)
     const std::string u64_Single = std::string("u64_Single_") + zero;
     const std::string r32_Single = std::string("r32_Single_") + zero;
     const std::string r64_Single = std::string("r64_Single_") + zero;
+    const std::string r128_Single = std::string("r128_Single_") + zero;
+    const std::string cr32_Single = std::string("cr32_Single_") + zero;
+    const std::string cr64_Single = std::string("cr64_Single_") + zero;
 
     // When collective meta generation has landed, use
     // generateNewSmallTestData(m_TestData, 0, mpiRank, mpiSize);
@@ -453,6 +524,13 @@ TEST_F(BPWriteReadAttributes, BPWriteReadSingleTypesVar)
                                   var.Name());
         io.DefineAttribute<double>(r64_Single, currentTestData.R64.front(),
                                    var.Name());
+        io.DefineAttribute<long double>(
+            r128_Single, currentTestData.R128.front(), var.Name());
+
+        io.DefineAttribute<std::complex<float>>(
+            cr32_Single, currentTestData.CR32.front(), var.Name());
+        io.DefineAttribute<std::complex<double>>(
+            cr64_Single, currentTestData.CR64.front(), var.Name());
 
         adios2::Engine engine = io.Open(fName, adios2::Mode::Write);
         engine.Put(var, 10);
@@ -490,6 +568,13 @@ TEST_F(BPWriteReadAttributes, BPWriteReadSingleTypesVar)
 
         auto attr_r32 = ioRead.InquireAttribute<float>(r32_Single, var.Name());
         auto attr_r64 = ioRead.InquireAttribute<double>(r64_Single, var.Name());
+        auto attr_r128 =
+            ioRead.InquireAttribute<long double>(r128_Single, var.Name());
+
+        auto attr_cr32 = ioRead.InquireAttribute<std::complex<float>>(
+            cr32_Single, var.Name());
+        auto attr_cr64 = ioRead.InquireAttribute<std::complex<double>>(
+            cr64_Single, var.Name());
 
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), var.Name() + separator + s1_Single);
@@ -557,6 +642,24 @@ TEST_F(BPWriteReadAttributes, BPWriteReadSingleTypesVar)
         ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
         ASSERT_EQ(attr_r64.Data().front(), currentTestData.R64.front());
 
+        EXPECT_TRUE(attr_r128);
+        ASSERT_EQ(attr_r128.Name(), var.Name() + separator + r128_Single);
+        ASSERT_EQ(attr_r128.Data().size() == 1, true);
+        ASSERT_EQ(attr_r128.Type(), adios2::GetType<long double>());
+        ASSERT_EQ(attr_r128.Data().front(), currentTestData.R128.front());
+
+        EXPECT_TRUE(attr_cr32);
+        ASSERT_EQ(attr_cr32.Name(), var.Name() + separator + cr32_Single);
+        ASSERT_EQ(attr_cr32.Data().size() == 1, true);
+        ASSERT_EQ(attr_cr32.Type(), adios2::GetType<std::complex<float>>());
+        ASSERT_EQ(attr_cr32.Data().front(), currentTestData.CR32.front());
+
+        EXPECT_TRUE(attr_cr64);
+        ASSERT_EQ(attr_cr64.Name(), var.Name() + separator + cr64_Single);
+        ASSERT_EQ(attr_cr64.Data().size() == 1, true);
+        ASSERT_EQ(attr_cr64.Type(), adios2::GetType<std::complex<double>>());
+        ASSERT_EQ(attr_cr64.Data().front(), currentTestData.CR64.front());
+
         bpRead.Close();
     }
 }
@@ -585,6 +688,9 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypesVar)
     const std::string u64_Array = std::string("u64_Array_") + zero;
     const std::string r32_Array = std::string("r32_Array_") + zero;
     const std::string r64_Array = std::string("r64_Array_") + zero;
+    const std::string r128_Array = std::string("r128_Array_") + zero;
+    const std::string cr32_Array = std::string("cr32_Array_") + zero;
+    const std::string cr64_Array = std::string("cr64_Array_") + zero;
 
     const std::string separator = "/";
 
@@ -627,6 +733,16 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypesVar)
                                   currentTestData.R32.size(), var.Name());
         io.DefineAttribute<double>(r64_Array, currentTestData.R64.data(),
                                    currentTestData.R64.size(), var.Name());
+        io.DefineAttribute<long double>(r128_Array, currentTestData.R128.data(),
+                                        currentTestData.R128.size(),
+                                        var.Name());
+
+        io.DefineAttribute<std::complex<float>>(
+            cr32_Array, currentTestData.CR32.data(),
+            currentTestData.CR32.size(), var.Name());
+        io.DefineAttribute<std::complex<double>>(
+            cr64_Array, currentTestData.CR64.data(),
+            currentTestData.CR64.size(), var.Name());
 
         if (!engineName.empty())
         {
@@ -673,6 +789,13 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypesVar)
 
         auto attr_r32 = ioRead.InquireAttribute<float>(r32_Array, var.Name());
         auto attr_r64 = ioRead.InquireAttribute<double>(r64_Array, var.Name());
+        auto attr_r128 =
+            ioRead.InquireAttribute<long double>(r128_Array, var.Name());
+
+        auto attr_cr32 = ioRead.InquireAttribute<std::complex<float>>(
+            cr32_Array, var.Name());
+        auto attr_cr64 = ioRead.InquireAttribute<std::complex<double>>(
+            cr64_Array, var.Name());
 
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), var.Name() + separator + s1_Array);
@@ -728,6 +851,21 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypesVar)
         ASSERT_EQ(attr_r64.Name(), var.Name() + separator + r64_Array);
         ASSERT_EQ(attr_r64.Data().size() == 1, false);
         ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
+
+        EXPECT_TRUE(attr_r128);
+        ASSERT_EQ(attr_r128.Name(), var.Name() + separator + r128_Array);
+        ASSERT_EQ(attr_r128.Data().size() == 1, false);
+        ASSERT_EQ(attr_r128.Type(), adios2::GetType<long double>());
+
+        EXPECT_TRUE(attr_cr32);
+        ASSERT_EQ(attr_cr32.Name(), var.Name() + separator + cr32_Array);
+        ASSERT_EQ(attr_cr32.Data().size() == 1, false);
+        ASSERT_EQ(attr_cr32.Type(), adios2::GetType<std::complex<float>>());
+
+        EXPECT_TRUE(attr_cr64);
+        ASSERT_EQ(attr_cr64.Name(), var.Name() + separator + cr64_Array);
+        ASSERT_EQ(attr_cr64.Data().size() == 1, false);
+        ASSERT_EQ(attr_cr64.Type(), adios2::GetType<std::complex<double>>());
 
         auto I8 = attr_i8.Data();
         auto I16 = attr_i16.Data();


### PR DESCRIPTION
This enables support for complex attribute types, just as in ADIOS1.

See request in #1908

- [x] add tests