### PR TITLE
Enable "buffered" parameter for file transports

### DIFF
--- a/examples/heatTransfer/heat_bp4.xml
+++ b/examples/heatTransfer/heat_bp4.xml
@@ -47,6 +47,7 @@
             
             <!-- POSIX, stdio (C FILE*), fstream (C++) -->
             <parameter key="Library" value="stdio"/>
+            <parameter key="Buffered" value="false"/>
             
             <!-- For read/write, Microseconds (default), Milliseconds, Seconds, 
                  Minutes, Hours. open/close always in Microseconds -->

--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -102,6 +102,11 @@ void FileFStream::Open(const std::string &name, const Mode openMode,
 
 void FileFStream::SetBuffer(char *buffer, size_t size)
 {
+    if (!buffer && size != 0)
+    {
+        throw std::invalid_argument(
+            "buffer size must be 0 when using a NULL buffer");
+    }
     m_FileStream.rdbuf()->pubsetbuf(buffer, size);
     CheckFile("couldn't set buffer in file " + m_Name +
               ", in call to fstream rdbuf()->pubsetbuf");

--- a/source/adios2/toolkit/transport/file/FileStdio.h
+++ b/source/adios2/toolkit/transport/file/FileStdio.h
@@ -59,6 +59,11 @@ private:
     bool m_IsOpening = false;
     std::future<FILE *> m_OpenFuture;
 
+    /** Buffer settings need to be delayed until after opening */
+    bool m_DelayedBufferSet = false;
+    char *m_DelayedBuffer = nullptr;
+    size_t m_DelayedBufferSize = 0;
+
     /**
      * Check for std::ferror and throw an exception if true
      * @param hint exception message

--- a/testing/adios2/transports/CMakeLists.txt
+++ b/testing/adios2/transports/CMakeLists.txt
@@ -3,11 +3,4 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-add_subdirectory(interface)
-add_subdirectory(engine)
-add_subdirectory(transports)
-add_subdirectory(bindings)
-add_subdirectory(xml)
-add_subdirectory(yaml)
-add_subdirectory(performance)
-add_subdirectory(helper)
+gtest_add_tests_helper(File FALSE "" Transports. "")

--- a/testing/adios2/transports/TestFile.cpp
+++ b/testing/adios2/transports/TestFile.cpp
@@ -1,0 +1,138 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <array>
+#include <stdexcept>
+#include <tuple>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+class BufferTest
+: public ::testing::TestWithParam<
+      std::tuple<std::string, std::string, std::string, std::string>>
+{
+};
+
+TEST_P(BufferTest, WriteRead)
+{
+    const std::string &transportWriteLibrary = std::get<0>(GetParam());
+    const std::string &transportWriteBuffer = std::get<1>(GetParam());
+    const std::string &transportReadLibrary = std::get<2>(GetParam());
+    const std::string &transportReadBuffer = std::get<3>(GetParam());
+
+    const std::string fname("FileBufferTest_" + transportWriteLibrary + "_" +
+                            transportWriteBuffer + "_" + transportReadLibrary +
+                            "_" + transportReadBuffer + ".bp");
+
+    std::array<double, 100> dataOrig;
+    for (size_t i = 0; i < 100; ++i)
+    {
+        dataOrig[i] = static_cast<double>(i);
+    }
+
+    adios2::ADIOS adios;
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        io.SetEngine("BP4");
+        const size_t transportID = io.AddTransport("file");
+        io.SetTransportParameter(transportID, "Library", transportWriteLibrary);
+        io.SetTransportParameter(transportID, "Buffer", transportWriteBuffer);
+
+        auto var = io.DefineVariable<double>("var", {100}, {0}, {100});
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+
+        writer.Put(var, dataOrig.data());
+
+        // Close the file
+        writer.Close();
+    }
+
+    std::array<double, 100> dataRead;
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        io.SetEngine("BP4");
+        const size_t transportID = io.AddTransport("file");
+        io.SetTransportParameter(transportID, "Library", transportReadLibrary);
+        io.SetTransportParameter(transportID, "Buffer", transportReadBuffer);
+
+        adios2::Engine reader = io.Open(fname, adios2::Mode::Read);
+        auto var = io.InquireVariable<double>("var");
+        ASSERT_EQ(var.Shape().size(), 1);
+        ASSERT_EQ(var.Shape()[0], 100);
+
+        reader.Get(var, dataRead.data());
+        reader.Close();
+    }
+
+    for (size_t i = 0; i < 100; ++i)
+    {
+        ASSERT_EQ(dataOrig[i], dataRead[i]);
+    }
+}
+
+#ifdef __unix__
+INSTANTIATE_TEST_CASE_P(
+    TransportTests, BufferTest,
+    ::testing::Values(std::make_tuple("fstream", "true", "posix", "false"),
+                      std::make_tuple("fstream", "false", "posix", "false"),
+                      std::make_tuple("posix", "false", "stdio", "true"),
+                      std::make_tuple("posix", "false", "stdio", "false"),
+                      std::make_tuple("posix", "false", "fstream", "true"),
+                      std::make_tuple("posix", "false", "fstream", "false"),
+                      std::make_tuple("posix", "false", "posix", "false"),
+                      std::make_tuple("stdio", "true", "posix", "false"),
+                      std::make_tuple("stdio", "false", "posix", "false"),
+
+                      std::make_tuple("stdio", "true", "stdio", "true"),
+                      std::make_tuple("stdio", "true", "stdio", "false"),
+                      std::make_tuple("stdio", "false", "stdio", "true"),
+                      std::make_tuple("stdio", "false", "stdio", "false"),
+                      std::make_tuple("stdio", "true", "fstream", "true"),
+                      std::make_tuple("stdio", "true", "fstream", "false"),
+                      std::make_tuple("stdio", "false", "fstream", "true"),
+                      std::make_tuple("stdio", "false", "fstream", "false"),
+
+                      std::make_tuple("fstream", "true", "stdio", "true"),
+                      std::make_tuple("fstream", "true", "stdio", "false"),
+                      std::make_tuple("fstream", "false", "stdio", "true"),
+                      std::make_tuple("fstream", "false", "stdio", "false"),
+                      std::make_tuple("fstream", "true", "fstream", "true"),
+                      std::make_tuple("fstream", "true", "fstream", "false"),
+                      std::make_tuple("fstream", "false", "fstream", "true"),
+                      std::make_tuple("fstream", "false", "fstream", "false")));
+#else
+INSTANTIATE_TEST_CASE_P(
+    TransportTests, BufferTest,
+    ::testing::Values(std::make_tuple("stdio", "true", "stdio", "true"),
+                      std::make_tuple("stdio", "true", "stdio", "false"),
+                      std::make_tuple("stdio", "false", "stdio", "true"),
+                      std::make_tuple("stdio", "false", "stdio", "false"),
+                      std::make_tuple("stdio", "true", "fstream", "true"),
+                      std::make_tuple("stdio", "true", "fstream", "false"),
+                      std::make_tuple("stdio", "false", "fstream", "true"),
+                      std::make_tuple("stdio", "false", "fstream", "false"),
+
+                      std::make_tuple("fstream", "true", "stdio", "true"),
+                      std::make_tuple("fstream", "true", "stdio", "false"),
+                      std::make_tuple("fstream", "false", "stdio", "true"),
+                      std::make_tuple("fstream", "false", "stdio", "false"),
+                      std::make_tuple("fstream", "true", "fstream", "true"),
+                      std::make_tuple("fstream", "true", "fstream", "false"),
+                      std::make_tuple("fstream", "false", "fstream", "true"),
+                      std::make_tuple("fstream", "false", "fstream", "false")));
+#endif
+
+int main(int argc, char **argv)
+{
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    result = RUN_ALL_TESTS();
+
+    return result;
+}


### PR DESCRIPTION
This allows the `fstream` and `stdio` transports to be configured for unbufferd I/O by setting the buffer to `null`.  See  https://gcc.gnu.org/onlinedocs/libstdc++/manual/streambufs.html#io.streambuf.buffering

The defaults remain unchanged but this now allows an extra transport parameter to disable buffered i/o.