### PR TITLE
Patch attribute handling to satisfy TSAN

### DIFF
--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -255,7 +255,6 @@ StepStatus SstReader::BeginStep(StepMode Mode, const float timeout_sec)
         break;
     }
     m_IO.RemoveAllVariables();
-    m_IO.RemoveAllAttributes();
     result = SstAdvanceStep(m_Input, timeout_sec);
     if (result == SstEndOfStream)
     {

--- a/source/adios2/toolkit/sst/cp/ffs_marshal.c
+++ b/source/adios2/toolkit/sst/cp/ffs_marshal.c
@@ -742,11 +742,16 @@ extern int SstFFSWriterBeginStep(SstStream Stream, int mode,
     return 0;
 }
 
-void SstReaderInitFFSCallback(SstStream Stream, void *Reader,
-                              VarSetupUpcallFunc VarCallback,
-                              ArraySetupUpcallFunc ArrayCallback,
-                              AttrSetupUpcallFunc AttrCallback,
-                              ArrayBlocksInfoUpcallFunc BlocksInfoCallback)
+/*
+ *  This code initializes upcall pointers during stream creation,
+ *  which are then read during stream usage (when locks are held).
+ *  The serialized init-then-use pattern is not a real TSAN problem,
+ *  so ignore this.
+ */
+void NO_SANITIZE_THREAD SstReaderInitFFSCallback(
+    SstStream Stream, void *Reader, VarSetupUpcallFunc VarCallback,
+    ArraySetupUpcallFunc ArrayCallback, AttrSetupUpcallFunc AttrCallback,
+    ArrayBlocksInfoUpcallFunc BlocksInfoCallback)
 {
     Stream->VarSetupUpcall = VarCallback;
     Stream->ArraySetupUpcall = ArrayCallback;


### PR DESCRIPTION
This includes another directive to TSAN to ignore a subroutine, this one that is the upcall function pointer initialization that is serialized with the uses of those pointers (which might happen when locks are held).  It's just not worth jumping through the hoops to make TSAN happy another way (by breaking critical sections which might introduce other race conditions).

The other change is moving attribute (and precious data) installation into the BeginStep search-for-timestep phase, rather than discarding metadata for known-to-be-unnecessary timesteps upon arrival.  This better fits the attribute model because we really shouldn't be installing attributes until we "pass" the timestep they appear on (so previously we were doing it too soon).  However, it does mean that we're keeping metadata around on the read side longer.  TSAN is happier because we're moving it to the main program thread rather than the network handler thread...