### PR TITLE
Sensible error message when parsing non-bp3

### DIFF
--- a/source/adios2/engine/bp3/BP3Reader.cpp
+++ b/source/adios2/engine/bp3/BP3Reader.cpp
@@ -175,6 +175,18 @@ void BP3Reader::InitBuffer()
         // Load/Read Minifooter
         const size_t miniFooterSize =
             m_BP3Deserializer.m_MetadataSet.MiniFooterSize;
+        if (fileSize < miniFooterSize)
+        {
+            if (m_DebugMode)
+            {
+                std::string err = "The size of the input file " +  m_Name
+                                   + "(" + std::to_string(fileSize)
+                                   + " bytes) is less than the minimum BP3 header size, which is "
+                                   + std::to_string(miniFooterSize) + " bytes."
+                                   + " It is unlikely that this is a .bp file.";
+                throw std::logic_error(err);
+            }
+        }
         const size_t miniFooterStart =
             helper::GetDistance(fileSize, miniFooterSize, m_DebugMode,
                                 " fileSize < miniFooterSize, in call to Open");

--- a/source/adios2/engine/bp3/BP3Reader.cpp
+++ b/source/adios2/engine/bp3/BP3Reader.cpp
@@ -179,11 +179,12 @@ void BP3Reader::InitBuffer()
         {
             if (m_DebugMode)
             {
-                std::string err = "The size of the input file " +  m_Name
-                                   + "(" + std::to_string(fileSize)
-                                   + " bytes) is less than the minimum BP3 header size, which is "
-                                   + std::to_string(miniFooterSize) + " bytes."
-                                   + " It is unlikely that this is a .bp file.";
+                std::string err = "The size of the input file " + m_Name + "(" +
+                                  std::to_string(fileSize) +
+                                  " bytes) is less than the minimum BP3 header "
+                                  "size, which is " +
+                                  std::to_string(miniFooterSize) + " bytes." +
+                                  " It is unlikely that this is a .bp file.";
                 throw std::logic_error(err);
             }
         }

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
@@ -75,9 +75,11 @@ void BP3Deserializer::ParseMinifooter(const BufferSTL &bufferSTL)
     const uint8_t endianness = helper::ReadValue<uint8_t>(buffer, position);
     if (endianness > 1)
     {
-        std::string err = "The endianness flag in the .bp file was neither zero nor one ("
-                         + std::to_string(endianness)
-                         + "), this indicates the the file is either corrupted, or not a .bp file.";
+        std::string err =
+            "The endianness flag in the .bp file was neither zero nor one (" +
+            std::to_string(endianness) +
+            "), this indicates the the file is either corrupted, or not a .bp "
+            "file.";
         throw std::runtime_error(err);
     }
     m_Minifooter.IsLittleEndian = (endianness == 0) ? true : false;
