### PR TITLE
Fix memory leak from CompressZFP.

### DIFF
--- a/scripts/ci/cmake/ci-fedora-asan.cmake
+++ b/scripts/ci/cmake/ci-fedora-asan.cmake
@@ -1,20 +1,18 @@
 # Client maintainer: chuck.atkins@kitware.com
 
-set(ENV{CC}  gcc)
-set(ENV{CXX} g++)
-set(ENV{FC}  gfortran)
-set(ASAN_FLAGS "-fsanitize=address -pthread")
+set(ENV{CC}  clang)
+set(ENV{CXX} clang++)
+set(ASAN_FLAGS "-fsanitize=address -fno-omit-frame-pointer -pthread")
 set(ENV{CFLAGS}   "${ASAN_FLAGS}")
 set(ENV{CXXFLAGS} "${ASAN_FLAGS}")
 set(ENV{FFLAGS}   "${ASAN_FLAGS}")
 
 set(dashboard_cache "
+ADIOS2_USE_Fortran:STRING=OFF
 ADIOS2_USE_HDF5:STRING=ON
 ADIOS2_USE_MPI:STRING=OFF
 ADIOS2_USE_Python:STRING=OFF
-
-HDF5_C_COMPILER_EXECUTABLE:FILEPATH=/usr/bin/h5cc
-HDF5_DIFF_EXECUTABLE:FILEPATH=/usr/bin/h5diff
+ADIOS2_USE_ZFP:STRING=ON
 ")
 
 set(dashboard_track "Analysis")

--- a/scripts/ci/images/fedora-asan/Dockerfile
+++ b/scripts/ci/images/fedora-asan/Dockerfile
@@ -3,6 +3,19 @@ FROM ornladios/adios2:fedora-sanitizers-base
 # Install core dev packages
 RUN dnf -y install libasan python3-devel python3-numpy hdf5-devel
 
+# Install ZFP
+WORKDIR /opt/zfp
+RUN curl -L https://github.com/LLNL/zfp/releases/download/0.5.5/zfp-0.5.5.tar.gz | tar -xvz && \
+    mkdir build && \
+    cd build && \
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/zfp/0.5.5 ../zfp-0.5.5 && \
+    make -j$(grep -c '^processor' /proc/cpuinfo) install && \
+    cd .. && \
+    rm -rf zfp-0.5.5 build
+ENV PATH=/opt/zfp/0.5.5/bin:${PATH} \
+    LD_LIBRARY_PATH=/opt/zfp/0.5.5/lib64:${LD_LIBRARY_PATH} \
+    CMAKE_PREFIX_PATH=/opt/zfp/0.5.5:${CMAKE_PREFIX_PATH}
+
 # Misc cleanup
 RUN dnf clean all && \
     rm -rfv /tmp/* /var/cache/dnf

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -63,7 +63,7 @@ size_t CompressZFP::Compress(const void *dataIn, const Dims &dimensions,
 
     zfp_field_free(field);
     zfp_stream_close(stream);
-    free(bitstream);
+    stream_close(bitstream);
     return sizeOut;
 }
 

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -63,6 +63,7 @@ size_t CompressZFP::Compress(const void *dataIn, const Dims &dimensions,
 
     zfp_field_free(field);
     zfp_stream_close(stream);
+    free(bitstream);
     return sizeOut;
 }
 

--- a/source/adios2/toolkit/sst/cp/ffs_zfp.c
+++ b/source/adios2/toolkit/sst/cp/ffs_zfp.c
@@ -153,6 +153,7 @@ extern char *FFS_ZFPCompress(SstStream Stream, const size_t DimCount,
     size_t sizeOut = zfp_compress(stream, field);
     zfp_field_free(field);
     zfp_stream_close(stream);
+    stream_close(bitstream);
     *ByteCountP = sizeOut;
     return bufferOut;
 }


### PR DESCRIPTION
This only fixes one memory leak, in one context in which it's being called, but still an improvement. To reproduce:

```
ADIOS2/build$  cmake -DCMAKE_CXX_COMPILER="clang++" -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_FLAGS="-fsanitize=address" -DADIOS2_USE_MPI=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address" -DCMAKE_SHARED_LINKER_FLAGS="${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address" ../
ADIOS2/build$ make -j`nproc`
ADIOS2/build$ ctest -R BPWRZFP.ADIOS2BPWRZFP1D -V # all will fail without this PR; none will fail with it
```

