### PR TITLE
Replace the active flag byte in md.idx header with a separate empty f…

### DIFF
--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -521,7 +521,6 @@ bool BP4Reader::CheckWriterActive()
         flag = m_ActiveFlagFileManager.FileExists(
             activeFlagFile, m_IO.m_TransportsParameters[0],
             m_BP4Deserializer.m_Profiler.m_IsActive);
-        std::cout << " -- Active flag status: " << flag << std::endl;
     }
     flag = m_BP4Deserializer.m_Comm.BroadcastValue(flag, 0);
     m_WriterIsActive = (flag > 0);

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -72,6 +72,7 @@ private:
 
     /* transport manager for managing the active flag file */
     transportman::TransportMan m_ActiveFlagFileManager;
+    bool m_WriterIsActive = true;
 
     /** used for per-step reads, TODO: to be moved to BP4Deserializer */
     size_t m_CurrentStep = 0;
@@ -100,9 +101,9 @@ private:
      */
     void ProcessMetadataForNewSteps(const size_t newIdxSize);
 
-    /** Check the active status flag in index file.
-     *  @return true if writer is still active
-     *  it sets BP4Deserialized.m_WriterIsActive
+    /** Check the active status of the writer.
+     *  @return true if writer is still active.
+     *  It sets m_WriterIsActive.
      */
     bool CheckWriterActive();
 

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -77,6 +77,7 @@ private:
     /** used for per-step reads, TODO: to be moved to BP4Deserializer */
     size_t m_CurrentStep = 0;
     bool m_FirstStep = true;
+    bool m_IdxHeaderParsed = false; // true after first index parsing
 
     void Init();
     void InitTransports();

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -70,6 +70,9 @@ private:
     transportman::TransportMan m_MDIndexFileManager;
     size_t m_MDIndexFileProcessedSize = 0;
 
+    /* transport manager for managing the active flag file */
+    transportman::TransportMan m_ActiveFlagFileManager;
+
     /** used for per-step reads, TODO: to be moved to BP4Deserializer */
     size_t m_CurrentStep = 0;
     bool m_FirstStep = true;

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -31,11 +31,13 @@ BP4Writer::BP4Writer(IO &io, const std::string &name, const Mode mode,
                      helper::Comm comm)
 : Engine("BP4Writer", io, name, mode, std::move(comm)), m_BP4Serializer(m_Comm),
   m_FileDataManager(m_Comm), m_FileMetadataManager(m_Comm),
-  m_FileMetadataIndexManager(m_Comm), m_FileDrainer()
+  m_FileMetadataIndexManager(m_Comm), m_FileActiveFlagManager(m_Comm),
+  m_FileDrainer()
 {
     TAU_SCOPED_TIMER("BP4Writer::Open");
     m_IO.m_ReadStreaming = false;
     m_EndMessage = " in call to IO Open BP4Writer " + m_Name + "\n";
+
     Init();
 }
 
@@ -256,6 +258,9 @@ void BP4Writer::InitTransports()
             m_MetadataIndexFileNames, m_OpenMode, m_IO.m_TransportsParameters,
             m_BP4Serializer.m_Profiler.m_IsActive);
 
+        m_ActiveFlagFileNames =
+            m_BP4Serializer.GetBPActiveFlagFileNames(transportsNames);
+
         if (m_DrainBB)
         {
             const std::vector<std::string> drainTransportNames =
@@ -266,42 +271,18 @@ void BP4Writer::InitTransports()
             m_DrainMetadataIndexFileNames =
                 m_BP4Serializer.GetBPMetadataIndexFileNames(
                     drainTransportNames);
+            m_DrainActiveFlagFileNames =
+                m_BP4Serializer.GetBPActiveFlagFileNames(drainTransportNames);
             for (const auto &name : m_DrainMetadataFileNames)
             {
                 m_FileDrainer.AddOperationOpen(name, m_OpenMode);
             }
+            /* We don't need to create the index file, will just add a write
+             * operation to drain which will take care of creating it */
         }
 
