### PR TITLE
bindings: Factor out MPI-specific bindings into separate sources

### DIFF
--- a/bindings/C/CMakeLists.txt
+++ b/bindings/C/CMakeLists.txt
@@ -20,6 +20,13 @@ if(NOT MSVC)
   target_compile_features(adios2 PRIVATE ${ADIOS2_C99_FEATURES})
 endif()
 
+if(ADIOS2_HAVE_MPI)
+  target_sources(adios2 PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/adios2/c/adios2_c_adios_mpi.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/adios2/c/adios2_c_io_mpi.cpp
+    )
+endif()
+
 install(
   FILES adios2_c.h 
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/bindings/C/adios2/c/adios2_c_adios.cpp
+++ b/bindings/C/adios2/c/adios2_c_adios.cpp
@@ -13,53 +13,8 @@
 #include "adios2/core/ADIOS.h"
 #include "adios2/helper/adiosFunctions.h"
 
-#ifdef ADIOS2_HAVE_MPI
-#include "adios2/helper/adiosCommMPI.h"
-#endif
-
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifdef ADIOS2_HAVE_MPI
-
-// to be called from other languages, hidden from the public apis
-adios2_adios *adios2_init_config_glue_mpi(const char *config_file,
-                                          MPI_Comm comm,
-                                          const adios2_debug_mode debug_mode,
-                                          const char *host_language)
-{
-    adios2_adios *adios = nullptr;
-
-    try
-    {
-        adios2::helper::CheckForNullptr(
-            config_file,
-            "for config_file, in call to adios2_init or adios2_init_config");
-        const bool debugBool =
-            (debug_mode == adios2_debug_mode_on) ? true : false;
-        adios = reinterpret_cast<adios2_adios *>(new adios2::core::ADIOS(
-            config_file, adios2::helper::CommFromMPI(comm), debugBool,
-            host_language));
-    }
-    catch (...)
-    {
-        adios2::helper::ExceptionToError("adios2_init or adios2_init_config");
-    }
-    return adios;
-}
-
-adios2_adios *adios2_init_mpi(MPI_Comm comm, const adios2_debug_mode debug_mode)
-{
-    return adios2_init_config("", comm, debug_mode);
-}
-
-adios2_adios *adios2_init_config_mpi(const char *config_file, MPI_Comm comm,
-                                     const adios2_debug_mode debug_mode)
-{
-    return adios2_init_config_glue_mpi(config_file, comm, debug_mode, "C");
-}
-
 #endif
 
 adios2_adios *adios2_init_config_glue_serial(const char *config_file,

--- a/bindings/C/adios2/c/adios2_c_adios_mpi.cpp
+++ b/bindings/C/adios2/c/adios2_c_adios_mpi.cpp
@@ -1,0 +1,54 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adios2_c_adios_mpi.cpp : MPI-specific C bindings
+ */
+
+#include "adios2_c_adios.h"
+
+#include "adios2/core/ADIOS.h"
+#include "adios2/helper/adiosFunctions.h"
+
+#include "adios2/helper/adiosCommMPI.h"
+
+extern "C" {
+
+// to be called from other languages, hidden from the public apis
+adios2_adios *adios2_init_config_glue_mpi(const char *config_file,
+                                          MPI_Comm comm,
+                                          const adios2_debug_mode debug_mode,
+                                          const char *host_language)
+{
+    adios2_adios *adios = nullptr;
+
+    try
+    {
+        adios2::helper::CheckForNullptr(
+            config_file,
+            "for config_file, in call to adios2_init or adios2_init_config");
+        const bool debugBool =
+            (debug_mode == adios2_debug_mode_on) ? true : false;
+        adios = reinterpret_cast<adios2_adios *>(new adios2::core::ADIOS(
+            config_file, adios2::helper::CommFromMPI(comm), debugBool,
+            host_language));
+    }
+    catch (...)
+    {
+        adios2::helper::ExceptionToError("adios2_init or adios2_init_config");
+    }
+    return adios;
+}
+
+adios2_adios *adios2_init_mpi(MPI_Comm comm, const adios2_debug_mode debug_mode)
+{
+    return adios2_init_config_mpi("", comm, debug_mode);
+}
+
+adios2_adios *adios2_init_config_mpi(const char *config_file, MPI_Comm comm,
+                                     const adios2_debug_mode debug_mode)
+{
+    return adios2_init_config_glue_mpi(config_file, comm, debug_mode, "C");
+}
+
+} // end extern C

--- a/bindings/C/adios2/c/adios2_c_io.cpp
+++ b/bindings/C/adios2/c/adios2_c_io.cpp
@@ -9,16 +9,13 @@
  */
 
 #include "adios2_c_io.h"
+#include "adios2_c_io.tcc"
 
 #include <vector>
 
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosFunctions.h" //GetType<T>
 #include "adios2_c_internal.h"
-
-#ifdef ADIOS2_HAVE_MPI
-#include "adios2/helper/adiosCommMPI.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -674,34 +671,6 @@ adios2_error adios2_remove_all_attributes(adios2_io *io)
     }
 }
 
