### PR TITLE
testing: Teach test helper functions to add both Serial and MPI tests

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -10,14 +10,12 @@ if(ADIOS2_HAVE_MPI)
   mark_as_advanced(MPIEXEC_EXTRA_FLAGS)
   separate_arguments(MPIEXEC_EXTRA_FLAGS)
 
-  set(NUM_TEST_PROCS ${MPIEXEC_MAX_NUMPROCS})
   set(MPIEXEC_COMMAND
     ${MPIEXEC_EXECUTABLE} ${MPIEXEC_EXTRA_FLAGS}
-    ${MPIEXEC_NUMPROC_FLAG} ${NUM_TEST_PROCS}
+    ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
   )
   set(test_mpi TRUE)
 else()
-  set(NUM_TEST_PROCS 1)
   set(test_mpi FALSE)
 endif()
 
@@ -66,7 +64,7 @@ function(gtest_add_tests_helper testname mpi src_pfx tst_pfx tst_sfx)
       EXEC_WRAPPER ${MPIEXEC_COMMAND} TEST_LIST added_tests
       ${ARGN}
     )
-    set_tests_properties(${added_tests} PROPERTIES PROCESSORS ${NUM_TEST_PROCS})
+    set_tests_properties(${added_tests} PROPERTIES PROCESSORS "${MPIEXEC_MAX_NUMPROCS}")
   else()
     gtest_add_tests(TARGET ${tgt}
       TEST_PREFIX "${tst_pfx}" TEST_SUFFIX "${tst_sfx}"

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -48,7 +48,9 @@ include(GoogleTest)
 #    Foo.Things.Test2.Baz
 #
 function(gtest_add_tests_helper testname mpi src_pfx tst_pfx tst_sfx)
+  set(test_targets "")
   set(tgt Test.${tst_pfx}${testname})
+  list(APPEND test_targets "${tgt}")
   if(NOT TARGET ${tgt})
     add_executable(${tgt} Test${src_pfx}${testname}.cpp)
     if(mpi)
@@ -71,6 +73,7 @@ function(gtest_add_tests_helper testname mpi src_pfx tst_pfx tst_sfx)
       ${ARGN}
     )
   endif()
+  set("Test.${tst_pfx}${testname}-TARGETS" "${test_targets}" PARENT_SCOPE)
 endfunction()
 
 add_subdirectory(adios2)

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -14,21 +14,19 @@ if(ADIOS2_HAVE_MPI)
     ${MPIEXEC_EXECUTABLE} ${MPIEXEC_EXTRA_FLAGS}
     ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS}
   )
-  set(test_mpi TRUE)
-else()
-  set(test_mpi FALSE)
 endif()
 
 include(GoogleTest)
 # gtest_add_tests_helper:
 # Create a wrapper around gtest_add_tests that uses common patterns for test
 # names, execurtable names, mpi usage, etc.
-# 
+#
 # Arguments:
 #   testname - The basename of the test file
-#   mpi      - TRUE - build with MPI, execute with mpiexec
-#              FALSE - no mpi
-#              NOEXEC - build with MPI but don't execute with MPI
+#   mpi      - MPI_ALLOW - build MPI test, execute with mpiexec; also build Serial test
+#              MPI_NONE - build Serial test only
+#              MPI_ONLY - build MPI test only, execute with mpiexec
+#              MPI_NOEXEC - build MPI test, execute without MPI; also build Serial test
 #   src_pfx  - Source filename prefix, Test${src_pfs}${testname}.cpp
 #   tst_pfx  - Test name prefix to be added to CTest
 #   tst_sfx  - Test name suffix to be added to CTest
@@ -38,40 +36,60 @@ include(GoogleTest)
 #   You have a gtest file, TestFooThings.cpp that containst Test1 and Test2
 #   gtest functions that can be called with different sets of arguments.
 #
-#     gtest_add_tests_helper(Things TRUE Foo Foo. .Bar EXTRA_ARGS "Bar")
-#     gtest_add_tests_helper(Things TRUE Foo Foo. .Baz EXTRA_ARGS "Baz")
+#     gtest_add_tests_helper(Things MPI_ALLOW Foo Foo. .Bar EXTRA_ARGS "Bar")
+#     gtest_add_tests_helper(Things MPI_ALLOW Foo Foo. .Baz EXTRA_ARGS "Baz")
 #
 #  will create the executable Test.Foo.Things and add the tests
-#    Foo.Things.Test1.Bar
-#    Foo.Things.Test2.Bar
-#    Foo.Things.Test1.Baz
-#    Foo.Things.Test2.Baz
+#    Foo.Things.Test1.Bar.Serial
+#    Foo.Things.Test1.Bar.MPI
+#    Foo.Things.Test2.Bar.Serial
+#    Foo.Things.Test2.Bar.MPI
+#    Foo.Things.Test1.Baz.Serial
+#    Foo.Things.Test1.Baz.MPI
+#    Foo.Things.Test2.Baz.Serial
+#    Foo.Things.Test2.Baz.MPI
 #
 function(gtest_add_tests_helper testname mpi src_pfx tst_pfx tst_sfx)
   set(test_targets "")
-  set(tgt Test.${tst_pfx}${testname})
-  list(APPEND test_targets "${tgt}")
-  if(NOT TARGET ${tgt})
-    add_executable(${tgt} Test${src_pfx}${testname}.cpp)
-    if(mpi)
-      target_link_libraries(${tgt} adios2::cxx11_mpi adios2::c_mpi adios2_core_mpi MPI::MPI_C)
-    else()
-      target_link_libraries(${tgt} adios2::cxx11 adios2::c adios2_core)
-    endif()
-    target_link_libraries(${tgt} gtest)
+  if(NOT mpi MATCHES "^MPI_(ALLOW|NONE|ONLY|NOEXEC)$")
+    message(FATAL_ERROR "Invalid mpi argument value '${mpi}'.")
   endif()
-  if(mpi AND NOT mpi STREQUAL "NOEXEC")
+  if(NOT mpi STREQUAL "MPI_ONLY")
+    set(tgt Test.${tst_pfx}${testname}.Serial)
+    list(APPEND test_targets "${tgt}")
+    if(NOT TARGET ${tgt})
+      add_executable(${tgt} Test${src_pfx}${testname}.cpp)
+      target_link_libraries(${tgt} adios2::cxx11 adios2::c adios2_core gtest)
+    endif()
     gtest_add_tests(TARGET ${tgt}
-      TEST_PREFIX "${tst_pfx}" TEST_SUFFIX "${tst_sfx}"
-      EXEC_WRAPPER ${MPIEXEC_COMMAND} TEST_LIST added_tests
+      TEST_PREFIX "${tst_pfx}"
+      TEST_SUFFIX "${tst_sfx}.Serial"
       ${ARGN}
     )
