### PR TITLE
Fix unaligned memory access in SSC engine

### DIFF
--- a/source/adios2/engine/ssc/SscReader.tcc
+++ b/source/adios2/engine/ssc/SscReader.tcc
@@ -96,8 +96,8 @@ void SscReader::GetDeferredCommon(Variable<T> &variable, T *data)
                     b.shape.size() == 1 and b.start[0] == 0 and
                     b.count[0] == 1 and b.shape[0] == 1)
                 {
-                    data[0] = reinterpret_cast<T *>(m_Buffer.data() +
-                                                    b.bufferStart)[0];
+                    std::memcpy(data, m_Buffer.data() + b.bufferStart,
+                                sizeof(T));
                 }
                 else
                 {

--- a/source/adios2/helper/adiosMpiHandshake.cpp
+++ b/source/adios2/helper/adiosMpiHandshake.cpp
@@ -56,11 +56,13 @@ void MpiHandshake::Test()
                 size_t offset = PlaceInBuffer(stream, rank);
                 char mode = m_Buffer[offset];
                 offset += sizeof(char);
-                int appMasterRank =
-                    reinterpret_cast<int *>(m_Buffer.data() + offset)[0];
+                int appMasterRank;
+                std::memcpy(&appMasterRank, m_Buffer.data() + offset,
+                            sizeof(appMasterRank));
                 offset += sizeof(int);
-                int appSize =
-                    reinterpret_cast<int *>(m_Buffer.data() + offset)[0];
+                int appSize;
+                std::memcpy(&appSize, m_Buffer.data() + offset,
+                            sizeof(appSize));
                 offset += sizeof(int);
                 std::string filename = m_Buffer.data() + offset;
                 m_AppsSize[appMasterRank] = appSize;


### PR DESCRIPTION
@JasonRuonanWang I was getting a bus error due to unaligned memory access on the JAXA system (it has strict alignment requirements). This PR removes the unaligned accesses.