-        if (m_OpenMode != Mode::Append ||
-            m_FileMetadataIndexManager.GetFileSize(0) == 0)
-        {
-            /* Prepare header and write now to Index Table indicating
-             * the start of streaming */
-            m_BP4Serializer.MakeHeader(m_BP4Serializer.m_MetadataIndex,
-                                       "Index Table", true);
-
-            m_FileMetadataIndexManager.WriteFiles(
-                m_BP4Serializer.m_MetadataIndex.m_Buffer.data(),
-                m_BP4Serializer.m_MetadataIndex.m_Position);
-            m_FileMetadataIndexManager.FlushFiles();
-            if (m_DrainBB)
-            {
-                for (const auto &name : m_DrainMetadataIndexFileNames)
-                {
-                    m_FileDrainer.AddOperationWrite(
-                        name, m_BP4Serializer.m_MetadataIndex.m_Position,
-                        m_BP4Serializer.m_MetadataIndex.m_Buffer.data());
-                    // Note:: the content is buffered safely inside drain thread
-                }
-            }
-            /* clear the metadata index buffer*/
-            m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_MetadataIndex, true);
-        }
-        else
-        {
-            /* Update header to indicate re-start of streaming */
-            UpdateActiveFlag(true);
-        }
+        /* Create active flag file to indicate a producer is active */
+        UpdateActiveFlag(true);
     }
 }
 
@@ -360,10 +341,6 @@ void BP4Writer::InitBPBuffer()
 
             if (m_BP4Serializer.m_RankMPI == 0)
             {
-                // Set the flag in the header of metadata index table to 0 again
-                // to indicate a new run begins
-                UpdateActiveFlag(true);
-
                 // Get the size of existing metadata file
                 m_BP4Serializer.m_PreMetadataFileLength =
                     m_FileMetadataManager.GetFileSize(0);
@@ -380,6 +357,8 @@ void BP4Writer::InitBPBuffer()
         {
             m_BP4Serializer.MakeHeader(m_BP4Serializer.m_Metadata, "Metadata",
                                        false);
+            m_BP4Serializer.MakeHeader(m_BP4Serializer.m_MetadataIndex,
+                                       "Index Table", false);
         }
         if (m_BP4Serializer.m_Aggregator.m_IsConsumer)
         {
@@ -443,6 +422,9 @@ void BP4Writer::DoClose(const int transportIndex)
 
         // close metadata index file
         m_FileMetadataIndexManager.CloseFiles();
+
+        // Delete the active flag file to indicate current run is over.
+        UpdateActiveFlag(false);
     }
 
     if (m_BP4Serializer.m_Aggregator.m_IsConsumer && m_DrainBB)
@@ -517,19 +499,28 @@ void BP4Writer::PopulateMetadataIndexFileContent(
 
 void BP4Writer::UpdateActiveFlag(const bool active)
 {
-    const char activeChar = (active ? '\1' : '\0');
-    m_FileMetadataIndexManager.WriteFileAt(
-        &activeChar, 1, m_BP4Serializer.m_ActiveFlagPosition, 0);
-    m_FileMetadataIndexManager.FlushFiles();
-    m_FileMetadataIndexManager.SeekToFileEnd();
-    if (m_DrainBB)
+    if (active)
     {
-        for (int i = 0; i < m_MetadataIndexFileNames.size(); ++i)
+        m_FileActiveFlagManager.OpenFiles(
+            m_ActiveFlagFileNames, Mode::Write, m_IO.m_TransportsParameters,
+            m_BP4Serializer.m_Profiler.m_IsActive);
+        if (m_DrainBB)
         {
-            m_FileDrainer.AddOperationWriteAt(
-                m_DrainMetadataIndexFileNames[i],
-                m_BP4Serializer.m_ActiveFlagPosition, 1, &activeChar);
-            m_FileDrainer.AddOperationSeekEnd(m_DrainMetadataIndexFileNames[i]);
+            for (const auto &name : m_DrainActiveFlagFileNames)
+            {
+                m_FileDrainer.AddOperationOpen(name, Mode::Write);
+            }
+        }
+    }
+    else
+    {
+        m_FileActiveFlagManager.DeleteFiles();
+        if (m_DrainBB)
+        {
+            for (const auto &name : m_DrainActiveFlagFileNames)
+            {
+                m_FileDrainer.AddOperationDelete(name);
+            }
         }
     }
 }
@@ -543,13 +534,6 @@ void BP4Writer::WriteCollectiveMetadataFile(const bool isFinal)
     {
         // If data pg count is zero, it means all metadata
         // has already been written, don't need to write it again.
-
-        if (m_BP4Serializer.m_RankMPI == 0)
-        {
-            // But the flag in the header of metadata index table needs to
-            // be modified to indicate current run is over.
-            UpdateActiveFlag(false);
-        }
         return;
     }
     m_BP4Serializer.AggregateCollectiveMetadata(
@@ -591,11 +575,6 @@ void BP4Writer::WriteCollectiveMetadataFile(const bool isFinal)
                                                "BP4 Index Table");
         for (auto const &t : timeSteps)
         {
-            /*if (t == 1)
-            {
-                m_BP4Serializer.MakeHeader(m_BP4Serializer.m_MetadataIndex,
-                                           "Index Table", true);
-            }*/
             const uint64_t pgIndexStartMetadataFile =
                 m_BP4Serializer
                     .m_MetadataIndexTable[m_BP4Serializer.m_RankMPI][t][0] +
@@ -640,14 +619,6 @@ void BP4Writer::WriteCollectiveMetadataFile(const bool isFinal)
                     m_BP4Serializer.m_MetadataIndex.m_Position,
                     m_BP4Serializer.m_MetadataIndex.m_Buffer.data());
             }
-        }
-
-        if (isFinal)
-        {
-            // Only one step of metadata is generated at close.
-            // The flag in the header of metadata index table
-            // needs to be modified to indicate current run is over.
-            UpdateActiveFlag(false);
         }
     }
     /*Clear the local indices buffer at the end of each step*/

