### PR TITLE
For specific engines, only utilize certain BP parameters

### DIFF
--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -314,7 +314,7 @@ StepStatus SstReader::BeginStep(StepMode Mode, const float timeout_sec)
 
         m_BP3Deserializer = new format::BP3Deserializer(m_Comm, m_DebugMode);
         m_BP3Deserializer->Init(m_IO.m_Parameters,
-                                "in call to BP3::Open for reading");
+                                "in call to BP3::Open for reading", "sst");
 
         m_BP3Deserializer->m_Metadata.Resize(
             (*m_CurrentStepMetaData->WriterMetadata)->DataSize,

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -143,7 +143,7 @@ StepStatus SstWriter::BeginStep(StepMode mode, const float timeout_sec)
         m_BP3Serializer = std::unique_ptr<format::BP3Serializer>(
             new format::BP3Serializer(m_Comm, m_DebugMode));
         m_BP3Serializer->Init(m_IO.m_Parameters,
-                              "in call to BP3::Open for writing");
+                              "in call to BP3::Open for writing", "sst");
         m_BP3Serializer->m_MetadataSet.TimeStep = 1;
         m_BP3Serializer->m_MetadataSet.CurrentStep = m_WriterStep;
     }

--- a/source/adios2/toolkit/format/bp/BPBase.h
+++ b/source/adios2/toolkit/format/bp/BPBase.h
@@ -284,7 +284,8 @@ public:
      * Init base don parameters passed from the user to IO
      * @param parameters input parameters
      */
-    void Init(const Params &parameters, const std::string hint);
+    void Init(const Params &parameters, const std::string hint,
+              const std::string engineType = "");
     /****************** NEED to check if some are virtual */
 
     /**


### PR DESCRIPTION
Add an EngineType parameter to BPBase::Init().  If the engine type is specified, use it to load only an "approved" subset of the specified BP parameters, leaving others at their defaults

This is one possible way to address #2053.  It doesn't give warnings about ignored parameters (generally we don't), or anything else, but it is a way to help make sure that engines that use BP don't get surprised by unsupported or new parameters that change the way BP behaves.