### PR TITLE
bindings: Factor out MPI-specific Fortran bindings into separate sources

### DIFF
--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -49,6 +49,10 @@ target_link_libraries(adios2_f PRIVATE adios2)
 
 
 if(ADIOS2_HAVE_MPI)
+  target_sources(adios2_f PRIVATE
+    f2c/adios2_f2c_adios_mpi.cpp
+    f2c/adios2_f2c_io_mpi.cpp
+  )
   target_compile_definitions(adios2_f PUBLIC ADIOS2_HAVE_MPI_F)
   target_link_libraries(adios2_f PRIVATE MPI::MPI_Fortran MPI::MPI_C)
 endif()

--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -22,10 +22,12 @@ add_library(adios2_f
   modules/adios2_parameters_mod.f90
   modules/adios2_adios_mod.f90
   modules/adios2_adios_init_mod.F90
+  modules/adios2_adios_init_mod_serial.f90
   modules/adios2_attribute_mod.f90
   modules/adios2_attribute_data_mod.f90
   modules/adios2_io_mod.f90
   modules/adios2_io_open_mod.F90
+  modules/adios2_io_open_mod_serial.f90
   modules/adios2_io_define_variable_mod.f90
   modules/adios2_io_define_attribute_mod.f90
   modules/adios2_engine_mod.f90
@@ -50,6 +52,8 @@ target_link_libraries(adios2_f PRIVATE adios2)
 
 if(ADIOS2_HAVE_MPI)
   target_sources(adios2_f PRIVATE
+    modules/adios2_adios_init_mod_mpi.f90
+    modules/adios2_io_open_mod_mpi.f90
     f2c/adios2_f2c_adios_mpi.cpp
     f2c/adios2_f2c_io_mpi.cpp
   )

--- a/bindings/Fortran/f2c/adios2_f2c_adios.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_adios.cpp
@@ -10,43 +10,8 @@
 
 #include "adios2_f2c_common.h"
 
-#ifdef ADIOS2_HAVE_MPI_F
-#include <mpi.h>
-#endif
-
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifdef ADIOS2_HAVE_MPI_F
-
-// this function is not exposed in the public APIs
-extern adios2_adios *
-adios2_init_config_glue_mpi(const char *config_file, MPI_Comm comm,
-                            const adios2_debug_mode debug_mode,
-                            const char *host_language);
-
-void FC_GLOBAL(adios2_init_config_mpi_f2c,
-               ADIOS2_INIT_CONFIG_MPI_F2C)(adios2_adios **adios,
-                                           const char *config_file,
-                                           MPI_Fint *comm,
-                                           const int *debug_mode, int *ierr)
-{
-    *adios = adios2_init_config_glue_mpi(
-        config_file, MPI_Comm_f2c(*comm),
-        static_cast<adios2_debug_mode>(*debug_mode), "Fortran");
-    *ierr = (*adios == NULL) ? static_cast<int>(adios2_error_exception)
-                             : static_cast<int>(adios2_error_none);
-}
-
-void FC_GLOBAL(adios2_init_mpi_f2c,
-               ADIOS2_INIT_MPI_F2C)(adios2_adios **adios, MPI_Fint *comm,
-                                    const int *debug_mode, int *ierr)
-{
-    FC_GLOBAL(adios2_init_config_mpi_f2c, ADIOS2_INIT_CONFIG_MPI_F2C)
-    (adios, "", comm, debug_mode, ierr);
-}
-
 #endif
 
 // this function is not exposed in the public APIs

--- a/bindings/Fortran/f2c/adios2_f2c_adios_mpi.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_adios_mpi.cpp
@@ -1,0 +1,40 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adios2_f2c_adios_mpi.cpp
+ */
+
+#include "adios2_f2c_common.h"
+
+#include <mpi.h>
+
+extern "C" {
+
+// this function is not exposed in the public APIs
+extern adios2_adios *
+adios2_init_config_glue_mpi(const char *config_file, MPI_Comm comm,
+                            const adios2_debug_mode debug_mode,
+                            const char *host_language);
+
+void FC_GLOBAL(adios2_init_config_mpi_f2c,
+               ADIOS2_INIT_CONFIG_MPI_F2C)(adios2_adios **adios,
+                                           const char *config_file,
+                                           MPI_Fint *comm,
+                                           const int *debug_mode, int *ierr)
+{
+    *adios = adios2_init_config_glue_mpi(
+        config_file, MPI_Comm_f2c(*comm),
+        static_cast<adios2_debug_mode>(*debug_mode), "Fortran");
+    *ierr = (*adios == NULL) ? static_cast<int>(adios2_error_exception)
+                             : static_cast<int>(adios2_error_none);
+}
+
+void FC_GLOBAL(adios2_init_mpi_f2c,
+               ADIOS2_INIT_MPI_F2C)(adios2_adios **adios, MPI_Fint *comm,
+                                    const int *debug_mode, int *ierr)
+{
+    FC_GLOBAL(adios2_init_config_mpi_f2c, ADIOS2_INIT_CONFIG_MPI_F2C)
+    (adios, "", comm, debug_mode, ierr);
+}
+}

--- a/bindings/Fortran/f2c/adios2_f2c_io.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_io.cpp
@@ -359,19 +359,6 @@ void FC_GLOBAL(adios2_remove_all_attributes_f2c,
     *ierr = static_cast<int>(adios2_remove_all_attributes(*io));
 }
 
-#ifdef ADIOS2_HAVE_MPI_F
-void FC_GLOBAL(adios2_open_new_comm_f2c,
-               ADIOS2_OPEN_NEW_COMM_F2C)(adios2_engine **engine, adios2_io **io,
-                                         const char *name, const int *open_mode,
-                                         MPI_Fint *comm, int *ierr)
-{
-    *engine = adios2_open_new_comm(
-        *io, name, static_cast<adios2_mode>(*open_mode), MPI_Comm_f2c(*comm));
-    *ierr = (*engine == NULL) ? static_cast<int>(adios2_error_exception)
-                              : static_cast<int>(adios2_error_none);
-}
-#endif
-
 void FC_GLOBAL(adios2_open_f2c,
                ADIOS2_OPEN_F2C)(adios2_engine **engine, adios2_io **io,
                                 const char *name, const int *open_mode,

--- a/bindings/Fortran/f2c/adios2_f2c_io_mpi.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_io_mpi.cpp
@@ -1,0 +1,29 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adios2_f2c_io_mpi.cpp
+ */
+
+#include "adios2_f2c_common.h"
+
+#include "adios2/common/ADIOSTypes.h"
+#include "adios2/helper/adiosFunctions.h"
+
+extern "C" {
+
+extern adios2_engine *adios2_open_new_comm(adios2_io *io, const char *name,
+                                           const adios2_mode mode,
+                                           MPI_Comm comm);
+
+void FC_GLOBAL(adios2_open_new_comm_f2c,
+               ADIOS2_OPEN_NEW_COMM_F2C)(adios2_engine **engine, adios2_io **io,
+                                         const char *name, const int *open_mode,
+                                         MPI_Fint *comm, int *ierr)
+{
+    *engine = adios2_open_new_comm(
+        *io, name, static_cast<adios2_mode>(*open_mode), MPI_Comm_f2c(*comm));
+    *ierr = (*engine == NULL) ? static_cast<int>(adios2_error_exception)
+                              : static_cast<int>(adios2_error_none);
+}
+}

--- a/bindings/Fortran/modules/adios2_adios_init_mod.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod.F90
@@ -28,7 +28,7 @@ contains
 
     subroutine adios2_init_serial(adios, adios2_debug_mode, ierr)
         type(adios2_adios), intent(out) :: adios
-        logical, value, intent(in) :: adios2_debug_mode
+        logical, intent(in) :: adios2_debug_mode
         integer, intent(out) :: ierr
 
         call adios2_init_config_serial(adios, char(0), adios2_debug_mode, ierr)
@@ -46,7 +46,7 @@ contains
     subroutine adios2_init_config_serial(adios, config_file, adios2_debug_mode, ierr)
         type(adios2_adios), intent(out) :: adios
         character*(*), intent(in) :: config_file
-        logical, value, intent(in) :: adios2_debug_mode
+        logical, intent(in) :: adios2_debug_mode
         integer, intent(out) :: ierr
         ! local
         integer debug_mode
@@ -71,7 +71,7 @@ contains
     subroutine adios2_init_mpi(adios, comm, adios2_debug_mode, ierr)
         type(adios2_adios), intent(out) :: adios
         integer, intent(in) :: comm
-        logical, value, intent(in) :: adios2_debug_mode
+        logical, intent(in) :: adios2_debug_mode
         integer, intent(out) :: ierr
 
         call adios2_init_config_mpi(adios, char(0), comm, adios2_debug_mode, ierr)
@@ -92,7 +92,7 @@ contains
         type(adios2_adios), intent(out) :: adios
         character*(*), intent(in) :: config_file
         integer, intent(in) :: comm
-        logical, value, intent(in) :: adios2_debug_mode
+        logical, intent(in) :: adios2_debug_mode
         integer, intent(out) :: ierr
         ! local
         integer debug_mode

--- a/bindings/Fortran/modules/adios2_adios_init_mod.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod.F90
@@ -2,120 +2,13 @@
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.
 !
-!  adios2_adios_init_mod.f90 : ADIOS2 Fortran bindings for ADIOS class Init
+!  adios2_adios_init_mod.F90 : ADIOS2 Fortran bindings for ADIOS class Init
 !                              functions
 !
 
 module adios2_adios_init_mod
-    use adios2_parameters_mod
-    use adios2_functions_mod
-    implicit none
-
-    interface adios2_init
-        module procedure adios2_init_serial
-        module procedure adios2_init_debug_serial
-        module procedure adios2_init_config_serial
-        module procedure adios2_init_config_debug_serial
+    use adios2_adios_init_mod_serial
 #ifdef ADIOS2_HAVE_MPI_F
-        module procedure adios2_init_mpi
-        module procedure adios2_init_debug_mpi
-        module procedure adios2_init_config_mpi
-        module procedure adios2_init_config_debug_mpi
+    use adios2_adios_init_mod_mpi
 #endif
-    end interface
-
-contains
-
-    subroutine adios2_init_serial(adios, adios2_debug_mode, ierr)
-        type(adios2_adios), intent(out) :: adios
-        logical, intent(in) :: adios2_debug_mode
-        integer, intent(out) :: ierr
-
-        call adios2_init_config_serial(adios, char(0), adios2_debug_mode, ierr)
-
-    end subroutine
-
-    subroutine adios2_init_debug_serial(adios, ierr)
-        type(adios2_adios), intent(out) :: adios
-        integer, intent(out) :: ierr
-
-        call adios2_init_config_serial(adios, char(0), .true., ierr)
-
-    end subroutine
-
-    subroutine adios2_init_config_serial(adios, config_file, adios2_debug_mode, ierr)
-        type(adios2_adios), intent(out) :: adios
-        character*(*), intent(in) :: config_file
-        logical, intent(in) :: adios2_debug_mode
-        integer, intent(out) :: ierr
-        ! local
-        integer debug_mode
-
-        debug_mode = adios2_LogicalToInt(adios2_debug_mode)
-        call adios2_init_config_serial_f2c(adios%f2c, config_file, debug_mode, ierr)
-        if( ierr == 0 ) adios%valid = .true.
-
-    end subroutine
-
-    subroutine adios2_init_config_debug_serial(adios, config_file, ierr)
-        type(adios2_adios), intent(out) :: adios
-        character*(*), intent(in) :: config_file
-        integer, intent(out) :: ierr
-
-        call adios2_init_config_serial(adios, config_file, .true., ierr)
-
-    end subroutine
-
-#ifdef ADIOS2_HAVE_MPI_F
-
-    subroutine adios2_init_mpi(adios, comm, adios2_debug_mode, ierr)
-        type(adios2_adios), intent(out) :: adios
-        integer, intent(in) :: comm
-        logical, intent(in) :: adios2_debug_mode
-        integer, intent(out) :: ierr
-
-        call adios2_init_config_mpi(adios, char(0), comm, adios2_debug_mode, ierr)
-
-    end subroutine
-
-    subroutine adios2_init_debug_mpi(adios, comm, ierr)
-        type(adios2_adios), intent(out) :: adios
-        integer, intent(in) :: comm
-        integer, intent(out) :: ierr
-
-        call adios2_init_config_mpi(adios, char(0), comm, .true., ierr)
-
-    end subroutine
-
-    subroutine adios2_init_config_mpi(adios, config_file, comm, adios2_debug_mode, &
-                                      ierr)
-        type(adios2_adios), intent(out) :: adios
-        character*(*), intent(in) :: config_file
-        integer, intent(in) :: comm
-        logical, intent(in) :: adios2_debug_mode
-        integer, intent(out) :: ierr
-        ! local
-        integer debug_mode
-
-        debug_mode = adios2_LogicalToInt(adios2_debug_mode)
-        call adios2_init_config_mpi_f2c(adios%f2c, &
-                                        TRIM(ADJUSTL(config_file))//char(0), &
-                                        comm, debug_mode, ierr)
-        if( ierr == 0 ) adios%valid = .true.
-
-    end subroutine
-
-
-    subroutine adios2_init_config_debug_mpi(adios, config_file, comm, ierr)
-        type(adios2_adios), intent(out) :: adios
-        character*(*), intent(in) :: config_file
-        integer, intent(in) :: comm
-        integer, intent(out) :: ierr
-
-        call adios2_init_config_mpi(adios, config_file, comm, .true., ierr)
-
-    end subroutine
-
-#endif
-
 end module

--- a/bindings/Fortran/modules/adios2_adios_init_mod_mpi.f90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod_mpi.f90
@@ -1,0 +1,70 @@
+!
+! Distributed under the OSI-approved Apache License, Version 2.0.  See
+!  accompanying file Copyright.txt for details.
+!
+!  adios2_adios_init_mod_mpi.f90 : ADIOS2 Fortran bindings for ADIOS
+!                                  class Init functions (MPI variants)
+!
+
+module adios2_adios_init_mod_mpi
+    use adios2_parameters_mod
+    use adios2_functions_mod
+    implicit none
+
+    interface adios2_init
+        module procedure adios2_init_mpi
+        module procedure adios2_init_debug_mpi
+        module procedure adios2_init_config_mpi
+        module procedure adios2_init_config_debug_mpi
+    end interface
+
+contains
+
+    subroutine adios2_init_mpi(adios, comm, adios2_debug_mode, ierr)
+        type(adios2_adios), intent(out) :: adios
+        integer, intent(in) :: comm
+        logical, intent(in) :: adios2_debug_mode
+        integer, intent(out) :: ierr
+
+        call adios2_init_config_mpi(adios, char(0), comm, adios2_debug_mode, ierr)
+
+    end subroutine
+
+    subroutine adios2_init_debug_mpi(adios, comm, ierr)
+        type(adios2_adios), intent(out) :: adios
+        integer, intent(in) :: comm
+        integer, intent(out) :: ierr
+
+        call adios2_init_config_mpi(adios, char(0), comm, .true., ierr)
+
+    end subroutine
+
+    subroutine adios2_init_config_mpi(adios, config_file, comm, adios2_debug_mode, &
+                                      ierr)
+        type(adios2_adios), intent(out) :: adios
+        character*(*), intent(in) :: config_file
+        integer, intent(in) :: comm
+        logical, intent(in) :: adios2_debug_mode
+        integer, intent(out) :: ierr
+        ! local
+        integer debug_mode
+
+        debug_mode = adios2_LogicalToInt(adios2_debug_mode)
+        call adios2_init_config_mpi_f2c(adios%f2c, &
+                                        TRIM(ADJUSTL(config_file))//char(0), &
+                                        comm, debug_mode, ierr)
+        if( ierr == 0 ) adios%valid = .true.
+
+    end subroutine
+
+    subroutine adios2_init_config_debug_mpi(adios, config_file, comm, ierr)
+        type(adios2_adios), intent(out) :: adios
+        character*(*), intent(in) :: config_file
+        integer, intent(in) :: comm
+        integer, intent(out) :: ierr
+
+        call adios2_init_config_mpi(adios, config_file, comm, .true., ierr)
+
+    end subroutine
+
+end module

--- a/bindings/Fortran/modules/adios2_adios_init_mod_serial.f90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod_serial.f90
@@ -1,0 +1,63 @@
+!
+! Distributed under the OSI-approved Apache License, Version 2.0.  See
+!  accompanying file Copyright.txt for details.
+!
+!  adios2_adios_init_mod_serial.f90 : ADIOS2 Fortran bindings for ADIOS
+!                                     class Init functions (serial variants)
+!
+
+module adios2_adios_init_mod_serial
+    use adios2_parameters_mod
+    use adios2_functions_mod
+    implicit none
+
+    interface adios2_init
+        module procedure adios2_init_serial
+        module procedure adios2_init_debug_serial
+        module procedure adios2_init_config_serial
+        module procedure adios2_init_config_debug_serial
+    end interface
+
+contains
+
+    subroutine adios2_init_serial(adios, adios2_debug_mode, ierr)
+        type(adios2_adios), intent(out) :: adios
+        logical, intent(in) :: adios2_debug_mode
+        integer, intent(out) :: ierr
+
+        call adios2_init_config_serial(adios, char(0), adios2_debug_mode, ierr)
+
+    end subroutine
+
+    subroutine adios2_init_debug_serial(adios, ierr)
+        type(adios2_adios), intent(out) :: adios
+        integer, intent(out) :: ierr
+
+        call adios2_init_config_serial(adios, char(0), .true., ierr)
+
+    end subroutine
+
+    subroutine adios2_init_config_serial(adios, config_file, adios2_debug_mode, ierr)
+        type(adios2_adios), intent(out) :: adios
+        character*(*), intent(in) :: config_file
+        logical, intent(in) :: adios2_debug_mode
+        integer, intent(out) :: ierr
+        ! local
+        integer debug_mode
+
+        debug_mode = adios2_LogicalToInt(adios2_debug_mode)
+        call adios2_init_config_serial_f2c(adios%f2c, config_file, debug_mode, ierr)
+        if( ierr == 0 ) adios%valid = .true.
+
+    end subroutine
+
+    subroutine adios2_init_config_debug_serial(adios, config_file, ierr)
+        type(adios2_adios), intent(out) :: adios
+        character*(*), intent(in) :: config_file
+        integer, intent(out) :: ierr
+
+        call adios2_init_config_serial(adios, config_file, .true., ierr)
+
+    end subroutine
+
+end module

--- a/bindings/Fortran/modules/adios2_io_open_mod.F90
+++ b/bindings/Fortran/modules/adios2_io_open_mod.F90
@@ -2,64 +2,12 @@
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.
 !
-!  adios2_io_open_mod.f90 : ADIOS2 Fortran bindings for IO class open function
+!  adios2_io_open_mod.F90 : ADIOS2 Fortran bindings for IO class open function
 !
 
 module adios2_io_open_mod
-    use adios2_parameters_mod
-    implicit none
-
-    interface adios2_open
-        module procedure adios2_open_old_comm
+    use adios2_io_open_mod_serial
 #ifdef ADIOS2_HAVE_MPI_F
-        module procedure adios2_open_new_comm
+    use adios2_io_open_mod_mpi
 #endif
-    end interface
-
-contains
-
-    subroutine adios2_open_old_comm(engine, io, name, adios2_mode, ierr)
-        type(adios2_engine), intent(out) :: engine
-        type(adios2_io), intent(in) :: io
-        character*(*), intent(in) :: name
-        integer, intent(in) :: adios2_mode
-        integer, intent(out) :: ierr
-
-        call adios2_open_f2c(engine%f2c, io%f2c, TRIM(ADJUSTL(name))//char(0), &
-                             adios2_mode, ierr)
-
-        if( ierr == 0 ) then
-            engine%valid = .true.
-            engine%name = name
-            call adios2_engine_get_type_f2c(engine%type, engine%f2c, ierr)
-            engine%mode = adios2_mode
-        end if
-
-    end subroutine
-
-#ifdef ADIOS2_HAVE_MPI_F
-
-    subroutine adios2_open_new_comm(engine, io, name, adios2_mode, comm, ierr)
-        type(adios2_engine), intent(out) :: engine
-        type(adios2_io), intent(in) :: io
-        character*(*), intent(in) :: name
-        integer, intent(in) :: adios2_mode
-        integer, intent(in) :: comm
-        integer, intent(out) :: ierr
-
-        call adios2_open_new_comm_f2c(engine%f2c, io%f2c, &
-                                      TRIM(ADJUSTL(name))//char(0), &
-                                      adios2_mode, comm, ierr)
-
-        if( ierr == 0 ) then
-            engine%valid = .true.
-            engine%name = name
-            call adios2_engine_get_type_f2c(engine%type, engine%f2c, ierr)
-            engine%mode = adios2_mode
-        end if
-
-    end subroutine
-
-#endif
-
 end module

--- a/bindings/Fortran/modules/adios2_io_open_mod_mpi.f90
+++ b/bindings/Fortran/modules/adios2_io_open_mod_mpi.f90
@@ -1,0 +1,40 @@
+!
+! Distributed under the OSI-approved Apache License, Version 2.0.  See
+!  accompanying file Copyright.txt for details.
+!
+!  adios2_io_open_mod_mpi.f90 : ADIOS2 Fortran bindings for IO
+!                               class open function (MPI variants)
+!
+
+module adios2_io_open_mod_mpi
+    use adios2_parameters_mod
+    implicit none
+
+    interface adios2_open
+        module procedure adios2_open_new_comm
+    end interface
+
+contains
+
+    subroutine adios2_open_new_comm(engine, io, name, adios2_mode, comm, ierr)
+        type(adios2_engine), intent(out) :: engine
+        type(adios2_io), intent(in) :: io
+        character*(*), intent(in) :: name
+        integer, intent(in) :: adios2_mode
+        integer, intent(in) :: comm
+        integer, intent(out) :: ierr
+
+        call adios2_open_new_comm_f2c(engine%f2c, io%f2c, &
+                                      TRIM(ADJUSTL(name))//char(0), &
+                                      adios2_mode, comm, ierr)
+
+        if( ierr == 0 ) then
+            engine%valid = .true.
+            engine%name = name
+            call adios2_engine_get_type_f2c(engine%type, engine%f2c, ierr)
+            engine%mode = adios2_mode
+        end if
+
+    end subroutine
+
+end module

--- a/bindings/Fortran/modules/adios2_io_open_mod_serial.f90
+++ b/bindings/Fortran/modules/adios2_io_open_mod_serial.f90
@@ -1,0 +1,38 @@
+!
+! Distributed under the OSI-approved Apache License, Version 2.0.  See
+!  accompanying file Copyright.txt for details.
+!
+!  adios2_io_open_mod_serial.f90 : ADIOS2 Fortran bindings for IO
+!                                  class open function (serial variants)
+!
+
+module adios2_io_open_mod_serial
+    use adios2_parameters_mod
+    implicit none
+
+    interface adios2_open
+        module procedure adios2_open_old_comm
+    end interface
+
+contains
+
+    subroutine adios2_open_old_comm(engine, io, name, adios2_mode, ierr)
+        type(adios2_engine), intent(out) :: engine
+        type(adios2_io), intent(in) :: io
+        character*(*), intent(in) :: name
+        integer, intent(in) :: adios2_mode
+        integer, intent(out) :: ierr
+
+        call adios2_open_f2c(engine%f2c, io%f2c, TRIM(ADJUSTL(name))//char(0), &
+                             adios2_mode, ierr)
+
+        if( ierr == 0 ) then
+            engine%valid = .true.
+            engine%name = name
+            call adios2_engine_get_type_f2c(engine%type, engine%f2c, ierr)
+            engine%mode = adios2_mode
+        end if
+
+    end subroutine
+
+end module


### PR DESCRIPTION
~~Combine the `bindings/Fortran/modules/{mpi,nompi}/*` sources to provide a single definition of the modules providing the `adios2_init` and `adios2_open` generic procedures.  Include the MPI signatures only when ADIOS is built with MPI enabled.~~ EDIT: This part was moved to #1994.

Split the implementations of the serial and MPI variants of the Fortran bindings into separate source files.  For each of the `adios2_init` and `adios2_open` generic procedures, ~~all signatures must remain declared in a single module, so use Fortran submodules~~ (EDIT: generic procedure interfaces can have different signatures added by different modules) put the implementations in separate modules in separate sources.  Later this will be useful for compiling the MPI-specific sources in a separate library.
