### PR TITLE
toolkit: link taustubs to 'dl' library explicitly

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -13,6 +13,8 @@ target_include_directories(taustubs PRIVATE
       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/source>
 )
 
+target_link_libraries(taustubs PRIVATE ${CMAKE_DL_LIBS})
+
 add_library(adios2_core
   common/ADIOSTypes.cpp
   


### PR DESCRIPTION
The `tautimer.cpp` source file uses `dlopen` and friends.  Link explicitly to the library providing those symbols.  Previously the symbols were only available when the library was used by a consumer that happened to link the 'dl' library or equivalent.