--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -60,6 +60,8 @@ private:
     /* transport manager for managing the metadata index file */
     transportman::TransportMan m_FileMetadataIndexManager;
 
+    transportman::TransportMan m_FileActiveFlagManager;
+
     /*
      *  Burst buffer variables
      */
@@ -84,6 +86,8 @@ private:
     std::vector<std::string> m_DrainMetadataFileNames;
     std::vector<std::string> m_MetadataIndexFileNames;
     std::vector<std::string> m_DrainMetadataIndexFileNames;
+    std::vector<std::string> m_ActiveFlagFileNames;
+    std::vector<std::string> m_DrainActiveFlagFileNames;
 
     void Init() final;
 

--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -131,8 +131,6 @@ private:
      * profilers*/
     void WriteProfilingJSONFile();
 
-    void UpdateActiveFlag(const bool active);
-
     void PopulateMetadataIndexFileContent(
         format::BufferSTL &buffer, const uint64_t currentStep,
         const uint64_t mpirank, const uint64_t pgIndexStart,

--- a/source/adios2/toolkit/burstbuffer/FileDrainer.cpp
+++ b/source/adios2/toolkit/burstbuffer/FileDrainer.cpp
@@ -11,6 +11,7 @@
 #include "FileDrainer.h"
 
 #include <chrono>
+#include <cstdio>  // std::remove
 #include <cstring> // std::memcpy
 #include <thread>  // std::this_thread::sleep_for
 
@@ -113,6 +114,12 @@ void FileDrainer::AddOperationOpen(const std::string &toFileName, Mode mode)
     }
 }
 
+void FileDrainer::AddOperationDelete(const std::string &toFileName)
+{
+    std::string emptyStr;
+    AddOperation(DrainOperation::Delete, emptyStr, toFileName, 0, 0, 0);
+}
+
 InputFile FileDrainer::GetFileForRead(const std::string &path)
 {
     auto it = m_InputFileMap.find(path);
@@ -182,6 +189,7 @@ void FileDrainer::CloseAll()
         Close(it->second);
         //}
     }
+    m_OutputFileMap.clear();
     for (auto it = m_InputFileMap.begin(); it != m_InputFileMap.end(); ++it)
     {
         // if (it->second->good())
@@ -264,6 +272,12 @@ size_t FileDrainer::Write(OutputFile &f, size_t count, const char *buffer,
     }
 
     return count;
+}
+
+void FileDrainer::Delete(OutputFile &f, const std::string &path)
+{
+    Close(f);
+    std::remove(path.c_str());
 }
 
 void FileDrainer::SetVerbose(int verboseLevel, int rank)

--- a/source/adios2/toolkit/burstbuffer/FileDrainer.cpp
+++ b/source/adios2/toolkit/burstbuffer/FileDrainer.cpp
@@ -11,7 +11,7 @@
 #include "FileDrainer.h"
 
 #include <chrono>