-    set_tests_properties(${added_tests} PROPERTIES PROCESSORS "${MPIEXEC_MAX_NUMPROCS}")
-  else()
-    gtest_add_tests(TARGET ${tgt}
-      TEST_PREFIX "${tst_pfx}" TEST_SUFFIX "${tst_sfx}"
-      ${ARGN}
-    )
+  endif()
+  if(ADIOS2_HAVE_MPI AND NOT mpi STREQUAL "MPI_NONE")
+    set(tgt Test.${tst_pfx}${testname}.MPI)
+    list(APPEND test_targets "${tgt}")
+    if(NOT TARGET ${tgt})
+      add_executable(${tgt} Test${src_pfx}${testname}.cpp)
+      target_link_libraries(${tgt} adios2::cxx11_mpi adios2::c_mpi adios2_core_mpi MPI::MPI_C gtest)
+    endif()
+    if(NOT mpi STREQUAL "MPI_NOEXEC")
+      gtest_add_tests(TARGET ${tgt}
+        TEST_PREFIX "${tst_pfx}"
+        TEST_SUFFIX "${tst_sfx}.MPI"
+        EXEC_WRAPPER ${MPIEXEC_COMMAND}
+        TEST_LIST added_tests
+        ${ARGN}
+        )
+      set_tests_properties(${added_tests} PROPERTIES PROCESSORS "${MPIEXEC_MAX_NUMPROCS}")
+    else()
+      gtest_add_tests(TARGET ${tgt}
+        TEST_PREFIX "${tst_pfx}"
+        TEST_SUFFIX "${tst_sfx}.MPI"
+        ${ARGN}
+        )
+    endif()
   endif()
   set("Test.${tst_pfx}${testname}-TARGETS" "${test_targets}" PARENT_SCOPE)
 endfunction()

--- a/testing/adios2/bindings/C/CMakeLists.txt
+++ b/testing/adios2/bindings/C/CMakeLists.txt
@@ -3,15 +3,7 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-if(ADIOS2_HAVE_MPI)
-  set(mpi TRUE)
-else()
-  set(mpi FALSE)
-endif()
-
-gtest_add_tests_helper(WriteTypes ${mpi} BP Bindings.C. "")
-gtest_add_tests_helper(WriteReadMultiblock ${mpi} BP Bindings.C. "")
-gtest_add_tests_helper(NullWriteRead ${mpi} "" Bindings.C. "")
-if(mpi)
-  gtest_add_tests_helper(WriteAggregateReadLocal TRUE BP Bindings.C. "")
-endif()
+gtest_add_tests_helper(WriteTypes MPI_ALLOW BP Bindings.C. "")
+gtest_add_tests_helper(WriteReadMultiblock MPI_ALLOW BP Bindings.C. "")
+gtest_add_tests_helper(NullWriteRead MPI_ALLOW "" Bindings.C. "")
+gtest_add_tests_helper(WriteAggregateReadLocal MPI_ONLY BP Bindings.C. "")

--- a/testing/adios2/bindings/fortran/CMakeLists.txt
+++ b/testing/adios2/bindings/fortran/CMakeLists.txt
@@ -14,7 +14,7 @@ macro(fortran_add_test_helper testname mpi)
       COMMAND ${MPIEXEC_COMMAND} $<TARGET_FILE:${tgt}>
     )
     set_tests_properties(${pfx}${testname} PROPERTIES
-      PROCESSORS ${NUM_TEST_PROCS}
+      PROCESSORS "${MPIEXEC_MAX_NUMPROCS}"
     )
   else()
     target_link_libraries(${tgt} adios2::fortran)
@@ -86,6 +86,6 @@ if(mpi)
   )
   set_tests_properties(Bindings.Fortran.F2C.BPReadFBlocks PROPERTIES
     DEPENDS "Bindings.Fortran.BPWriteReadHeatMap2D;Bindings.Fortran.BPWriteReadHeatMap3D"
-    PROCESSORS ${NUM_TEST_PROCS}
+    PROCESSORS "${MPIEXEC_MAX_NUMPROCS}"
   )
 endif()

--- a/testing/adios2/bindings/fortran/CMakeLists.txt
+++ b/testing/adios2/bindings/fortran/CMakeLists.txt
@@ -5,52 +5,57 @@
 
 macro(fortran_add_test_helper testname mpi)
   set(test_targets "")
+  if(NOT "${mpi}" MATCHES "^MPI_(ALLOW|ONLY|NONE)$")
+    message(FATAL_ERROR "Invalid mpi argument value '${mpi}'.")
+  endif()
   set(pfx Bindings.Fortran.)
-  set(tgt Test.${pfx}${testname})
-  list(APPEND test_targets "${tgt}")
-  add_executable(${tgt} Test${testname}.F90)
-  set_target_properties(${tgt} PROPERTIES LINKER_LANGUAGE Fortran)
-  if(mpi)
+  if(NOT "${mpi}" STREQUAL "MPI_ONLY")
+    set(tgt Test.${pfx}${testname}.Serial)
+    list(APPEND test_targets "${tgt}")
+    add_executable(${tgt} Test${testname}.F90)
+    set_target_properties(${tgt} PROPERTIES LINKER_LANGUAGE Fortran)
+    target_link_libraries(${tgt} adios2::fortran)
+    add_test(
+      NAME ${pfx}${testname}.Serial
+      COMMAND ${tgt}
+    )
+  endif()
+  if(ADIOS2_HAVE_MPI AND NOT "${mpi}" STREQUAL "MPI_NONE")
+    set(tgt Test.${pfx}${testname}.MPI)
+    list(APPEND test_targets "${tgt}")
+    add_executable(${tgt} Test${testname}.F90)
+    set_target_properties(${tgt} PROPERTIES LINKER_LANGUAGE Fortran)
     target_link_libraries(${tgt} adios2::fortran_mpi MPI::MPI_Fortran)
