### PR TITLE
Inline engine fixes

### DIFF
--- a/source/adios2/core/Engine.tcc
+++ b/source/adios2/core/Engine.tcc
@@ -160,19 +160,13 @@ template <class T>
 typename Variable<T>::Info *Engine::Get(Variable<T> &variable,
                                         const Mode launch)
 {
-    if (m_DebugMode)
-    {
-        // CommonChecks<T>(variable, nullptr, {{Mode::Read}}, "in call to Get");
-    }
-
+    typename Variable<T>::Info *info = nullptr;
     switch (launch)
     {
     case Mode::Deferred:
-        // TODO different? Should use DoGetDeferred?
-        return DoGetBlockSync(variable);
     case Mode::Sync:
-        // TODO should use DoGetSync()?
-        return DoGetBlockSync(variable);
+        info = DoGetBlockSync(variable);
+        break;
     default:
         if (m_DebugMode)
         {
@@ -182,7 +176,12 @@ typename Variable<T>::Info *Engine::Get(Variable<T> &variable,
                 "GetBlock\n");
         }
     }
-    return nullptr;
+    if (m_DebugMode)
+    {
+        CommonChecks<T>(variable, info->Data, {{Mode::Read}}, "in call to Get");
+    }
+
+    return info;
 }
 
 template <class T>

--- a/source/adios2/engine/inline/InlineReader.h
+++ b/source/adios2/engine/inline/InlineReader.h
@@ -42,7 +42,7 @@ public:
     InlineReader(IO &adios, const std::string &name, const Mode mode,
                  helper::Comm comm);
 
-    ~InlineReader();
+    ~InlineReader() = default;
     StepStatus BeginStep(StepMode mode = StepMode::Read,
                          const float timeoutSeconds = -1.0) final;
     void PerformGets() final;
@@ -55,9 +55,6 @@ private:
 
     // step info should be received from the writer side in BeginStep()
     int m_CurrentStep = -1;
-
-    // EndStep must call PerformGets if necessary
-    bool m_NeedPerformGets = false;
 
     std::string m_WriterID;
 

