### PR TITLE
helper: Enable adiosNetwork functions for Table engine

### DIFF
--- a/source/adios2/helper/adiosNetwork.cpp
+++ b/source/adios2/helper/adiosNetwork.cpp
@@ -13,7 +13,7 @@
 #include "adios2/toolkit/transport/file/FileFStream.h"
 
 #ifndef _WIN32
-#if defined(ADIOS2_HAVE_DATAMAN) || defined(ADIOS2_HAVE_SSC)
+#if defined(ADIOS2_HAVE_DATAMAN) || defined(ADIOS2_HAVE_TABLE)
 
 #include <iostream>
 #include <thread>

--- a/source/adios2/helper/adiosNetwork.h
+++ b/source/adios2/helper/adiosNetwork.h
@@ -13,7 +13,10 @@
 #define ADIOS2_HELPER_ADIOSNETWORK_H_
 
 #ifndef _WIN32
-#if defined(ADIOS2_HAVE_DATAMAN) || defined(ADIOS2_HAVE_SSC)
+// The function implementations use <nlohmann/json.hpp> which does not
+// work with all of the compilers we support.  Provide these functions
+// only when one of the engines that needs them is enabled.
+#if defined(ADIOS2_HAVE_DATAMAN) || defined(ADIOS2_HAVE_TABLE)
 
 /// \cond EXCLUDE_FROM_DOXYGEN
 #include <string>
@@ -47,6 +50,6 @@ void HandshakeReader(Comm const &comm, size_t &appID,
 } // end namespace helper
 } // end namespace adios2
 
-#endif // ADIOS2_HAVE_DATAMAN || ADIOS2_HAVE_SSC
+#endif // ADIOS2_HAVE_DATAMAN || ADIOS2_HAVE_TABLE
 #endif // _WIN32
 #endif // ADIOS2_HELPER_ADIOSNETWORK_H_


### PR DESCRIPTION
Since  #1659 the `AvailableIpAddresses` function is needed by the Table engine but its conditions only make it available for dataman or ssc.  Update the conditions to enable the functions for Table and drop them for SSC (which does not use them).  Also add a comment explaining why the conditions are needed in the first place.