### PR TITLE
bindings: Remove debug_mode flag from C adios2_init_{serial,mpi}

### DIFF
--- a/bindings/C/adios2/c/adios2_c_adios.cpp
+++ b/bindings/C/adios2/c/adios2_c_adios.cpp
@@ -41,15 +41,14 @@ adios2_adios *adios2_init_config_glue_serial(const char *config_file,
     return adios;
 }
 
-adios2_adios *adios2_init_serial(const adios2_debug_mode debug_mode)
+adios2_adios *adios2_init_serial()
 {
-    return adios2_init_config_serial("", debug_mode);
+    return adios2_init_config_glue_serial("", adios2_debug_mode_off, "C");
 }
 
-adios2_adios *adios2_init_config_serial(const char *config_file,
-                                        const adios2_debug_mode debug_mode)
+adios2_adios *adios2_init_config_serial(const char *config_file)
 {
-    return adios2_init_config_glue_serial("", debug_mode, "C");
+    return adios2_init_config_glue_serial("", adios2_debug_mode_off, "C");
 }
 
 adios2_io *adios2_declare_io(adios2_adios *adios, const char *name)

--- a/bindings/C/adios2/c/adios2_c_adios.h
+++ b/bindings/C/adios2/c/adios2_c_adios.h
@@ -22,19 +22,17 @@ extern "C" {
 #endif
 
 #if ADIOS2_USE_MPI
-#define adios2_init adios2_init_mpi
-#define adios2_init_config adios2_init_config_mpi
+#define adios2_init(comm, debug_mode) adios2_init_mpi(comm)
+#define adios2_init_config(config_file, comm, debug_mode)                      \
+    adios2_init_config_mpi(config_file, comm)
 
 /**
  * Starting point for MPI apps. Creates an ADIOS handler.
  * MPI collective and it calls MPI_Comm_dup
  * @param comm defines domain scope from application
- * @param debug_mode true: extra user-input debugging information, false:
- * run without checking user-input (stable workflows)
  * @return success: handler, failure: NULL
  */
-adios2_adios *adios2_init_mpi(MPI_Comm comm,
-                              const adios2_debug_mode debug_mode);
+adios2_adios *adios2_init_mpi(MPI_Comm comm);
 
 /**
  * Starting point for MPI apps. Creates an ADIOS handler allowing a runtime
@@ -43,37 +41,28 @@ adios2_adios *adios2_init_mpi(MPI_Comm comm,
  * configFile contents
  * @param config_file runtime configuration file in xml format
  * @param comm defines domain scope from application
- * @param debug_mode true: extra user-input debugging information, false:
- * run without checking user-input (stable workflows)
  * @return success: handler, failure: NULL
  */
-adios2_adios *adios2_init_config_mpi(const char *config_file, MPI_Comm comm,
-                                     const adios2_debug_mode debug_mode);
+adios2_adios *adios2_init_config_mpi(const char *config_file, MPI_Comm comm);
 #else
-#define adios2_init adios2_init_serial
-#define adios2_init_config adios2_init_config_serial
+#define adios2_init(debug_mode) adios2_init_serial()
+#define adios2_init_config(config_file, debug_mode)                            \
+    adios2_init_config_serial(config_file)
 #endif
 
 /**
  * Initialize an ADIOS struct pointer handler in a serial, non-MPI application.
  * Doesn't require a runtime config file.
- * @param debug_mode adios2_debug_mode_on or adios2_debug_mode_off, adds extra
- * checking to user input to be captured by adios2_error. Use it for stable
- * workflows
  * @return success: handler, failure: NULL
  */
-adios2_adios *adios2_init_serial(const adios2_debug_mode debug_mode);
+adios2_adios *adios2_init_serial(void);
 
 /**
  * Initialize an ADIOS struct pointer handler in a serial, non-MPI application.
  * Doesn't require a runtime config file.
- * @param debug_mode adios2_debug_mode_on or adios2_debug_mode_off, adds extra
- * checking to user input to be captured by adios2_error. Use it for stable
- * workflows
  * @return success: handler, failure: NULL
  */
-adios2_adios *adios2_init_config_serial(const char *config_file,
-                                        const adios2_debug_mode debug_mode);
+adios2_adios *adios2_init_config_serial(const char *config_file);
 
 /**
  * Declares a new io handler

--- a/bindings/C/adios2/c/adios2_c_adios_mpi.cpp
+++ b/bindings/C/adios2/c/adios2_c_adios_mpi.cpp
@@ -37,15 +37,15 @@ adios2_adios *adios2_init_config_glue_mpi(const char *config_file,
     return adios;
 }
 
-adios2_adios *adios2_init_mpi(MPI_Comm comm, const adios2_debug_mode debug_mode)
+adios2_adios *adios2_init_mpi(MPI_Comm comm)
 {
-    return adios2_init_config_mpi("", comm, debug_mode);
+    return adios2_init_config_glue_mpi("", comm, adios2_debug_mode_off, "C");
 }
 
-adios2_adios *adios2_init_config_mpi(const char *config_file, MPI_Comm comm,
-                                     const adios2_debug_mode debug_mode)
+adios2_adios *adios2_init_config_mpi(const char *config_file, MPI_Comm comm)
 {
-    return adios2_init_config_glue_mpi(config_file, comm, debug_mode, "C");
+    return adios2_init_config_glue_mpi(config_file, comm, adios2_debug_mode_off,
+                                       "C");
 }
 
 } // end extern C


### PR DESCRIPTION
The `adios2_init{,_config}_{serial,mpi}` constructor functions were added by #1946.  They have not yet been included in a release, so we can change the signatures.  Drop the `debug_mode` argument.

~~Create undocumented/private `..._with_debug_mode` variants of the constructor functions to implement the legacy `adios2_init` and `adios2_init_config` constructors (whose args vary based on use of MPI).~~ EDIT: Define the legacy `adios2_init` and `adios2_init_config` constructors (whose args vary based on use of MPI) as function-like preprocessor macros that drop the `debug_mode` argument.  This preserves compatibility with callers of the original signatures.

Issue: #2127