### PR TITLE
Prevent hang when throwing out of adios constructor in MPI.

### DIFF
--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -17,6 +17,7 @@
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosCommDummy.h"
 #include "adios2/helper/adiosFunctions.h" //InquireKey, BroadcastFile
+#include <adios2sys/SystemTools.hxx>
 
 // OPERATORS
 
@@ -65,8 +66,7 @@ ADIOS::ADIOS(const std::string configFile, helper::Comm comm,
 {
     if (!configFile.empty())
     {
-        std::ifstream f(configFile.c_str());
-        if (!f.good())
+        if (!adios2sys::SystemTools::FileExists(configFile))
         {
             throw std::logic_error("Config file " + configFile +
                                    " passed to ADIOS does not exist.");

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -11,7 +11,8 @@
 #include "ADIOS.h"
 
 #include <algorithm> // std::transform
-#include <ios>       //std::ios_base::failure
+#include <fstream>
+#include <ios> //std::ios_base::failure
 
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosCommDummy.h"
@@ -64,6 +65,12 @@ ADIOS::ADIOS(const std::string configFile, helper::Comm comm,
 {
     if (!configFile.empty())
     {
+        std::ifstream f(configFile.c_str());
+        if (!f.good())
+        {
+            throw std::logic_error("Config file " + configFile +
+                                   " passed to ADIOS does not exist.");
+        }
         if (helper::EndsWith(configFile, ".xml"))
         {
             XMLInit(configFile);

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -40,9 +40,10 @@ bp3_bp4_gtest_add_tests_helper(ChangingShape)
 bp3_bp4_gtest_add_tests_helper(WriteReadBlockInfo)
 bp3_bp4_gtest_add_tests_helper(WriteReadVariableSpan)
 bp3_bp4_gtest_add_tests_helper(TimeAggregation)
+bp3_bp4_gtest_add_tests_helper(NoXMLRecovery)
 
 if(ADIOS2_HAVE_MPI)
-  bp3_bp4_gtest_add_tests_helper(WriteAggregateRead) 
+  bp3_bp4_gtest_add_tests_helper(WriteAggregateRead)
 endif()
 
 # BP3 only for now

--- a/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
+++ b/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <vector>
+
+#include <adios2.h>
+#include <mpi.h>
+
+
+int main(int argc, char *argv[])
+{
+    int rank = 0;
+    int size = 1;
+#ifdef ADIOS2_HAVE_MPI
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+#endif
+    adios2::ADIOS ad;
+    try
+    {
+        ad = adios2::ADIOS("does_not_exist.xml", MPI_COMM_WORLD, adios2::DebugON);
+    }
+    catch (std::exception &e)
+    {
+        if (rank == 0)
+        {
+            std::cout << e.what() << "\n";
+        }
+        ad = adios2::ADIOS(MPI_COMM_WORLD, adios2::DebugON);
+    }
+
+#ifdef ADIOS2_HAVE_MPI
+    return MPI_Finalize();
+#endif
+}

--- a/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
+++ b/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
@@ -2,8 +2,9 @@
 #include <vector>
 
 #include <adios2.h>
+#ifdef ADIOS2_HAVE_MPI
 #include <mpi.h>
-
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -17,7 +18,12 @@ int main(int argc, char *argv[])
     adios2::ADIOS ad;
     try
     {
-        ad = adios2::ADIOS("does_not_exist.xml", MPI_COMM_WORLD, adios2::DebugON);
+#ifdef ADIOS2_HAVE_MPI
+        ad = adios2::ADIOS("does_not_exist.xml", MPI_COMM_WORLD,
+                           adios2::DebugON);
+#else
+        ad = adios2::ADIOS("does_not_exist.xml", adios2::DebugON);
+#endif
     }
     catch (std::exception &e)
     {
@@ -25,7 +31,11 @@ int main(int argc, char *argv[])
         {
             std::cout << e.what() << "\n";
         }
+#ifdef ADIOS2_HAVE_MPI
         ad = adios2::ADIOS(MPI_COMM_WORLD, adios2::DebugON);
+#else
+        ad = adios2::ADIOS(adios2::DebugON);
+#endif
     }
 
 #ifdef ADIOS2_HAVE_MPI

--- a/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
+++ b/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
@@ -10,10 +10,8 @@ int main(int argc, char *argv[])
 {
     int rank = 0;
 #ifdef ADIOS2_HAVE_MPI
-    int size = 1;
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
 #endif
     adios2::ADIOS ad;
     try

--- a/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
+++ b/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
@@ -9,8 +9,8 @@
 int main(int argc, char *argv[])
 {
     int rank = 0;
-    int size = 1;
 #ifdef ADIOS2_HAVE_MPI
+    int size = 1;
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);


### PR DESCRIPTION
Fixes #1938 