### PR TITLE
testing: Switch inline engine test MPI usage based on libraries linked

### DIFF
--- a/testing/adios2/engine/inline/TestInlineWriteRead.cpp
+++ b/testing/adios2/engine/inline/TestInlineWriteRead.cpp
@@ -627,12 +627,12 @@ TEST_F(InlineWriteRead, InlineWriteReadContracts)
     // Number of steps
     const size_t NSteps = 3;
 
-#ifdef ADIOS2_HAVE_MPI
+#if ADIOS2_USE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
 #endif
 
-#ifdef ADIOS2_HAVE_MPI
+#if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
 #else
     adios2::ADIOS adios(adios2::DebugON);
@@ -754,12 +754,12 @@ TEST_F(InlineWriteRead, InlineWriteReadContracts2)
     // Number of steps
     const size_t NSteps = 3;
 
-#ifdef ADIOS2_HAVE_MPI
+#if ADIOS2_USE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
 #endif
 
-#ifdef ADIOS2_HAVE_MPI
+#if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
 #else
     adios2::ADIOS adios(adios2::DebugON);


### PR DESCRIPTION
This was accidentally left out of #2145.
