### PR TITLE
Move async file open functionality to transports

### DIFF
--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -188,16 +188,14 @@ void BP3Writer::InitTransports()
     {
         if (m_BP3Serializer.m_Parameters.AsyncTasks)
         {
-            m_FileDataManager.OpenFilesAsync(
-                bpSubStreamNames, m_OpenMode, m_IO.m_TransportsParameters,
-                m_BP3Serializer.m_Profiler.m_IsActive);
+            for (size_t i = 0; i < m_IO.m_TransportsParameters.size(); ++i)
+            {
+                m_IO.m_TransportsParameters[i]["asynctasks"] = "true";
+            }
         }
-        else
-        {
-            m_FileDataManager.OpenFiles(bpSubStreamNames, m_OpenMode,
-                                        m_IO.m_TransportsParameters,
-                                        m_BP3Serializer.m_Profiler.m_IsActive);
-        }
+        m_FileDataManager.OpenFiles(bpSubStreamNames, m_OpenMode,
+                                    m_IO.m_TransportsParameters,
+                                    m_BP3Serializer.m_Profiler.m_IsActive);
     }
 }
 

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -190,16 +190,14 @@ void BP4Writer::InitTransports()
     {
         if (m_BP4Serializer.m_Parameters.AsyncTasks)
         {
-            m_FileDataManager.OpenFilesAsync(
-                bpSubStreamNames, m_OpenMode, m_IO.m_TransportsParameters,
-                m_BP4Serializer.m_Profiler.m_IsActive);
+            for (size_t i = 0; i < m_IO.m_TransportsParameters.size(); ++i)
+            {
+                m_IO.m_TransportsParameters[i]["asynctasks"] = "true";
+            }
         }
-        else
-        {
-            m_FileDataManager.OpenFiles(bpSubStreamNames, m_OpenMode,
-                                        m_IO.m_TransportsParameters,
-                                        m_BP4Serializer.m_Profiler.m_IsActive);
-        }
+        m_FileDataManager.OpenFiles(bpSubStreamNames, m_OpenMode,
+                                    m_IO.m_TransportsParameters,
+                                    m_BP4Serializer.m_Profiler.m_IsActive);
     }
 
     if (m_BP4Serializer.m_RankMPI == 0)

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -58,11 +58,14 @@ public:
     void InitProfiler(const Mode openMode, const TimeUnit timeUnit);
 
     /**
-     * Opens transport, required before SetBuffer, Write, Read, Flush, Close
+     * Opens transport, possibly asynchronously, required before SetBuffer,
+     * Write, Read, Flush, Close
      * @param name
      * @param openMode
+     * @param async
      */
-    virtual void Open(const std::string &name, const Mode openMode) = 0;
+    virtual void Open(const std::string &name, const Mode openMode,
+                      const bool async = false) = 0;
 
     /**
      * If OS buffered (FILE* or fstream), sets the buffer size

--- a/source/adios2/toolkit/transport/file/FileFStream.h
+++ b/source/adios2/toolkit/transport/file/FileFStream.h
@@ -12,6 +12,7 @@
 #define ADIOS2_TOOLKIT_TRANSPORT_FILE_FILESTREAM_H_
 
 #include <fstream>
+#include <future> //std::async, std::future
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/helper/adiosComm.h"
@@ -31,7 +32,8 @@ public:
 
     ~FileFStream() = default;
 
-    void Open(const std::string &name, const Mode openMode) final;
+    void Open(const std::string &name, const Mode openMode,
+              const bool async = false) final;
 
     void SetBuffer(char *buffer, size_t size) final;
 
@@ -52,12 +54,15 @@ public:
 private:
     /** file stream using fstream library */
     std::fstream m_FileStream;
+    bool m_IsOpening = false;
+    std::future<void> m_OpenFuture;
 
     /**
      * Check if m_FileStream is false after an operation
      * @param hint exception message
      */
     void CheckFile(const std::string hint) const;
+    void WaitForOpen();
 };
 
 } // end namespace transport

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -11,6 +11,8 @@
 #ifndef ADIOS2_TOOLKIT_TRANSPORT_FILE_FILEDESCRIPTOR_H_
 #define ADIOS2_TOOLKIT_TRANSPORT_FILE_FILEDESCRIPTOR_H_
 
+#include <future> //std::async, std::future
+
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/toolkit/transport/Transport.h"
 
@@ -32,7 +34,8 @@ public:
 
     ~FilePOSIX();
 
-    void Open(const std::string &name, const Mode openMode) final;
+    void Open(const std::string &name, const Mode openMode,
+              const bool async = false) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
 