@@ -187,8 +189,7 @@ void BP3Deserializer::ParseVariablesIndex(const BufferSTL &bufferSTL,
         {
 
 #define make_case(T)                                                           \
-    case (TypeTraits<T>::type_enum):                                           \
-    {                                                                          \
+    case (TypeTraits<T>::type_enum): {                                         \
         DefineVariableInEngineIO<T>(header, engine, buffer, position);         \
         break;                                                                 \
     }
@@ -281,15 +282,13 @@ void BP3Deserializer::ParseAttributesIndex(const BufferSTL &bufferSTL,
         {
 
 #define make_case(T)                                                           \
-    case (TypeTraits<T>::type_enum):                                           \
-    {                                                                          \
+    case (TypeTraits<T>::type_enum): {                                         \
         DefineAttributeInEngineIO<T>(header, engine, buffer, position);        \
         break;                                                                 \
     }
             ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(make_case)
 #undef make_case
-        case (type_string_array):
-        {
+        case (type_string_array): {
             DefineAttributeInEngineIO<std::string>(header, engine, buffer,
                                                    position);
             break;

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
@@ -73,6 +73,13 @@ void BP3Deserializer::ParseMinifooter(const BufferSTL &bufferSTL)
     const size_t bufferSize = buffer.size();
     size_t position = bufferSize - 4;
     const uint8_t endianness = helper::ReadValue<uint8_t>(buffer, position);
+    if (endianness > 1)
+    {
+        std::string err = "The endianness flag in the .bp file was neither zero nor one ("
+                         + std::to_string(endianness)
+                         + "), this indicates the the file is either corrupted, or not a .bp file.";
+        throw std::runtime_error(err);
+    }
     m_Minifooter.IsLittleEndian = (endianness == 0) ? true : false;
 #ifndef ADIOS2_HAVE_ENDIAN_REVERSE
     if (m_DebugMode)

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
@@ -189,7 +189,8 @@ void BP3Deserializer::ParseVariablesIndex(const BufferSTL &bufferSTL,
         {
 
 #define make_case(T)                                                           \
-    case (TypeTraits<T>::type_enum): {                                         \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
         DefineVariableInEngineIO<T>(header, engine, buffer, position);         \
         break;                                                                 \
     }
@@ -282,13 +283,15 @@ void BP3Deserializer::ParseAttributesIndex(const BufferSTL &bufferSTL,
         {
 
 #define make_case(T)                                                           \
-    case (TypeTraits<T>::type_enum): {                                         \
+    case (TypeTraits<T>::type_enum):                                           \
+    {                                                                          \
         DefineAttributeInEngineIO<T>(header, engine, buffer, position);        \
         break;                                                                 \
     }
             ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(make_case)
 #undef make_case
-        case (type_string_array): {
+        case (type_string_array):
+        {
             DefineAttributeInEngineIO<std::string>(header, engine, buffer,
                                                    position);
             break;

--- a/testing/adios2/helper/CMakeLists.txt
+++ b/testing/adios2/helper/CMakeLists.txt
@@ -6,3 +6,4 @@
 gtest_add_tests_helper(Strings FALSE Helper Helper. "")
 gtest_add_tests_helper(DivideBlock FALSE "" Helper. "")
 gtest_add_tests_helper(MinMaxs FALSE "" Helper. "")
+gtest_add_tests_helper(ReadNonBPFile FALSE "" Helper. "")

--- a/testing/adios2/helper/TestReadNonBPFile.cpp
+++ b/testing/adios2/helper/TestReadNonBPFile.cpp
@@ -1,0 +1,50 @@
+#include <fstream>
+#include <adios2.h>
+#include <gtest/gtest.h>
+
+
+TEST(ADIOS2ReadNonBPFile, ShortBadFile)
+{
+    std::ofstream of{"foo.bp"};
+    of << "Hello, world!\n";
+    of.close();
+
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("Test");
+    EXPECT_THROW(io.Open("foo.bp", adios2::Mode::Read), std::exception);
+    std::remove("foo.bp");
+}
+
+TEST(ADIOS2ReadNonBPFile, LongBadFile)
+{
+    std::ofstream of{"foo.bp"};
+    of << "hellohellohellohellohellohellohellohellohellohellohellohellohello\n";
+    of.close();
+
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("Test");
+    //auto bpReader = io.Open("foo.bp", adios2::Mode::Read);
+    EXPECT_THROW(io.Open("foo.bp", adios2::Mode::Read), std::exception);
+    std::remove("foo.bp");
+}
+
+TEST(ADIOS2ReadNonBPFile, LongBadFileWithValidEndianness)
+{
+    std::ofstream of("foo.bp",  std::ios::out | std::ios::binary);
+    char a = 0x00;
+    for (size_t i = 0; i < 100; ++i) {
+        of.write(static_cast<char*>(&a), 1);
+    }
+    of.close();
+
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("Test");
+    EXPECT_THROW(io.Open("foo.bp", adios2::Mode::Read), std::exception);
+    std::remove("foo.bp");
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/testing/adios2/helper/TestReadNonBPFile.cpp
+++ b/testing/adios2/helper/TestReadNonBPFile.cpp
@@ -1,7 +1,6 @@
-#include <fstream>
 #include <adios2.h>
+#include <fstream>
 #include <gtest/gtest.h>
-
 
 TEST(ADIOS2ReadNonBPFile, ShortBadFile)
 {
@@ -23,17 +22,18 @@ TEST(ADIOS2ReadNonBPFile, LongBadFile)
 
     adios2::ADIOS adios;
     adios2::IO io = adios.DeclareIO("Test");
-    //auto bpReader = io.Open("foo.bp", adios2::Mode::Read);
+    // auto bpReader = io.Open("foo.bp", adios2::Mode::Read);
     EXPECT_THROW(io.Open("foo.bp", adios2::Mode::Read), std::exception);
     std::remove("foo.bp");
 }
 
 TEST(ADIOS2ReadNonBPFile, LongBadFileWithValidEndianness)
 {
-    std::ofstream of("foo.bp",  std::ios::out | std::ios::binary);
+    std::ofstream of("foo.bp", std::ios::out | std::ios::binary);
     char a = 0x00;
-    for (size_t i = 0; i < 100; ++i) {
-        of.write(static_cast<char*>(&a), 1);
+    for (size_t i = 0; i < 100; ++i)
+    {
+        of.write(static_cast<char *>(&a), 1);
     }
     of.close();
 


### PR DESCRIPTION
Previously, when opening a non-.bp through adios, it would tell you that the .bp file was big endian, rather than saying that it wasn't a .bp file.

This PR fixes that.

Fixes 1702.