### PR TITLE
Fix ZFP error message.

### DIFF
--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -30,6 +30,7 @@
 
 #include "adios2/helper/adiosComm.h"
 #include "adios2/helper/adiosFunctions.h" //BuildParametersMap
+#include "adios2/helper/adiosString.h"
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 #include <adios2sys/SystemTools.hxx> // FileIsDirectory()
 
@@ -560,7 +561,8 @@ std::string IO::InquireAttributeType(const std::string &name,
 size_t IO::AddOperation(Operator &op, const Params &parameters) noexcept
 {
     TAU_SCOPED_TIMER("IO::other");
-    m_Operations.push_back(Operation{&op, parameters, Params()});
+    m_Operations.push_back(
+        Operation{&op, helper::LowerCaseParams(parameters), Params()});
     return m_Operations.size() - 1;
 }
 

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -21,6 +21,7 @@
 #include "adios2/core/IO.h"
 #include "adios2/core/Variable.h"
 #include "adios2/helper/adiosFunctions.h" //helper::GetTotalSize
+#include "adios2/helper/adiosString.h"
 
 namespace adios2
 {
@@ -218,7 +219,8 @@ void VariableBase::SetStepSelection(const Box<size_t> &boxSteps)
 size_t VariableBase::AddOperation(Operator &op,
                                   const Params &parameters) noexcept
 {
-    m_Operations.push_back(Operation{&op, parameters, Params()});
+    m_Operations.push_back(
+        Operation{&op, helper::LowerCaseParams(parameters), Params()});
     return m_Operations.size() - 1;
 }
 

--- a/source/adios2/helper/adiosString.cpp
+++ b/source/adios2/helper/adiosString.cpp
@@ -357,6 +357,22 @@ std::string LowerCase(const std::string &input)
     return output;
 }
 
+// The design decision is that user-supplied parameters are case-insensitive.
+// Make sure that they are converted to lowercase internally.
+Params LowerCaseParams(const Params &params)
+{
+    // Keys cannot be changed in maps, so if we get an uppercase key, we have to
+    // copy the entire map.
+    Params lower_case_params;
+    for (auto &p : params)
+    {
+        // The values cannot be changed to lower case, because third-party
+        // libraries (like PNG) require arguments like "PNG_COLOR_TYPE_" . .
+        lower_case_params.insert({LowerCase(p.first), p.second});
+    }
+    return lower_case_params;
+}
+
 std::set<std::string>
 PrefixMatches(const std::string &prefix,
               const std::set<std::string> &inputs) noexcept

--- a/source/adios2/helper/adiosString.h
+++ b/source/adios2/helper/adiosString.h
@@ -177,6 +177,14 @@ size_t StringToByteUnits(const std::string &input, const bool debugMode,
 std::string LowerCase(const std::string &input);
 
 /**
+ * Transforms parameter map to LowerCase.
+ * @param params parameter map
+ * @return parameter map with keys and values lower case.
+ */
+
+Params LowerCaseParams(const Params &params);
+
+/**
  * Extract inputs subset that matches a prefix input
  * @param prefix input prefix
  * @param inputs input names

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -7,7 +7,7 @@
  *  Created on: Jul 25, 2017
  *      Author: William F Godoy godoywf@ornl.gov
  */
-
+#include <sstream>
 #include "CompressZFP.h"
 
 #include "adios2/helper/adiosFunctions.h"
@@ -244,11 +244,15 @@ zfp_stream *CompressZFP::GetZFPStream(const Dims &dimensions,
             (hasRate && hasPrecision) ||
             !(hasAccuracy || hasRate || hasPrecision))
         {
-            throw std::invalid_argument("ERROR: zfp parameters accuracy, "
-                                        "rate, and precision are mutually "
-                                        "exclusive, only one of them is "
-                                        "mandatory, from "
-                                        "operator CompressZfp\n");
+            std::ostringstream oss;
+            oss << "\nError: Requisite parameters to zfp not found.";
+            oss << " The key must be one and only one of 'accuracy', 'rate', or 'precision', case sensitive.";
+            oss << " The key and value provided are ";
+            for (auto & p : parameters)
+            {
+                oss << "(" << p.first << ", " << p.second << ").";
+            }
+            throw std::invalid_argument(oss.str());
         }
     }
 

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -246,7 +246,7 @@ zfp_stream *CompressZFP::GetZFPStream(const Dims &dimensions,
             std::ostringstream oss;
             oss << "\nError: Requisite parameters to zfp not found.";
             oss << " The key must be one and only one of 'accuracy', 'rate', "
-                   "or 'precision', case sensitive.";
+                   "or 'precision'.";
             oss << " The key and value provided are ";
             for (auto &p : parameters)
             {

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -7,10 +7,9 @@
  *  Created on: Jul 25, 2017
  *      Author: William F Godoy godoywf@ornl.gov
  */
-#include <sstream>
 #include "CompressZFP.h"
-
 #include "adios2/helper/adiosFunctions.h"
+#include <sstream>
 
 namespace adios2
 {
@@ -246,9 +245,10 @@ zfp_stream *CompressZFP::GetZFPStream(const Dims &dimensions,
         {
             std::ostringstream oss;
             oss << "\nError: Requisite parameters to zfp not found.";
-            oss << " The key must be one and only one of 'accuracy', 'rate', or 'precision', case sensitive.";
+            oss << " The key must be one and only one of 'accuracy', 'rate', "
+                   "or 'precision', case sensitive.";
             oss << " The key and value provided are ";
-            for (auto & p : parameters)
+            for (auto &p : parameters)
             {
                 oss << "(" << p.first << ", " << p.second << ").";
             }

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfp.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfp.cpp
@@ -200,7 +200,7 @@ void ZFPRate2D(const std::string rate)
         adios2::Operator szOp =
             adios.DefineOperator("ZFPCompressor", adios2::ops::LossyZFP);
 
-        var_r32.AddOperation(szOp, {{"accuracy", rate}});
+        var_r32.AddOperation(szOp, {{"Accuracy", rate}});
         var_r64.AddOperation(szOp, {{"accuracy", rate}});
 
         adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);


### PR DESCRIPTION
Fixes #1875.

Note that I did not add the ability to be case insensitive; as suggested in the issue. I merely added an error message which states clearly what is required, and states clearly what was provided.