### PR TITLE
Kill lurking instances of BeginStep() where timeout is specified as 0.0

### DIFF
--- a/testing/adios2/bindings/C/TestBPWriteReadMultiblock.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteReadMultiblock.cpp
@@ -106,7 +106,7 @@ TEST_F(BPWriteReadMultiblockCC, ZeroSizeBlocks)
 
         for (auto i = 0; i < steps; ++i)
         {
-            adios2_begin_step(engineH, adios2_step_mode_append, 0., &status);
+            adios2_begin_step(engineH, adios2_step_mode_append, -1., &status);
 
             adios2_set_selection(varI8, 1, startNull.data(), countNull.data());
             adios2_put(engineH, varI8, nullptr, adios2_mode_sync);
@@ -207,8 +207,8 @@ TEST_F(BPWriteReadMultiblockCC, ZeroSizeBlocks)
         adios2_steps(&nsteps, engineH);
         EXPECT_EQ(nsteps, steps);
 
-        while (adios2_begin_step(engineH, adios2_step_mode_read, 0., &status) ==
-               adios2_error_none)
+        while (adios2_begin_step(engineH, adios2_step_mode_read, -1.,
+                                 &status) == adios2_error_none)
         {
             if (status == adios2_step_status_end_of_stream)
             {

--- a/testing/adios2/engine/staging-common/TestCommonWriteF.F90
+++ b/testing/adios2/engine/staging-common/TestCommonWriteF.F90
@@ -173,7 +173,7 @@ program TestSstWrite
   !Put array contents to bp buffer, based on var1 metadata
   do i = 1, insteps
      call GenerateTestData(i - 1, irank, isize)
-     call adios2_begin_step(sstWriter, adios2_step_mode_append, 0.0, &
+     call adios2_begin_step(sstWriter, adios2_step_mode_append, -1.0, &
                             status, ierr)
      call adios2_put(sstWriter, variables(12), data_scalar_r64, ierr)
      call adios2_put(sstWriter, variables(1), data_I8, ierr)

--- a/testing/adios2/performance/manyvars/PerfManyVars.c
+++ b/testing/adios2/performance/manyvars/PerfManyVars.c
@@ -279,7 +279,7 @@ int write_file(int step)
     tb = MPI_Wtime();
 
     adios2_step_status status;
-    adios2_begin_step(engineW, adios2_step_mode_append, 0.0, &status);
+    adios2_begin_step(engineW, adios2_step_mode_append, -1., &status);
     for (block = 0; block < NBLOCKS; block++)
     {
         v = VALUE(rank, step, block);
@@ -382,7 +382,7 @@ int read_file()
     }
 
     adios2_step_status status;
-    adios2_begin_step(engineR, adios2_step_mode_read, 0.0, &status);
+    adios2_begin_step(engineR, adios2_step_mode_read, -1., &status);
 
     log("  Check variable definitions... %s\n", FILENAME);
     tb = MPI_Wtime();
@@ -404,7 +404,7 @@ int read_file()
         ts = 0;
         if (step > 0)
         {
-            adios2_begin_step(engineR, adios2_step_mode_read, 0.0, &status);
+            adios2_begin_step(engineR, adios2_step_mode_read, -1., &status);
         }
         for (block = 0; block < NBLOCKS; block++)
         {

--- a/testing/adios2/performance/manyvars/TestManyVars.cpp
+++ b/testing/adios2/performance/manyvars/TestManyVars.cpp
@@ -330,7 +330,7 @@ public:
         auto tb = std::chrono::high_resolution_clock::now();
 
         adios2_step_status status;
-        adios2_begin_step(engineW, adios2_step_mode_append, 0.0, &status);
+        adios2_begin_step(engineW, adios2_step_mode_append, -1., &status);
         for (block = 0; block < NBLOCKS; block++)
         {
             v = VALUE(rank, step, block);
@@ -391,7 +391,7 @@ public:
         }
 
         adios2_step_status status;
-        adios2_begin_step(engineR, adios2_step_mode_read, 0.0, &status);
+        adios2_begin_step(engineR, adios2_step_mode_read, -1., &status);
 
         log("  Check variable definitions... %s\n", FILENAME);
         tb = std::chrono::high_resolution_clock::now();
@@ -417,7 +417,7 @@ public:
             ts = std::chrono::duration<double>::zero();
             if (step > 0)
             {
-                adios2_begin_step(engineR, adios2_step_mode_read, 0.0, &status);
+                adios2_begin_step(engineR, adios2_step_mode_read, -1., &status);
             }
             for (size_t block = 0; block < NBLOCKS; block++)
             {


### PR DESCRIPTION
In very early days of ADIOS2, a timeout of 0.0 in BeginStep() meant "Block, don't timeout", but this convention got changed when we actually implemented timeout and realized that 0.0 would be a better value for "poll" or "try to do this now, but if it's not immediately doable, return NotReady".  This PR corrects some places that still have the old convention, perhaps added since PR #1493 (which changed the convention).   None changes of these are likely impactful, in that they were either on write-mode (where we don't do timeouts anywhere AFAIK), or were restricted to engines that don't implement timeouts.