### PR TITLE
Optimize SST/BP Reader

### DIFF
--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -52,7 +52,14 @@ public:
 
 private:
     template <class T>
-    void ReadVariableBlocks(Variable<T> &variable);
+    void ReadVariableBlocksRequests(Variable<T> &variable,
+                                    std::vector<void *> &sstReadHandlers,
+                                    std::vector<std::vector<char>> &buffers);
+
+    template <class T>
+    void ReadVariableBlocksFill(Variable<T> &variable,
+                                std::vector<std::vector<char>> &buffers,
+                                size_t &iter);
 
     template <class T>
     void SstBPPerformGets();

--- a/source/adios2/engine/sst/SstReader.tcc
+++ b/source/adios2/engine/sst/SstReader.tcc
@@ -24,11 +24,11 @@ namespace engine
 {
 
 template <class T>
-void SstReader::ReadVariableBlocks(Variable<T> &variable)
+void SstReader::ReadVariableBlocksRequests(
+    Variable<T> &variable, std::vector<void *> &sstReadHandlers,
+    std::vector<std::vector<char>> &buffers)
 {
     TAU_SCOPED_TIMER_FUNC();
-    std::vector<void *> sstReadHandlers;
-    std::vector<std::vector<char>> buffers;
 
 #ifdef ADIOS2_HAVE_ENDIAN_REVERSE
     const bool endianReverse = helper::IsLittleEndian() !=
@@ -36,8 +36,8 @@ void SstReader::ReadVariableBlocks(Variable<T> &variable)
 #else
     constexpr bool endianReverse = false;
 #endif
-
     size_t threadID = 0;
+
     for (typename Variable<T>::Info &blockInfo : variable.m_BlocksInfo)
     {
         T *originalBlockData = blockInfo.Data;
@@ -119,18 +119,23 @@ void SstReader::ReadVariableBlocks(Variable<T> &variable)
         // move back to original position
         blockInfo.Data = originalBlockData;
     }
+}
 
-    // wait for all SstRead requests to finish
-    for (const auto &i : sstReadHandlers)
-    {
-        if (SstWaitForCompletion(m_Input, i) != SstSuccess)
-        {
-            throw std::runtime_error(
-                "ERROR:  Writer failed before returning data");
-        }
-    }
+template <class T>
+void SstReader::ReadVariableBlocksFill(Variable<T> &variable,
+                                       std::vector<std::vector<char>> &buffers,
+                                       size_t &iter)
+{
+    TAU_SCOPED_TIMER_FUNC();
 
-    size_t iter = 0;
+#ifdef ADIOS2_HAVE_ENDIAN_REVERSE
+    const bool endianReverse = helper::IsLittleEndian() !=
+                               m_BP3Deserializer->m_Minifooter.IsLittleEndian;
+#else
+    constexpr bool endianReverse = false;
+#endif
+    size_t threadID = 0;
+
     threadID = 0;
     for (typename Variable<T>::Info &blockInfo : variable.m_BlocksInfo)
     {


### PR DESCRIPTION
In the existing formulation, ReadVariableBlocks() is a per-variable call.  It requests all writer-side data necessary to fulfill the local read (possibly multiple requests), waits for those requests to complete and then fills the read buffers for that variable.  If latency is long on those requests, this incurs a lot of overhead because multiple variables are handled only serially, while SST can handle many concurrent data requests.  This refactoring breaks ReadVariableBlocks() into two routines, ReadVariableBlocksRequests() and ReadVariableBlocksFill(), with a step in between that waits for all the read requests to complete.  The object is to maximize concurrency in the read requests by issuing the read requests for all pending variables (not just one) and then waiting on all those requests at once.