### PR TITLE
utils: Provide separate serial and MPI 'adios_reorganize{,_mpi}' tools

### DIFF
--- a/docs/user_guide/source/ecosystem/utilities/adios_reorganize.rst
+++ b/docs/user_guide/source/ecosystem/utilities/adios_reorganize.rst
@@ -2,7 +2,10 @@
 adios_reorganize
 *****************
 
-adios_reorganize is a generic ADIOS tool to read in ADIOS streams and output the same data into another ADIOS stream. It can be used for
+``adios_reorganize`` and ``adios_reorganize_mpi`` are generic ADIOS tools
+to read in ADIOS streams and output the same data into another ADIOS stream.
+The two tools are for serial and MPI environments, respectively.
+They can be used for
 
 * converting files between ADIOS BP and HDF5 format
 * using separate compute nodes to stage I/O from/to disk to/from a large scale application
@@ -29,7 +32,7 @@ In our example, we have an array, ``T``. It is a 2-dimensional ``double`` array,
 
    .. code-block:: bash
    
-       $ mpirun -n 2 adios_reorganize sim.bp sim.h5 BPFile "" HDF5 "" 2 1 
+       $ mpirun -n 2 adios_reorganize_mpi sim.bp sim.h5 BPFile "" HDF5 "" 2 1
       
        $ bpls sim.h5
          double   T     3*{15, 16}
@@ -61,7 +64,7 @@ In our example, we have an array, ``T``. It is a 2-dimensional ``double`` array,
 
 
         $ mpirun -n 12 ./heatSimulation  sim.bp  3 4   5 4   3 1 : \
-                 -n 2 adios_reorganize sim.bp staged.bp SST "" BPFile "" 2 1 
+                 -n 2 adios_reorganize_mpi sim.bp staged.bp SST "" BPFile "" 2 1
         
         $ bpls staged.bp
           double   T     3*{15, 16}
@@ -72,7 +75,7 @@ In our example, we have an array, ``T``. It is a 2-dimensional ``double`` array,
     
 * Reorganizing the data blocks in file for a different number of blocks
 
-    In the above example, the application writes the array from 12 processes, but then ``adios_reorganize`` reads the global arrays on 2 processes. The output file on disk will therefore contain the array in 2 blocks. This reorganization of the array may be useful if reading is too slow for a dataset created by many-many processes. One may want to reorganize a file written by tens or hundreds of thousands of processes if one wants to read the content more than one time and the read time proves to be a bottleneck in one's work flow. 
+    In the above example, the application writes the array from 12 processes, but then ``adios_reorganize_mpi`` reads the global arrays on 2 processes. The output file on disk will therefore contain the array in 2 blocks. This reorganization of the array may be useful if reading is too slow for a dataset created by many-many processes. One may want to reorganize a file written by tens or hundreds of thousands of processes if one wants to read the content more than one time and the read time proves to be a bottleneck in one's work flow.
     
     .. code-block:: bash
     
@@ -120,7 +123,7 @@ In our example, we have an array, ``T``. It is a 2-dimensional ``double`` array,
                 block 11: [10:14, 12:15]
 
           
-        $ mpirun -n 2 adios_reorganize sim.bp reorg.bp BPFile "" BPFile "" 2 1 
+        $ mpirun -n 2 adios_reorganize_mpi sim.bp reorg.bp BPFile "" BPFile "" 2 1
         $ bpls reorg.bp -D
           double   T     3*{15, 16}
               step 0: 

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -46,13 +46,18 @@ else()
   set(maybe_mgard)
 endif()
 add_executable(adios_reorganize ${adios_reorganize_srcs})
+target_link_libraries(adios_reorganize PRIVATE adios2_core ${maybe_mgard})
+
 if(ADIOS2_HAVE_MPI)
-  target_link_libraries(adios_reorganize PRIVATE adios2_core_mpi ${maybe_mgard})
+  add_executable(adios_reorganize_mpi ${adios_reorganize_srcs})
+  target_link_libraries(adios_reorganize_mpi PRIVATE adios2_core_mpi ${maybe_mgard})
+  set(maybe_adios_reorganize_mpi adios_reorganize_mpi)
 else()
-  target_link_libraries(adios_reorganize PRIVATE adios2_core ${maybe_mgard})
+  set(maybe_adios_reorganize_mpi)
 endif()
 
 install(TARGETS adios_reorganize
+  ${maybe_adios_reorganize_mpi}
   EXPORT adios2
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(adios_reorganize
                ./adios_reorganize/main.cpp 
                ./adios_reorganize/Reorganize.cpp 
                Utils.cpp)
-target_link_libraries(adios_reorganize PRIVATE adios2_cxx11 ${maybe_adios2_core_mpi} adios2_core)
+target_link_libraries(adios_reorganize PRIVATE ${maybe_adios2_core_mpi} adios2_core)
 install(TARGETS adios_reorganize EXPORT adios2
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -9,12 +9,6 @@ configure_file(
   @ONLY
 )
 
-if(ADIOS2_HAVE_MPI)
-  set(maybe_adios2_core_mpi adios2_core_mpi)
-else()
-  set(maybe_adios2_core_mpi)
-endif()
-
 # BPLS
 add_executable(bpls ./bpls/bpls.cpp)
 target_link_libraries(bpls adios2_core adios2sys pugixml)
@@ -41,18 +35,27 @@ file(GENERATE
 #)
 
 # ADIOS_REORGANIZE
-add_executable(adios_reorganize 
-               ./adios_reorganize/main.cpp 
-               ./adios_reorganize/Reorganize.cpp 
-               Utils.cpp)
-target_link_libraries(adios_reorganize PRIVATE ${maybe_adios2_core_mpi} adios2_core)
-install(TARGETS adios_reorganize EXPORT adios2
+set(adios_reorganize_srcs
+  adios_reorganize/main.cpp
+  adios_reorganize/Reorganize.cpp
+  Utils.cpp
+  )
+if(ADIOS2_HAVE_MGARD)
+  set(maybe_mgard MGARD::MGARD)
+else()
+  set(maybe_mgard)
+endif()
+add_executable(adios_reorganize ${adios_reorganize_srcs})
+if(ADIOS2_HAVE_MPI)
+  target_link_libraries(adios_reorganize PRIVATE adios2_core_mpi ${maybe_mgard})
+else()
+  target_link_libraries(adios_reorganize PRIVATE adios2_core ${maybe_mgard})
+endif()
+
+install(TARGETS adios_reorganize
+  EXPORT adios2
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
-
-if(ADIOS2_HAVE_MGARD)
-  target_link_libraries(adios_reorganize MGARD::MGARD)
-endif()
 
 if(ADIOS2_HAVE_MPI)
   add_subdirectory(adios_iotest)

--- a/source/utils/adios_reorganize/Reorganize.h
+++ b/source/utils/adios_reorganize/Reorganize.h
@@ -11,7 +11,6 @@
 #ifndef UTILS_REORGANIZE_REORGANIZE_H_
 #define UTILS_REORGANIZE_REORGANIZE_H_
 
-#include "adios2.h"
 #include "adios2/core/IO.h" // DataMap
 #include "adios2/helper/adiosComm.h"
 #include "utils/Utils.h"


### PR DESCRIPTION
Provide a serial `adios_reorganize` tool that does not need MPI.  Split the MPI variant into a separate `adios_reorganize_mpi` tool that uses MPI and is available only when ADIOS2 is built with MPI support.
