### PR TITLE
Python available_variables to allow list of specific keys

### DIFF
--- a/bindings/Python/py11File.cpp
+++ b/bindings/Python/py11File.cpp
@@ -54,9 +54,11 @@ size_t File::AddTransport(const std::string type, const Params &parameters)
     return m_Stream->m_IO->AddTransport(type, parameters);
 }
 
-std::map<std::string, adios2::Params> File::AvailableVariables() noexcept
+std::map<std::string, adios2::Params>
+File::AvailableVariables(const std::vector<std::string> &keys) noexcept
 {
-    return m_Stream->m_IO->GetAvailableVariables();
+    const std::set<std::string> keysSet = helper::VectorToSet(keys);
+    return m_Stream->m_IO->GetAvailableVariables(keysSet);
 }
 
 std::map<std::string, adios2::Params> File::AvailableAttributes() noexcept

--- a/bindings/Python/py11File.h
+++ b/bindings/Python/py11File.h
@@ -54,7 +54,9 @@ public:
     size_t AddTransport(const std::string type,
                         const Params &parameters = Params());
 
-    std::map<std::string, adios2::Params> AvailableVariables() noexcept;
+    std::map<std::string, adios2::Params>
+    AvailableVariables(const std::vector<std::string> &keys =
+                           std::vector<std::string>()) noexcept;
 
     std::map<std::string, adios2::Params> AvailableAttributes() noexcept;
 

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -580,10 +580,17 @@ PYBIND11_MODULE(adios2, m)
         )md")
 
         .def("available_variables", &adios2::py11::File::AvailableVariables,
-             pybind11::return_value_policy::move, R"md(
+             pybind11::return_value_policy::move,
+             pybind11::arg("keys") = std::vector<std::string>(), R"md(
              Returns a 2-level dictionary with variable information. 
              Read mode only.
              
+             Parameters
+                 keys
+                    list of variable information keys to be extracted (case insensitive)
+                    keys=['AvailableStepsCount','Type','Max','Min','SingleValue','Shape']
+                    leave empty to return all possible keys
+
              Returns
                  variables dictionary
                      key 

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -589,6 +589,7 @@ PYBIND11_MODULE(adios2, m)
                  keys
                     list of variable information keys to be extracted (case insensitive)
                     keys=['AvailableStepsCount','Type','Max','Min','SingleValue','Shape']
+                    keys=['Name'] returns only the variable names as 1st-level keys
                     leave empty to return all possible keys
 
              Returns

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -403,9 +403,14 @@ void IO::RemoveAllAttributes() noexcept
 #undef declare_type
 }
 
