### PR TITLE
Tsan writer

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -1012,6 +1012,7 @@ extern void SstStreamDestroy(SstStream Stream)
     }
     if (Stream->DP_Stream)
     {
+        pthread_mutex_unlock(&Stream->DataLock);
         if (Stream->Role == ReaderRole)
         {
             Stream->DP_Interface->destroyReader(&Svcs, Stream->DP_Stream);
@@ -1020,6 +1021,7 @@ extern void SstStreamDestroy(SstStream Stream)
         {
             Stream->DP_Interface->destroyWriter(&Svcs, Stream->DP_Stream);
         }
+        pthread_mutex_lock(&Stream->DataLock);
     }
     if (Stream->Readers)
     {


### PR DESCRIPTION
This runs cleanly for me under TSAN with only the following 4 exclusions:
race:*RemoveAllAttributes*
race:*LoadAttributes*
race:free_FFSBuffer
race:read_generation_environment_variables

Of these, the first two relate to the attribute issues and await reworking those semantics.  The last one is FFS-level and is *supposed* to be excluded by a __attribute__((no_sanitize("thread"))), but doesn't seem to be for some reason.  Still have to see why.  And what's going on with free_FFSBuffer.