### PR TITLE
helper: Avoid freeing Comm-held MPI_Comm more than once

### DIFF
--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -198,7 +198,9 @@ void CommImplMPI::Free(const std::string &hint)
     if (m_MPIComm != MPI_COMM_NULL && m_MPIComm != MPI_COMM_WORLD &&
         m_MPIComm != MPI_COMM_SELF)
     {
-        CheckMPIReturn(MPI_Comm_free(&m_MPIComm), hint);
+        MPI_Comm mpiComm = m_MPIComm;
+        m_MPIComm = MPI_COMM_NULL; // prevent freeing a second time
+        CheckMPIReturn(MPI_Comm_free(&mpiComm), hint);
     }
 }
 


### PR DESCRIPTION
When various destructors are called, the MPI communicator helper
will clean up by deleting the adios communicator.  Well, this change
prevents that from happening twice.  When compiled with PGI and
executed with TAU profiling, this double-free causes memory to be
corrupted.  This PR fixes issue #2001 