@@ -52,12 +55,15 @@ public:
 private:
     /** POSIX file handle returned by Open */
     int m_FileDescriptor = -1;
+    bool m_IsOpening = false;
+    std::future<int> m_OpenFuture;
 
     /**
      * Check if m_FileDescriptor is -1 after an operation
      * @param hint exception message
      */
     void CheckFile(const std::string hint) const;
+    void WaitForOpen();
 };
 
 } // end namespace transport

--- a/source/adios2/toolkit/transport/file/FileStdio.h
+++ b/source/adios2/toolkit/transport/file/FileStdio.h
@@ -12,6 +12,7 @@
 #define ADIOS2_TOOLKIT_TRANSPORT_FILE_FILEPOINTER_H_
 
 #include <cstdio> // FILE*
+#include <future> //std::async, std::future
 
 #include "adios2/toolkit/transport/Transport.h"
 
@@ -33,7 +34,8 @@ public:
 
     ~FileStdio();
 
-    void Open(const std::string &name, const Mode openMode) final;
+    void Open(const std::string &name, const Mode openMode,
+              const bool async = false) final;
 
     void SetBuffer(char *buffer, size_t size) final;
 
@@ -54,12 +56,15 @@ public:
 private:
     /** C File pointer */
     FILE *m_File = nullptr;
+    bool m_IsOpening = false;
+    std::future<FILE *> m_OpenFuture;
 
     /**
      * Check for std::ferror and throw an exception if true
      * @param hint exception message
      */
     void CheckFile(const std::string hint) const;
+    void WaitForOpen();
 };
 
 } // end namespace transport

--- a/source/adios2/toolkit/transport/null/NullTransport.cpp
+++ b/source/adios2/toolkit/transport/null/NullTransport.cpp
@@ -31,7 +31,8 @@ NullTransport::NullTransport(helper::Comm const &comm, const bool debugMode)
 
 NullTransport::~NullTransport() = default;
 
-void NullTransport::Open(const std::string &name, const Mode openMode)
+void NullTransport::Open(const std::string &name, const Mode openMode,
+                         const bool async)
 {
     if (Impl->IsOpen)
     {

--- a/source/adios2/toolkit/transport/null/NullTransport.h
+++ b/source/adios2/toolkit/transport/null/NullTransport.h
@@ -34,7 +34,8 @@ public:
 
     virtual ~NullTransport();
 
-    void Open(const std::string &name, const Mode openMode) override;
+    void Open(const std::string &name, const Mode openMode,
+              const bool async = false) override;
 
     void SetBuffer(char *buffer, size_t size) override;
 

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
@@ -47,7 +47,8 @@ ShmSystemV::~ShmSystemV() // this might not be correct
     }
 }
 
-void ShmSystemV::Open(const std::string &name, const Mode openMode)
+void ShmSystemV::Open(const std::string &name, const Mode openMode,
+                      const bool async)
 {
     m_Name = name;
     CheckName();

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.h
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.h
@@ -40,7 +40,8 @@ public:
 
     ~ShmSystemV();
 
-    void Open(const std::string &name, const Mode openMode) final;
+    void Open(const std::string &name, const Mode openMode,
+              const bool async = false) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
 

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -72,21 +72,6 @@ public:
                    const bool profile);
 
     /**
-     * Async version of OpenFiles
-     * @param fileNames
-     * @param openMode
-     * @param parametersVector
-     * @param profile
-     *
-     *   Opens happen asynchronously, but any future call waits for their
-     * completion
-     */
-    void OpenFilesAsync(const std::vector<std::string> &fileNames,
-                        const Mode openMode,
-                        const std::vector<Params> &parametersVector,
-                        const bool profile);
-
-    /**
      * Used for sub-files defined by index
      * @param name
      * @param id
@@ -178,7 +163,6 @@ public:
 protected:
     helper::Comm const &m_Comm;
     const bool m_DebugMode = false;
-    mutable std::future<void> m_FutureOpenFiles;
 
     std::shared_ptr<Transport> OpenFileTransport(const std::string &fileName,
                                                  const Mode openMode,


### PR DESCRIPTION
This implements async open() in the fstream, stdio and posix transports only, and only for the write/create open mode.  @pnorbert , I think this is one of those features that is not exercised in CI at all, and perhaps can't trivially be, lacking a super slow filesystem, so please if there's a way to test other than my own efforts let me know.  (I did add a thread sleep into the asynchronous open threads and it still passed tests, so hopefully OK.)  @KyleFromKitware , this looks good to TSAN on my end, but a check from you would be appreciated too.

Closes #1990 