### PR TITLE
Enable External yaml-cpp compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ adios_option(Fortran   "Enable support for Fortran bindings" AUTO)
 adios_option(SysVShMem "Enable support for SysV Shared Memory IPC on *NIX" AUTO)
 adios_option(Profiling "Enable support for profiling" AUTO)
 adios_option(Endian_Reverse "Enable support for Little/Big Endian Interoperability" AUTO)
+adios_option(EXTERNAL_yaml-cpp "Enable support for using a external yaml-cpp library for packaging" AUTO)
 include(${PROJECT_SOURCE_DIR}/cmake/DetectOptions.cmake)
 
 if(ADIOS2_HAVE_MPI)
@@ -140,7 +141,7 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 set(ADIOS2_CONFIG_OPTS
-    Blosc BZip2 ZFP SZ MGARD PNG MPI DataMan Table SSC SST DataSpaces ZeroMQ HDF5 Python Fortran SysVShMem Profiling Endian_Reverse
+    Blosc BZip2 ZFP SZ MGARD PNG MPI DataMan Table SSC SST DataSpaces ZeroMQ HDF5 Python Fortran SysVShMem Profiling Endian_Reverse EXTERNAL_yaml-cpp
 )
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})
 configure_file(

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -337,5 +337,14 @@ if(ADIOS2_USE_Endian_Reverse STREQUAL ON)
   set(ADIOS2_HAVE_Endian_Reverse TRUE)
 endif()
 
+# EXTERNAL_yaml-cpp
+if(ADIOS2_USE_EXTERNAL_yaml-cpp STREQUAL ON)
+  find_package(yaml-cpp REQUIRED)
+  message("-- Using EXTERNAL yaml-cpp package") 
+  set(ADIOS2_HAVE_EXTERNAL_yaml-cpp TRUE)
+else()
+  set(ADIOS2_USE_EXTERNAL_yaml-cpp OFF)
+endif()
+
 # Multithreading
 find_package(Threads REQUIRED)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -33,7 +33,10 @@ endif()
 add_subdirectory(pugixml)
 add_subdirectory(nlohmann_json)
 add_subdirectory(RapidJSON)
-add_subdirectory(yaml-cpp)
+
+if(NOT ADIOS2_USE_EXTERNAL_yaml-cpp)
+  add_subdirectory(yaml-cpp)
+endif()
 
 if(WIN32)
   add_subdirectory(mingw-w64)


### PR DESCRIPTION
yaml-cpp has been pretty stable and ships with `cmake` support.
Works on vanilla systems: 

- Ubuntu 18.04 from synaptic 
- macOS Mojave 10.14.6 from Homebrew 2.2.13

Can be added to CI. 
Related to #2143 and #2089
CC: @ax3l 