### PR TITLE
core: Re-implement IO::Open with an internal engine factory

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -229,6 +229,7 @@ endif()
 
 if(ADIOS2_HAVE_MPI)
   target_sources(adios2 PRIVATE
+    core/IOMPI.cpp
     helper/adiosCommMPI.h  helper/adiosCommMPI.cpp
     engine/insitumpi/InSituMPIWriter.cpp engine/insitumpi/InSituMPIWriter.tcc
     engine/insitumpi/InSituMPIReader.cpp engine/insitumpi/InSituMPIReader.tcc
@@ -252,6 +253,7 @@ if(ADIOS2_HAVE_HDF5)
       )
   endif()
   if(HDF5_IS_PARALLEL)
+    set_property(SOURCE core/IOMPI.cpp APPEND PROPERTY COMPILE_DEFINITIONS ADIOS2_HAVE_HDF5_PARALLEL)
     target_sources(adios2 PRIVATE
       toolkit/interop/hdf5/HDF5CommonMPI.cpp
       )

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -238,30 +238,26 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 if(ADIOS2_HAVE_HDF5)
+  target_sources(adios2 PRIVATE
+    engine/hdf5/HDF5ReaderP.cpp
+    engine/hdf5/HDF5WriterP.cpp
+    toolkit/interop/hdf5/HDF5Common.cpp toolkit/interop/hdf5/HDF5Common.tcc
+    )
+  if(NOT HDF5_VERSION VERSION_LESS 1.11)
+    target_sources(adios2 PRIVATE
+      engine/mixer/HDFMixer.cpp
+      engine/mixer/HDFMixer.tcc
+      engine/mixer/HDFMixerWriter.cpp
+      )
+  endif()
+
+  target_link_libraries(adios2 PRIVATE ${HDF5_C_LIBRARIES})
+
   if(HDF5_C_INCLUDE_DIRS)
     target_include_directories(adios2 PRIVATE ${HDF5_C_INCLUDE_DIRS})
   else()
     target_include_directories(adios2 PRIVATE ${HDF5_INCLUDE_DIRS})
   endif()
-
-  if(HDF5_VERSION VERSION_LESS 1.11)
-    target_sources(adios2 PRIVATE
-      engine/hdf5/HDF5ReaderP.cpp
-      engine/hdf5/HDF5WriterP.cpp
-      toolkit/interop/hdf5/HDF5Common.cpp toolkit/interop/hdf5/HDF5Common.tcc
-    )  
-  else()
-    target_sources(adios2 PRIVATE
-      engine/hdf5/HDF5ReaderP.cpp
-      engine/hdf5/HDF5WriterP.cpp
-      engine/mixer/HDFMixer.cpp	
-      engine/mixer/HDFMixer.tcc
-      engine/mixer/HDFMixerWriter.cpp
-      toolkit/interop/hdf5/HDF5Common.cpp toolkit/interop/hdf5/HDF5Common.tcc
-    )
-  endif()
-
-  target_link_libraries(adios2 PRIVATE ${HDF5_C_LIBRARIES})
 endif()
 
 # Set library version information

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -250,6 +250,11 @@ if(ADIOS2_HAVE_HDF5)
       engine/mixer/HDFMixerWriter.cpp
       )
   endif()