-std::map<std::string, Params> IO::GetAvailableVariables() noexcept
+std::map<std::string, Params>
+IO::GetAvailableVariables(const std::set<std::string> &keys) noexcept
 {
     TAU_SCOPED_TIMER("IO::GetAvailableVariables");
+
+    std::set<std::string> keysLC = helper::LowerCase(keys);
+    // TODO
+
     std::map<std::string, Params> variablesInfo;
     for (const auto &variablePair : m_Variables)
     {

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -408,14 +408,11 @@ IO::GetAvailableVariables(const std::set<std::string> &keys) noexcept
 {
     TAU_SCOPED_TIMER("IO::GetAvailableVariables");
 
-    std::set<std::string> keysLC = helper::LowerCase(keys);
-    // TODO
-
     std::map<std::string, Params> variablesInfo;
     for (const auto &variablePair : m_Variables)
     {
-        const std::string name(variablePair.first);
-        const std::string type = InquireVariableType(name);
+        const std::string variableName = variablePair.first;
+        const std::string type = InquireVariableType(variableName);
 
         if (type == "compound")
         {
@@ -423,23 +420,7 @@ IO::GetAvailableVariables(const std::set<std::string> &keys) noexcept
 #define declare_template_instantiation(T)                                      \
     else if (type == helper::GetType<T>())                                     \
     {                                                                          \
-        variablesInfo[name]["Type"] = type;                                    \
-        Variable<T> &variable = *InquireVariable<T>(name);                     \
-        variablesInfo[name]["AvailableStepsCount"] =                           \
-            helper::ValueToString(variable.m_AvailableStepsCount);             \
-        variablesInfo[name]["Shape"] = helper::VectorToCSV(variable.Shape());  \
-        if (variable.m_SingleValue)                                            \
-        {                                                                      \
-            variablesInfo[name]["SingleValue"] = "true";                       \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            variablesInfo[name]["SingleValue"] = "false";                      \
-            variablesInfo[name]["Min"] =                                       \
-                helper::ValueToString(variable.Min());                         \
-            variablesInfo[name]["Max"] =                                       \
-                helper::ValueToString(variable.Max());                         \
-        }                                                                      \
+        variablesInfo[variableName] = GetVariableInfo<T>(variableName, keys);  \
     }
         ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -269,11 +269,16 @@ public:
 
     /**
      * @brief Retrieve map with variables info. Use when reading.
+     * @param keys list of variable information keys to be extracted (case
+     * insensitive). Leave empty to return all possible keys.
+     * Possible values:
+     * keys=['AvailableStepsCount','Type','Max','Min','SingleValue','Shape']
      * @return map with current variables and info
      * keys: Type, Min, Max, Value, AvailableStepsStart,
      * AvailableStepsCount, Shape, Start, Count, SingleValue
      */
-    std::map<std::string, Params> GetAvailableVariables() noexcept;
+    std::map<std::string, Params> GetAvailableVariables(
+        const std::set<std::string> &keys = std::set<std::string>()) noexcept;
 
     /**
      * @brief Gets an existing variable of primitive type by name

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -549,6 +549,10 @@ private:
     template <class T>
     bool IsAvailableStep(const size_t step,
                          const unsigned int variableIndex) noexcept;
+
+    template <class T>
+    Params GetVariableInfo(const std::string &variableName,
+                           const std::set<std::string> &keys);
 };
 
 // Explicit declaration of the public template methods

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -266,7 +266,7 @@ Params IO::GetVariableInfo(const std::string &variableName,
     }
     else
     {
-        lf_Insert("SingleValue", "true");
+        lf_Insert("SingleValue", "false");
         lf_Insert("Min", helper::ValueToString(variable.Min()));
         lf_Insert("Max", helper::ValueToString(variable.Max()));
     }

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -243,32 +243,57 @@ Params IO::GetVariableInfo(const std::string &variableName,
                            const std::set<std::string> &keys)
 {
     Params info;
+    // keys input are case insensitive
     const std::set<std::string> keysLC = helper::LowerCase(keys);
-    // small strings so passing by value
-    auto lf_Insert = [&](const std::string key, const std::string value) {
-        const std::string keyLC = helper::LowerCase(key);
-        if (keys.empty() || keysLC.count(keyLC) == 1)
-        {
-            info[key] = value;
-        }
-    };
+
+    // return empty map if only "name" key is requested
+    if (keys.size() == 1 && keysLC.count("name") == 1)
+    {
+        return info;
+    }
 
     Variable<T> &variable = *InquireVariable<T>(variableName);
 
-    lf_Insert("Type", variable.m_Type);
-    lf_Insert("AvailableStepsCount",
-              helper::ValueToString(variable.m_AvailableStepsCount));
-    lf_Insert("Shape", helper::VectorToCSV(variable.Shape()));
+    if (keys.empty() || keysLC.count("type") == 1)
+    {
+        info["Type"] = variable.m_Type;
+    }
+
+    if (keys.empty() || keysLC.count("availablestepscount") == 1)
+    {
+        info["AvailableStepsCount"] =
+            helper::ValueToString(variable.m_AvailableStepsCount);
+    }
+
+    if (keys.empty() || keysLC.count("shape") == 1)
+    {
+        // expensive function
+        info["Shape"] = helper::VectorToCSV(variable.Shape());
+    }
 
     if (variable.m_SingleValue)
     {
-        lf_Insert("SingleValue", "true");
+        if (keys.empty() || keysLC.count("singlevalue") == 1)
+        {
+            info["SingleValue"] = "true";
+        }
     }
     else
     {
-        lf_Insert("SingleValue", "false");
-        lf_Insert("Min", helper::ValueToString(variable.Min()));
-        lf_Insert("Max", helper::ValueToString(variable.Max()));
+        if (keys.empty() || keysLC.count("singlevalue") == 1)
+        {
+            info["SingleValue"] = "false";
+        }
+        if (keys.empty() || keysLC.count("min") == 1)
+        {
+            // expensive function
+            info["Min"] = helper::ValueToString(variable.Min());
+        }
+        if (keys.empty() || keysLC.count("max") == 1)
+        {
+            // expensive function
+            info["Max"] = helper::ValueToString(variable.Max());
+        }
     }
     return info;
 }

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -271,29 +271,26 @@ Params IO::GetVariableInfo(const std::string &variableName,
         info["Shape"] = helper::VectorToCSV(variable.Shape());
     }
 
-    if (variable.m_SingleValue)
+    if (keys.empty() || keysLC.count("singlevalue") == 1)
     {
-        if (keys.empty() || keysLC.count("singlevalue") == 1)
-        {
-            info["SingleValue"] = "true";
-        }
+        const std::string isSingleValue =
+            variable.m_SingleValue ? "true" : "false";
+        info["SingleValue"] = isSingleValue;
     }
-    else
+
+    if (keys.empty() || (keysLC.count("min") == 1 && keysLC.count("max") == 1))
     {
-        if (keys.empty() || keysLC.count("singlevalue") == 1)
-        {
-            info["SingleValue"] = "false";
-        }
-        if (keys.empty() || keysLC.count("min") == 1)
-        {
-            // expensive function
-            info["Min"] = helper::ValueToString(variable.Min());
-        }
-        if (keys.empty() || keysLC.count("max") == 1)
-        {
-            // expensive function
-            info["Max"] = helper::ValueToString(variable.Max());
-        }
+        const auto pairMinMax = variable.MinMax();
+        info["Min"] = helper::ValueToString(pairMinMax.first);
+        info["Max"] = helper::ValueToString(pairMinMax.second);
+    }
+    else if (keysLC.count("min") == 1)
+    {
+        info["Min"] = helper::ValueToString(variable.Min());
+    }
+    else if (keysLC.count("max") == 1)
+    {
+        info["Max"] = helper::ValueToString(variable.Min());
     }
     return info;
 }

--- a/source/adios2/helper/adiosString.cpp
+++ b/source/adios2/helper/adiosString.cpp
@@ -12,7 +12,6 @@
 #include "adiosString.tcc"
 
 /// \cond EXCLUDE_FROM_DOXYGEN
-#include <algorithm> //std::transform
 #include <fstream>
 #include <ios> //std::ios_base::failure
 #include <sstream>
@@ -393,13 +392,6 @@ size_t StringToByteUnits(const std::string &input, const std::string &hint)
     const size_t factor = BytesFactor(units);
 
     return static_cast<size_t>(std::stoul(number) * factor);
-}
-
-std::string LowerCase(const std::string &input)
-{
-    std::string output = input;
-    std::transform(output.begin(), output.end(), output.begin(), ::tolower);
-    return output;
 }
 
 // The design decision is that user-supplied parameters are case-insensitive.

--- a/source/adios2/helper/adiosString.h
+++ b/source/adios2/helper/adiosString.h
@@ -26,6 +26,14 @@ namespace helper
 {
 
 /**
+ * Transforms string to LowerCase: either single string or set of strings
+ * @param input string or set of strings
+ * @return input contents in lower case
+ */
+template <class T>
+T LowerCase(const T &input);
+
+/**
  * Opens and checks for file and dumps content to a single string.
  * @param fileName of text file
  * @param hint exception message
@@ -168,18 +176,10 @@ size_t StringToSizeT(const std::string &input, const std::string &hint);
 size_t StringToByteUnits(const std::string &input, const std::string &hint);
 
 /**
- * Transforms string to LowerCase
- * @param input string
- * @return input contents in lower case
- */
-std::string LowerCase(const std::string &input);
-
-/**
  * Transforms parameter map to LowerCase.
  * @param params parameter map
  * @return parameter map with keys and values lower case.
  */
-
 Params LowerCaseParams(const Params &params);
 
 /**

--- a/source/adios2/helper/adiosString.tcc
+++ b/source/adios2/helper/adiosString.tcc
@@ -14,6 +14,7 @@
 #include "adiosString.h"
 
 #include <algorithm> //std::transform
+#include <iterator>  //std::inserter
 
 namespace adios2
 {

--- a/source/adios2/helper/adiosString.tcc
+++ b/source/adios2/helper/adiosString.tcc
@@ -13,10 +13,30 @@
 
 #include "adiosString.h"
 
+#include <algorithm> //std::transform
+
 namespace adios2
 {
 namespace helper
 {
+
+template <>
+std::string LowerCase(const std::string &input)
+{
+    std::string output = input;
+    std::transform(output.begin(), output.end(), output.begin(), ::tolower);
+    return output;
+}
+
+template <>
+std::set<std::string> LowerCase(const std::set<std::string> &input)
+{
+    std::set<std::string> output;
+    std::transform(input.begin(), input.end(),
+                   std::inserter(output, output.begin()),
+                   [](const std::string &in) { return LowerCase(in); });
+    return output;
+}
 
 template <>
 bool StringTo(const std::string &input, const std::string &hint)

--- a/source/adios2/helper/adiosType.h
+++ b/source/adios2/helper/adiosType.h
@@ -227,6 +227,14 @@ template <class T, class U>
 std::set<T> KeysToSet(const std::unordered_map<T, U> &hash) noexcept;
 
 /**
+ * Convert a vector to a set (without duplicate entries)
+ * @param input vector
+ * @return ordered keys content
+ */
+template <class T>
+std::set<T> VectorToSet(const std::vector<T> &input) noexcept;
+
+/**
  * Calls map.erase(key) returning current value. Throws an exception if Key not
  * found.
  * @param key input

--- a/source/adios2/helper/adiosType.inl
+++ b/source/adios2/helper/adiosType.inl
@@ -267,6 +267,17 @@ std::set<T> KeysToSet(const std::unordered_map<T, U> &hash) noexcept
     return output;
 }
 
+template <class T>
+std::set<T> VectorToSet(const std::vector<T> &input) noexcept
+{
+    std::set<T> output;
+    for (const T &in : input)
+    {
+        output.insert(in);
+    }
+    return output;
+}
+
 template <class T, class U>
 U EraseKey(const T &key, std::map<T, U> &map)
 {

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -162,16 +162,20 @@ class TestReadAvailableVariables(unittest.TestCase):
             for fh_step in fh:
                 vars_info = fh_step.available_variables()
                 
+#                 for name, info in vars_info.items():
+#                     print("variable_name: " + name)
+#                     for key, value in info.items():
+#                         print("\t" + key + ": " + value)
+#                     print("\n")
+                
+                keys=['Type']
+                
+                vars_info = fh_step.available_variables(keys)
                 for name, info in vars_info.items():
                     print("variable_name: " + name)
                     for key, value in info.items():
                         print("\t" + key + ": " + value)
                     print("\n")
-                
-                keys=['Type']
-                print(keys)
-                
-                vars_info = fh_step.available_variables(keys)
 
 if __name__ == '__main__':
     unittest.main()

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -177,10 +177,15 @@ class TestReadAvailableVariables(unittest.TestCase):
                 self.assertTrue(vars_info['global_array']['Type'] == 'int64_t')
                 self.assertTrue(vars_info['global_array']
                                 ['SingleValue'] == 'false')
+                self.assertTrue(vars_info['global_value']
+                                ['SingleValue'] == 'true')
 
                 vars_info = fh_step.available_variables(['shape'])
                 self.assertTrue(len(vars_info['global_array']) == 1)
                 self.assertTrue(vars_info['global_array']['Shape'] == '2, 16')
+
+                vars_info = fh_step.available_variables(['Name'])
+                self.assertTrue(len(vars_info['global_array']) == 0)
 
 
 if __name__ == '__main__':

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -156,29 +156,32 @@ class TestReadStepSelection(unittest.TestCase):
 
 
 class TestReadAvailableVariables(unittest.TestCase):
-    
+
     def test_AvailableVariables(self):
         with adios2.open(filename, 'r') as fh:
             for fh_step in fh:
                 vars_info = fh_step.available_variables()
                 self.assertTrue(len(vars_info['global_array']) == 6)
-                
+
                 vars_info = fh_step.available_variables(['type'])
                 self.assertTrue(len(vars_info['global_array']) == 1)
                 self.assertTrue(vars_info['global_array']['Type'] == 'int64_t')
-                
+
                 vars_info = fh_step.available_variables(['type', 'min', 'max'])
                 self.assertTrue(len(vars_info['global_array']) == 3)
                 self.assertTrue(vars_info['global_array']['Type'] == 'int64_t')
-                
-                vars_info = fh_step.available_variables(['Type','Min','Max', 'SingleValue'])
+
+                vars_info = fh_step.available_variables(
+                    ['Type', 'Min', 'Max', 'SingleValue'])
                 self.assertTrue(len(vars_info['global_array']) == 4)
                 self.assertTrue(vars_info['global_array']['Type'] == 'int64_t')
-                self.assertTrue(vars_info['global_array']['SingleValue'] == 'false')
-                
+                self.assertTrue(vars_info['global_array']
+                                ['SingleValue'] == 'false')
+
                 vars_info = fh_step.available_variables(['shape'])
                 self.assertTrue(len(vars_info['global_array']) == 1)
-                self.assertTrue(vars_info['global_array']['Shape']=='2, 16')
+                self.assertTrue(vars_info['global_array']['Shape'] == '2, 16')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -161,21 +161,24 @@ class TestReadAvailableVariables(unittest.TestCase):
         with adios2.open(filename, 'r') as fh:
             for fh_step in fh:
                 vars_info = fh_step.available_variables()
+                self.assertTrue(len(vars_info['global_array']) == 6)
                 
-#                 for name, info in vars_info.items():
-#                     print("variable_name: " + name)
-#                     for key, value in info.items():
-#                         print("\t" + key + ": " + value)
-#                     print("\n")
+                vars_info = fh_step.available_variables(['type'])
+                self.assertTrue(len(vars_info['global_array']) == 1)
+                self.assertTrue(vars_info['global_array']['Type'] == 'int64_t')
                 
-                keys=['Type']
+                vars_info = fh_step.available_variables(['type', 'min', 'max'])
+                self.assertTrue(len(vars_info['global_array']) == 3)
+                self.assertTrue(vars_info['global_array']['Type'] == 'int64_t')
                 
-                vars_info = fh_step.available_variables(keys)
-                for name, info in vars_info.items():
-                    print("variable_name: " + name)
-                    for key, value in info.items():
-                        print("\t" + key + ": " + value)
-                    print("\n")
+                vars_info = fh_step.available_variables(['Type','Min','Max', 'SingleValue'])
+                self.assertTrue(len(vars_info['global_array']) == 4)
+                self.assertTrue(vars_info['global_array']['Type'] == 'int64_t')
+                self.assertTrue(vars_info['global_array']['SingleValue'] == 'false')
+                
+                vars_info = fh_step.available_variables(['shape'])
+                self.assertTrue(len(vars_info['global_array']) == 1)
+                self.assertTrue(vars_info['global_array']['Shape']=='2, 16')
 
 if __name__ == '__main__':
     unittest.main()

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -155,5 +155,23 @@ class TestReadStepSelection(unittest.TestCase):
                     val, local_arrays[1:3, b, 1:5, 1:3]))
 
 
+class TestReadAvailableVariables(unittest.TestCase):
+    
+    def test_AvailableVariables(self):
+        with adios2.open(filename, 'r') as fh:
+            for fh_step in fh:
+                vars_info = fh_step.available_variables()
+                
+                for name, info in vars_info.items():
+                    print("variable_name: " + name)
+                    for key, value in info.items():
+                        print("\t" + key + ": " + value)
+                    print("\n")
+                
+                keys=['Type']
+                print(keys)
+                
+                vars_info = fh_step.available_variables(keys)
+
 if __name__ == '__main__':
     unittest.main()

--- a/testing/adios2/bindings/python/TestHighLevelAPI.py
+++ b/testing/adios2/bindings/python/TestHighLevelAPI.py
@@ -160,8 +160,15 @@ class TestReadAvailableVariables(unittest.TestCase):
     def test_AvailableVariables(self):
         with adios2.open(filename, 'r') as fh:
             for fh_step in fh:
+
+                step = fh_step.current_step()
+
                 vars_info = fh_step.available_variables()
                 self.assertTrue(len(vars_info['global_array']) == 6)
+
+                self.assertTrue(len(vars_info['global_value']) == 6)
+                self.assertTrue(vars_info['global_value']['Min'] == str(step))
+                self.assertTrue(vars_info['global_value']['Max'] == str(step))
 
                 vars_info = fh_step.available_variables(['type'])
                 self.assertTrue(len(vars_info['global_array']) == 1)
@@ -177,8 +184,14 @@ class TestReadAvailableVariables(unittest.TestCase):
                 self.assertTrue(vars_info['global_array']['Type'] == 'int64_t')
                 self.assertTrue(vars_info['global_array']
                                 ['SingleValue'] == 'false')
+
+                self.assertTrue(len(vars_info['global_value']) == 4)
+                self.assertTrue(vars_info['global_value']['Type'] == 'int64_t')
                 self.assertTrue(vars_info['global_value']
                                 ['SingleValue'] == 'true')
+
+                self.assertTrue(vars_info['global_value']['Min'] == str(step))
+                self.assertTrue(vars_info['global_value']['Max'] == str(step))
 
                 vars_info = fh_step.available_variables(['shape'])
                 self.assertTrue(len(vars_info['global_array']) == 1)


### PR DESCRIPTION
Related to #2196 and #2197 to allow passing a list of case-insensitive input keys to customized variables information.
This PR does not break the current API for `available_variables`.

CC: @khuck @dyokelson