--- a/source/adios2/engine/inline/InlineReader.tcc
+++ b/source/adios2/engine/inline/InlineReader.tcc
@@ -23,9 +23,8 @@ namespace core
 namespace engine
 {
 
-template <>
-inline void InlineReader::GetSyncCommon(Variable<std::string> &variable,
-                                        std::string *data)
+template <class T>
+inline void InlineReader::GetSyncCommon(Variable<T> &variable, T *data)
 {
     variable.m_Data = data;
     auto blockInfo = variable.m_BlocksInfo.back();
@@ -45,22 +44,6 @@ inline void InlineReader::GetSyncCommon(Variable<std::string> &variable,
 }
 
 template <class T>
-inline void InlineReader::GetSyncCommon(Variable<T> &variable, T *data)
-{
-    variable.m_Data = data;
-    auto blockInfo = variable.m_BlocksInfo.back();
-    if (blockInfo.IsValue)
-    {
-        *data = blockInfo.Value;
-    }
-    if (m_Verbosity == 5)
-    {
-        std::cout << "Inline Reader " << m_ReaderRank << "     GetSync("
-                  << variable.m_Name << ")\n";
-    }
-}
-
-template <class T>
 void InlineReader::GetDeferredCommon(Variable<T> &variable, T *data)
 {
     // returns immediately
@@ -69,18 +52,16 @@ void InlineReader::GetDeferredCommon(Variable<T> &variable, T *data)
         std::cout << "Inline Reader " << m_ReaderRank << "     GetDeferred("
                   << variable.m_Name << ")\n";
     }
-    m_NeedPerformGets = true;
 }
 
 template <class T>
 inline typename Variable<T>::Info *
 InlineReader::GetBlockSyncCommon(Variable<T> &variable)
 {
-    InlineWriter &writer =
-        dynamic_cast<InlineWriter &>(m_IO.GetEngine(m_WriterID));
-    writer.AddReadVariable(variable.m_Name);
     if (m_DebugMode)
     {
+        InlineWriter &writer =
+            dynamic_cast<InlineWriter &>(m_IO.GetEngine(m_WriterID));
         if (variable.m_BlockID >= variable.m_BlocksInfo.size())
         {
             throw std::invalid_argument(

--- a/source/adios2/engine/inline/InlineWriter.cpp
+++ b/source/adios2/engine/inline/InlineWriter.cpp
@@ -12,6 +12,7 @@
 #include "InlineWriter.tcc"
 
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 
 #include <iostream>
 
@@ -26,6 +27,7 @@ InlineWriter::InlineWriter(IO &io, const std::string &name, const Mode mode,
                            helper::Comm comm)
 : Engine("InlineWriter", io, name, mode, std::move(comm))
 {
+    TAU_SCOPED_TIMER("InlineWriter::Open");
     m_EndMessage = " in call to InlineWriter " + m_Name + " Open\n";
     m_WriterRank = m_Comm.Rank();
     Init();
@@ -38,6 +40,7 @@ InlineWriter::InlineWriter(IO &io, const std::string &name, const Mode mode,
 
 StepStatus InlineWriter::BeginStep(StepMode mode, const float timeoutSeconds)
 {
+    TAU_SCOPED_TIMER("InlineWriter::BeginStep");
     m_CurrentStep++; // 0 is the first step
     if (m_Verbosity == 5)
     {
@@ -74,6 +77,7 @@ size_t InlineWriter::CurrentStep() const { return m_CurrentStep; }
 /* PutDeferred = PutSync, so nothing to be done in PerformPuts */
 void InlineWriter::PerformPuts()
 {
+    TAU_SCOPED_TIMER("InlineWriter::PerformPuts");
     if (m_Verbosity == 5)
     {
         std::cout << "Inline Writer " << m_WriterRank << "     PerformPuts()\n";
@@ -82,6 +86,7 @@ void InlineWriter::PerformPuts()
 
 void InlineWriter::EndStep()
 {
+    TAU_SCOPED_TIMER("InlineWriter::EndStep");
     if (m_Verbosity == 5)
     {
         std::cout << "Inline Writer " << m_WriterRank << " EndStep() Step "
@@ -91,6 +96,7 @@ void InlineWriter::EndStep()
 
 void InlineWriter::Flush(const int)
 {
+    TAU_SCOPED_TIMER("InlineWriter::Flush");
     if (m_Verbosity == 5)
     {
         std::cout << "Inline Writer " << m_WriterRank << "   Flush()\n";
@@ -102,10 +108,12 @@ void InlineWriter::Flush(const int)
 #define declare_type(T)                                                        \
     void InlineWriter::DoPutSync(Variable<T> &variable, const T *data)         \
     {                                                                          \
+        TAU_SCOPED_TIMER("InlineWriter::DoPutSync");                           \
         PutSyncCommon(variable, variable.SetBlockInfo(data, CurrentStep()));   \
     }                                                                          \
     void InlineWriter::DoPutDeferred(Variable<T> &variable, const T *data)     \
     {                                                                          \
+        TAU_SCOPED_TIMER("InlineWriter::DoPutDeferred");                       \
         PutDeferredCommon(variable, data);                                     \
     }
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
@@ -149,6 +157,7 @@ void InlineWriter::InitTransports()
 
 void InlineWriter::DoClose(const int transportIndex)
 {
+    TAU_SCOPED_TIMER("InlineWriter::DoClose");
     if (m_Verbosity == 5)
     {
         std::cout << "Inline Writer " << m_WriterRank << " Close(" << m_Name

--- a/source/adios2/engine/inline/InlineWriter.h
+++ b/source/adios2/engine/inline/InlineWriter.h
@@ -47,21 +47,10 @@ public:
     void EndStep() final;
     void Flush(const int transportIndex = -1) final;
 
-    void AddReadVariable(const std::string &name)
-    {
-        m_ReadVariables.insert(name);
-    }
-
 private:
     int m_Verbosity = 0;
     int m_WriterRank;       // my rank in the writers' comm
     int m_CurrentStep = -1; // steps start from 0
-
-    // EndStep must call PerformPuts if necessary
-    bool m_NeedPerformPuts = false;
-
-    // track which variables have been read, so their blockinfo can be cleared.
-    std::set<std::string> m_ReadVariables;
 
     void Init() final;
     void InitParameters() final;
@@ -88,7 +77,7 @@ private:
      */
     template <class T>
     void PutSyncCommon(Variable<T> &variable,
-                       const typename Variable<T>::Info &blockInfo);
+                       typename Variable<T>::Info &blockInfo);
 
     template <class T>
     void PutDeferredCommon(Variable<T> &variable, const T *values);

--- a/source/adios2/engine/inline/InlineWriter.tcc
+++ b/source/adios2/engine/inline/InlineWriter.tcc
@@ -23,16 +23,13 @@ namespace engine
 
 template <class T>
 void InlineWriter::PutSyncCommon(Variable<T> &variable,
-                                 const typename Variable<T>::Info &blockInfo)
+                                 typename Variable<T>::Info &blockInfo)
 {
-    auto &info = variable.m_BlocksInfo.back();
-    info.BlockID = variable.m_BlocksInfo.size() - 1;
-    // passed in blockInfo has current blockInfo.Data member.
-    if (blockInfo.Shape.size() == 0 && blockInfo.Count.size() == 0 &&
-        blockInfo.StepsCount == 1)
+    if (variable.m_ShapeID == ShapeID::GlobalValue ||
+        variable.m_ShapeID == ShapeID::LocalValue)
     {
-        info.IsValue = true;
-        info.Value = blockInfo.Data[0];
+        blockInfo.IsValue = true;
+        blockInfo.Value = blockInfo.Data[0];
     }
     if (m_Verbosity == 5)
     {
@@ -45,15 +42,11 @@ template <class T>
 void InlineWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
 {
     variable.SetBlockInfo(data, CurrentStep());
-    auto &info = variable.m_BlocksInfo.back();
-    info.BlockID = variable.m_BlocksInfo.size() - 1;
-
     if (m_Verbosity == 5)
     {
         std::cout << "Inline Writer " << m_WriterRank << "     PutDeferred("
                   << variable.m_Name << ")\n";
     }
-    m_NeedPerformPuts = true;
 }
 
 } // end namespace engine


### PR DESCRIPTION
There's some clean up and stuff to the inline engine, along with these two fixes:
- All variables now have their block info cleared out when starting to write a new step, instead of only the variables that were read on the previous step.
- Reader now reports that it is on the same step as the Writer, since for the inline engine, it doesn't make sense for them to be on different steps.