### PR TITLE
WIP: Always reuse the incoming connection to the rank 0 reader

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -499,7 +499,6 @@ static int initWSReader(WS_ReaderInfo reader, int ReaderSize,
                 attr_list_from_string(reader_info[i]->ContactInfo);
         }
         reader->Connections[i].RemoteStreamID = reader_info[i]->ReaderID;
-        reader->Connections[i].CMconn = NULL;
     }
     if (Stream->ConfigParams->CPCommPattern == SstCPCommPeer)
     {
@@ -799,6 +798,12 @@ WS_ReaderInfo WriterParticipateInReaderOpen(SstStream Stream)
             // (only not NULL if this is writer rank 0)
             CMConnection_add_reference(conn);
             connections_to_reader[i].CMconn = conn;
+            CMconn_register_close_handler(conn, WriterConnCloseHandler,
+                                          (void *)CP_WSR_Stream);
+        }
+        else
+        {
+            connections_to_reader[i].CMconn = NULL;
         }
     }
 

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -739,7 +739,7 @@ WS_ReaderInfo WriterParticipateInReaderOpen(SstStream Stream)
     reader_data_t ReturnData;
     void *free_block = NULL;
     int WriterResponseCondition = -1;
-    CMConnection conn;
+    CMConnection conn = NULL;
     long MyStartingTimestep, GlobalStartingTimestep;
     WS_ReaderInfo CP_WSR_Stream = malloc(sizeof(*CP_WSR_Stream));
 
@@ -793,6 +793,13 @@ WS_ReaderInfo WriterParticipateInReaderOpen(SstStream Stream)
         connections_to_reader[i].ContactList = attrs;
         connections_to_reader[i].RemoteStreamID =
             ReturnData->CP_ReaderInfo[i]->ReaderID;
+        if ((i == 0) && (conn != NULL))
+        {
+            // reuse existing connection to reader rank 0
+            // (only not NULL if this is writer rank 0)
+            CMConnection_add_reference(conn);
+            connections_to_reader[i].CMconn = conn;
+        }
     }
 
     per_reader_Stream = Stream->DP_Interface->initWriterPerReader(


### PR DESCRIPTION
Always reuse the incoming connection to the rank 0 reader rather than using CMget_conn() to get a new one.  This is no real change with public IP on both sides because CMget_conn() should just return that incoming connection.  However if the reader is behind a NAT, CMget_conn() wouldn't work *and* initiating a new connection won't work either.  This will allow limited functionality for 1x1 staging with a private reader.

Currently creating the PR to run this through the sanitizers.