### PR TITLE
Add a test in which we write/read changing local variables

### DIFF
--- a/testing/adios2/engine/staging-common/CMakeLists.txt
+++ b/testing/adios2/engine/staging-common/CMakeLists.txt
@@ -164,7 +164,7 @@ endif()
 set (SIMPLE_MPI_TESTS "")
 set (SIMPLE_MPI_FORTRAN_TESTS "")
 if (ADIOS2_HAVE_MPI)
-  set (SIMPLE_MPI_TESTS "2x1;1x2;3x5;5x3;DelayedReader_3x5;3x5LockGeometry;2x1.Local;1x2.Local;3x5.Local;5x3.Local;2x1ZeroDataVar;2x1ZeroDataR64")
+  set (SIMPLE_MPI_TESTS "2x1;1x2;3x5;5x3;DelayedReader_3x5;3x5LockGeometry;2x1.Local;1x2.Local;3x5.Local;5x3.Local;1x1.LocalVarying;5x3.LocalVarying;2x1ZeroDataVar;2x1ZeroDataR64")
   list (APPEND SPECIAL_TESTS "2x1.NoPreload;2x3.ForcePreload")
   if (ADIOS2_HAVE_Fortran)
     set (SIMPLE_MPI_FORTRAN_TESTS "FtoC.3x5;CtoF.3x5;FtoF.3x5")
@@ -218,6 +218,8 @@ if(ADIOS2_HAVE_MPI)
     list (REMOVE_ITEM INSITU_TESTS "TimeoutOnOpen" "1x1.Modes" "1x1.Attrs")
     # Local Vars don't work for InSitu
     list (FILTER INSITU_TESTS EXCLUDE REGEX ".*Local$")
+    # Local Vars don't work for InSitu
+    list (FILTER INSITU_TESTS EXCLUDE REGEX ".*LocalVarying$")
     # Multiple streams don't work for InSitu
     list (FILTER INSITU_TESTS EXCLUDE REGEX "x1.Shared")
     # Fortran Destination doesn't work for InSitu

--- a/testing/adios2/engine/staging-common/ParseArgs.h
+++ b/testing/adios2/engine/staging-common/ParseArgs.h
@@ -32,6 +32,8 @@ int DelayWhileHoldingStep = 0;
 int LongFirstDelay = 0;
 int FirstTimestepMustBeZero = 0;
 int LockGeometry = 0;
+bool VaryingDataSize = false;
+
 std::string shutdown_name = "DieTest";
 adios2::Mode GlobalWriteMode = adios2::Mode::Deferred;
 
@@ -208,6 +210,10 @@ static void ParseArgs(int argc, char **argv)
         {
             IncreasingDelay = 1;
             Latest = 1;
+        }
+        else if (std::string(argv[1]) == "--varying_data_size")
+        {
+            VaryingDataSize = true;
         }
         else if (std::string(argv[1]) == "--long_first_delay")
         {

--- a/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
@@ -84,7 +84,6 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
 
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         EXPECT_TRUE(var_i8);
-
         ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::LocalArray);
 
         auto var_i16 = io.InquireVariable<int16_t>("i16");
@@ -141,20 +140,78 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
         long unsigned int hisLength = (long unsigned int)Nx;
 
         var_i8.SetBlockSelection(rankToRead);
+        if (VaryingDataSize)
+        {
+            ASSERT_EQ(
+                engine.BlocksInfo(var_i8, currentStep).at(rankToRead).Count[0],
+                hisLength - currentStep - rankToRead);
+        }
+        else
+        {
+            ASSERT_EQ(
+                engine.BlocksInfo(var_i8, currentStep).at(rankToRead).Count[0],
+                hisLength);
+        }
         var_i16.SetBlockSelection(rankToRead);
+        ASSERT_EQ(
+            engine.BlocksInfo(var_i16, currentStep).at(rankToRead).Count[0],
+            hisLength);
         var_i32.SetBlockSelection(rankToRead);
+        ASSERT_EQ(
+            engine.BlocksInfo(var_i32, currentStep).at(rankToRead).Count[0],
+            hisLength);
         var_i64.SetBlockSelection(rankToRead);