+  if(HDF5_IS_PARALLEL)
+    target_sources(adios2 PRIVATE
+      toolkit/interop/hdf5/HDF5CommonMPI.cpp
+      )
+  endif()
 
   target_link_libraries(adios2 PRIVATE ${HDF5_C_LIBRARIES})
 

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -239,6 +239,7 @@ endif()
 
 if(ADIOS2_HAVE_HDF5)
   target_sources(adios2 PRIVATE
+    core/IOHDF5.cpp
     engine/hdf5/HDF5ReaderP.cpp
     engine/hdf5/HDF5WriterP.cpp
     toolkit/interop/hdf5/HDF5Common.cpp toolkit/interop/hdf5/HDF5Common.tcc

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -38,28 +38,9 @@
 #include "adios2/engine/dataman/DataManWriter.h"
 #endif
 
-#ifdef ADIOS2_HAVE_SSC // external dependencies
-#include "adios2/engine/ssc/SscReader.h"
-#include "adios2/engine/ssc/SscWriter.h"
-#endif
-
-#ifdef ADIOS2_HAVE_TABLE // external dependencies
-#include "adios2/engine/table/TableWriter.h"
-#endif
-
 #ifdef ADIOS2_HAVE_SST // external dependencies
 #include "adios2/engine/sst/SstReader.h"
 #include "adios2/engine/sst/SstWriter.h"
-#endif
-
-#ifdef ADIOS2_HAVE_DATASPACES // external dependencies
-#include "adios2/engine/dataspaces/DataSpacesReader.h"
-#include "adios2/engine/dataspaces/DataSpacesWriter.h"
-#endif
-
-#ifdef ADIOS2_HAVE_MPI // external dependencies
-#include "adios2/engine/insitumpi/InSituMPIReader.h"
-#include "adios2/engine/insitumpi/InSituMPIWriter.h"
 #endif
 
 namespace adios2
@@ -95,25 +76,10 @@ std::unordered_map<std::string, IO::EngineFactoryEntry> Factory = {
                        "DataMan library, can't use DataMan engine\n")
 #endif
     },
-    {"ssc",
-#ifdef ADIOS2_HAVE_SSC
-     {IO::MakeEngine<engine::SscReader>, IO::MakeEngine<engine::SscWriter>}
-#else
-     IO::NoEngineEntry("ERROR: this version didn't compile with "
-                       "SSC library, can't use SSC engine\n")
-#endif
-    },
-    {"table",
-#ifdef ADIOS2_HAVE_TABLE
-     {IO::NoEngine("ERROR: Table engine only supports Write. It uses other "
-                   "engines as backend. Please use corresponding engines for "
-                   "Read\n"),
-      IO::MakeEngine<engine::TableWriter>}
-#else
-     IO::NoEngineEntry("ERROR: this version didn't compile with "
-                       "Table library, can't use Table engine\n")
-#endif
-    },
+    {"ssc", IO::NoEngineEntry("ERROR: this version didn't compile with "
+                              "SSC library, can't use SSC engine\n")},
+    {"table", IO::NoEngineEntry("ERROR: this version didn't compile with "
+                                "Table library, can't use Table engine\n")},
     {"sst",
 #ifdef ADIOS2_HAVE_SST
      {IO::MakeEngine<engine::SstReader>, IO::MakeEngine<engine::SstWriter>}
@@ -131,14 +97,8 @@ std::unordered_map<std::string, IO::EngineFactoryEntry> Factory = {
 #endif
     },
     {"dataspaces",
-#ifdef ADIOS2_HAVE_DATASPACES
-     {IO::MakeEngine<engine::DataSpacesReader>,
-      IO::MakeEngine<engine::DataSpacesWriter>}
-#else
      IO::NoEngineEntry("ERROR: this version didn't compile with "
-                       "DataSpaces library, can't use DataSpaces engine\n")
-#endif
-    },
+                       "DataSpaces library, can't use DataSpaces engine\n")},
     {"hdf5",
 #ifdef ADIOS2_HAVE_HDF5
      IO_MakeEngine_HDF5()
@@ -147,15 +107,8 @@ std::unordered_map<std::string, IO::EngineFactoryEntry> Factory = {
                        "HDF5 library, can't use HDF5 engine\n")
 #endif
     },
-    {"insitumpi",
-#ifdef ADIOS2_HAVE_MPI
-     {IO::MakeEngine<engine::InSituMPIReader>,
-      IO::MakeEngine<engine::InSituMPIWriter>}
-#else
-     IO::NoEngineEntry("ERROR: this version didn't compile with "
-                       "MPI, can't use InSituMPI engine\n")
-#endif
-    },
+    {"insitumpi", IO::NoEngineEntry("ERROR: this version didn't compile with "
+                                    "MPI, can't use InSituMPI engine\n")},
     {"skeleton",
      {IO::MakeEngine<engine::SkeletonReader>,
       IO::MakeEngine<engine::SkeletonWriter>}},

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -57,14 +57,6 @@
 #include "adios2/engine/dataspaces/DataSpacesWriter.h"
 #endif
 
