### PR TITLE
Allow setting absolute paths for CMAKE_INSTALL_BINDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,8 +156,9 @@ install(FILES ${PROJECT_BINARY_DIR}/source/adios2/common/ADIOSConfig.h
 #------------------------------------------------------------------------------#
 # Some specialized shared library and RPATH handling
 #------------------------------------------------------------------------------#
-set(ADIOS2_RUN_INSTALL_TEST TRUE)
-if(BUILD_SHARED_LIBS)
+option(ADIOS2_RUN_INSTALL_TEST "Enable / disable the install test" TRUE)
+mark_as_advanced(ADIOS2_RUN_INSTALL_TEST)
+if(BUILD_SHARED_LIBS AND ADIOS2_RUN_INSTALL_TEST)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
   string(REGEX REPLACE "[^/]+" ".." relative_base "${CMAKE_INSTALL_LIBDIR}")
 
@@ -171,6 +172,7 @@ if(BUILD_SHARED_LIBS)
       else()
         set(CMAKE_INSTALL_NAME_DIR
           "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+        message(STATUS "Skipping install tests due to platform specific rpath oddities")
         set(ADIOS2_RUN_INSTALL_TEST FALSE)
       endif()
     else()

--- a/cmake/install/post/generate-adios2-config.sh.in
+++ b/cmake/install/post/generate-adios2-config.sh.in
@@ -146,11 +146,20 @@ else
   echo ADIOS2_Fortran_LDFLAGS="" >> adios2.flags
 fi
 
-echo "Writing ${adios2_DIR}/@CMAKE_INSTALL_BINDIR@/adios2-config"
+if [[ "@CMAKE_INSTALL_BINDIR@" == /* ]]
+then
+  # absolute path
+  BINDIR="@CMAKE_INSTALL_BINDIR@"
+else
+  # relative path
+  BINDIR="${adios2_DIR}/@CMAKE_INSTALL_BINDIR@"
+fi
+
+echo "Writing ${BINDIR}/adios2-config"
 cat \
   "@ADIOS2_BINARY_DIR@/cmake/install/post/adios2-config.pre.sh" \
   adios2.flags \
-  "@ADIOS2_BINARY_DIR@/cmake/install/post/adios2-config.post.sh" > "${adios2_DIR}/@CMAKE_INSTALL_BINDIR@/adios2-config"
-chmod +x "${adios2_DIR}/@CMAKE_INSTALL_BINDIR@/adios2-config"
+  "@ADIOS2_BINARY_DIR@/cmake/install/post/adios2-config.post.sh" > "${BINDIR}/adios2-config"
+chmod +x "${BINDIR}/adios2-config"
 popd 
 rm -rf ${BUILD_DIR}


### PR DESCRIPTION
By default, Cmake will set the `CMAKE_INSTALL_BINDIR` variable to `"bin"`, denoting a path within
`CMAKE_INSTALL_PREFIX`. It may also be an absolute path which is currently
not considered in the post-install scripts. This PR allows using absolute paths, too.