### PR TITLE
bindings: Always provide non-MPI constructors

### DIFF
--- a/bindings/C/adios2/c/adios2_c_adios.cpp
+++ b/bindings/C/adios2/c/adios2_c_adios.cpp
@@ -24,9 +24,10 @@ extern "C" {
 #ifdef ADIOS2_HAVE_MPI
 
 // to be called from other languages, hidden from the public apis
-adios2_adios *adios2_init_config_glue(const char *config_file, MPI_Comm comm,
-                                      const adios2_debug_mode debug_mode,
-                                      const char *host_language)
+adios2_adios *adios2_init_config_glue_mpi(const char *config_file,
+                                          MPI_Comm comm,
+                                          const adios2_debug_mode debug_mode,
+                                          const char *host_language)
 {
     adios2_adios *adios = nullptr;
 
@@ -48,22 +49,22 @@ adios2_adios *adios2_init_config_glue(const char *config_file, MPI_Comm comm,
     return adios;
 }
 
-adios2_adios *adios2_init(MPI_Comm comm, const adios2_debug_mode debug_mode)
+adios2_adios *adios2_init_mpi(MPI_Comm comm, const adios2_debug_mode debug_mode)
 {
     return adios2_init_config("", comm, debug_mode);
 }
 
-adios2_adios *adios2_init_config(const char *config_file, MPI_Comm comm,
-                                 const adios2_debug_mode debug_mode)
+adios2_adios *adios2_init_config_mpi(const char *config_file, MPI_Comm comm,
+                                     const adios2_debug_mode debug_mode)
 {
-    return adios2_init_config_glue(config_file, comm, debug_mode, "C");
+    return adios2_init_config_glue_mpi(config_file, comm, debug_mode, "C");
 }
 
-#else
+#endif
 
-adios2_adios *adios2_init_config_glue(const char *config_file,
-                                      const adios2_debug_mode debug_mode,
-                                      const char *host_language)
+adios2_adios *adios2_init_config_glue_serial(const char *config_file,
+                                             const adios2_debug_mode debug_mode,
+                                             const char *host_language)
 {
     adios2_adios *adios = nullptr;
     try
@@ -83,17 +84,16 @@ adios2_adios *adios2_init_config_glue(const char *config_file,
     return adios;
 }
 
-adios2_adios *adios2_init(const adios2_debug_mode debug_mode)
+adios2_adios *adios2_init_serial(const adios2_debug_mode debug_mode)
 {
-    return adios2_init_config("", debug_mode);
+    return adios2_init_config_serial("", debug_mode);
 }
 
-adios2_adios *adios2_init_config(const char *config_file,
-                                 const adios2_debug_mode debug_mode)
+adios2_adios *adios2_init_config_serial(const char *config_file,
+                                        const adios2_debug_mode debug_mode)
 {
-    return adios2_init_config_glue("", debug_mode, "C");
+    return adios2_init_config_glue_serial("", debug_mode, "C");
 }
-#endif
 
 adios2_io *adios2_declare_io(adios2_adios *adios, const char *name)
 {

--- a/bindings/C/adios2/c/adios2_c_adios.h
+++ b/bindings/C/adios2/c/adios2_c_adios.h
@@ -22,6 +22,9 @@ extern "C" {
 #endif
 
 #ifdef ADIOS2_HAVE_MPI
+#define adios2_init adios2_init_mpi
+#define adios2_init_config adios2_init_config_mpi
+
 /**
  * Starting point for MPI apps. Creates an ADIOS handler.
  * MPI collective and it calls MPI_Comm_dup
@@ -30,7 +33,8 @@ extern "C" {
  * run without checking user-input (stable workflows)
  * @return success: handler, failure: NULL
  */
-adios2_adios *adios2_init(MPI_Comm comm, const adios2_debug_mode debug_mode);
+adios2_adios *adios2_init_mpi(MPI_Comm comm,
+                              const adios2_debug_mode debug_mode);
 
 /**
  * Starting point for MPI apps. Creates an ADIOS handler allowing a runtime
@@ -43,32 +47,33 @@ adios2_adios *adios2_init(MPI_Comm comm, const adios2_debug_mode debug_mode);
  * run without checking user-input (stable workflows)
  * @return success: handler, failure: NULL
  */
-adios2_adios *adios2_init_config(const char *config_file, MPI_Comm comm,
-                                 const adios2_debug_mode debug_mode);
-
+adios2_adios *adios2_init_config_mpi(const char *config_file, MPI_Comm comm,
+                                     const adios2_debug_mode debug_mode);
 #else
-
-/**
- * Initialize an ADIOS struct pointer handler in a serial, non-MPI application.
- * Doesn't require a runtime config file.
- * @param debug_mode adios2_debug_mode_on or adios2_debug_mode_off, adds extra
- * checking to user input to be captured by adios2_error. Use it for stable
- * workflows
- * @return success: handler, failure: NULL
- */
-adios2_adios *adios2_init(const adios2_debug_mode debug_mode);
-
-/**
- * Initialize an ADIOS struct pointer handler in a serial, non-MPI application.
- * Doesn't require a runtime config file.
- * @param debug_mode adios2_debug_mode_on or adios2_debug_mode_off, adds extra
- * checking to user input to be captured by adios2_error. Use it for stable
- * workflows
- * @return success: handler, failure: NULL
- */
-adios2_adios *adios2_init_config(const char *config_file,
-                                 const adios2_debug_mode debug_mode);
+#define adios2_init adios2_init_serial
+#define adios2_init_config adios2_init_config_serial
 #endif
+
+/**
+ * Initialize an ADIOS struct pointer handler in a serial, non-MPI application.
+ * Doesn't require a runtime config file.
+ * @param debug_mode adios2_debug_mode_on or adios2_debug_mode_off, adds extra
+ * checking to user input to be captured by adios2_error. Use it for stable
+ * workflows
+ * @return success: handler, failure: NULL
+ */
+adios2_adios *adios2_init_serial(const adios2_debug_mode debug_mode);
+
+/**
+ * Initialize an ADIOS struct pointer handler in a serial, non-MPI application.
+ * Doesn't require a runtime config file.
+ * @param debug_mode adios2_debug_mode_on or adios2_debug_mode_off, adds extra
+ * checking to user input to be captured by adios2_error. Use it for stable
+ * workflows
+ * @return success: handler, failure: NULL
+ */
+adios2_adios *adios2_init_config_serial(const char *config_file,
+                                        const adios2_debug_mode debug_mode);
 
 /**
  * Declares a new io handler

--- a/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstream.cpp
+++ b/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstream.cpp
@@ -34,8 +34,8 @@ fstream::fstream(const std::string &name, const openmode mode, MPI_Comm comm,
                                           ioInConfigFile, "C++"))
 {
 }
+#endif
 
-#else
 fstream::fstream(const std::string &name, const openmode mode,
                  const std::string engineType)
 : m_Stream(
@@ -50,7 +50,6 @@ fstream::fstream(const std::string &name, const openmode mode,
                                           ioInConfigFile, "C++"))
 {
 }
-#endif
 
 #ifdef ADIOS2_HAVE_MPI
 void fstream::open(const std::string &name, const openmode mode, MPI_Comm comm,
@@ -70,7 +69,8 @@ void fstream::open(const std::string &name, const openmode mode, MPI_Comm comm,
         name, ToMode(mode), helper::CommFromMPI(comm), configFile,
         ioInConfigFile, "C++");
 }
-#else
+#endif
+
 void fstream::open(const std::string &name, const openmode mode,
                    const std::string engineType)
 {
@@ -87,7 +87,6 @@ void fstream::open(const std::string &name, const openmode mode,
     m_Stream = std::make_shared<core::Stream>(name, ToMode(mode), configFile,
                                               ioInConfigFile, "C++");
 }
-#endif
 
 fstream::operator bool() const noexcept
 {

--- a/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstream.h
+++ b/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstream.h
@@ -81,7 +81,8 @@ public:
     fstream(const std::string &name, const adios2::fstream::openmode mode,
             MPI_Comm comm, const std::string &configFile,
             const std::string ioInConfigFile);
-#else
+#endif
+
     /**
      * High-level API non-MPI constructor, based on C++11 fstream. Allows for
      * passing parameters in source code.
@@ -108,7 +109,7 @@ public:
      */
     fstream(const std::string &name, const adios2::fstream::openmode mode,
             const std::string &configFile, const std::string ioInConfigFile);
-#endif
+
     /** Empty constructor, allows the use of open later in the code */
     fstream() = default;
 
@@ -149,7 +150,8 @@ public:
      */
     void open(const std::string &name, const openmode mode, MPI_Comm comm,
               const std::string configFile, const std::string ioInConfigFile);
-#else
+#endif
+
     /**
      * High-level API non-MPI open, based on C++11 fstream. Allows for
      * passing parameters in source code. Used after empty constructor.
@@ -176,7 +178,6 @@ public:
      */
     void open(const std::string &name, const openmode mode,
               const std::string configFile, const std::string ioInConfigFile);
-#endif
 
     /**
      * Set a single stream parameter based on Engine supported parameters.

--- a/bindings/Fortran/f2c/adios2_f2c_adios.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_adios.cpp
@@ -21,56 +21,58 @@ extern "C" {
 #ifdef ADIOS2_HAVE_MPI_F
 
 // this function is not exposed in the public APIs
-extern adios2_adios *adios2_init_config_glue(const char *config_file,
-                                             MPI_Comm comm,
-                                             const adios2_debug_mode debug_mode,
-                                             const char *host_language);
+extern adios2_adios *
+adios2_init_config_glue_mpi(const char *config_file, MPI_Comm comm,
+                            const adios2_debug_mode debug_mode,
+                            const char *host_language);
 
-void FC_GLOBAL(adios2_init_config_f2c,
-               ADIOS2_INIT_CONFIG_F2C)(adios2_adios **adios,
-                                       const char *config_file, MPI_Fint *comm,
-                                       const int *debug_mode, int *ierr)
+void FC_GLOBAL(adios2_init_config_mpi_f2c,
+               ADIOS2_INIT_CONFIG_MPI_F2C)(adios2_adios **adios,
+                                           const char *config_file,
+                                           MPI_Fint *comm,
+                                           const int *debug_mode, int *ierr)
 {
-    *adios = adios2_init_config_glue(
+    *adios = adios2_init_config_glue_mpi(
         config_file, MPI_Comm_f2c(*comm),
         static_cast<adios2_debug_mode>(*debug_mode), "Fortran");
     *ierr = (*adios == NULL) ? static_cast<int>(adios2_error_exception)
                              : static_cast<int>(adios2_error_none);
 }
 
-void FC_GLOBAL(adios2_init_f2c,
-               ADIOS2_INIT_F2C)(adios2_adios **adios, MPI_Fint *comm,
-                                const int *debug_mode, int *ierr)
+void FC_GLOBAL(adios2_init_mpi_f2c,
+               ADIOS2_INIT_MPI_F2C)(adios2_adios **adios, MPI_Fint *comm,
+                                    const int *debug_mode, int *ierr)
 {
-    FC_GLOBAL(adios2_init_config_f2c, ADIOS2_INIT_CONFIG_F2C)
+    FC_GLOBAL(adios2_init_config_mpi_f2c, ADIOS2_INIT_CONFIG_MPI_F2C)
     (adios, "", comm, debug_mode, ierr);
 }
-#else
+
+#endif
 
 // this function is not exposed in the public APIs
-extern adios2_adios *adios2_init_config_glue(const char *config_file,
-                                             const adios2_debug_mode debug_mode,
-                                             const char *host_language);
+extern adios2_adios *
+adios2_init_config_glue_serial(const char *config_file,
+                               const adios2_debug_mode debug_mode,
+                               const char *host_language);
 
-void FC_GLOBAL(adios2_init_config_f2c,
-               ADIOS2_INIT_CONFIG_F2C)(adios2_adios **adios,
-                                       const char *config_file,
-                                       const int *debug_mode, int *ierr)
+void FC_GLOBAL(adios2_init_config_serial_f2c,
+               ADIOS2_INIT_CONFIG_SERIAL_F2C)(adios2_adios **adios,
+                                              const char *config_file,
+                                              const int *debug_mode, int *ierr)
 {
-    *adios = adios2_init_config_glue(
+    *adios = adios2_init_config_glue_serial(
         config_file, static_cast<adios2_debug_mode>(*debug_mode), "Fortran");
     *ierr = (*adios == NULL) ? static_cast<int>(adios2_error_exception)
                              : static_cast<int>(adios2_error_none);
 }
 
-void FC_GLOBAL(adios2_init_f2c, ADIOS2_INIT_F2C)(adios2_adios **adios,
-                                                 const int *debug_mode,
-                                                 int *ierr)
+void FC_GLOBAL(adios2_init_serial_f2c,
+               ADIOS2_INIT_SERIAL_F2C)(adios2_adios **adios,
+                                       const int *debug_mode, int *ierr)
 {
-    FC_GLOBAL(adios2_init_config_f2c, ADIOS2_INIT_CONFIG_F2C)
+    FC_GLOBAL(adios2_init_config_serial_f2c, ADIOS2_INIT_CONFIG_SERIAL_F2C)
     (adios, "", debug_mode, ierr);
 }
-#endif
 
 void FC_GLOBAL(adios2_declare_io_f2c,
                ADIOS2_DECLARE_IO_F2C)(adios2_io **io, adios2_adios **adios,

--- a/bindings/Fortran/modules/mpi/adios2_adios_init_mod.f90
+++ b/bindings/Fortran/modules/mpi/adios2_adios_init_mod.f90
@@ -54,9 +54,9 @@ contains
         integer debug_mode
 
         debug_mode = adios2_LogicalToInt(adios2_debug_mode)
-        call adios2_init_config_f2c(adios%f2c, &
-                                    TRIM(ADJUSTL(config_file))//char(0), &
-                                    comm, debug_mode, ierr)
+        call adios2_init_config_mpi_f2c(adios%f2c, &
+                                        TRIM(ADJUSTL(config_file))//char(0), &
+                                        comm, debug_mode, ierr)
         if( ierr == 0 ) adios%valid = .true.
 
     end subroutine

--- a/bindings/Fortran/modules/nompi/adios2_adios_init_mod.f90
+++ b/bindings/Fortran/modules/nompi/adios2_adios_init_mod.f90
@@ -48,7 +48,7 @@ contains
         integer debug_mode
 
         debug_mode = adios2_LogicalToInt(adios2_debug_mode)
-        call adios2_init_config_f2c(adios%f2c, config_file, debug_mode, ierr)
+        call adios2_init_config_serial_f2c(adios%f2c, config_file, debug_mode, ierr)
         if( ierr == 0 ) adios%valid = .true.
 
     end subroutine


### PR DESCRIPTION
Applications should be able to choose non-MPI constructors even when
using an ADIOS with MPI support available:

* For `adios2::fstream` we can simply provide overloads with and without MPI.

* For C bindings, provide `adios2_init` and `adios2_init_config` variants
  named with `_serial` and `_mpi` suffixes.  Define the original names
  using macros to match the old interface provided based on whether MPI
  support is available.

* For Fortran bindings, update their implementation to cooperate with
  the C bindings correctly.  For now we continue to provide only the
  MPI-based or non-MPI-based module to Fortran.