-#ifdef ADIOS2_HAVE_HDF5 // external dependencies
-#include "adios2/engine/hdf5/HDF5ReaderP.h"
-#include "adios2/engine/hdf5/HDF5WriterP.h"
-#if H5_VERSION_GE(1, 11, 0)
-#include "adios2/engine/mixer/HDFMixer.h"
-#endif
-#endif
-
 #ifdef ADIOS2_HAVE_MPI // external dependencies
 #include "adios2/engine/insitumpi/InSituMPIReader.h"
 #include "adios2/engine/insitumpi/InSituMPIWriter.h"
@@ -74,6 +66,9 @@ namespace adios2
 {
 namespace core
 {
+
+IO::EngineFactoryEntry IO_MakeEngine_HDFMixer();
+IO::EngineFactoryEntry IO_MakeEngine_HDF5();
 
 namespace
 {
@@ -85,11 +80,7 @@ std::unordered_map<std::string, IO::EngineFactoryEntry> Factory = {
      {IO::MakeEngine<engine::BP4Reader>, IO::MakeEngine<engine::BP4Writer>}},
     {"hdfmixer",
 #ifdef ADIOS2_HAVE_HDF5
-#if H5_VERSION_GE(1, 11, 0)
-     {IO::MakeEngine<engine::HDF5ReaderP>, IO::MakeEngine<engine::HDFMixer>}
-#else
-     IO::NoEngineEntry("ERROR: update HDF5 >= 1.11 to support VDS.")
-#endif
+     IO_MakeEngine_HDFMixer()
 #else
      IO::NoEngineEntry("ERROR: this version didn't compile with "
                        "HDF5 library, can't use HDF5 engine\n")
@@ -150,7 +141,7 @@ std::unordered_map<std::string, IO::EngineFactoryEntry> Factory = {
     },
     {"hdf5",
 #ifdef ADIOS2_HAVE_HDF5
-     {IO::MakeEngine<engine::HDF5ReaderP>, IO::MakeEngine<engine::HDF5WriterP>}
+     IO_MakeEngine_HDF5()
 #else
      IO::NoEngineEntry("ERROR: this version didn't compile with "
                        "HDF5 library, can't use HDF5 engine\n")

--- a/source/adios2/core/IOHDF5.cpp
+++ b/source/adios2/core/IOHDF5.cpp
@@ -1,0 +1,38 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * IOHDF5.cpp: HDF5-specific IO engine factory
+ */
+
+#include "IO.h"
+
+#include "adios2/engine/hdf5/HDF5ReaderP.h"
+#include "adios2/engine/hdf5/HDF5WriterP.h"
+#if H5_VERSION_GE(1, 11, 0)
+#include "adios2/engine/mixer/HDFMixer.h"
+#endif
+
+namespace adios2
+{
+namespace core
+{
+
+IO::EngineFactoryEntry IO_MakeEngine_HDFMixer()
+{
+#if H5_VERSION_GE(1, 11, 0)
+    return IO::EngineFactoryEntry{IO::MakeEngine<engine::HDF5ReaderP>,
+                                  IO::MakeEngine<engine::HDFMixer>};
+#else
+    return IO::NoEngineEntry("ERROR: update HDF5 >= 1.11 to support VDS.");
+#endif
+}
+
+IO::EngineFactoryEntry IO_MakeEngine_HDF5()
+{
+    return IO::EngineFactoryEntry{IO::MakeEngine<engine::HDF5ReaderP>,
+                                  IO::MakeEngine<engine::HDF5WriterP>};
+}
+
+} // end namespace core
+} // end namespace adios2

--- a/source/adios2/core/IOHDF5.cpp
+++ b/source/adios2/core/IOHDF5.cpp
@@ -18,11 +18,30 @@ namespace adios2
 namespace core
 {
 
+namespace
+{
+
+template <typename T>
+std::shared_ptr<Engine> MakeEngineHDF5(IO &io, const std::string &name,
+                                       const Mode mode, helper::Comm comm)
+{
+#ifndef H5_HAVE_PARALLEL
+    if (comm.IsMPI())
+    {
+        throw std::invalid_argument("A serial HDF5 engine cannot be used "
+                                    "with a communicator that is MPI-based.");
+    }
+#endif
+    return IO::MakeEngine<T>(io, name, mode, std::move(comm));
+}
+
+} // end anonymous namespace
+
 IO::EngineFactoryEntry IO_MakeEngine_HDFMixer()
 {
 #if H5_VERSION_GE(1, 11, 0)
-    return IO::EngineFactoryEntry{IO::MakeEngine<engine::HDF5ReaderP>,
-                                  IO::MakeEngine<engine::HDFMixer>};
+    return IO::EngineFactoryEntry{MakeEngineHDF5<engine::HDF5ReaderP>,
+                                  MakeEngineHDF5<engine::HDFMixer>};
 #else
     return IO::NoEngineEntry("ERROR: update HDF5 >= 1.11 to support VDS.");
 #endif
@@ -30,8 +49,8 @@ IO::EngineFactoryEntry IO_MakeEngine_HDFMixer()
 
 IO::EngineFactoryEntry IO_MakeEngine_HDF5()
 {
-    return IO::EngineFactoryEntry{IO::MakeEngine<engine::HDF5ReaderP>,
-                                  IO::MakeEngine<engine::HDF5WriterP>};
+    return IO::EngineFactoryEntry{MakeEngineHDF5<engine::HDF5ReaderP>,
+                                  MakeEngineHDF5<engine::HDF5WriterP>};
 }
 
 } // end namespace core

--- a/source/adios2/core/IOMPI.cpp
+++ b/source/adios2/core/IOMPI.cpp
@@ -1,0 +1,100 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * IOMPI.cpp : MPI-specific IO engine factory registration
+ */
+
+#include "IO.h"
+
+#include "adios2/helper/adiosCommMPI.h"
+
+#include "adios2/engine/insitumpi/InSituMPIReader.h"
+#include "adios2/engine/insitumpi/InSituMPIWriter.h"
+
+#ifdef ADIOS2_HAVE_SSC // external dependencies
+#include "adios2/engine/ssc/SscReader.h"
+#include "adios2/engine/ssc/SscWriter.h"
+#endif
+
+#ifdef ADIOS2_HAVE_TABLE // external dependencies
+#include "adios2/engine/table/TableWriter.h"
+#endif
+
+#ifdef ADIOS2_HAVE_DATASPACES // external dependencies
+#include "adios2/engine/dataspaces/DataSpacesReader.h"
+#include "adios2/engine/dataspaces/DataSpacesWriter.h"
+#endif
+
+namespace adios2
+{
+
+#if defined(ADIOS2_HAVE_HDF5_PARALLEL)
+namespace interop
+{
+void RegisterHDF5Common_MPI_API();
+} // namespace interop
+#endif
+
+namespace core
+{
+
+namespace
+{
+template <typename T>
+std::shared_ptr<Engine> MakeEngineMPI(IO &io, const std::string &name,
+                                      const Mode mode, helper::Comm comm)
+{
+    if (!comm.IsMPI())
+    {
+        throw std::invalid_argument("A MPI-only engine cannot be used with a "
+                                    "communicator that is not MPI-based.");
+    }
+    return IO::MakeEngine<T>(io, name, mode, std::move(comm));
+}
+struct ThrowError
+{
+    std::shared_ptr<Engine> operator()(IO &, const std::string &, const Mode,
+                                       helper::Comm) const
+    {
+        throw std::invalid_argument(Err);
+    }
+    std::string Err;
+};
+
+}
+
+void RegisterMPIEngines()
+{
+    IO::RegisterEngine(
+        "insitumpi",
+        IO::EngineFactoryEntry{MakeEngineMPI<engine::InSituMPIReader>,
+                               MakeEngineMPI<engine::InSituMPIWriter>});
+#ifdef ADIOS2_HAVE_SSC
+    IO::RegisterEngine(
+        "ssc", IO::EngineFactoryEntry{MakeEngineMPI<engine::SscReader>,
+                                      MakeEngineMPI<engine::SscWriter>});
+#endif
+#ifdef ADIOS2_HAVE_TABLE
+    IO::RegisterEngine(
+        "table",
+        IO::EngineFactoryEntry{
+            ThrowError{
+                "ERROR: Table engine only supports Write. It uses other "
+                "engines as backend. Please use corresponding engines for "
+                "Read\n"},
+            MakeEngineMPI<engine::TableWriter>});
+#endif
+#ifdef ADIOS2_HAVE_DATASPACES
+    IO::RegisterEngine(
+        "dataspaces",
+        IO::EngineFactoryEntry{MakeEngineMPI<engine::DataSpacesReader>,
+                               MakeEngineMPI<engine::DataSpacesWriter>});
+#endif
+#if defined(ADIOS2_HAVE_HDF5_PARALLEL)
+    interop::RegisterHDF5Common_MPI_API();
+#endif
+}
+
+} // end namespace core
+} // end namespace adios2

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -74,6 +74,8 @@ int Comm::Rank() const { return m_Impl->Rank(); }
 
 int Comm::Size() const { return m_Impl->Size(); }
 
+bool Comm::IsMPI() const { return m_Impl->IsMPI(); }
+
 void Comm::Barrier(const std::string &hint) const { m_Impl->Barrier(hint); }
 
 std::string Comm::BroadcastFile(const std::string &fileName,

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -121,6 +121,11 @@ public:
     int Rank() const;
     int Size() const;
 
+    /**
+     * @brief Return true if the communicator is backed by MPI, false otherwise.
+     */
+    bool IsMPI() const;
+
     void Barrier(const std::string &hint = std::string()) const;
 
     /**
@@ -361,6 +366,7 @@ public:
     virtual std::unique_ptr<CommImpl> World(const std::string &hint) const = 0;
     virtual int Rank() const = 0;
     virtual int Size() const = 0;
+    virtual bool IsMPI() const = 0;
     virtual void Barrier(const std::string &hint) const = 0;
     virtual void Allgather(const void *sendbuf, size_t sendcount,
                            Datatype sendtype, void *recvbuf, size_t recvcount,

--- a/source/adios2/helper/adiosCommDummy.cpp
+++ b/source/adios2/helper/adiosCommDummy.cpp
@@ -52,6 +52,7 @@ public:
 
     int Rank() const override;
     int Size() const override;
+    bool IsMPI() const override;
     void Barrier(const std::string &hint) const override;
 
     void Allgather(const void *sendbuf, size_t sendcount, Datatype sendtype,
@@ -121,6 +122,8 @@ std::unique_ptr<CommImpl> CommImplDummy::World(const std::string &) const
 int CommImplDummy::Rank() const { return 0; }
 
 int CommImplDummy::Size() const { return 1; }
+
+bool CommImplDummy::IsMPI() const { return false; }
 
 void CommImplDummy::Barrier(const std::string &) const {}
 

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -21,9 +21,9 @@
 
 namespace adios2
 {
-namespace interop
+namespace core
 {
-void RegisterHDF5Common_MPI_API();
+void RegisterMPIEngines();
 }
 namespace helper
 {
@@ -32,7 +32,7 @@ namespace
 {
 struct InitMPI
 {
-    InitMPI() { interop::RegisterHDF5Common_MPI_API(); }
+    InitMPI() { core::RegisterMPIEngines(); }
 };
 
 const MPI_Op OpToMPI[] = {

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -21,11 +21,19 @@
 
 namespace adios2
 {
+namespace interop
+{
+void RegisterHDF5Common_MPI_API();
+}
 namespace helper
 {
 
 namespace
 {
+struct InitMPI
+{
+    InitMPI() { interop::RegisterHDF5Common_MPI_API(); }
+};
 
 const MPI_Op OpToMPI[] = {
     MPI_OP_NULL, MPI_MAX,    MPI_MIN,    MPI_SUM,     MPI_PROD,
@@ -532,6 +540,7 @@ Comm::Status CommReqImplMPI::Wait(const std::string &hint)
 
 Comm CommFromMPI(MPI_Comm mpiComm)
 {
+    static InitMPI const initMPI;
     if (mpiComm == MPI_COMM_NULL)
     {
         return CommDummy();

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -125,6 +125,7 @@ public:
 
     int Rank() const override;
     int Size() const override;
+    bool IsMPI() const override;
     void Barrier(const std::string &hint) const override;
 
     void Allgather(const void *sendbuf, size_t sendcount, Datatype sendtype,
@@ -229,6 +230,8 @@ int CommImplMPI::Size() const
     CheckMPIReturn(MPI_Comm_size(m_MPIComm, &size), {});
     return size;
 }
+
+bool CommImplMPI::IsMPI() const { return true; }
 
 void CommImplMPI::Barrier(const std::string &hint) const
 {

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -194,6 +194,12 @@ public:
 
     bool m_IsGeneratedByAdios = false;
 
+    struct MPI_API
+    {
+        bool (*init)(helper::Comm const &comm, hid_t id, int *rank, int *size);
+        herr_t (*set_dxpl_mpio)(hid_t dxpl_id, H5FD_mpio_xfer_t xfer_mode);
+    };
+
 private:
     void ReadInStringAttr(core::IO &io, const std::string &attrName,
                           hid_t attrId, hid_t h5Type, hid_t sid);
@@ -210,6 +216,7 @@ private:
     bool m_WriteMode = false;
     unsigned int m_NumAdiosSteps = 0;
 
+    MPI_API const *m_MPI = nullptr;
     int m_CommRank = 0;
     int m_CommSize = 1;
 

--- a/source/adios2/toolkit/interop/hdf5/HDF5CommonMPI.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5CommonMPI.cpp
@@ -1,0 +1,58 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * HDF5CommonMPI.cpp : MPI-specific HDF5 engine functionality
+ */
+
+#include "adios2/helper/adiosCommMPI.h"
+
+#include "adios2/toolkit/interop/hdf5/HDF5Common.h"
+
+#include <mutex>
+
+namespace adios2
+{
+
+namespace interop
+{
+
+namespace
+{
+
+bool init(helper::Comm const &comm, hid_t id, int *rank, int *size)
+{
+    MPI_Comm mpiComm = helper::CommAsMPI(comm);
+    if (mpiComm == MPI_COMM_NULL)
+    {
+        return false;
+    }
+    MPI_Comm_rank(mpiComm, rank);
+    MPI_Comm_size(mpiComm, size);
+    if (*size != 1)
+    {
+        H5Pset_fapl_mpio(id, mpiComm, MPI_INFO_NULL);
+    }
+    return true;
+}
+
+herr_t set_dxpl_mpio(hid_t dxpl_id, H5FD_mpio_xfer_t xfer_mode)
+{
+    return H5Pset_dxpl_mpio(dxpl_id, xfer_mode);
+}
+
+HDF5Common::MPI_API HDF5Common_MPI_API_Impl = {&init, &set_dxpl_mpio};
+
+} // end anonymous namespace
+
+extern std::mutex HDF5Common_MPI_API_Mutex;
+extern HDF5Common::MPI_API const *HDF5Common_MPI_API;
+
+void RegisterHDF5Common_MPI_API()
+{
+    std::lock_guard<std::mutex> guard(HDF5Common_MPI_API_Mutex);
+    HDF5Common_MPI_API = &HDF5Common_MPI_API_Impl;
+}
+
+} // namespace interop
+} // end namespace adios2


### PR DESCRIPTION
Replace the hard-coded cascading-if table of engine construction with a factory using runtime lookup.  This will be useful for runtime registration of optional engines.

Split registration of IO factory entries.  Register serial engines statically.  Add runtime registration of MPI engines that are guaranteed to be available if the application creates a MPI-backed ADIOS communicator.

The HDF5 engine is special in that it is serial or parallel based on how HDF5 itself was built.  Register it only as one or the other.  Teach the HDF5 engine factory function to create the engine only when using the matching kind of communicator.

The SST engine also supports working with or without MPI.  Leave it registered statically for now.  Later the two variants can be split.
