### PR TITLE
helper: Always provide adiosNetwork functions on UNIX platforms

### DIFF
--- a/source/adios2/helper/adiosNetwork.cpp
+++ b/source/adios2/helper/adiosNetwork.cpp
@@ -13,7 +13,6 @@
 #include "adios2/toolkit/transport/file/FileFStream.h"
 
 #ifndef _WIN32
-#if defined(ADIOS2_HAVE_DATAMAN) || defined(ADIOS2_HAVE_SSC)
 
 #include <iostream>
 #include <thread>
@@ -251,5 +250,4 @@ void HandshakeReader(Comm const &comm, size_t &appID,
 } // end namespace helper
 } // end namespace adios2
 
-#endif
 #endif

--- a/source/adios2/helper/adiosNetwork.h
+++ b/source/adios2/helper/adiosNetwork.h
@@ -13,7 +13,6 @@
 #define ADIOS2_HELPER_ADIOSNETWORK_H_
 
 #ifndef _WIN32
-#if defined(ADIOS2_HAVE_DATAMAN) || defined(ADIOS2_HAVE_SSC)
 
 /// \cond EXCLUDE_FROM_DOXYGEN
 #include <string>
@@ -47,6 +46,5 @@ void HandshakeReader(Comm const &comm, size_t &appID,
 } // end namespace helper
 } // end namespace adios2
 
-#endif // ADIOS2_HAVE_DATAMAN || ADIOS2_HAVE_SSC
 #endif // _WIN32
 #endif // ADIOS2_HELPER_ADIOSNETWORK_H_


### PR DESCRIPTION
Since #1659 the `AvailableIpAddresses` function is needed by the Table engine but its conditions only make it available for dataman or ssc.  Drop those conditions so it is available in general.

For now we still need to leave these out on Windows.  The `AvailableIpAddresses` function in particular needs a conditional alternative implementation on Windows.