### PR TITLE
Debug mode changes

### DIFF
--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -290,16 +290,12 @@ void IO::SetTransportParameter(const size_t transportIndex,
                                const std::string key, const std::string value)
 {
     TAU_SCOPED_TIMER("IO::other");
-    if (m_DebugMode)
+    if (transportIndex >= m_TransportsParameters.size())
     {
-        if (transportIndex >= m_TransportsParameters.size())
-        {
-            throw std::invalid_argument(
-                "ERROR: transportIndex is larger than "
-                "transports created with AddTransport, for key: " +
-                key + ", value: " + value +
-                "in call to SetTransportParameter\n");
-        }
+        throw std::invalid_argument(
+            "ERROR: transportIndex is larger than "
+            "transports created with AddTransport, for key: " +
+            key + ", value: " + value + "in call to SetTransportParameter\n");
     }
 
     m_TransportsParameters[transportIndex][key] = value;
@@ -580,7 +576,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         }
     }
 
-    if (m_DebugMode && isEngineFound)
+    if (isEngineFound)
     {
         if (isEngineActive) // check if active
         {
@@ -665,25 +661,19 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
     }
     else
     {
-        if (m_DebugMode)
-        {
-            throw std::invalid_argument("ERROR: engine " + m_EngineType +
-                                        " not supported, IO SetEngine must add "
-                                        "a supported engine, in call to "
-                                        "Open\n");
-        }
+        throw std::invalid_argument("ERROR: engine " + m_EngineType +
+                                    " not supported, IO SetEngine must add "
+                                    "a supported engine, in call to "
+                                    "Open\n");
     }
 
     auto itEngine = m_Engines.emplace(name, std::move(engine));
 
-    if (m_DebugMode)
+    if (!itEngine.second)
     {
-        if (!itEngine.second)
-        {
-            throw std::invalid_argument(
-                "ERROR: engine of type " + m_EngineType + " and name " + name +
-                " could not be created, in call to Open\n");
-        }
+        throw std::invalid_argument("ERROR: engine of type " + m_EngineType +
+                                    " and name " + name +
+                                    " could not be created, in call to Open\n");
     }
     // return a reference
     return *itEngine.first->second.get();
@@ -698,14 +688,11 @@ Engine &IO::GetEngine(const std::string &name)
 {
     TAU_SCOPED_TIMER("IO::other");
     auto itEngine = m_Engines.find(name);
-    if (m_DebugMode)
+    if (itEngine == m_Engines.end())
     {
-        if (itEngine == m_Engines.end())
-        {
-            throw std::invalid_argument(
-                "ERROR: engine name " + name +
-                " could not be found, in call to GetEngine\n");
-        }
+        throw std::invalid_argument(
+            "ERROR: engine name " + name +
+            " could not be found, in call to GetEngine\n");
     }
     // return a reference
     return *itEngine->second.get();

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -33,7 +33,7 @@ Variable<T> &IO::DefineVariable(const std::string &name, const Dims &shape,
                                 const bool constantDims)
 {
     TAU_SCOPED_TIMER("IO::DefineVariable");
-    if (m_DebugMode)
+
     {
         auto itVariable = m_Variables.find(name);
         if (!IsEnd(itVariable, m_Variables))
@@ -103,15 +103,12 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T &value,
                                   const std::string separator)
 {
     TAU_SCOPED_TIMER("IO::DefineAttribute");
-    if (m_DebugMode)
+    if (!variableName.empty() && InquireVariableType(variableName).empty())
     {
-        if (!variableName.empty() && InquireVariableType(variableName).empty())
-        {
-            throw std::invalid_argument(
-                "ERROR: variable " + variableName +
-                " doesn't exist, can't associate attribute " + name +
-                ", in call to DefineAttribute");
-        }
+        throw std::invalid_argument(
+            "ERROR: variable " + variableName +
+            " doesn't exist, can't associate attribute " + name +
+            ", in call to DefineAttribute");
     }
 
     const std::string globalName =
@@ -140,15 +137,12 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T *array,
                                   const std::string separator)
 {
     TAU_SCOPED_TIMER("IO::DefineAttribute");
-    if (m_DebugMode)
+    if (!variableName.empty() && InquireVariableType(variableName).empty())
     {
-        if (!variableName.empty() && InquireVariableType(variableName).empty())
-        {
-            throw std::invalid_argument(
-                "ERROR: variable " + variableName +
-                " doesn't exist, can't associate attribute " + name +
-                ", in call to DefineAttribute");
-        }
+        throw std::invalid_argument(
+            "ERROR: variable " + variableName +
+            " doesn't exist, can't associate attribute " + name +
+            ", in call to DefineAttribute");
     }
 
     const std::string globalName =

--- a/source/adios2/core/Operator.cpp
+++ b/source/adios2/core/Operator.cpp
@@ -54,14 +54,9 @@ void Operator::RunCallback2(void *arg0, const std::string &arg1,
 
 size_t Operator::BufferMaxSize(const size_t sizeIn) const
 {
-    if (m_DebugMode)
-    {
-        throw std::invalid_argument(
-            "ERROR: signature (const size_t) not supported "
-            "by derived class implemented with " +
-            m_Type + ", in call to BufferMaxSize\n");
-    }
-    return 0;
+    throw std::invalid_argument("ERROR: signature (const size_t) not supported "
+                                "by derived class implemented with " +
+                                m_Type + ", in call to BufferMaxSize\n");
 }
 
 #define declare_type(T)                                                        \
@@ -80,30 +75,21 @@ size_t Operator::Compress(const void * /*dataIn*/, const Dims & /*dimensions*/,
                           const std::string /*type*/, void * /*bufferOut*/,
                           const Params & /*params*/, Params & /*info*/) const
 {
-    if (m_DebugMode)
-    {
-        throw std::invalid_argument("ERROR: signature (const void*, const "
-                                    "Dims, const size_t, const std::string, "
-                                    "void*, const Params&) not supported "
-                                    "by derived class implemented with " +
-                                    m_Type + ", in call to Compress\n");
-    }
-    return 0;
+    throw std::invalid_argument("ERROR: signature (const void*, const "
+                                "Dims, const size_t, const std::string, "
+                                "void*, const Params&) not supported "
+                                "by derived class implemented with " +
+                                m_Type + ", in call to Compress\n");
 }
 
 size_t Operator::Decompress(const void *bufferIn, const size_t sizeIn,
                             void *dataOut, const size_t sizeOut,
                             Params &info) const
 {
-    if (m_DebugMode)
-    {
-        throw std::invalid_argument(
-            "ERROR: signature (const void*, const size_t, void) not supported "
-            "by derived class implemented with " +
-            m_Type + ", in call to Decompress\n");
-    }
-
-    return 0;
+    throw std::invalid_argument(
+        "ERROR: signature (const void*, const size_t, void) not supported "
+        "by derived class implemented with " +
+        m_Type + ", in call to Decompress\n");
 }
 
 size_t Operator::Decompress(const void * /*bufferIn*/, const size_t /*sizeIn*/,
@@ -111,16 +97,11 @@ size_t Operator::Decompress(const void * /*bufferIn*/, const size_t /*sizeIn*/,
                             const std::string /*type*/,
                             const Params & /*parameters*/) const
 {
-    if (m_DebugMode)
-    {
-        throw std::invalid_argument("ERROR: signature (const void*, const "
-                                    "size_t, void*, const Dims&, const "
-                                    "std::string ) not supported "
-                                    "by derived class implemented with " +
-                                    m_Type + ", in call to Decompress\n");
-    }
-
-    return 0;
+    throw std::invalid_argument("ERROR: signature (const void*, const "
+                                "size_t, void*, const Dims&, const "
+                                "std::string ) not supported "
+                                "by derived class implemented with " +
+                                m_Type + ", in call to Decompress\n");
 }
 
 // PROTECTED
@@ -128,22 +109,16 @@ size_t Operator::DoBufferMaxSize(const void *dataIn, const Dims &dimensions,
                                  const std::string type,
                                  const Params &parameters) const
 {
-    if (m_DebugMode)
-    {
-        throw std::invalid_argument(
-            "ERROR: signature (const void*, const Dims& "
-            "std::string ) not supported "
-            "by derived class implemented with " +
-            m_Type + ", in call to BufferMaxSize\n");
-    }
-
-    return 0;
+    throw std::invalid_argument("ERROR: signature (const void*, const Dims& "
+                                "std::string ) not supported "
+                                "by derived class implemented with " +
+                                m_Type + ", in call to BufferMaxSize\n");
 }
 
 // PRIVATE
 void Operator::CheckCallbackType(const std::string type) const
 {
-    if (m_DebugMode && m_Type != type)
+    if (m_Type != type)
     {
         throw std::invalid_argument("ERROR: operator of type " + m_Type +
                                     " doesn't match expected callback type " +

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -204,7 +204,7 @@ size_t VariableBase::GetAvailableStepsCount() const
 
 void VariableBase::SetStepSelection(const Box<size_t> &boxSteps)
 {
-    if (m_DebugMode && boxSteps.second == 0)
+    if (boxSteps.second == 0)
     {
         throw std::invalid_argument("ERROR: boxSteps.second count argument "
                                     " can't be zero, from variable " +
@@ -228,15 +228,12 @@ void VariableBase::SetOperationParameter(const size_t operationID,
                                          const std::string key,
                                          const std::string value)
 {
-    if (m_DebugMode)
+    if (operationID >= m_Operations.size())
     {
-        if (operationID >= m_Operations.size())
-        {
-            throw std::invalid_argument(
-                "ERROR: invalid operationID " + std::to_string(operationID) +
-                ", check returned id from AddOperation, in call to "
-                "SetOperationParameter\n");
-        }
+        throw std::invalid_argument(
+            "ERROR: invalid operationID " + std::to_string(operationID) +
+            ", check returned id from AddOperation, in call to "
+            "SetOperationParameter\n");
     }
 
     m_Operations[operationID].Parameters[key] = value;
@@ -274,7 +271,7 @@ bool VariableBase::IsValidStep(const size_t step) const noexcept
 
 void VariableBase::CheckRandomAccessConflict(const std::string hint) const
 {
-    if (m_DebugMode && m_RandomAccess && !m_FirstStreamingStep)
+    if (m_RandomAccess && !m_FirstStreamingStep)
     {
         throw std::invalid_argument("ERROR: can't mix streaming and "
                                     "random-access (call to SetStepSelection)"
@@ -422,7 +419,7 @@ void VariableBase::InitShapeType()
             else
             {
 
-                if (m_DebugMode && m_ConstantDims)
+                if (m_ConstantDims)
                 {
                     throw std::invalid_argument(
                         "ERROR: isConstantShape (true) argument is invalid "
@@ -494,14 +491,11 @@ void VariableBase::InitShapeType()
         }
         else
         {
-            if (m_DebugMode)
-            {
-                throw std::invalid_argument(
-                    "ERROR: if the "
-                    "shape is empty, start must be empty as well, in call to "
-                    "DefineVariable " +
-                    m_Name + "\n");
-            }
+            throw std::invalid_argument(
+                "ERROR: if the "
+                "shape is empty, start must be empty as well, in call to "
+                "DefineVariable " +
+                m_Name + "\n");
         }
     }
 


### PR DESCRIPTION
Simple tweaks to a few files using DebugMode.  The idea here is that if it's worth raising an exception in DebugMode, it's worth raising it unconditionally.  None of the changes here affect anything where the actual checks inside an "if(DebugMode)" conditional are more expensive than a compare or two.  It does remove some checks which had the effect of making semantics different in DebugMode than in normal mode.  (Specifically, normal mode would allow multiple variables with the same name to be defined without error, but with unclear consequences.  Now multiple definition is disallowed always.)

(This is just for a few files in core for now, but other uses could benefit from examination.)