+        ASSERT_EQ(
+            engine.BlocksInfo(var_i64, currentStep).at(rankToRead).Count[0],
+            hisLength);
 
         var_r32.SetBlockSelection(rankToRead);
+        ASSERT_EQ(
+            engine.BlocksInfo(var_r32, currentStep).at(rankToRead).Count[0],
+            hisLength);
         var_r64.SetBlockSelection(rankToRead);
+        ASSERT_EQ(
+            engine.BlocksInfo(var_r64, currentStep).at(rankToRead).Count[0],
+            hisLength);
+
         if (var_c32)
+        {
             var_c32.SetBlockSelection(rankToRead);
+            ASSERT_EQ(
+                engine.BlocksInfo(var_c32, currentStep).at(rankToRead).Count[0],
+                hisLength);
+        }
         if (var_c64)
+        {
             var_c64.SetBlockSelection(rankToRead);
+            ASSERT_EQ(
+                engine.BlocksInfo(var_c64, currentStep).at(rankToRead).Count[0],
+                hisLength);
+        }
         if (var_r64_2d)
+        {
             var_r64_2d.SetBlockSelection(rankToRead);
+            ASSERT_EQ(engine.BlocksInfo(var_r64_2d, currentStep)
+                          .at(rankToRead)
+                          .Count[0],
+                      hisLength);
+            ASSERT_EQ(engine.BlocksInfo(var_r64_2d, currentStep)
+                          .at(rankToRead)
+                          .Count[1],
+                      2);
+        }
         if (var_r64_2d_rev)
+        {
             var_r64_2d_rev.SetBlockSelection(rankToRead);
+            ASSERT_EQ(engine.BlocksInfo(var_r64_2d_rev, currentStep)
+                          .at(rankToRead)
+                          .Count[0],
+                      2);
+            ASSERT_EQ(engine.BlocksInfo(var_r64_2d_rev, currentStep)
+                          .at(rankToRead)
+                          .Count[1],
+                      hisLength);
+        }
 
         const adios2::Dims start_time{0};
         const adios2::Dims count_time{1};
@@ -192,7 +249,9 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
         engine.Get(var_time, (int64_t *)&write_time);
         engine.EndStep();
 
-        EXPECT_EQ(validateCommonTestData(hisStart, hisLength, t, !var_c32), 0);
+        EXPECT_EQ(validateCommonTestData(hisStart, hisLength, t, !var_c32,
+                                         VaryingDataSize, rankToRead),
+                  0);
         write_times.push_back(write_time);
         ++t;
     }

--- a/testing/adios2/engine/staging-common/TestCommonWriteLocal.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteLocal.cpp
@@ -50,6 +50,13 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
     // Declare 1D variables (NumOfProcesses * Nx)
     // The local process' part (start, count) can be defined now or later
     // before Write().
