### PR TITLE
Revamp locking macros on SST reader side

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -145,6 +145,7 @@ struct _SstStream
 
     pthread_mutex_t DataLock;
     pthread_cond_t DataCondition;
+    int Locked;
     SstParams ConfigParams;
 
     /* WRITER-SIDE FIELDS */


### PR DESCRIPTION
No changes in locking here, just modifying the macros so that the Locked boolean is stream-local and we're a bit more uniform.  Doing piece-wise movement towards making TSAN happy to make it easier to evaluate each change.