### PR TITLE
Readme: Conda Badge

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,6 +3,7 @@
 
 [![GitHub (pre-)release](https://img.shields.io/github/release/ornladios/adios2/all.svg)]()
 [![Spack Version](https://img.shields.io/spack/v/adios2.svg)](https://spack.readthedocs.io/en/latest/package_list.html#adios2)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/adios2)](https://anaconda.org/conda-forge/adios2)
 
 [![Circle CI](https://circleci.com/gh/ornladios/ADIOS2.svg?style=shield)](https://circleci.com/gh/ornladios/ADIOS2)
 [![Travis CI](https://api.travis-ci.com/ornladios/ADIOS2.svg)](https://travis-ci.com/ornladios/ADIOS2)


### PR DESCRIPTION
Add a badge to install ADIOS2 via conda-forge: [![Conda Version](https://img.shields.io/conda/vn/conda-forge/adios2)](https://anaconda.org/conda-forge/adios2) 

Conda-forge packages are currently built for win-64, osx-64, linux-64, linux-aarch64, and linux-ppc64le.

By default, conda-forge packages install without MPI. The user can control variants via:

- `conda install -c conda-forge adios2` default, nompi variant
- `conda install -c conda-forge adios2=*=mpi*` any mpi-compatible implementation
- `conda install -c conda-forge adios2=*=mpi_mpich*` pick mpich variant.
  Same result as `conda install -c conda-forge mpich adios2=*=mpi*` .
- `conda install -c conda-forge adios2=1.13=nompi*` explicitly forbid MPI.
  Usually not necessary, as the build number offset causes `nompi` to be preferred unless MPI is explicitly requested.

User-facing conda-forge package index: https://anaconda.org/conda-forge/adios2
Feedstock that automatically builds the packages: https://github.com/conda-forge/adios2-feedstock