-    add_test(NAME ${pfx}${testname}
+    add_test(
+      NAME ${pfx}${testname}.MPI
       COMMAND ${MPIEXEC_COMMAND} $<TARGET_FILE:${tgt}>
     )
-    set_tests_properties(${pfx}${testname} PROPERTIES
+    set_tests_properties(${pfx}${testname}.MPI PROPERTIES
       PROCESSORS "${MPIEXEC_MAX_NUMPROCS}"
     )
-  else()
-    target_link_libraries(${tgt} adios2::fortran)
-    add_test(NAME ${pfx}${testname} COMMAND ${tgt})
   endif()
   set("Test.${pfx}${testname}-TARGETS" "${test_targets}")
 endmacro()
 
+fortran_add_test_helper(BPWriteTypes MPI_ALLOW)
+fortran_add_test_helper(Remove MPI_ALLOW)
+
+fortran_add_test_helper(Adios2BindingsFortranIO MPI_ONLY)
+fortran_add_test_helper(BPWriteReadAttributes MPI_ONLY)
+fortran_add_test_helper(BPWriteVariableAttributes MPI_ONLY)
+fortran_add_test_helper(BPWriteTypesByName MPI_ONLY)
+fortran_add_test_helper(BPWriteTypesLocal MPI_ONLY)
+fortran_add_test_helper(BPWriteReadHeatMap2D MPI_ONLY)
+fortran_add_test_helper(BPWriteReadHeatMap3D MPI_ONLY)
+fortran_add_test_helper(BPWriteReadHeatMap4D MPI_ONLY)
+fortran_add_test_helper(BPWriteReadHeatMap5D MPI_ONLY)
+fortran_add_test_helper(BPWriteReadHeatMap6D MPI_ONLY)
+fortran_add_test_helper(BPReadGlobalsByName MPI_ONLY)
+fortran_add_test_helper(BPWriteMemorySelectionRead2D MPI_ONLY)
+fortran_add_test_helper(BPWriteMemorySelectionRead3D MPI_ONLY)
+fortran_add_test_helper(NullEngine MPI_ONLY)
+
 if(ADIOS2_HAVE_MPI)
-  set(mpi TRUE)
-else()
-  set(mpi FALSE)
-endif()
-
-fortran_add_test_helper(BPWriteTypes ${mpi})
-
-fortran_add_test_helper(Remove ${mpi})
-
-if(mpi)
-  fortran_add_test_helper(Adios2BindingsFortranIO TRUE)
-  fortran_add_test_helper(BPWriteReadAttributes TRUE)
-  fortran_add_test_helper(BPWriteVariableAttributes TRUE) 
-  fortran_add_test_helper(BPWriteTypesByName TRUE)
-  fortran_add_test_helper(BPWriteTypesLocal TRUE)
-  fortran_add_test_helper(BPWriteReadHeatMap2D TRUE)
-  fortran_add_test_helper(BPWriteReadHeatMap3D TRUE)
-  fortran_add_test_helper(BPWriteReadHeatMap4D TRUE)
-  fortran_add_test_helper(BPWriteReadHeatMap5D TRUE)
-  fortran_add_test_helper(BPWriteReadHeatMap6D TRUE)
-  fortran_add_test_helper(BPReadGlobalsByName TRUE)
-  fortran_add_test_helper(BPWriteMemorySelectionRead2D TRUE)
-  fortran_add_test_helper(BPWriteMemorySelectionRead3D TRUE)
-  fortran_add_test_helper(NullEngine TRUE)
-
   add_subdirectory(operation) 
   
   # F2C 

--- a/testing/adios2/bindings/fortran/CMakeLists.txt
+++ b/testing/adios2/bindings/fortran/CMakeLists.txt
@@ -4,8 +4,10 @@
 #------------------------------------------------------------------------------#
 
 macro(fortran_add_test_helper testname mpi)
+  set(test_targets "")
   set(pfx Bindings.Fortran.)
   set(tgt Test.${pfx}${testname})
+  list(APPEND test_targets "${tgt}")
   add_executable(${tgt} Test${testname}.F90)
   set_target_properties(${tgt} PROPERTIES LINKER_LANGUAGE Fortran)
   if(mpi)
@@ -20,6 +22,7 @@ macro(fortran_add_test_helper testname mpi)
     target_link_libraries(${tgt} adios2::fortran)
     add_test(NAME ${pfx}${testname} COMMAND ${tgt})
   endif()
+  set("Test.${pfx}${testname}-TARGETS" "${test_targets}")
 endmacro()
 
 if(ADIOS2_HAVE_MPI)
@@ -28,39 +31,16 @@ else()
   set(mpi FALSE)
 endif()
 
-add_library(SmallTestData_f OBJECT SmallTestData_mod.F90)
-add_library(ISmallTestData_f INTERFACE)
-target_sources(ISmallTestData_f INTERFACE $<TARGET_OBJECTS:SmallTestData_f>)
-
 fortran_add_test_helper(BPWriteTypes ${mpi})
-target_link_libraries(Test.Bindings.Fortran.BPWriteTypes ISmallTestData_f)
 
 fortran_add_test_helper(Remove ${mpi})
-target_link_libraries(Test.Bindings.Fortran.Remove ISmallTestData_f)
 
 if(mpi)
   fortran_add_test_helper(Adios2BindingsFortranIO TRUE)
-  
   fortran_add_test_helper(BPWriteReadAttributes TRUE)
-  target_link_libraries(Test.Bindings.Fortran.BPWriteReadAttributes
-    ISmallTestData_f
-  )
-
   fortran_add_test_helper(BPWriteVariableAttributes TRUE) 
-  target_link_libraries(Test.Bindings.Fortran.BPWriteVariableAttributes
-    ISmallTestData_f
-  )
-
   fortran_add_test_helper(BPWriteTypesByName TRUE)
-  target_link_libraries(Test.Bindings.Fortran.BPWriteTypesByName
-    ISmallTestData_f
-  )
- 
   fortran_add_test_helper(BPWriteTypesLocal TRUE)
-  target_link_libraries(Test.Bindings.Fortran.BPWriteTypesLocal
-    ISmallTestData_f
-  )
-  
   fortran_add_test_helper(BPWriteReadHeatMap2D TRUE)
   fortran_add_test_helper(BPWriteReadHeatMap3D TRUE)
   fortran_add_test_helper(BPWriteReadHeatMap4D TRUE)
@@ -89,3 +69,18 @@ if(mpi)
     PROCESSORS "${MPIEXEC_MAX_NUMPROCS}"
   )
 endif()
+
+add_library(SmallTestData_f OBJECT SmallTestData_mod.F90)
+add_library(ISmallTestData_f INTERFACE)
+target_sources(ISmallTestData_f INTERFACE $<TARGET_OBJECTS:SmallTestData_f>)
+
+foreach(tgt
+    ${Test.Bindings.Fortran.BPWriteTypes-TARGETS}
+    ${Test.Bindings.Fortran.Remove-TARGETS}
+    ${Test.Bindings.Fortran.BPWriteReadAttributes-TARGETS}
+    ${Test.Bindings.Fortran.BPWriteVariableAttributes-TARGETS}
+    ${Test.Bindings.Fortran.BPWriteTypesByName-TARGETS}
+    ${Test.Bindings.Fortran.BPWriteTypesLocal-TARGETS}
+    )
+  target_link_libraries(${tgt} ISmallTestData_f)
+endforeach()

--- a/testing/adios2/bindings/fortran/operation/CMakeLists.txt
+++ b/testing/adios2/bindings/fortran/operation/CMakeLists.txt
@@ -1,8 +1,8 @@
 if(ADIOS2_HAVE_SZ)
-  fortran_add_test_helper(BPWriteReadSZ2D TRUE)
-  fortran_add_test_helper(BPWriteReadSZ3D TRUE)
+  fortran_add_test_helper(BPWriteReadSZ2D MPI_ONLY)
+  fortran_add_test_helper(BPWriteReadSZ3D MPI_ONLY)
 endif()
 
 if(ADIOS2_HAVE_ZFP)
-  fortran_add_test_helper(BPWriteReadZfp2D TRUE)
+  fortran_add_test_helper(BPWriteReadZfp2D MPI_ONLY)
 endif()

--- a/testing/adios2/bindings/python/CMakeLists.txt
+++ b/testing/adios2/bindings/python/CMakeLists.txt
@@ -8,7 +8,7 @@ function(add_python_mpi_test testname)
     EXEC_WRAPPER ${MPIEXEC_COMMAND}
   )
   set_tests_properties(Bindings.Python.${testname} PROPERTIES
-    PROCESSORS ${NUM_TEST_PROCS}
+    PROCESSORS "${MPIEXEC_MAX_NUMPROCS}"
   )
 endfunction()
 

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -8,51 +8,51 @@ set(BP4_DIR ${CMAKE_CURRENT_BINARY_DIR}/bp4)
 file(MAKE_DIRECTORY ${BP3_DIR})
 file(MAKE_DIRECTORY ${BP4_DIR})
 
