### PR TITLE
Fixing a few problems for single values in SSC

### DIFF
--- a/source/adios2/engine/ssc/SscHelper.cpp
+++ b/source/adios2/engine/ssc/SscHelper.cpp
@@ -129,6 +129,10 @@ void BlockVecToJson(const BlockVec &input, nlohmann::json &output)
         jref["Count"] = b.count;
         jref["BufferStart"] = b.bufferStart;
         jref["BufferCount"] = b.bufferCount;
+        if (!b.value.empty())
+        {
+            jref["Value"] = b.value;
+        }
     }
 }
 
@@ -214,6 +218,13 @@ void JsonToBlockVecVec(const nlohmann::json &input, BlockVecVec &output)
                 b.shape = j["Shape"].get<Dims>();
                 b.bufferStart = j["BufferStart"].get<size_t>();
                 b.bufferCount = j["BufferCount"].get<size_t>();
+                auto it = j.find("Value");
+                if (it != j.end())
+                {
+                    auto value = it->get<std::vector<char>>();
+                    b.value.resize(value.size());
+                    std::memcpy(b.value.data(), value.data(), value.size());
+                }
             }
         }
     }

--- a/source/adios2/engine/ssc/SscHelper.h
+++ b/source/adios2/engine/ssc/SscHelper.h
@@ -35,6 +35,7 @@ struct BlockInfo
     Dims count;
     size_t bufferStart;
     size_t bufferCount;
+    std::vector<char> value;
 };
 using BlockVec = std::vector<BlockInfo>;
 using BlockVecVec = std::vector<BlockVec>;

--- a/source/adios2/engine/ssc/SscReader.tcc
+++ b/source/adios2/engine/ssc/SscReader.tcc
@@ -163,13 +163,16 @@ SscReader::BlocksInfoCommon(const Variable<T> &variable,
                 if (v.shapeId == ShapeID::GlobalValue ||
                     v.shapeId == ShapeID::LocalValue)
                 {
-                    T value;
-                    std::memcpy(&value, m_Buffer.data() + v.bufferStart,
-                                v.bufferCount);
                     b.IsValue = true;
-                    b.Max = value;
-                    b.Min = value;
-                    b.Value = value;
+                    if (m_CurrentStep == 0)
+                    {
+                        std::memcpy(&b.Value, v.value.data(), v.value.size());
+                    }
+                    else
+                    {
+                        std::memcpy(&b.Value, m_Buffer.data() + v.bufferStart,
+                                    v.bufferCount);
+                    }
                 }
             }
         }

--- a/source/adios2/engine/ssc/SscWriter.tcc
+++ b/source/adios2/engine/ssc/SscWriter.tcc
@@ -52,7 +52,7 @@ void SscWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
         }
     }
 
-    if (not found)
+    if (!found)
     {
         if (m_CurrentStep == 0)
         {
@@ -68,6 +68,12 @@ void SscWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
             b.bufferCount = ssc::TotalDataSize(b.count, b.type, b.shapeId);
             m_Buffer.resize(b.bufferStart + b.bufferCount);
             std::memcpy(m_Buffer.data() + b.bufferStart, data, b.bufferCount);
+            if (b.shapeId == ShapeID::GlobalValue ||
+                b.shapeId == ShapeID::LocalValue)
+            {
+                b.value.resize(sizeof(T));
+                std::memcpy(b.value.data(), data, b.bufferCount);
+            }
         }
         else
         {

--- a/testing/adios2/engine/ssc/TestSscBase.cpp
+++ b/testing/adios2/engine/ssc/TestSscBase.cpp
@@ -121,6 +121,15 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
         adios2::StepStatus status = dataManReader.BeginStep(StepMode::Read, 5);
         if (status == adios2::StepStatus::OK)
         {
+            auto scalarInt = dataManIO.InquireVariable<int>("scalarInt");
+            auto blocksInfo = dataManReader.BlocksInfo(
+                scalarInt, dataManReader.CurrentStep());
+
+            for (const auto &bi : blocksInfo)
+            {
+                ASSERT_EQ(bi.IsValue, true);
+                ASSERT_EQ(bi.Value, dataManReader.CurrentStep());
+            }
 
             const auto &vars = dataManIO.AvailableVariables();
             ASSERT_EQ(vars.size(), 11);
@@ -170,15 +179,6 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             dataManReader.Get(bpDComplexes, myDComplexes.data(),
                               adios2::Mode::Sync);
 
-            auto scalarInt = dataManIO.InquireVariable<int>("scalarInt");
-            auto blocksInfo = dataManReader.BlocksInfo(
-                scalarInt, dataManReader.CurrentStep());
-
-            for (const auto &bi : blocksInfo)
-            {
-                ASSERT_EQ(bi.IsValue, true);
-                ASSERT_EQ(bi.Value, dataManReader.CurrentStep());
-            }
             int i;
             dataManReader.Get(scalarInt, &i);
             ASSERT_EQ(i, currentStep);

--- a/testing/adios2/engine/ssc/TestSscBase.cpp
+++ b/testing/adios2/engine/ssc/TestSscBase.cpp
@@ -129,6 +129,8 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             {
                 ASSERT_EQ(bi.IsValue, true);
                 ASSERT_EQ(bi.Value, dataManReader.CurrentStep());
+                ASSERT_EQ(scalarInt.Min(), dataManReader.CurrentStep());
+                ASSERT_EQ(scalarInt.Max(), dataManReader.CurrentStep());
             }
 
             const auto &vars = dataManIO.AvailableVariables();


### PR DESCRIPTION
@pnorbert This should work once it is merged. You should be able to use both the BlocksInfo API and the Variable API to get single values.