### PR TITLE
bindings: Convert Fortran MPI- and non-MPI implementations to submodules

### DIFF
--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -22,12 +22,12 @@ add_library(adios2_f
   modules/adios2_parameters_mod.f90
   modules/adios2_adios_mod.f90
   modules/adios2_adios_init_mod.F90
-  modules/adios2_adios_init_mod_serial.f90
+  modules/adios2_adios_init_mod_serial.F90
   modules/adios2_attribute_mod.f90
   modules/adios2_attribute_data_mod.f90
   modules/adios2_io_mod.f90
   modules/adios2_io_open_mod.F90
-  modules/adios2_io_open_mod_serial.f90
+  modules/adios2_io_open_mod_serial.F90
   modules/adios2_io_define_variable_mod.f90
   modules/adios2_io_define_attribute_mod.f90
   modules/adios2_engine_mod.f90
@@ -53,8 +53,8 @@ target_link_libraries(adios2_f PRIVATE adios2)
 if(ADIOS2_HAVE_MPI)
   target_compile_definitions(adios2_f PRIVATE "$<$<COMPILE_LANGUAGE:Fortran>:ADIOS2_HAVE_MPI_F>")
   target_sources(adios2_f PRIVATE
-    modules/adios2_adios_init_mod_mpi.f90
-    modules/adios2_io_open_mod_mpi.f90
+    modules/adios2_adios_init_mod_mpi.F90
+    modules/adios2_io_open_mod_mpi.F90
     f2c/adios2_f2c_adios_mpi.cpp
     f2c/adios2_f2c_io_mpi.cpp
   )

--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -51,13 +51,13 @@ target_link_libraries(adios2_f PRIVATE adios2)
 
 
 if(ADIOS2_HAVE_MPI)
+  target_compile_definitions(adios2_f PRIVATE "$<$<COMPILE_LANGUAGE:Fortran>:ADIOS2_HAVE_MPI_F>")
   target_sources(adios2_f PRIVATE
     modules/adios2_adios_init_mod_mpi.f90
     modules/adios2_io_open_mod_mpi.f90
     f2c/adios2_f2c_adios_mpi.cpp
     f2c/adios2_f2c_io_mpi.cpp
   )
-  target_compile_definitions(adios2_f PUBLIC ADIOS2_HAVE_MPI_F)
   target_link_libraries(adios2_f PRIVATE MPI::MPI_Fortran MPI::MPI_C)
 endif()
 

--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -8,6 +8,9 @@ include(FortranCInterface)
 FortranCInterface_HEADER(FC.h MACRO_NAMESPACE "FC_")
 FortranCInterface_VERIFY(CXX QUIET)
 
+# Check whether the compiler supports Fortran submodule constructs we need.
+adios2_check_fortran_submodules(ADIOS2_HAVE_FORTRAN_SUBMODULES)
+
 add_library(adios2_f
   f2c/adios2_f2c_adios.cpp
   f2c/adios2_f2c_attribute.cpp
@@ -49,6 +52,9 @@ target_include_directories(adios2_f
 
 target_link_libraries(adios2_f PRIVATE adios2)
 
+if(ADIOS2_HAVE_FORTRAN_SUBMODULES)
+  target_compile_definitions(adios2_f PRIVATE "$<$<COMPILE_LANGUAGE:Fortran>:ADIOS2_HAVE_FORTRAN_SUBMODULES>")
+endif()
 
 if(ADIOS2_HAVE_MPI)
   target_compile_definitions(adios2_f PRIVATE "$<$<COMPILE_LANGUAGE:Fortran>:ADIOS2_HAVE_MPI_F>")
@@ -71,7 +77,7 @@ install(
 install(
   DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/adios2/fortran
-  FILES_MATCHING 
-    PATTERN "adios2*.mod" 
+  FILES_MATCHING
+    PATTERN "adios2*.mod"
     PATTERN "CMakeFiles" EXCLUDE
 )

--- a/bindings/Fortran/modules/adios2_adios_init_mod.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod.F90
@@ -7,8 +7,71 @@
 !
 
 module adios2_adios_init_mod
+
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+    use adios2_parameters_mod
+    implicit none
+
+    interface adios2_init
+
+        module subroutine adios2_init_serial(adios, adios2_debug_mode, ierr)
+            type(adios2_adios), intent(out) :: adios
+            logical, intent(in) :: adios2_debug_mode
+            integer, intent(out) :: ierr
+        end subroutine
+        module subroutine adios2_init_debug_serial(adios, ierr)
+            type(adios2_adios), intent(out) :: adios
+            integer, intent(out) :: ierr
+        end subroutine
+        module subroutine adios2_init_config_serial(adios, config_file, adios2_debug_mode, ierr)
+            type(adios2_adios), intent(out) :: adios
+            character*(*), intent(in) :: config_file
+            logical, intent(in) :: adios2_debug_mode
+            integer, intent(out) :: ierr
+        end subroutine
+        module subroutine adios2_init_config_debug_serial(adios, config_file, ierr)
+            type(adios2_adios), intent(out) :: adios
+            character*(*), intent(in) :: config_file
+            integer, intent(out) :: ierr
+        end subroutine
+
+# ifdef ADIOS2_HAVE_MPI_F
+
+        module subroutine adios2_init_mpi(adios, comm, adios2_debug_mode, ierr)
+            type(adios2_adios), intent(out) :: adios
+            integer, intent(in) :: comm
+            logical, intent(in) :: adios2_debug_mode
+            integer, intent(out) :: ierr
+        end subroutine
+        module subroutine adios2_init_debug_mpi(adios, comm, ierr)
+            type(adios2_adios), intent(out) :: adios
+            integer, intent(in) :: comm
+            integer, intent(out) :: ierr
+        end subroutine
+        module subroutine adios2_init_config_mpi(adios, config_file, comm, adios2_debug_mode, ierr)
+            type(adios2_adios), intent(out) :: adios
+            character*(*), intent(in) :: config_file
+            integer, intent(in) :: comm
+            logical, intent(in) :: adios2_debug_mode
+            integer, intent(out) :: ierr
+        end subroutine
+        module subroutine adios2_init_config_debug_mpi(adios, config_file, comm, ierr)
+            type(adios2_adios), intent(out) :: adios
+            character*(*), intent(in) :: config_file
+            integer, intent(in) :: comm
+            integer, intent(out) :: ierr
+        end subroutine
+# endif
+
+    end interface
+
+#else
+
     use adios2_adios_init_mod_serial
-#ifdef ADIOS2_HAVE_MPI_F
+# ifdef ADIOS2_HAVE_MPI_F
     use adios2_adios_init_mod_mpi
+# endif
+
 #endif
+
 end module

--- a/bindings/Fortran/modules/adios2_adios_init_mod_mpi.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod_mpi.F90
@@ -6,20 +6,34 @@
 !                                  class Init functions (MPI variants)
 !
 
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+# define ADIOS2_MODULE_PROCEDURE module &
+#else
+# define ADIOS2_MODULE_PROCEDURE
+#endif
+
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+submodule ( adios2_adios_init_mod ) mpi
+#else
 module adios2_adios_init_mod_mpi
+#endif
+
     use adios2_parameters_mod
     use adios2_functions_mod
     implicit none
 
+#ifndef ADIOS2_HAVE_FORTRAN_SUBMODULES
     interface adios2_init
         module procedure adios2_init_mpi
         module procedure adios2_init_debug_mpi
         module procedure adios2_init_config_mpi
         module procedure adios2_init_config_debug_mpi
     end interface
+#endif
 
 contains
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_init_mpi(adios, comm, adios2_debug_mode, ierr)
         type(adios2_adios), intent(out) :: adios
         integer, intent(in) :: comm
@@ -30,6 +44,7 @@ contains
 
     end subroutine
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_init_debug_mpi(adios, comm, ierr)
         type(adios2_adios), intent(out) :: adios
         integer, intent(in) :: comm
@@ -39,6 +54,7 @@ contains
 
     end subroutine
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_init_config_mpi(adios, config_file, comm, adios2_debug_mode, &
                                       ierr)
         type(adios2_adios), intent(out) :: adios
@@ -57,6 +73,7 @@ contains
 
     end subroutine
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_init_config_debug_mpi(adios, config_file, comm, ierr)
         type(adios2_adios), intent(out) :: adios
         character*(*), intent(in) :: config_file
@@ -67,4 +84,8 @@ contains
 
     end subroutine
 
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+end submodule
+#else
 end module
+#endif

--- a/bindings/Fortran/modules/adios2_adios_init_mod_mpi.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod_mpi.F90
@@ -2,7 +2,7 @@
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.
 !
-!  adios2_adios_init_mod_mpi.f90 : ADIOS2 Fortran bindings for ADIOS
+!  adios2_adios_init_mod_mpi.F90 : ADIOS2 Fortran bindings for ADIOS
 !                                  class Init functions (MPI variants)
 !
 

--- a/bindings/Fortran/modules/adios2_adios_init_mod_serial.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod_serial.F90
@@ -2,7 +2,7 @@
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.
 !
-!  adios2_adios_init_mod_serial.f90 : ADIOS2 Fortran bindings for ADIOS
+!  adios2_adios_init_mod_serial.F90 : ADIOS2 Fortran bindings for ADIOS
 !                                     class Init functions (serial variants)
 !
 

--- a/bindings/Fortran/modules/adios2_adios_init_mod_serial.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod_serial.F90
@@ -6,20 +6,34 @@
 !                                     class Init functions (serial variants)
 !
 
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+# define ADIOS2_MODULE_PROCEDURE module &
+#else
+# define ADIOS2_MODULE_PROCEDURE
+#endif
+
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+submodule ( adios2_adios_init_mod ) serial
+#else
 module adios2_adios_init_mod_serial
+#endif
+
     use adios2_parameters_mod
     use adios2_functions_mod
     implicit none
 
+#ifndef ADIOS2_HAVE_FORTRAN_SUBMODULES
     interface adios2_init
         module procedure adios2_init_serial
         module procedure adios2_init_debug_serial
         module procedure adios2_init_config_serial
         module procedure adios2_init_config_debug_serial
     end interface
+#endif
 
 contains
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_init_serial(adios, adios2_debug_mode, ierr)
         type(adios2_adios), intent(out) :: adios
         logical, intent(in) :: adios2_debug_mode
@@ -29,6 +43,7 @@ contains
 
     end subroutine
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_init_debug_serial(adios, ierr)
         type(adios2_adios), intent(out) :: adios
         integer, intent(out) :: ierr
@@ -37,6 +52,7 @@ contains
 
     end subroutine
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_init_config_serial(adios, config_file, adios2_debug_mode, ierr)
         type(adios2_adios), intent(out) :: adios
         character*(*), intent(in) :: config_file
@@ -51,6 +67,7 @@ contains
 
     end subroutine
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_init_config_debug_serial(adios, config_file, ierr)
         type(adios2_adios), intent(out) :: adios
         character*(*), intent(in) :: config_file
@@ -60,4 +77,8 @@ contains
 
     end subroutine
 
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+end submodule
+#else
 end module
+#endif

--- a/bindings/Fortran/modules/adios2_io_open_mod.F90
+++ b/bindings/Fortran/modules/adios2_io_open_mod.F90
@@ -6,8 +6,43 @@
 !
 
 module adios2_io_open_mod
+
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+    use adios2_parameters_mod
+    implicit none
+
+    interface adios2_open
+
+        module subroutine adios2_open_old_comm(engine, io, name, adios2_mode, ierr)
+            type(adios2_engine), intent(out) :: engine
+            type(adios2_io), intent(in) :: io
+            character*(*), intent(in) :: name
+            integer, intent(in) :: adios2_mode
+            integer, intent(out) :: ierr
+        end subroutine
+
+# ifdef ADIOS2_HAVE_MPI_F
+
+        module subroutine adios2_open_new_comm(engine, io, name, adios2_mode, comm, ierr)
+            type(adios2_engine), intent(out) :: engine
+            type(adios2_io), intent(in) :: io
+            character*(*), intent(in) :: name
+            integer, intent(in) :: adios2_mode
+            integer, intent(in) :: comm
+            integer, intent(out) :: ierr
+        end subroutine
+
+# endif
+
+    end interface
+
+#else
+
     use adios2_io_open_mod_serial
-#ifdef ADIOS2_HAVE_MPI_F
+# ifdef ADIOS2_HAVE_MPI_F
     use adios2_io_open_mod_mpi
+# endif
+
 #endif
+
 end module

--- a/bindings/Fortran/modules/adios2_io_open_mod_mpi.F90
+++ b/bindings/Fortran/modules/adios2_io_open_mod_mpi.F90
@@ -6,16 +6,30 @@
 !                               class open function (MPI variants)
 !
 
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+# define ADIOS2_MODULE_PROCEDURE module &
+#else
+# define ADIOS2_MODULE_PROCEDURE
+#endif
+
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+submodule ( adios2_io_open_mod ) mpi
+#else
 module adios2_io_open_mod_mpi
+#endif
+
     use adios2_parameters_mod
     implicit none
 
+#ifndef ADIOS2_HAVE_FORTRAN_SUBMODULES
     interface adios2_open
         module procedure adios2_open_new_comm
     end interface
+#endif
 
 contains
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_open_new_comm(engine, io, name, adios2_mode, comm, ierr)
         type(adios2_engine), intent(out) :: engine
         type(adios2_io), intent(in) :: io
@@ -37,4 +51,8 @@ contains
 
     end subroutine
 
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+end submodule
+#else
 end module
+#endif

--- a/bindings/Fortran/modules/adios2_io_open_mod_mpi.F90
+++ b/bindings/Fortran/modules/adios2_io_open_mod_mpi.F90
@@ -2,7 +2,7 @@
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.
 !
-!  adios2_io_open_mod_mpi.f90 : ADIOS2 Fortran bindings for IO
+!  adios2_io_open_mod_mpi.F90 : ADIOS2 Fortran bindings for IO
 !                               class open function (MPI variants)
 !
 

--- a/bindings/Fortran/modules/adios2_io_open_mod_serial.F90
+++ b/bindings/Fortran/modules/adios2_io_open_mod_serial.F90
@@ -6,16 +6,30 @@
 !                                  class open function (serial variants)
 !
 
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+# define ADIOS2_MODULE_PROCEDURE module &
+#else
+# define ADIOS2_MODULE_PROCEDURE
+#endif
+
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+submodule ( adios2_io_open_mod ) serial
+#else
 module adios2_io_open_mod_serial
+#endif
+
     use adios2_parameters_mod
     implicit none
 
+#ifndef ADIOS2_HAVE_FORTRAN_SUBMODULES
     interface adios2_open
         module procedure adios2_open_old_comm
     end interface
+#endif
 
 contains
 
+    ADIOS2_MODULE_PROCEDURE
     subroutine adios2_open_old_comm(engine, io, name, adios2_mode, ierr)
         type(adios2_engine), intent(out) :: engine
         type(adios2_io), intent(in) :: io
@@ -35,4 +49,8 @@ contains
 
     end subroutine
 
+#ifdef ADIOS2_HAVE_FORTRAN_SUBMODULES
+end submodule
+#else
 end module
+#endif

--- a/bindings/Fortran/modules/adios2_io_open_mod_serial.F90
+++ b/bindings/Fortran/modules/adios2_io_open_mod_serial.F90
@@ -2,7 +2,7 @@
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.
 !
-!  adios2_io_open_mod_serial.f90 : ADIOS2 Fortran bindings for IO
+!  adios2_io_open_mod_serial.F90 : ADIOS2 Fortran bindings for IO
 !                                  class open function (serial variants)
 !
 

--- a/cmake/ADIOSFunctions.cmake
+++ b/cmake/ADIOSFunctions.cmake
@@ -199,3 +199,29 @@ function(SetupTestPipeline basename pipeline do_setup)
   endforeach()
 endfunction()
 
+macro(adios2_check_fortran_submodules var)
+  include(CheckFortranSourceCompiles)
+  CHECK_Fortran_SOURCE_COMPILES([[
+module foo
+  interface bar
+    module subroutine bar_integer(x)
+      integer, intent(in) :: x
+    end subroutine
+    module subroutine bar_real(x)
+      real, intent(in) :: x
+    end subroutine
+  end interface
+end module
+submodule ( foo ) sub
+contains
+  module subroutine bar_integer(x)
+    integer, intent(in) :: x
+  end subroutine
+  module subroutine bar_real(x)
+    real, intent(in) :: x
+  end subroutine
+end submodule
+program main
+end program
+]] ${var} SRC_EXT F90)
+endmacro()


### PR DESCRIPTION
Convert the separate modules implementing Fortran `adios2_init` and `adios2_open` generic procedure signatures for MPI and non-MPI variants into submodules.  This allows the primary modules to be built first and the implementation submodules built later in separate libraries.

In order to support compilers that do not support Fortran submodules, use preprocessor conditions to optionally build without submodules as before.