-macro(bp3_bp4_gtest_add_tests_helper testname)
-  gtest_add_tests_helper(${testname} ${test_mpi} BP Engine.BP. .BP3
+macro(bp3_bp4_gtest_add_tests_helper testname mpi)
+  gtest_add_tests_helper(${testname} ${mpi} BP Engine.BP. .BP3
     WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3"
   )
-  gtest_add_tests_helper(${testname} ${test_mpi} BP Engine.BP. .BP4
+  gtest_add_tests_helper(${testname} ${mpi} BP Engine.BP. .BP4
     WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4"
   )
 endmacro()
 
 add_subdirectory(operations)
 
-bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2)
-bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2fstream)
-bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2stdio)
-bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2)
-bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2_Threads)
-bp3_bp4_gtest_add_tests_helper(WriteReadAttributes)
-bp3_bp4_gtest_add_tests_helper(FStreamWriteReadHighLevelAPI)
-bp3_bp4_gtest_add_tests_helper(WriteFlushRead)
-bp3_bp4_gtest_add_tests_helper(WriteMultiblockRead)
-bp3_bp4_gtest_add_tests_helper(WriteReadMultiblock)
-bp3_bp4_gtest_add_tests_helper(WriteReadVector)
-bp3_bp4_gtest_add_tests_helper(WriteReadAttributesMultirank)
-bp3_bp4_gtest_add_tests_helper(LargeMetadata)
-bp3_bp4_gtest_add_tests_helper(WriteMemorySelectionRead)
-bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariables)
-bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariablesSel)
-bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariablesSelHighLevel)
-bp3_bp4_gtest_add_tests_helper(ChangingShape)
-bp3_bp4_gtest_add_tests_helper(WriteReadBlockInfo)
-bp3_bp4_gtest_add_tests_helper(WriteReadVariableSpan)
-bp3_bp4_gtest_add_tests_helper(TimeAggregation)
-bp3_bp4_gtest_add_tests_helper(NoXMLRecovery)
+bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2 MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2fstream MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadADIOS2stdio MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2 MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadAsStreamADIOS2_Threads MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadAttributes MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(FStreamWriteReadHighLevelAPI MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteFlushRead MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteMultiblockRead MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadMultiblock MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadVector MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadAttributesMultirank MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(LargeMetadata MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteMemorySelectionRead MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariables MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariablesSel MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadLocalVariablesSelHighLevel MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(ChangingShape MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadBlockInfo MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(WriteReadVariableSpan MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(TimeAggregation MPI_ALLOW)
+bp3_bp4_gtest_add_tests_helper(NoXMLRecovery MPI_ALLOW)
 
 if(ADIOS2_HAVE_MPI)
-  bp3_bp4_gtest_add_tests_helper(WriteAggregateRead)
+  bp3_bp4_gtest_add_tests_helper(WriteAggregateRead MPI_ONLY)
 endif()
 
 # BP3 only for now
-gtest_add_tests_helper(WriteNull ${test_mpi} BP Engine.BP. .BP3
+gtest_add_tests_helper(WriteNull MPI_ALLOW BP Engine.BP. .BP3
   WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3"
 )
 
 # BP4 only for now
-gtest_add_tests_helper(WriteAppendReadADIOS2 ${test_mpi} BP Engine.BP. .BP4
+gtest_add_tests_helper(WriteAppendReadADIOS2 MPI_ALLOW BP Engine.BP. .BP4
   WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4"
 )
 

--- a/testing/adios2/engine/bp/operations/CMakeLists.txt
+++ b/testing/adios2/engine/bp/operations/CMakeLists.txt
@@ -9,14 +9,14 @@ file(MAKE_DIRECTORY ${BP3_DIR})
 file(MAKE_DIRECTORY ${BP4_DIR})
 
 if(ADIOS2_HAVE_SZ)
-  bp3_bp4_gtest_add_tests_helper(WriteReadSZ)
+  bp3_bp4_gtest_add_tests_helper(WriteReadSZ MPI_ALLOW)
 endif()
 
 
 if(ADIOS2_HAVE_ZFP)
-  bp3_bp4_gtest_add_tests_helper(WriteReadZfp)
-  bp3_bp4_gtest_add_tests_helper(WriteReadZfpHighLevelAPI)
-  bp3_bp4_gtest_add_tests_helper(WriteReadZfpConfig)
+  bp3_bp4_gtest_add_tests_helper(WriteReadZfp MPI_ALLOW)
+  bp3_bp4_gtest_add_tests_helper(WriteReadZfpHighLevelAPI MPI_ALLOW)
+  bp3_bp4_gtest_add_tests_helper(WriteReadZfpConfig MPI_ALLOW)
 
   foreach(tgt
       ${Test.Engine.BP.WriteReadZfpConfig-TARGETS}
@@ -28,17 +28,17 @@ if(ADIOS2_HAVE_ZFP)
 endif()
 
 if(ADIOS2_HAVE_MGARD)
-  bp3_bp4_gtest_add_tests_helper(WriteReadMGARD)
+  bp3_bp4_gtest_add_tests_helper(WriteReadMGARD MPI_ALLOW)
 endif()
 
 if(ADIOS2_HAVE_BZip2)
-  bp3_bp4_gtest_add_tests_helper(WriteReadBZIP2)
+  bp3_bp4_gtest_add_tests_helper(WriteReadBZIP2 MPI_ALLOW)
 endif()
 
 if(ADIOS2_HAVE_PNG)
-  bp3_bp4_gtest_add_tests_helper(WriteReadPNG)
+  bp3_bp4_gtest_add_tests_helper(WriteReadPNG MPI_ALLOW)
 endif()
 
 if(ADIOS2_HAVE_Blosc)
-  bp3_bp4_gtest_add_tests_helper(WriteReadBlosc)
+  bp3_bp4_gtest_add_tests_helper(WriteReadBlosc MPI_ALLOW)
 endif()

--- a/testing/adios2/engine/bp/operations/CMakeLists.txt
+++ b/testing/adios2/engine/bp/operations/CMakeLists.txt
@@ -17,9 +17,14 @@ if(ADIOS2_HAVE_ZFP)
   bp3_bp4_gtest_add_tests_helper(WriteReadZfp)
   bp3_bp4_gtest_add_tests_helper(WriteReadZfpHighLevelAPI)
   bp3_bp4_gtest_add_tests_helper(WriteReadZfpConfig)
-  target_compile_definitions(Test.Engine.BP.WriteReadZfpConfig PRIVATE
-    "XML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
-  )
+
+  foreach(tgt
+      ${Test.Engine.BP.WriteReadZfpConfig-TARGETS}
+      )
+    target_compile_definitions(${tgt} PRIVATE
+      "XML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
+      )
+  endforeach()
 endif()
 
 if(ADIOS2_HAVE_MGARD)

--- a/testing/adios2/engine/common/CMakeLists.txt
+++ b/testing/adios2/engine/common/CMakeLists.txt
@@ -6,42 +6,41 @@
 find_package(Threads REQUIRED)
 
 add_executable(Test.Engine.Common TestEngineCommon.cpp)
-if(ADIOS2_HAVE_MPI)
-  target_link_libraries(Test.Engine.Common gtest_interface adios2::cxx11_mpi MPI::MPI_C)
-else()
-  target_link_libraries(Test.Engine.Common adios2::cxx11)
-endif()
-target_link_libraries(Test.Engine.Common gtest ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(Test.Engine.Common PRIVATE
+  gtest_interface
+  adios2::cxx11_mpi
+  MPI::MPI_C
+  gtest
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 # Note: extra arguments
 #   1st arg: Engine
 #   2nd arg: 1 for serialized execution, 0 for concurrent execution of Writer/Reader
 #   3rd arg: engine parameters
 
-gtest_add_tests_helper(Common ${test_mpi} "" Engine. .File
+gtest_add_tests_helper(Common TRUE "" Engine. .File
   EXTRA_ARGS "File" "1"
 )
                 
 if(ADIOS2_HAVE_HDF5 AND HDF5_IS_PARALLEL)
-  gtest_add_tests_helper(Common ${test_mpi} "" Engine. .HDF5
+  gtest_add_tests_helper(Common TRUE "" Engine. .HDF5
     EXTRA_ARGS "HDF5" "1"
   )
 endif()
 
 if(ADIOS2_HAVE_SST)
-  gtest_add_tests_helper(Common ${test_mpi} "" Engine. .SST.FFS
+  gtest_add_tests_helper(Common TRUE "" Engine. .SST.FFS
     EXTRA_ARGS "SST" "0" "MarshalMethod:FFS"
   )
-  gtest_add_tests_helper(Common ${test_mpi} "" Engine. .SST.BP
+  gtest_add_tests_helper(Common TRUE "" Engine. .SST.BP
     EXTRA_ARGS "SST" "0" "MarshalMethod:BP"
   )
 endif()
 
-if(ADIOS2_HAVE_MPI)
-  gtest_add_tests_helper(Common TRUE "" Engine. .InSituMPI
-    EXTRA_ARGS "InSituMPI" "0"
-  )
-endif()
+gtest_add_tests_helper(Common TRUE "" Engine. .InSituMPI
+  EXTRA_ARGS "InSituMPI" "0"
+)
 
 #if(ADIOS2_HAVE_DataMan)
 #  gtest_add_tests_helper(Common TRUE "" Engine. .DataMan

--- a/testing/adios2/engine/common/CMakeLists.txt
+++ b/testing/adios2/engine/common/CMakeLists.txt
@@ -5,8 +5,8 @@
 
 find_package(Threads REQUIRED)
 
-add_executable(Test.Engine.Common TestEngineCommon.cpp)
-target_link_libraries(Test.Engine.Common PRIVATE
+add_executable(Test.Engine.Common.MPI TestEngineCommon.cpp)
+target_link_libraries(Test.Engine.Common.MPI PRIVATE
   gtest_interface
   adios2::cxx11_mpi
   MPI::MPI_C
@@ -19,31 +19,31 @@ target_link_libraries(Test.Engine.Common PRIVATE
 #   2nd arg: 1 for serialized execution, 0 for concurrent execution of Writer/Reader
 #   3rd arg: engine parameters
 
-gtest_add_tests_helper(Common TRUE "" Engine. .File
+gtest_add_tests_helper(Common MPI_ONLY "" Engine. .File
   EXTRA_ARGS "File" "1"
 )
                 
 if(ADIOS2_HAVE_HDF5 AND HDF5_IS_PARALLEL)
-  gtest_add_tests_helper(Common TRUE "" Engine. .HDF5
+  gtest_add_tests_helper(Common MPI_ONLY "" Engine. .HDF5
     EXTRA_ARGS "HDF5" "1"
   )
 endif()
 
 if(ADIOS2_HAVE_SST)
-  gtest_add_tests_helper(Common TRUE "" Engine. .SST.FFS
+  gtest_add_tests_helper(Common MPI_ONLY "" Engine. .SST.FFS
     EXTRA_ARGS "SST" "0" "MarshalMethod:FFS"
   )
-  gtest_add_tests_helper(Common TRUE "" Engine. .SST.BP
+  gtest_add_tests_helper(Common MPI_ONLY "" Engine. .SST.BP
     EXTRA_ARGS "SST" "0" "MarshalMethod:BP"
   )
 endif()
 
-gtest_add_tests_helper(Common TRUE "" Engine. .InSituMPI
+gtest_add_tests_helper(Common MPI_ONLY "" Engine. .InSituMPI
   EXTRA_ARGS "InSituMPI" "0"
 )
 
 #if(ADIOS2_HAVE_DataMan)
-#  gtest_add_tests_helper(Common TRUE "" Engine. .DataMan
+#  gtest_add_tests_helper(Common MPI_ONLY "" Engine. .DataMan
 #    EXTRA_ARGS "DataMan" "0"
 #  )
 #endif()

--- a/testing/adios2/engine/dataman/CMakeLists.txt
+++ b/testing/adios2/engine/dataman/CMakeLists.txt
@@ -4,9 +4,9 @@
 #------------------------------------------------------------------------------#
 
 if(ADIOS2_HAVE_MPI)
-  gtest_add_tests_helper(1D NOEXEC DataMan Engine.DataMan. "")
-  gtest_add_tests_helper(2DMemSelect NOEXEC DataMan Engine.DataMan. "")
-  gtest_add_tests_helper(3DMemSelect NOEXEC DataMan Engine.DataMan. "")
-  gtest_add_tests_helper(WriterDoubleBuffer NOEXEC DataMan Engine.DataMan. "")
-  gtest_add_tests_helper(ReaderDirectReceive NOEXEC DataMan Engine.DataMan. "")
+  gtest_add_tests_helper(1D MPI_NOEXEC DataMan Engine.DataMan. "")
+  gtest_add_tests_helper(2DMemSelect MPI_NOEXEC DataMan Engine.DataMan. "")
+  gtest_add_tests_helper(3DMemSelect MPI_NOEXEC DataMan Engine.DataMan. "")
+  gtest_add_tests_helper(WriterDoubleBuffer MPI_NOEXEC DataMan Engine.DataMan. "")
+  gtest_add_tests_helper(ReaderDirectReceive MPI_NOEXEC DataMan Engine.DataMan. "")
 endif()

--- a/testing/adios2/engine/hdf5/CMakeLists.txt
+++ b/testing/adios2/engine/hdf5/CMakeLists.txt
@@ -4,10 +4,12 @@
 #------------------------------------------------------------------------------#
 
 if(ADIOS2_HAVE_MPI AND HDF5_IS_PARALLEL)
-  set(hdf5_mpi TRUE)
+  set(hdf5_mpi MPI_ONLY)
   add_definitions(-DTEST_HDF5_MPI)
+  set(hdf5_sfx ".MPI")
 else()
-  set(hdf5_mpi FALSE)
+  set(hdf5_mpi MPI_NONE)
+  set(hdf5_sfx ".Serial")
 endif()
 
 gtest_add_tests_helper(WriteReadAsStream ${hdf5_mpi} HDF5 Engine.HDF5. "")
@@ -23,12 +25,12 @@ gtest_add_tests_helper(WriteMemorySelectionRead  ${hdf5_mpi}
 
 gtest_add_tests_helper(NativeHDF5WriteRead ${hdf5_mpi} "" Engine.HDF5. "")
 if(HDF5_C_INCLUDE_DIRS)
-  target_include_directories(Test.Engine.HDF5.NativeHDF5WriteRead
+  target_include_directories(Test.Engine.HDF5.NativeHDF5WriteRead${hdf5_sfx}
     PRIVATE ${HDF5_C_INCLUDE_DIRS}
   )
 else()
-  target_include_directories(Test.Engine.HDF5.NativeHDF5WriteRead
+  target_include_directories(Test.Engine.HDF5.NativeHDF5WriteRead${hdf5_sfx}
     PRIVATE ${HDF5_INCLUDE_DIRS}
   )
 endif()
-target_link_libraries(Test.Engine.HDF5.NativeHDF5WriteRead ${HDF5_C_LIBRARIES})
+target_link_libraries(Test.Engine.HDF5.NativeHDF5WriteRead${hdf5_sfx} ${HDF5_C_LIBRARIES})

--- a/testing/adios2/engine/inline/CMakeLists.txt
+++ b/testing/adios2/engine/inline/CMakeLists.txt
@@ -3,4 +3,4 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(WriteRead ${test_mpi} Inline Engine.Inline. "")
+gtest_add_tests_helper(WriteRead MPI_ALLOW Inline Engine.Inline. "")

--- a/testing/adios2/engine/insitumpi/CMakeLists.txt
+++ b/testing/adios2/engine/insitumpi/CMakeLists.txt
@@ -3,5 +3,5 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(FunctionAssignPeers TRUE InSituMPI Engine.InSituMPI. "")
-gtest_add_tests_helper(MPMDExceptions TRUE InSituMPI Engine.InSituMPI. "")
+gtest_add_tests_helper(FunctionAssignPeers MPI_ONLY InSituMPI Engine.InSituMPI. "")
+gtest_add_tests_helper(MPMDExceptions MPI_ONLY InSituMPI Engine.InSituMPI. "")

--- a/testing/adios2/engine/null/CMakeLists.txt
+++ b/testing/adios2/engine/null/CMakeLists.txt
@@ -3,4 +3,4 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(WriteRead ${test_mpi} Null Engine.Null. "")
+gtest_add_tests_helper(WriteRead MPI_ALLOW Null Engine.Null. "")

--- a/testing/adios2/engine/nullcore/CMakeLists.txt
+++ b/testing/adios2/engine/nullcore/CMakeLists.txt
@@ -3,4 +3,4 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(Write ${test_mpi} NullCore Engine.NullCore. "")
+gtest_add_tests_helper(Write MPI_ALLOW NullCore Engine.NullCore. "")

--- a/testing/adios2/engine/ssc/CMakeLists.txt
+++ b/testing/adios2/engine/ssc/CMakeLists.txt
@@ -6,52 +6,52 @@
 include(ADIOSFunctions)
 
 if(ADIOS2_HAVE_MPI)
-  gtest_add_tests_helper(Base TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscBase "" TRUE)
+  gtest_add_tests_helper(Base MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscBase.MPI "" TRUE)
 
-  gtest_add_tests_helper(OneSidedFencePush TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscOneSidedFencePush "" TRUE)
+  gtest_add_tests_helper(OneSidedFencePush MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscOneSidedFencePush.MPI "" TRUE)
 
-  gtest_add_tests_helper(OneSidedPostPush TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscOneSidedPostPush "" TRUE)
+  gtest_add_tests_helper(OneSidedPostPush MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscOneSidedPostPush.MPI "" TRUE)
 
-  gtest_add_tests_helper(OneSidedFencePull TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscOneSidedFencePull "" TRUE)
+  gtest_add_tests_helper(OneSidedFencePull MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscOneSidedFencePull.MPI "" TRUE)
 
-  gtest_add_tests_helper(OneSidedPostPull TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscOneSidedPostPull "" TRUE)
+  gtest_add_tests_helper(OneSidedPostPull MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscOneSidedPostPull.MPI "" TRUE)
 
-  gtest_add_tests_helper(Unbalanced TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscUnbalanced "" TRUE)
+  gtest_add_tests_helper(Unbalanced MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscUnbalanced.MPI "" TRUE)
 
-  gtest_add_tests_helper(WriterMultiblock TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscWriterMultiblock "" TRUE)
+  gtest_add_tests_helper(WriterMultiblock MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscWriterMultiblock.MPI "" TRUE)
 
-  gtest_add_tests_helper(ReaderMultiblock TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscReaderMultiblock "" TRUE)
+  gtest_add_tests_helper(ReaderMultiblock MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscReaderMultiblock.MPI "" TRUE)
 
-  gtest_add_tests_helper(NoAttributes TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscNoAttributes "" TRUE)
+  gtest_add_tests_helper(NoAttributes MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscNoAttributes.MPI "" TRUE)
 
-  gtest_add_tests_helper(NoSelection TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscNoSelection "" TRUE)
+  gtest_add_tests_helper(NoSelection MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscNoSelection.MPI "" TRUE)
 
-  gtest_add_tests_helper(7d TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSsc7d "" TRUE)
+  gtest_add_tests_helper(7d MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSsc7d.MPI "" TRUE)
 
-  gtest_add_tests_helper(MoreReadersThanWriters TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscMoreReadersThanWriters "" TRUE)
+  gtest_add_tests_helper(MoreReadersThanWriters MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscMoreReadersThanWriters.MPI "" TRUE)
 
-  gtest_add_tests_helper(MoreWritersThanReaders TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscMoreWritersThanReaders "" TRUE)
+  gtest_add_tests_helper(MoreWritersThanReaders MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscMoreWritersThanReaders.MPI "" TRUE)
 
-  gtest_add_tests_helper(MultiApp TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscMultiApp "" TRUE)
+  gtest_add_tests_helper(MultiApp MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscMultiApp.MPI "" TRUE)
 
-  gtest_add_tests_helper(Xgc2Way TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscXgc2Way "" TRUE)
+  gtest_add_tests_helper(Xgc2Way MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscXgc2Way.MPI "" TRUE)
 
-  gtest_add_tests_helper(Xgc3Way TRUE Ssc Engine.SSC. "")
-  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscXgc3Way "" TRUE)
+  gtest_add_tests_helper(Xgc3Way MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscXgc3Way.MPI "" TRUE)
 
 endif()

--- a/testing/adios2/engine/staging-common/CMakeLists.txt
+++ b/testing/adios2/engine/staging-common/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ADIOS2_HAVE_MPI)
       TEST_LIST _gtest_added_tests
     )
     set_tests_properties(${_gtest_added_tests} PROPERTIES
-      PROCESSORS ${NUM_TEST_PROCS}
+      PROCESSORS "${MPIEXEC_MAX_NUMPROCS}"
     )
     gtest_add_tests(TARGET TestStagingMPMD ${extra_test_args} 
       EXTRA_ARGS "SST" "MarshalMethod=BP"
@@ -28,7 +28,7 @@ if(ADIOS2_HAVE_MPI)
       TEST_LIST _gtest_added_tests
     )
     set_tests_properties(${_gtest_added_tests} PROPERTIES
-      PROCESSORS ${NUM_TEST_PROCS}
+      PROCESSORS "${MPIEXEC_MAX_NUMPROCS}"
     )
   endif()
 
@@ -38,7 +38,7 @@ if(ADIOS2_HAVE_MPI)
     TEST_LIST _gtest_added_tests
   )
   set_tests_properties(${_gtest_added_tests} PROPERTIES
-    PROCESSORS ${NUM_TEST_PROCS}
+    PROCESSORS "${MPIEXEC_MAX_NUMPROCS}"
   )
 endif()
 

--- a/testing/adios2/engine/table/CMakeLists.txt
+++ b/testing/adios2/engine/table/CMakeLists.txt
@@ -3,8 +3,6 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(SingleRank FALSE Table Engine.Table. "")
+gtest_add_tests_helper(SingleRank MPI_NONE Table Engine.Table. "")
 
-if(ADIOS2_HAVE_MPI)
-  gtest_add_tests_helper(MultiRank "${ADIOS2_HAVE_MPI}" Table Engine.Table. "")
-endif()
+gtest_add_tests_helper(MultiRank MPI_ONLY Table Engine.Table. "")

--- a/testing/adios2/helper/CMakeLists.txt
+++ b/testing/adios2/helper/CMakeLists.txt
@@ -3,7 +3,7 @@
 #accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(Strings FALSE Helper Helper. "")
-gtest_add_tests_helper(DivideBlock FALSE "" Helper. "")
-gtest_add_tests_helper(MinMaxs FALSE "" Helper. "")
-gtest_add_tests_helper(ReadNonBPFile FALSE "" Helper. "")
+gtest_add_tests_helper(Strings MPI_NONE Helper Helper. "")
+gtest_add_tests_helper(DivideBlock MPI_NONE "" Helper. "")
+gtest_add_tests_helper(MinMaxs MPI_NONE "" Helper. "")
+gtest_add_tests_helper(ReadNonBPFile MPI_NONE "" Helper. "")

--- a/testing/adios2/interface/CMakeLists.txt
+++ b/testing/adios2/interface/CMakeLists.txt
@@ -3,13 +3,9 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(Interface ${test_mpi} ADIOS Interface. "")
-gtest_add_tests_helper(Write ${test_mpi} ADIOSInterface Interface. "")
-gtest_add_tests_helper(DefineVariable ${test_mpi} ADIOS Interface. "")
-gtest_add_tests_helper(DefineAttribute ${test_mpi} ADIOS Interface. "")
-if(ADIOS2_HAVE_MPI)
-  gtest_add_tests_helper(Selection NOEXEC ADIOS Interface. "")
-else()
-  gtest_add_tests_helper(Selection FALSE ADIOS Interface. "")
-endif()
-gtest_add_tests_helper(NoMpi FALSE ADIOS Interface. "")
+gtest_add_tests_helper(Interface MPI_ALLOW ADIOS Interface. "")
+gtest_add_tests_helper(Write MPI_ALLOW ADIOSInterface Interface. "")
+gtest_add_tests_helper(DefineVariable MPI_ALLOW ADIOS Interface. "")
+gtest_add_tests_helper(DefineAttribute MPI_ALLOW ADIOS Interface. "")
+gtest_add_tests_helper(Selection MPI_NOEXEC ADIOS Interface. "")
+gtest_add_tests_helper(NoMpi MPI_NONE ADIOS Interface. "")

--- a/testing/adios2/performance/manyvars/CMakeLists.txt
+++ b/testing/adios2/performance/manyvars/CMakeLists.txt
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------#
 
 if(ADIOS2_HAVE_MPI AND NOT WIN32) # Doesn't reliably work on windows
-  gtest_add_tests_helper(ManyVars ${test_mpi} "" Performance. "")
+  gtest_add_tests_helper(ManyVars MPI_ONLY "" Performance. "")
 
   # Pure C code, not added to test, 
   # just for executing manually for performance studies

--- a/testing/adios2/performance/query/CMakeLists.txt
+++ b/testing/adios2/performance/query/CMakeLists.txt
@@ -3,4 +3,4 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(Query ${test_mpi} BP Performance. "")
+gtest_add_tests_helper(Query MPI_ALLOW BP Performance. "")

--- a/testing/adios2/transports/CMakeLists.txt
+++ b/testing/adios2/transports/CMakeLists.txt
@@ -3,4 +3,4 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(File FALSE "" Transports. "")
+gtest_add_tests_helper(File MPI_NONE "" Transports. "")

--- a/testing/adios2/xml/CMakeLists.txt
+++ b/testing/adios2/xml/CMakeLists.txt
@@ -10,10 +10,11 @@ else()
   gtest_add_tests_helper(XMLConfigSerial FALSE "" "" "")
 endif()
 
-target_compile_definitions(Test.XMLConfig PRIVATE
-  "XML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
-)
-
-target_compile_definitions(Test.XMLConfigSerial PRIVATE
-  "XML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
-)
+foreach(tgt
+    ${Test.XMLConfig-TARGETS}
+    ${Test.XMLConfigSerial-TARGETS}
+    )
+  target_compile_definitions(${tgt} PRIVATE
+    "XML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endforeach()

--- a/testing/adios2/xml/CMakeLists.txt
+++ b/testing/adios2/xml/CMakeLists.txt
@@ -3,12 +3,8 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(XMLConfig ${test_mpi} "" "" "")
-if(ADIOS2_HAVE_MPI)
-  gtest_add_tests_helper(XMLConfigSerial NOEXEC "" "" "")
-else()
-  gtest_add_tests_helper(XMLConfigSerial FALSE "" "" "")
-endif()
+gtest_add_tests_helper(XMLConfig MPI_ALLOW "" "" "")
+gtest_add_tests_helper(XMLConfigSerial MPI_NOEXEC "" "" "")
 
 foreach(tgt
     ${Test.XMLConfig-TARGETS}

--- a/testing/adios2/yaml/CMakeLists.txt
+++ b/testing/adios2/yaml/CMakeLists.txt
@@ -10,10 +10,11 @@ else()
   gtest_add_tests_helper(YAMLConfigSerial FALSE "" "" "")
 endif()
 
-target_compile_definitions(Test.YAMLConfig PRIVATE
-  "YAML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
-)
-
-target_compile_definitions(Test.YAMLConfigSerial PRIVATE
-  "YAML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
-)
+foreach(tgt
+    ${Test.YAMLConfig-TARGETS}
+    ${Test.YAMLConfigSerial-TARGETS}
+    )
+  target_compile_definitions(${tgt} PRIVATE
+    "YAML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endforeach()

--- a/testing/adios2/yaml/CMakeLists.txt
+++ b/testing/adios2/yaml/CMakeLists.txt
@@ -3,12 +3,8 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-gtest_add_tests_helper(YAMLConfig ${test_mpi} "" "" "")
-if(ADIOS2_HAVE_MPI)
-  gtest_add_tests_helper(YAMLConfigSerial NOEXEC "" "" "")
-else()
-  gtest_add_tests_helper(YAMLConfigSerial FALSE "" "" "")
-endif()
+gtest_add_tests_helper(YAMLConfig MPI_ALLOW "" "" "")
+gtest_add_tests_helper(YAMLConfigSerial MPI_NOEXEC "" "" "")
 
 foreach(tgt
     ${Test.YAMLConfig-TARGETS}


### PR DESCRIPTION
Teach `gtest_add_tests_helper` and `fortran_add_test_helper` to add both serial and MPI tests when possible.  Update the `mpi` argument allowed enumeration values to distinguish the case of "mpi allowed" from "mpi only".  Update all call sites accordingly.

With this, tests can run both serial and MPI variants when ADIOS2 is built with MPI enabled.  Previously the tests would only run one or the other variant.
