### PR TITLE
TransportMan TSAN changes

### DIFF
--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -188,7 +188,7 @@ void BP3Writer::InitTransports()
     {
         if (m_BP3Serializer.m_Parameters.AsyncTasks)
         {
-            m_FutureOpenFiles = m_FileDataManager.OpenFilesAsync(
+            m_FileDataManager.OpenFilesAsync(
                 bpSubStreamNames, m_OpenMode, m_IO.m_TransportsParameters,
                 m_BP3Serializer.m_Profiler.m_IsActive);
         }
@@ -341,11 +341,6 @@ void BP3Writer::WriteData(const bool isFinal, const int transportIndex)
         m_BP3Serializer.CloseStream(m_IO);
     }
 
-    if (m_FutureOpenFiles.valid())
-    {
-        m_FutureOpenFiles.get();
-    }
-
     m_FileDataManager.WriteFiles(m_BP3Serializer.m_Data.m_Buffer.data(),
                                  dataSize, transportIndex);
 
@@ -373,11 +368,6 @@ void BP3Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
             const format::Buffer &bufferSTL =
                 m_BP3Serializer.m_Aggregator.GetConsumerBuffer(
                     m_BP3Serializer.m_Data);
-
-            if (m_FutureOpenFiles.valid())
-            {
-                m_FutureOpenFiles.get();
-            }
 
             m_FileDataManager.WriteFiles(bufferSTL.Data(), bufferSTL.m_Position,
                                          transportIndex);

--- a/source/adios2/engine/bp3/BP3Writer.h
+++ b/source/adios2/engine/bp3/BP3Writer.h
@@ -53,9 +53,6 @@ private:
     /** Manage BP data files Transports from IO AddTransport */
     transportman::TransportMan m_FileDataManager;
 
-    /** future returned by m_FileDataManager at OpenFiles */
-    std::future<void> m_FutureOpenFiles;
-
     /** Manages the optional collective metadata files */
     transportman::TransportMan m_FileMetadataManager;
 

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -190,7 +190,7 @@ void BP4Writer::InitTransports()
     {
         if (m_BP4Serializer.m_Parameters.AsyncTasks)
         {
-            m_FutureOpenFiles = m_FileDataManager.OpenFilesAsync(
+            m_FileDataManager.OpenFilesAsync(
                 bpSubStreamNames, m_OpenMode, m_IO.m_TransportsParameters,
                 m_BP4Serializer.m_Profiler.m_IsActive);
         }
@@ -294,10 +294,6 @@ void BP4Writer::InitBPBuffer()
 
             if (m_BP4Serializer.m_Aggregator.m_IsConsumer)
             {
-                if (m_FutureOpenFiles.valid())
-                {
-                    m_FutureOpenFiles.get();
-                }
                 m_BP4Serializer.m_PreDataFileLength =
                     m_FileDataManager.GetFileSize(0);
             }
@@ -577,11 +573,6 @@ void BP4Writer::WriteData(const bool isFinal, const int transportIndex)
         dataSize = m_BP4Serializer.CloseStream(m_IO, false);
     }
 
-    if (m_FutureOpenFiles.valid())
-    {
-        m_FutureOpenFiles.get();
-    }
-
     m_FileDataManager.WriteFiles(m_BP4Serializer.m_Data.m_Buffer.data(),
                                  dataSize, transportIndex);
 
@@ -611,11 +602,6 @@ void BP4Writer::AggregateWriteData(const bool isFinal, const int transportIndex)
                     m_BP4Serializer.m_Data);
             if (bufferSTL.m_Position > 0)
             {
-                if (m_FutureOpenFiles.valid())
-                {
-                    m_FutureOpenFiles.get();
-                }
-
                 m_FileDataManager.WriteFiles(
                     bufferSTL.Data(), bufferSTL.m_Position, transportIndex);
 

--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -53,9 +53,6 @@ private:
     /** Manage BP data files Transports from IO AddTransport */
     transportman::TransportMan m_FileDataManager;
 
-    /** future returned by m_FileDataManager at OpenFiles */
-    std::future<void> m_FutureOpenFiles;
-
     /** Manages the optional collective metadata files */
     transportman::TransportMan m_FileMetadataManager;
 

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -77,11 +77,14 @@ public:
      * @param openMode
      * @param parametersVector
      * @param profile
-     * @return
+     *
+     *   Opens happen asynchronously, but any future call waits for their
+     * completion
      */
-    std::future<void> OpenFilesAsync(
-        const std::vector<std::string> &fileNames, const Mode openMode,
-        const std::vector<Params> &parametersVector, const bool profile);
+    void OpenFilesAsync(const std::vector<std::string> &fileNames,
+                        const Mode openMode,
+                        const std::vector<Params> &parametersVector,
+                        const bool profile);
 
     /**
      * Used for sub-files defined by index
@@ -175,6 +178,7 @@ public:
 protected:
     helper::Comm const &m_Comm;
     const bool m_DebugMode = false;
+    mutable std::future<void> m_FutureOpenFiles;
 
     std::shared_ptr<Transport> OpenFileTransport(const std::string &fileName,
                                                  const Mode openMode,
@@ -185,6 +189,8 @@ protected:
         std::unordered_map<size_t, std::shared_ptr<Transport>>::const_iterator
             itTransport,
         const std::string hint) const;
+
+    void WaitForAsync() const;
 };
 
 } // end namespace transport


### PR DESCRIPTION
Change OpenFilesAsync so that it no longer returns a future, but rather the future remains in the class and subsequent calls into the class wait for the async task before they continue.  This preserves the current state of functionality while clearing up TSAN warnings, at a cost of an additional .valid() check on every public member invocation (rather than the one-time cost when those checks were in BP3/BP4 writer).