-#include <cstdio>  // std::remove
+#include <cstdio>
 #include <cstring> // std::memcpy
 #include <thread>  // std::this_thread::sleep_for
 

--- a/source/adios2/toolkit/burstbuffer/FileDrainer.h
+++ b/source/adios2/toolkit/burstbuffer/FileDrainer.h
@@ -39,8 +39,8 @@ enum class DrainOperation
     WriteAt, // Write data from memory to toFileName directly at offset
     Write,   // Write data from memory to toFileName directly (without seek)
     Create,  // Open file for writing (creat) - only toFile
-    Open     // Open file for append - only toFile
-
+    Open,    // Open file for append - only toFile
+    Delete // Remove a file on disk (file will be opened if not already opened)
 };
 
 struct FileDrainOperation
@@ -88,6 +88,8 @@ public:
                            const void *data);
     void AddOperationOpen(const std::string &toFileName, Mode mode);
 
+    void AddOperationDelete(const std::string &toFileName);
+
     /** Create thread */
     virtual void Start() = 0;
 
@@ -133,6 +135,8 @@ protected:
                                    const std::string &path);
     size_t Write(OutputFile &f, size_t count, const char *buffer,
                  const std::string &path);
+
+    void Delete(OutputFile &f, const std::string &path);
 
 private:
     InputFileMap m_InputFileMap;

--- a/source/adios2/toolkit/burstbuffer/FileDrainerSingleThread.cpp
+++ b/source/adios2/toolkit/burstbuffer/FileDrainerSingleThread.cpp
@@ -288,11 +288,25 @@ void FileDrainerSingleThread::DrainThread()
         {
             if (m_Verbose >= 2)
             {
-                std::cout << "Drain " << m_Rank << "Open file "
+                std::cout << "Drain " << m_Rank << ": Open file "
                           << fdo.toFileName << " for append " << std::endl;
             }
             ts = std::chrono::steady_clock::now();
             GetFileForWrite(fdo.toFileName, true);
+            te = std::chrono::steady_clock::now();
+            timeWrite += te - ts;
+            break;
+        }
+        case DrainOperation::Delete:
+        {
+            if (m_Verbose >= 2)
+            {
+                std::cout << "Drain " << m_Rank << ": Delete file "
+                          << fdo.toFileName << std::endl;
+            }
+            ts = std::chrono::steady_clock::now();
+            auto fdw = GetFileForWrite(fdo.toFileName, true);
+            Delete(fdw, fdo.toFileName);
             te = std::chrono::steady_clock::now();
             timeWrite += te - ts;
             break;

--- a/source/adios2/toolkit/format/bp/BPBase.h
+++ b/source/adios2/toolkit/format/bp/BPBase.h
@@ -118,7 +118,7 @@ public:
         size_t StepsStart = 0;
 
         /** Used at Read, number of total steps */
-        size_t StepsCount = 1;
+        size_t StepsCount = 0;
 
         /** Similar to TimeStep, but uses uint64_t and start from zero. Used for
          * streaming a large number of steps */

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
@@ -84,6 +84,29 @@ std::string BP4Base::GetBPMetadataIndexFileName(const std::string &name) const
 }
 
 std::vector<std::string>