-namespace
-{
-
-adios2::Mode adios2_ToOpenMode(const adios2_mode modeC)
-{
-    adios2::Mode mode = adios2::Mode::Undefined;
-    switch (modeC)
-    {
-
-    case adios2_mode_write:
-        mode = adios2::Mode::Write;
-        break;
-
-    case adios2_mode_read:
-        mode = adios2::Mode::Read;
-        break;
-
-    case adios2_mode_append:
-        mode = adios2::Mode::Append;
-        break;
-
-    default:
-        break;
-    }
-    return mode;
-}
-} // end anonymous namespace
-
 adios2_engine *adios2_open(adios2_io *io, const char *name,
                            const adios2_mode mode)
 {
@@ -720,28 +689,6 @@ adios2_engine *adios2_open(adios2_io *io, const char *name,
     }
     return engine;
 }
-
-#ifdef ADIOS2_HAVE_MPI
-adios2_engine *adios2_open_new_comm(adios2_io *io, const char *name,
-                                    const adios2_mode mode, MPI_Comm comm)
-{
-    adios2_engine *engine = nullptr;
-    try
-    {
-        adios2::helper::CheckForNullptr(
-            io, "for adios2_io, in call to adios2_open");
-        engine = reinterpret_cast<adios2_engine *>(
-            &reinterpret_cast<adios2::core::IO *>(io)->Open(
-                name, adios2_ToOpenMode(mode),
-                adios2::helper::CommFromMPI(comm)));
-    }
-    catch (...)
-    {
-        adios2::helper::ExceptionToError("adios2_open_new_comm");
-    }
-    return engine;
-}
-#endif
 
 adios2_error adios2_flush_all_engines(adios2_io *io)
 {

--- a/bindings/C/adios2/c/adios2_c_io.tcc
+++ b/bindings/C/adios2/c/adios2_c_io.tcc
@@ -1,0 +1,42 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adios2_c_io.tcc
+ */
+
+#ifndef ADIOS2_BINDINGS_C_ADIOS2_C_IO_TCC_
+#define ADIOS2_BINDINGS_C_ADIOS2_C_IO_TCC_
+
+#include "adios2_c_io.h"
+
+#include "adios2/core/IO.h"
+
+namespace
+{
+adios2::Mode adios2_ToOpenMode(const adios2_mode modeC)
+{
+    adios2::Mode mode = adios2::Mode::Undefined;
+    switch (modeC)
+    {
+
+    case adios2_mode_write:
+        mode = adios2::Mode::Write;
+        break;
+
+    case adios2_mode_read:
+        mode = adios2::Mode::Read;
+        break;
+
+    case adios2_mode_append:
+        mode = adios2::Mode::Append;
+        break;
+
+    default:
+        break;
+    }
+    return mode;
+}
+} // end anonymous namespace
+
+#endif

--- a/bindings/C/adios2/c/adios2_c_io_mpi.cpp
+++ b/bindings/C/adios2/c/adios2_c_io_mpi.cpp
@@ -1,0 +1,41 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adios2_c_io_mpi.cpp : MPI-specific C bindings for IO
+ */
+
+#include "adios2_c_io.h"
+#include "adios2_c_io.tcc"
+
+#include <vector>
+
+#include "adios2/core/IO.h"
+#include "adios2/helper/adiosFunctions.h" //GetType<T>
+#include "adios2_c_internal.h"
+
+#include "adios2/helper/adiosCommMPI.h"
+
+extern "C" {
+
+adios2_engine *adios2_open_new_comm(adios2_io *io, const char *name,
+                                    const adios2_mode mode, MPI_Comm comm)
+{
+    adios2_engine *engine = nullptr;
+    try
+    {
+        adios2::helper::CheckForNullptr(
+            io, "for adios2_io, in call to adios2_open");
+        engine = reinterpret_cast<adios2_engine *>(
+            &reinterpret_cast<adios2::core::IO *>(io)->Open(
+                name, adios2_ToOpenMode(mode),
+                adios2::helper::CommFromMPI(comm)));
+    }
+    catch (...)
+    {
+        adios2::helper::ExceptionToError("adios2_open_new_comm");
+    }
+    return engine;
+}
+
+} // end extern C

--- a/bindings/CXX11/CMakeLists.txt
+++ b/bindings/CXX11/CMakeLists.txt
@@ -17,6 +17,13 @@ target_sources(adios2 PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/adios2/cxx11/Variable.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/adios2/cxx11/fstream/ADIOS2fstream.cpp
 )
+if(ADIOS2_HAVE_MPI)
+  target_sources(adios2 PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/adios2/cxx11/ADIOSMPI.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/adios2/cxx11/IOMPI.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/adios2/cxx11/fstream/ADIOS2fstreamMPI.cpp
+    )
+endif()
 
 target_include_directories(adios2
   PUBLIC

--- a/bindings/CXX11/adios2/cxx11/ADIOS.cpp
+++ b/bindings/CXX11/adios2/cxx11/ADIOS.cpp
@@ -12,24 +12,8 @@
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosFunctions.h" //CheckForNullptr
 
-#ifdef ADIOS2_HAVE_MPI
-#include "adios2/helper/adiosCommMPI.h"
-#endif
-
 namespace adios2
 {
-#ifdef ADIOS2_HAVE_MPI
-ADIOS::ADIOS(const std::string &configFile, MPI_Comm comm, const bool debugMode)
-: m_ADIOS(std::make_shared<core::ADIOS>(configFile, helper::CommFromMPI(comm),
-                                        debugMode, "C++"))
-{
-}
-
-ADIOS::ADIOS(MPI_Comm comm, const bool debugMode) : ADIOS("", comm, debugMode)
-{
-}
-
-#endif
 ADIOS::ADIOS(const std::string &configFile, const bool debugMode)
 : m_ADIOS(std::make_shared<core::ADIOS>(configFile, debugMode, "C++"))
 {

--- a/bindings/CXX11/adios2/cxx11/ADIOSMPI.cpp
+++ b/bindings/CXX11/adios2/cxx11/ADIOSMPI.cpp
@@ -1,0 +1,25 @@
+/* Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * ADIOSMPI.cpp : MPI constructors of public ADIOS class for C++11 bindings
+ */
+
+#include "ADIOS.h"
+
+#include "adios2/core/ADIOS.h"
+
+#include "adios2/helper/adiosCommMPI.h"
+
+namespace adios2
+{
+ADIOS::ADIOS(const std::string &configFile, MPI_Comm comm, const bool debugMode)
+: m_ADIOS(std::make_shared<core::ADIOS>(configFile, helper::CommFromMPI(comm),
+                                        debugMode, "C++"))
+{
+}
+
+ADIOS::ADIOS(MPI_Comm comm, const bool debugMode) : ADIOS("", comm, debugMode)
+{
+}
+
+} // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -13,10 +13,6 @@
 
 #include "adios2/core/IO.h"
 
-#ifdef ADIOS2_HAVE_MPI
-#include "adios2/helper/adiosCommMPI.h"
-#endif
-
 namespace adios2
 {
 
@@ -106,15 +102,6 @@ void IO::RemoveAllAttributes()
     helper::CheckForNullptr(m_IO, "in call to IO::RemoveAllAttributes");
     m_IO->RemoveAllAttributes();
 }
-
-#ifdef ADIOS2_HAVE_MPI
-Engine IO::Open(const std::string &name, const Mode mode, MPI_Comm comm)
-{
-    helper::CheckForNullptr(m_IO,
-                            "for engine " + name + ", in call to IO::Open");
-    return Engine(&m_IO->Open(name, mode, helper::CommFromMPI(comm)));
-}
-#endif
 
 Engine IO::Open(const std::string &name, const Mode mode)
 {

--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -250,8 +250,6 @@ public:
 
     /**
      * Open an Engine to start heavy-weight input/output operations.
-     * This version reuses the ADIOS object communicator
-     * MPI Collective function as it calls MPI_Comm_dup
      * @param name unique engine identifier
      * @param mode adios2::Mode::Write, adios2::Mode::Read, or
      *             adios2::Mode::Append (not yet support)

--- a/bindings/CXX11/adios2/cxx11/IOMPI.cpp
+++ b/bindings/CXX11/adios2/cxx11/IOMPI.cpp
@@ -1,0 +1,24 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * IOMPI.cpp :
+ */
+
+#include "IO.h"
+
+#include "adios2/core/IO.h"
+
+#include "adios2/helper/adiosCommMPI.h"
+
+namespace adios2
+{
+
+Engine IO::Open(const std::string &name, const Mode mode, MPI_Comm comm)
+{
+    helper::CheckForNullptr(m_IO,
+                            "for engine " + name + ", in call to IO::Open");
+    return Engine(&m_IO->Open(name, mode, helper::CommFromMPI(comm)));
+}
+
+} // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstream.cpp
+++ b/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstream.cpp
@@ -11,30 +11,8 @@
 #include "ADIOS2fstream.h"
 #include "ADIOS2fstream.tcc"
 
-#ifdef ADIOS2_HAVE_MPI
-#include "adios2/helper/adiosCommMPI.h"
-#endif
-
 namespace adios2
 {
-
-#ifdef ADIOS2_HAVE_MPI
-fstream::fstream(const std::string &name, const openmode mode, MPI_Comm comm,
-                 const std::string engineType)
-: m_Stream(std::make_shared<core::Stream>(
-      name, ToMode(mode), helper::CommFromMPI(comm), engineType, "C++"))
-{
-}
-
-fstream::fstream(const std::string &name, const openmode mode, MPI_Comm comm,
-                 const std::string &configFile,
-                 const std::string ioInConfigFile)
-: m_Stream(std::make_shared<core::Stream>(name, ToMode(mode),
-                                          helper::CommFromMPI(comm), configFile,
-                                          ioInConfigFile, "C++"))
-{
-}
-#endif
 
 fstream::fstream(const std::string &name, const openmode mode,
                  const std::string engineType)
@@ -50,26 +28,6 @@ fstream::fstream(const std::string &name, const openmode mode,
                                           ioInConfigFile, "C++"))
 {
 }
-
-#ifdef ADIOS2_HAVE_MPI
-void fstream::open(const std::string &name, const openmode mode, MPI_Comm comm,
-                   const std::string engineType)
-{
-    CheckOpen(name);
-    m_Stream = std::make_shared<core::Stream>(
-        name, ToMode(mode), helper::CommFromMPI(comm), engineType, "C++");
-}
-
-void fstream::open(const std::string &name, const openmode mode, MPI_Comm comm,
-                   const std::string configFile,
-                   const std::string ioInConfigFile)
-{
-    CheckOpen(name);
-    m_Stream = std::make_shared<core::Stream>(
-        name, ToMode(mode), helper::CommFromMPI(comm), configFile,
-        ioInConfigFile, "C++");
-}
-#endif
 
 void fstream::open(const std::string &name, const openmode mode,
                    const std::string engineType)

--- a/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstreamMPI.cpp
+++ b/bindings/CXX11/adios2/cxx11/fstream/ADIOS2fstreamMPI.cpp
@@ -1,0 +1,50 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adios2fstreamMPI.cpp : MPI interfaces to adios2::fstream C++11 bindings
+ */
+
+#include "ADIOS2fstream.h"
+#include "ADIOS2fstream.tcc"
+
+#include "adios2/helper/adiosCommMPI.h"
+
+namespace adios2
+{
+
+fstream::fstream(const std::string &name, const openmode mode, MPI_Comm comm,
+                 const std::string engineType)
+: m_Stream(std::make_shared<core::Stream>(
+      name, ToMode(mode), helper::CommFromMPI(comm), engineType, "C++"))
+{
+}
+
+fstream::fstream(const std::string &name, const openmode mode, MPI_Comm comm,
+                 const std::string &configFile,
+                 const std::string ioInConfigFile)
+: m_Stream(std::make_shared<core::Stream>(name, ToMode(mode),
+                                          helper::CommFromMPI(comm), configFile,
+                                          ioInConfigFile, "C++"))
+{
+}
+
+void fstream::open(const std::string &name, const openmode mode, MPI_Comm comm,
+                   const std::string engineType)
+{
+    CheckOpen(name);
+    m_Stream = std::make_shared<core::Stream>(
+        name, ToMode(mode), helper::CommFromMPI(comm), engineType, "C++");
+}
+
+void fstream::open(const std::string &name, const openmode mode, MPI_Comm comm,
+                   const std::string configFile,
+                   const std::string ioInConfigFile)
+{
+    CheckOpen(name);
+    m_Stream = std::make_shared<core::Stream>(
+        name, ToMode(mode), helper::CommFromMPI(comm), configFile,
+        ioInConfigFile, "C++");
+}
+
+} // end namespace adios2

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -378,7 +378,6 @@ Comm::Status CommImplMPI::Recv(void *buf, size_t count, Datatype datatype,
                    hint);
 
     Comm::Status status;
-#ifdef ADIOS2_HAVE_MPI
     status.Source = mpiStatus.MPI_SOURCE;
     status.Tag = mpiStatus.MPI_TAG;
     {
@@ -387,7 +386,6 @@ Comm::Status CommImplMPI::Recv(void *buf, size_t count, Datatype datatype,
                        hint);
         status.Count = mpiCount;
     }
-#endif
     return status;
 }
 
@@ -514,7 +512,6 @@ Comm::Status CommReqImplMPI::Wait(const std::string &hint)
         return status;
     }
 
-#ifdef ADIOS2_HAVE_MPI
     std::vector<MPI_Request> mpiRequests = std::move(m_MPIReqs);
     std::vector<MPI_Status> mpiStatuses(mpiRequests.size());
 
@@ -564,7 +561,6 @@ Comm::Status CommReqImplMPI::Wait(const std::string &hint)
             break;
         }
     }
-#endif
 
     return status;
 }


### PR DESCRIPTION
Move code conditioned by `ADIOS2_HAVE_MPI` into source files that are built only when that condition is true.  Later this will be useful for compiling the MPI-specific sources in a separate library.
