### PR TITLE
Reader side connection close race

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -201,6 +201,7 @@ struct _SstStream
     long DiscardPriorTimestep; /* timesteps numerically less than this will be
                                   discarded with prejudice */
     long LastDPNotifiedTimestep;
+    int FailureContactRank;
 
     /* reader side marshal info */
     FFSContext ReaderFFSContext;


### PR DESCRIPTION
This corrects a possible race condition that has to do with the timing of connection close detection and how it's handled on the reader side.  Generally, a close of the connection to the writer (from the reader) is interpreted as a failure, *unless* we have received a Close message from the writer and/or the reader Status has been updated to Closed by status propogation on the reader side.  But, it is possible that we'll get a connection close on a link either 1) in peer mode, but on a connection upon which we won't get the close, or 2) in commmin mode when we're not rank 0 (and therefore won't get a Close message) but before we do status propogation.  In these circumstances, we should *not* interpret the connection close as an immediate failure.  (If it is a failure we should get later closes that we *will* interpret that way.)  Also, in DP, we should fail only the requests for that rank, but if any of those exist, we should fail all for any rank.   (This is a race outside of the knowledge of TSAN.)