+BP4Base::GetBPActiveFlagFileNames(const std::vector<std::string> &names) const
+    noexcept
+{
+    std::vector<std::string> metadataIndexFileNames;
+    metadataIndexFileNames.reserve(names.size());
+    for (const auto &name : names)
+    {
+        metadataIndexFileNames.push_back(GetBPActiveFlagFileName(name));
+    }
+    return metadataIndexFileNames;
+}
+
+std::string BP4Base::GetBPActiveFlagFileName(const std::string &name) const
+    noexcept
+{
+    const std::string bpName = helper::RemoveTrailingSlash(name);
+    /* the name of the metadata index file is "md.idx" */
+    const std::string bpMetaDataIndexRankName(bpName + PathSeparator +
+                                              "active");
+    return bpMetaDataIndexRankName;
+}
+
+std::vector<std::string>
 BP4Base::GetBPSubStreamNames(const std::vector<std::string> &names) const
     noexcept
 {

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.h
@@ -102,6 +102,12 @@ public:
     std::string GetBPMetadataIndexFileName(const std::string &name) const
         noexcept;
 
+    std::vector<std::string>
+    GetBPActiveFlagFileNames(const std::vector<std::string> &names) const
+        noexcept;
+
+    std::string GetBPActiveFlagFileName(const std::string &name) const noexcept;
+
     std::string GetBPSubFileName(const std::string &name,
                                  const size_t subFileIndex,
                                  const bool hasSubFiles = true,

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
@@ -102,11 +102,13 @@ void BP4Deserializer::ParseMetadataIndex(const BufferSTL &bufferSTL,
                 std::to_string(m_Minifooter.Version) + " version \n");
         }
 
-        // Writer active flag
-        position = m_ActiveFlagPosition;
-        const char activeChar = helper::ReadValue<uint8_t>(
-            buffer, position, m_Minifooter.IsLittleEndian);
-        m_WriterIsActive = (activeChar == '\1' ? true : false);
+        /* Writer active flag (not used anymore)
+            //
+            //position = m_ActiveFlagPosition;
+            //const char activeChar = helper::ReadValue<uint8_t>(
+            //    buffer, position, m_Minifooter.IsLittleEndian);
+            //m_WriterIsActive = (activeChar == '\1' ? true : false);
+        */
 
         // move position to first row
         position = 64;
@@ -630,21 +632,6 @@ void BP4Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
     }
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
-}
-
-bool BP4Deserializer::ReadActiveFlag(std::vector<char> &buffer)
-{
-    if (buffer.size() < m_ActiveFlagPosition)
-    {
-        throw std::runtime_error("BP4Deserializer::CheckActiveFlag() is called "
-                                 "with a buffer smaller than required");
-    }
-    // Writer active flag
-    size_t position = m_ActiveFlagPosition;
-    const char activeChar = helper::ReadValue<uint8_t>(
-        buffer, position, m_Minifooter.IsLittleEndian);
-    m_WriterIsActive = (activeChar == '\1' ? true : false);
-    return m_WriterIsActive;
 }
 
 #define declare_template_instantiation(T)                                      \

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
@@ -36,8 +36,6 @@ public:
     /** BP Minifooter fields */
     Minifooter m_Minifooter;
 
-    bool m_WriterIsActive = false;
-
     /**
      * Unique constructor
      * @param comm multi-process communicator
@@ -153,12 +151,6 @@ public:
     template <class T>
     std::vector<typename core::Variable<T>::Info>
     BlocksInfo(const core::Variable<T> &variable, const size_t step) const;
-
-    /** Parse active flag in index table header (64 bytes).
-     *  Header must be read by caller into a vector of 64 characters.
-     *  It sets m_WriterIsActive and returns the same value
-     */
-    bool ReadActiveFlag(std::vector<char> &buffer);
 
     // TODO : Will deprecate all function below
     std::map<std::string, helper::SubFileInfoMap>

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
@@ -45,8 +45,8 @@ public:
     ~BP4Deserializer() = default;
 
     void ParseMetadataIndex(const BufferSTL &bufferSTL,
-                            const size_t absoluteStartPos = 0,
-                            const bool hasHeader = true);
+                            const size_t absoluteStartPos,
+                            const bool hasHeader);
 
     /* Return the position in the buffer where processing ends. The processing
      * is controlled by the number of records in the Index, which may be less

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -114,6 +114,9 @@ public:
     /** closes current file, after this file becomes unreachable */
     virtual void Close() = 0;
 
+    /** deletes current file, after this file becomes unreachable */
+    virtual void Delete() = 0;
+
     virtual void SeekToEnd() = 0;
 
     virtual void SeekToBegin() = 0;

--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -8,6 +8,7 @@
  *      Author: William F Godoy godoywf@ornl.gov
  */
 #include "FileFStream.h"
+#include <cstdio> // remove
 
 /// \cond EXCLUDE_FROM_DOXYGEN
 #include <ios> // std::ios_base::failure
@@ -220,6 +221,16 @@ void FileFStream::Close()
 
     CheckFile("couldn't close file " + m_Name + ", in call to fstream close");
     m_IsOpen = false;
+}
+
+void FileFStream::Delete()
+{
+    WaitForOpen();
+    if (m_IsOpen)
+    {
+        Close();
+    }
+    std::remove(m_Name.c_str());
 }
 
 void FileFStream::CheckFile(const std::string hint) const

--- a/source/adios2/toolkit/transport/file/FileFStream.h
+++ b/source/adios2/toolkit/transport/file/FileFStream.h
@@ -47,6 +47,8 @@ public:
 
     void Close() final;
 
