### PR TITLE
bindings: Clean up Python binding MPI interfaces

### DIFF
--- a/bindings/Python/CMakeLists.txt
+++ b/bindings/Python/CMakeLists.txt
@@ -38,6 +38,14 @@ set_target_properties(adios2_py PROPERTIES
   PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/adios2
   COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/adios2
 )
+
+string(REGEX REPLACE "[^/]+" ".." relative_base "${CMAKE_INSTALL_PYTHONDIR}/adios2")
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set_target_properties(adios2_py PROPERTIES
+    INSTALL_RPATH "$ORIGIN/${relative_base}/${CMAKE_INSTALL_LIBDIR}"
+  )
+endif()
+
 install(TARGETS adios2_py
   DESTINATION ${CMAKE_INSTALL_PYTHONDIR}/adios2
 )

--- a/bindings/Python/CMakeLists.txt
+++ b/bindings/Python/CMakeLists.txt
@@ -1,4 +1,4 @@
-Python_add_library(adios2py MODULE
+Python_add_library(adios2_py MODULE
   py11ADIOS.cpp
   py11IO.cpp
   py11Variable.cpp
@@ -17,7 +17,7 @@ else()
   set(maybe_adios2_core_mpi)
   set(maybe_mpi4py)
 endif()
-target_link_libraries(adios2py PRIVATE
+target_link_libraries(adios2_py PRIVATE
   ${maybe_adios2_cxx11_mpi} adios2_cxx11
   ${maybe_adios2_core_mpi} adios2_core
   pybind11
@@ -29,7 +29,7 @@ configure_file(
   COPYONLY
 )
 
-set_target_properties(adios2py PROPERTIES
+set_target_properties(adios2_py PROPERTIES
   CXX_VISIBILITY_PRESET hidden
   OUTPUT_NAME adios2
   ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/adios2
@@ -38,7 +38,7 @@ set_target_properties(adios2py PROPERTIES
   PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/adios2
   COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/adios2
 )
-install(TARGETS adios2py
+install(TARGETS adios2_py
   DESTINATION ${CMAKE_INSTALL_PYTHONDIR}/adios2
 )
 install(FILES __init__.py

--- a/bindings/Python/CMakeLists.txt
+++ b/bindings/Python/CMakeLists.txt
@@ -9,6 +9,11 @@ Python_add_library(adios2_py MODULE
   py11glue.cpp
 )
 if(ADIOS2_HAVE_MPI)
+  target_sources(adios2_py PRIVATE
+    py11ADIOSMPI.cpp
+    py11FileMPI.cpp
+    py11IOMPI.cpp
+  )
   set(maybe_adios2_cxx11_mpi adios2_cxx11_mpi)
   set(maybe_adios2_core_mpi adios2_core_mpi)
   set(maybe_mpi4py Python::mpi4py)

--- a/bindings/Python/py11ADIOS.cpp
+++ b/bindings/Python/py11ADIOS.cpp
@@ -2,7 +2,7 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * ADIOSPy.cpp
+ * py11ADIOS.cpp
  *
  *  Created on: Mar 13, 2017
  *      Author: William F Godoy godoywf@ornl.gov
@@ -10,25 +10,11 @@
 
 #include "py11ADIOS.h"
 
-#if ADIOS2_USE_MPI
-#include "adios2/helper/adiosCommMPI.h"
-#endif
-
 namespace adios2
 {
 namespace py11
 {
 
-#if ADIOS2_USE_MPI
-ADIOS::ADIOS(const std::string &configFile, MPI4PY_Comm mpiComm,
-             const bool debugMode)
-: m_ADIOS(std::make_shared<adios2::core::ADIOS>(
-      configFile, helper::CommDupMPI(mpiComm), "Python"))
-{
-}
-
-ADIOS::ADIOS(MPI4PY_Comm mpiComm, const bool debugMode) : ADIOS("", mpiComm) {}
-#endif
 ADIOS::ADIOS(const std::string &configFile, const bool debugMode)
 : m_ADIOS(std::make_shared<adios2::core::ADIOS>(configFile, "Python"))
 {

--- a/bindings/Python/py11ADIOSMPI.cpp
+++ b/bindings/Python/py11ADIOSMPI.cpp
@@ -1,0 +1,27 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * py11ADIOSMPI.cpp
+ */
+
+#include "py11ADIOS.h"
+
+#include "adios2/helper/adiosCommMPI.h"
+
+namespace adios2
+{
+namespace py11
+{
+
+ADIOS::ADIOS(const std::string &configFile, MPI4PY_Comm mpiComm,
+             const bool debugMode)
+: m_ADIOS(std::make_shared<adios2::core::ADIOS>(
+      configFile, helper::CommDupMPI(mpiComm), "Python"))
+{
+}
+
+ADIOS::ADIOS(MPI4PY_Comm mpiComm, const bool debugMode) : ADIOS("", mpiComm) {}
+
+} // end namespace py11
+} // end namespace adios2

--- a/bindings/Python/py11File.cpp
+++ b/bindings/Python/py11File.cpp
@@ -15,12 +15,7 @@
 #include <iostream>
 
 #include "adios2/common/ADIOSMacros.h"
-#include "adios2/helper/adiosCommDummy.h"
 #include "adios2/helper/adiosFunctions.h"
-
-#if ADIOS2_USE_MPI
-#include "adios2/helper/adiosCommMPI.h"
-#endif
 
 #include "py11types.h"
 
@@ -28,25 +23,6 @@ namespace adios2
 {
 namespace py11
 {
-
-#if ADIOS2_USE_MPI
-File::File(const std::string &name, const std::string mode, MPI_Comm comm,
-           const std::string engineType)
-: m_Name(name), m_Mode(mode),
-  m_Stream(std::make_shared<core::Stream>(
-      name, ToMode(mode), helper::CommDupMPI(comm), engineType, "Python"))
-{
-}
-
-File::File(const std::string &name, const std::string mode, MPI_Comm comm,
-           const std::string &configFile, const std::string ioInConfigFile)
-: m_Name(name), m_Mode(mode),
-  m_Stream(std::make_shared<core::Stream>(name, ToMode(mode),
-                                          helper::CommDupMPI(comm), configFile,
-                                          ioInConfigFile, "Python"))
-{
-}
-#endif
 
 File::File(const std::string &name, const std::string mode,
            const std::string engineType)

--- a/bindings/Python/py11FileMPI.cpp
+++ b/bindings/Python/py11FileMPI.cpp
@@ -1,0 +1,35 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * py11FileMPI.cpp
+ */
+
+#include "py11File.h"
+
+#include "adios2/helper/adiosCommMPI.h"
+
+namespace adios2
+{
+namespace py11
+{
+
+File::File(const std::string &name, const std::string mode, MPI_Comm comm,
+           const std::string engineType)
+: m_Name(name), m_Mode(mode),
+  m_Stream(std::make_shared<core::Stream>(
+      name, ToMode(mode), helper::CommDupMPI(comm), engineType, "Python"))
+{
+}
+
+File::File(const std::string &name, const std::string mode, MPI_Comm comm,
+           const std::string &configFile, const std::string ioInConfigFile)
+: m_Name(name), m_Mode(mode),
+  m_Stream(std::make_shared<core::Stream>(name, ToMode(mode),
+                                          helper::CommDupMPI(comm), configFile,
+                                          ioInConfigFile, "Python"))
+{
+}
+
+} // end namespace py11
+} // end namespace adios2

--- a/bindings/Python/py11IO.cpp
+++ b/bindings/Python/py11IO.cpp
@@ -2,7 +2,7 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * IO.cpp
+ * py11IO.cpp
  *
  *  Created on: Mar 14, 2017
  *      Author: William F Godoy godoywf@ornl.gov
@@ -12,11 +12,6 @@
 
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/helper/adiosFunctions.h" //GetType<T>
-
-#if ADIOS2_USE_MPI
-#include "adios2/helper/adiosCommMPI.h"
-#include <mpi4py/mpi4py.h>
-#endif
 
 #include "py11types.h"
 
@@ -246,17 +241,6 @@ Engine IO::Open(const std::string &name, const int mode)
                             "for engine " + name + ", in call to IO::Open");
     return Engine(&m_IO->Open(name, static_cast<adios2::Mode>(mode)));
 }
-
-#if ADIOS2_USE_MPI
-Engine IO::Open(const std::string &name, const int mode, MPI4PY_Comm comm)
-{
-    helper::CheckForNullptr(m_IO,
-                            "for engine " + name + ", in call to IO::Open");
-
-    return Engine(&m_IO->Open(name, static_cast<adios2::Mode>(mode),
-                              helper::CommDupMPI(comm)));
-}
-#endif
 
 void IO::FlushAll()
 {

--- a/bindings/Python/py11IOMPI.cpp
+++ b/bindings/Python/py11IOMPI.cpp
@@ -1,0 +1,30 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * py11IOMPI.cpp
+ */
+
+#include "py11IO.h"
+
+#include "adios2/helper/adiosCommMPI.h"
+#include <mpi4py/mpi4py.h>
+
+#include "py11types.h"
+
+namespace adios2
+{
+namespace py11
+{
+
+Engine IO::Open(const std::string &name, const int mode, MPI4PY_Comm comm)
+{
+    helper::CheckForNullptr(m_IO,
+                            "for engine " + name + ", in call to IO::Open");
+
+    return Engine(&m_IO->Open(name, static_cast<adios2::Mode>(mode),
+                              helper::CommDupMPI(comm)));
+}
+
+} // end namespace py11
+} // end namespace adios2

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -80,32 +80,32 @@ public:
 
 #if ADIOS2_USE_MPI
 
-adios2::py11::File Open(const std::string &name, const std::string mode,
-                        adios2::py11::MPI4PY_Comm comm,
-                        const std::string enginetype)
+adios2::py11::File OpenMPI(const std::string &name, const std::string mode,
+                           adios2::py11::MPI4PY_Comm comm,
+                           const std::string enginetype)
 {
     return adios2::py11::File(name, mode, comm, enginetype);
 }
 
-adios2::py11::File OpenConfig(const std::string &name, const std::string mode,
-                              adios2::py11::MPI4PY_Comm comm,
-                              const std::string &configfile,
-                              const std::string ioinconfigfile)
+adios2::py11::File OpenConfigMPI(const std::string &name,
+                                 const std::string mode,
+                                 adios2::py11::MPI4PY_Comm comm,
+                                 const std::string &configfile,
+                                 const std::string ioinconfigfile)
 {
     return adios2::py11::File(name, mode, comm, configfile, ioinconfigfile);
 }
 
 #endif
-adios2::py11::File OpenNoComm(const std::string &name, const std::string mode,
-                              const std::string enginetype)
+adios2::py11::File Open(const std::string &name, const std::string mode,
+                        const std::string enginetype)
 {
     return adios2::py11::File(name, mode, enginetype);
 }
 
-adios2::py11::File OpenConfigNoComm(const std::string &name,
-                                    const std::string mode,
-                                    const std::string configfile,
-                                    const std::string ioinconfigfile)
+adios2::py11::File OpenConfig(const std::string &name, const std::string mode,
+                              const std::string configfile,
+                              const std::string ioinconfigfile)
 {
     return adios2::py11::File(name, mode, configfile, ioinconfigfile);
 }
@@ -153,7 +153,7 @@ PYBIND11_MODULE(adios2, m)
         .export_values();
 
 #if ADIOS2_USE_MPI
-    m.def("open", &Open, pybind11::arg("name"), pybind11::arg("mode"),
+    m.def("open", &OpenMPI, pybind11::arg("name"), pybind11::arg("mode"),
           pybind11::arg("comm"), pybind11::arg("engine_type") = "BPFile", R"md(
           Simple API MPI open, based on python IO. 
           Allows for passing parameters in source code.
@@ -177,7 +177,7 @@ PYBIND11_MODULE(adios2, m)
                   handler to adios File for the simple Python API
     )md");
 
-    m.def("open", &OpenConfig, pybind11::arg("name"), pybind11::arg("mode"),
+    m.def("open", &OpenConfigMPI, pybind11::arg("name"), pybind11::arg("mode"),
           pybind11::arg("comm"), pybind11::arg("config_file"),
           pybind11::arg("io_in_config_file"), R"md(
           Simple API MPI open, based on python IO. 
@@ -207,11 +207,11 @@ PYBIND11_MODULE(adios2, m)
     )md");
 
 #endif
-    m.def("open", &OpenNoComm, "High-level API, file object open",
+    m.def("open", &Open, "High-level API, file object open",
           pybind11::arg("name"), pybind11::arg("mode"),
           pybind11::arg("engine_type") = "BPFile");
 
-    m.def("open", &OpenConfigNoComm,
+    m.def("open", &OpenConfig,
           "High-level API, file object open with a runtime config file",
           pybind11::arg("name"), pybind11::arg("mode"),
           pybind11::arg("config_file"), pybind11::arg("io_in_config_file"));


### PR DESCRIPTION
Rename Python glue helpers to match current conventions.

Move method definitions guarded by `#if ADIOS2_USE_MPI` into separate source files that are added only when using MPI.

While at it, fix the `INSTALL_RPATH` of the `.so` on Linux.