+
+    /* we'll be dropping the size for some vars */
+    if (VaryingDataSize)
+    {
+        assert(Nx > NSteps + mpiSize);
+    }
+
     {
         adios2::Dims shape{static_cast<unsigned int>(Nx * mpiSize)};
         adios2::Dims start{static_cast<unsigned int>(Nx * mpiRank)};
@@ -117,13 +124,17 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         auto var_time = io.InquireVariable<int64_t>("time");
 
         // // Make a 1D selection to describe the local dimensions of the
-        // // variable we write and its offsets in the global spaces
+        // // variable we write
+        adios2::Box<adios2::Dims> sel_shrinking({}, {Nx - step - mpiRank});
         // adios2::Box<adios2::Dims> sel({mpiRank * Nx}, {Nx});
         // adios2::Box<adios2::Dims> sel2({mpiRank * Nx, 0}, {Nx, 2});
         // adios2::Box<adios2::Dims> sel3({0, mpiRank * Nx}, {2, Nx});
         // adios2::Box<adios2::Dims> sel_time(
         //     {static_cast<unsigned long>(mpiRank)}, {1});
-        // var_i8.SetSelection(sel);
+        if (VaryingDataSize)
+        {
+            var_i8.SetSelection(sel_shrinking);
+        }
         // var_i16.SetSelection(sel);
         // var_i32.SetSelection(sel);
         // var_i64.SetSelection(sel);

--- a/testing/adios2/engine/staging-common/TestData.h
+++ b/testing/adios2/engine/staging-common/TestData.h
@@ -172,7 +172,8 @@ void generateCommonTestData(int step, int rank, int size, int Nx, int r64_Nx)
 }
 
 int validateCommonTestData(int start, int length, size_t step,
-                           int missing_end_data)
+                           int missing_end_data, bool varying = false,
+                           int writerRank = 0)
 {
     int failures = 0;
     if (in_scalar_R64 != 1.5 * (step + 1))
@@ -184,13 +185,16 @@ int validateCommonTestData(int start, int length, size_t step,
     }
     for (int i = 0; i < length; i++)
     {
-        if (in_I8[i] != (int8_t)((i + start) * 10 + step))
+        if ((!varying) || (i < length - step - writerRank))
         {
-            std::cout << "Expected 0x" << std::hex
-                      << (int8_t)((i + start) * 10 + step) << ", got 0x"
-                      << std::hex << in_I8[i] << " for in_I8[" << i
-                      << "](global[" << i + start << "])" << std::endl;
-            failures++;
+            if (in_I8[i] != (int8_t)((i + start) * 10 + step))
+            {
+                std::cout << "Expected 0x" << std::hex
+                          << (int8_t)((i + start) * 10 + step) << ", got 0x"
+                          << std::hex << in_I8[i] << " for in_I8[" << i
+                          << "](global[" << i + start << "])" << std::endl;
+                failures++;
+            }
         }
         if (in_I16[i] != (int16_t)((i + start) * 10 + step))
         {

--- a/testing/adios2/engine/staging-common/TestSupp.cmake
+++ b/testing/adios2/engine/staging-common/TestSupp.cmake
@@ -81,6 +81,8 @@ set (2x1.Local_CMD "run_test.py.$<CONFIG> -nw 2 -nr 1  -w $<TARGET_FILE:TestComm
 set (1x2.Local_CMD "run_test.py.$<CONFIG> -nw 1 -nr 2  -w $<TARGET_FILE:TestCommonWriteLocal> -r $<TARGET_FILE:TestCommonReadLocal>")
 set (3x5.Local_CMD "run_test.py.$<CONFIG> -nw 3 -nr 5  -w $<TARGET_FILE:TestCommonWriteLocal> -r $<TARGET_FILE:TestCommonReadLocal>")
 set (5x3.Local_CMD "run_test.py.$<CONFIG> -nw 5 -nr 3  -w $<TARGET_FILE:TestCommonWriteLocal> -r $<TARGET_FILE:TestCommonReadLocal>")
+set (1x1.LocalVarying_CMD "run_test.py.$<CONFIG> -nw 1 -nr 1  -w $<TARGET_FILE:TestCommonWriteLocal> --warg=--nx --warg=20 --warg=--varying_data_size -r $<TARGET_FILE:TestCommonReadLocal> --rarg=--nx --rarg=20 --rarg=--varying_data_size ")
+set (5x3.LocalVarying_CMD "run_test.py.$<CONFIG> -nw 5 -nr 3  -w $<TARGET_FILE:TestCommonWriteLocal> --warg=--nx --warg=20 --warg=--varying_data_size -r $<TARGET_FILE:TestCommonReadLocal> --rarg=--nx --rarg=20 --rarg=--varying_data_size ")
 set (DelayedReader_3x5_CMD "run_test.py.$<CONFIG> -rd 5 -nw 3 -nr 5")
 set (FtoC.3x5_CMD "run_test.py.$<CONFIG> -nw 3 -nr 5  -w $<TARGET_FILE:TestCommonWrite_f>")
 set (FtoF.3x5_CMD "run_test.py.$<CONFIG> -nw 3 -nr 5  -w $<TARGET_FILE:TestCommonWrite_f> -r $<TARGET_FILE:TestCommonRead_f>")


### PR DESCRIPTION
Add a test in which we write/read local variables and the size of one of which varies across ranks and timesteps.  @pnorbert Please look at this.  One of the variables written, i8, has a different size across ranks and timesteps.  But I'm not seeing failures with BP or SST.  Can you help sort what the code where you are seeing failures might be doing differently?