+    void Delete() final;
+
     void SeekToEnd() final;
 
     void SeekToBegin() final;

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -9,6 +9,7 @@
  */
 #include "FilePOSIX.h"
 
+#include <cstdio>      // remove
 #include <fcntl.h>     // open
 #include <stddef.h>    // write output
 #include <sys/stat.h>  // open, fstat
@@ -261,6 +262,16 @@ void FilePOSIX::Close()
     }
 
     m_IsOpen = false;
+}
+
+void FilePOSIX::Delete()
+{
+    WaitForOpen();
+    if (m_IsOpen)
+    {
+        Close();
+    }
+    std::remove(m_Name.c_str());
 }
 
 void FilePOSIX::CheckFile(const std::string hint) const

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -48,6 +48,8 @@ public:
 
     void Close() final;
 
+    void Delete() final;
+
     void SeekToEnd() final;
 
     void SeekToBegin() final;

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -296,6 +296,16 @@ void FileStdio::Close()
     m_IsOpen = false;
 }
 
+void FileStdio::Delete()
+{
+    WaitForOpen();
+    if (m_IsOpen)
+    {
+        Close();
+    };
+    std::remove(m_Name.c_str());
+}
+
 void FileStdio::CheckFile(const std::string hint) const
 {
     if (std::ferror(m_File))

--- a/source/adios2/toolkit/transport/file/FileStdio.h
+++ b/source/adios2/toolkit/transport/file/FileStdio.h
@@ -49,6 +49,8 @@ public:
 
     void Close() final;
 
+    void Delete() final;
+
     void SeekToEnd() final;
 
     void SeekToBegin() final;

--- a/source/adios2/toolkit/transport/null/NullTransport.cpp
+++ b/source/adios2/toolkit/transport/null/NullTransport.cpp
@@ -109,6 +109,8 @@ void NullTransport::Close()
     Impl->IsOpen = false;
 }
 
+void NullTransport::Delete() { Close(); }
+
 void NullTransport::SeekToEnd()
 {
     if (!Impl->IsOpen)

--- a/source/adios2/toolkit/transport/null/NullTransport.h
+++ b/source/adios2/toolkit/transport/null/NullTransport.h
@@ -50,6 +50,8 @@ public:
 
     void Close() override;
 
+    void Delete() final;
+
     void SeekToEnd() override;
 
     void SeekToBegin() override;

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -33,7 +33,7 @@ namespace adios2
 namespace transportman
 {
 
-TransportMan::TransportMan(helper::Comm const &comm) : m_Comm(comm) {}
+TransportMan::TransportMan(helper::Comm &comm) : m_Comm(comm) {}
 
 void TransportMan::MkDirsBarrier(const std::vector<std::string> &fileNames,
                                  const bool nodeLocal)
@@ -273,6 +273,29 @@ void TransportMan::CloseFiles(const int transportIndex)
         CheckFile(itTransport, ", in call to CloseFiles with index " +
                                    std::to_string(transportIndex));
         itTransport->second->Close();
+    }
+}
+
+void TransportMan::DeleteFiles(const int transportIndex)
+{
+    if (transportIndex == -1)
+    {
+        for (auto &transportPair : m_Transports)
+        {
+            auto &transport = transportPair.second;
+
+            if (transport->m_Type == "File")
+            {
+                transport->Delete();
+            }
+        }
+    }
+    else
+    {
+        auto itTransport = m_Transports.find(transportIndex);
+        CheckFile(itTransport, ", in call to CloseFiles with index " +
+                                   std::to_string(transportIndex));
+        itTransport->second->Delete();
     }
 }
 

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -326,7 +326,7 @@ bool TransportMan::FileExists(const std::string &name, const Params &parameters,
         exists = true;
         file->Close();
     }
-    catch (std::ios_base::failure &e)
+    catch (std::ios_base::failure &)
     {
     }
     return exists;

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -315,6 +315,23 @@ bool TransportMan::AllTransportsClosed() const noexcept
     return allClose;
 }
 
+bool TransportMan::FileExists(const std::string &name, const Params &parameters,
+                              const bool profile)
+{
+    bool exists = false;
+    try
+    {
+        std::shared_ptr<Transport> file =
+            OpenFileTransport(name, Mode::Read, parameters, profile);
+        exists = true;
+        file->Close();
+    }
+    catch (std::ios_base::failure &e)
+    {
+    }
+    return exists;
+}
+
 // PRIVATE
 std::shared_ptr<Transport>
 TransportMan::OpenFileTransport(const std::string &fileName,

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -165,6 +165,15 @@ public:
 
     void SeekToFileBegin(const int transportIndex = 0);
 
+    /**
+     * Check if a file exists.
+     * @param name
+     * @param parameters
+     * @param profile
+     */
+    bool FileExists(const std::string &name, const Params &parameters,
+                    const bool profile);
+
 protected:
     helper::Comm const &m_Comm;
 

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -45,7 +45,7 @@ public:
      * Unique base constructor
      * @param comm
      */
-    TransportMan(helper::Comm const &comm);
+    TransportMan(helper::Comm &comm);
 
     virtual ~TransportMan() = default;
 
@@ -151,6 +151,12 @@ public:
      * @param transportIndex -1: all transports, otherwise index in m_Transports
      */
     void CloseFiles(const int transportIndex = -1);
+
+    /**
+     * Delete file or files depending on transport index. The files
+     * must be open for this function to have an effect.
+     */
+    void DeleteFiles(const int transportIndex = -1);
 
     /** Checks if all transports are closed */
     bool AllTransportsClosed() const noexcept;

--- a/source/utils/adios_iotest/adiosStream.cpp
+++ b/source/utils/adios_iotest/adiosStream.cpp
@@ -147,13 +147,7 @@ adios2::StepStatus adiosStream::readADIOS(CommandRead *cmdR, Config &cfg,
 {
     if (!settings.myRank && settings.verbose)
     {
-        std::cout << "    Read ";
-        if (cmdR->stepMode == adios2::StepMode::Read)
-        {
-            std::cout << "got a step from ";
-        }
-
-        std::cout << cmdR->streamName << " with timeout value "
+        std::cout << "    Read " << cmdR->streamName << " with timeout value "
                   << cmdR->timeout_sec << " using the group "
                   << cmdR->groupName;
         if (!cmdR->variables.empty())
@@ -164,7 +158,7 @@ adios2::StepStatus adiosStream::readADIOS(CommandRead *cmdR, Config &cfg,
                 std::cout << v->name << " ";
             }
         }
-        std::cout << std::endl;
+        std::cout << "... " << std::endl;
     }
     double timeStart, timeEnd;
     double readTime;

--- a/source/utils/adios_iotest/adios_iotest.cpp
+++ b/source/utils/adios_iotest/adios_iotest.cpp
@@ -85,6 +85,11 @@ int main(int argc, char *argv[])
         /* writing to one stream using two groups is not supported.
          * FIXME: we need to check for this condition and raise error
          */
+        if (!settings.myRank && settings.verbose)
+        {
+            std::cout << "Start App " + std::to_string(settings.appId) + ": "
+                      << std::endl;
+        }
         /* 1. Assign stream names with group names that appear in
            commands */
         // map of <streamName, groupName>
@@ -137,6 +142,11 @@ int main(int argc, char *argv[])
                 auto it = writeStreamMap.find(streamName);
                 if (it == writeStreamMap.end())
                 {
+                    if (!settings.myRank && settings.verbose)
+                    {
+                        std::cout << "    Create Output Stream " << streamName
+                                  << "... " << std::endl;
+                    }
                     std::shared_ptr<Stream> writer =
                         openStream(streamName, io, adios2::Mode::Write,
                                    settings.iolib, settings.appComm);
@@ -148,6 +158,8 @@ int main(int argc, char *argv[])
                 auto it = readStreamMap.find(streamName);
                 if (it == readStreamMap.end())
                 {
+                    std::cout << "    Open Input Stream " << streamName
+                              << "... " << std::endl;
                     std::shared_ptr<Stream> reader =
                         openStream(streamName, io, adios2::Mode::Read,
                                    settings.iolib, settings.appComm);


### PR DESCRIPTION
…ile "active" for indicating the presence of an active producer. This is needed to enable an async .bp/ directory/file creation  in the future.

Writer only creates the output files (.bp/ data.N, md.0, md.idx and active) but does not write a single byte in Open(). 

Reader now only checks for the presence on md.idx file in Open() within the timeout, but it does not read anything if there is no data in there. 