### PR TITLE
Handle pending releases when closing writer

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -25,6 +25,8 @@ extern void CP_verbose(SstStream Stream, char *Format, ...);
 static void CP_PeerFailCloseWSReader(WS_ReaderInfo CP_WSR_Stream,
                                      enum StreamStatus NewState);
 
+static void ProcessReleaseList(SstStream Stream, ReturnMetadataInfo Metadata);
+
 #define gettid() pthread_self()
 #ifdef MUTEX_DEBUG
 #define STREAM_MUTEX_LOCK(Stream)                                              \
@@ -1470,6 +1472,7 @@ void SstWriterClose(SstStream Stream)
     memset(&Msg, 0, sizeof(Msg));
     STREAM_MUTEX_LOCK(Stream);
     Msg.FinalTimestep = Stream->LastProvidedTimestep;
+    ReturnMetadataInfo ReleaseData;
     CP_verbose(
         Stream,
         "SstWriterClose, Sending Close at Timestep %d, one to each reader\n",
@@ -1488,6 +1491,17 @@ void SstWriterClose(SstStream Stream)
     if ((Stream->ConfigParams->CPCommPattern == SstCPCommPeer) ||
         (Stream->Rank == 0))
     {
+        PTHREAD_MUTEX_LOCK(&Stream->DataLock);
+        if (Stream->ReleaseCount > 0)
+        {
+            SMPI_Bcast(&Stream->ReleaseCount, 1, MPI_INT, 0, Stream->mpiComm);
+            SMPI_Bcast(Stream->ReleaseList,
+                       Stream->ReleaseCount * sizeof(*(Stream->ReleaseList)),
+                       MPI_BYTE, 0, Stream->mpiComm);
+            Stream->ReleaseCount = 0;
+            free(Stream->ReleaseList);
+            Stream->ReleaseList = NULL;
+        }
         while (Stream->QueuedTimesteps)
         {
             CP_verbose(Stream,
@@ -1502,7 +1516,7 @@ void SstWriterClose(SstStream Stream)
                 {
                     char tmp[20];
                     CP_verbose(Stream,
-                               "IN TS WAIT, ENTRIES areTimestep %ld (exp %d, "
+                               "IN TS WAIT, ENTRIES are Timestep %ld (exp %d, "
                                "Prec %d, Ref %d), Count now %d\n",
                                List->Timestep, List->Expired,
                                List->PreciousTimestep, List->ReferenceCount,
@@ -1526,10 +1540,54 @@ void SstWriterClose(SstStream Stream)
             }
             /* NEED TO HANDLE FAILURE HERE */
             STREAM_CONDITION_WAIT(Stream);
+            SST_REAFFIRM_LOCKED_AFTER_CONDITION();
+            SMPI_Bcast(&Stream->ReleaseCount, 1, MPI_INT, 0, Stream->mpiComm);
+            if (Stream->ReleaseCount > 0)
+            {
+                SMPI_Bcast(Stream->ReleaseList,
+                           Stream->ReleaseCount *
+                               sizeof(*(Stream->ReleaseList)),
+                           MPI_BYTE, 0, Stream->mpiComm);
+                Stream->ReleaseCount = 0;
+                free(Stream->ReleaseList);
+                Stream->ReleaseList = NULL;
+            }
         }
+        Stream->ReleaseCount = -1;
+        SMPI_Bcast(&Stream->ReleaseCount, 1, MPI_INT, 0, Stream->mpiComm);
+        Stream->ReleaseCount = 0;
+        PTHREAD_MUTEX_UNLOCK(&Stream->DataLock);
     }
+
     if (Stream->ConfigParams->CPCommPattern == SstCPCommMin)
     {
+        if (Stream->Rank != 0)
+        {
+            ReleaseData = malloc(sizeof(*ReleaseData));
+            while (1)
+            {
+                SMPI_Bcast(&ReleaseData->ReleaseCount, 1, MPI_INT, 0,
+                           Stream->mpiComm);
+                if (ReleaseData->ReleaseCount == -1)
+                {
+                    break;
+                }
+                else if (ReleaseData->ReleaseCount > 0)
+                {
+                    ReleaseData->ReleaseList =
+                        malloc(ReleaseData->ReleaseCount *
+                               sizeof(*ReleaseData->ReleaseList));
+                    SMPI_Bcast(ReleaseData->ReleaseList,
+                               ReleaseData->ReleaseCount *
+                                   sizeof(*(ReleaseData->ReleaseList)),
+                               MPI_BYTE, 0, Stream->mpiComm);
+                    ProcessReleaseList(Stream, ReleaseData);
+                    free(ReleaseData->ReleaseList);
+                    ReleaseData->ReleaseList = NULL;
+                }
+            }
+            free(ReleaseData);
+        }
         /*
          * if we're CommMin, getting here implies that Rank 0 has released all
          * timesteps, other ranks can follow suit after barrier
@@ -1537,7 +1595,6 @@ void SstWriterClose(SstStream Stream)
         STREAM_MUTEX_UNLOCK(Stream);
         SMPI_Barrier(Stream->mpiComm);
         STREAM_MUTEX_LOCK(Stream);
-        ReleaseAndDiscardRemainingTimesteps(Stream);
     }
     STREAM_MUTEX_UNLOCK(Stream);
     gettimeofday(&CloseTime, NULL);

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -1493,11 +1493,14 @@ void SstWriterClose(SstStream Stream)
     {
         if (Stream->ReleaseCount > 0)
         {
-            if(Stream->ConfigParams->CPCommPattern == SstCPCommMin) {
-                SMPI_Bcast(&Stream->ReleaseCount, 1, SMPI_INT, 0, Stream->mpiComm);
+            if (Stream->ConfigParams->CPCommPattern == SstCPCommMin)
+            {
+                SMPI_Bcast(&Stream->ReleaseCount, 1, SMPI_INT, 0,
+                           Stream->mpiComm);
                 SMPI_Bcast(Stream->ReleaseList,
-                       Stream->ReleaseCount * sizeof(*(Stream->ReleaseList)),
-                       SMPI_BYTE, 0, Stream->mpiComm);
+                           Stream->ReleaseCount *
+                               sizeof(*(Stream->ReleaseList)),
+                           SMPI_BYTE, 0, Stream->mpiComm);
             }
             Stream->ReleaseCount = 0;
             free(Stream->ReleaseList);
@@ -1541,21 +1544,23 @@ void SstWriterClose(SstStream Stream)
             }
             /* NEED TO HANDLE FAILURE HERE */
             STREAM_CONDITION_WAIT(Stream);
-            if(Stream->ConfigParams->CPCommPattern == SstCPCommMin) {
-                SMPI_Bcast(&Stream->ReleaseCount, 1, SMPI_INT, 0, Stream->mpiComm);
+            if (Stream->ConfigParams->CPCommPattern == SstCPCommMin)
+            {
+                SMPI_Bcast(&Stream->ReleaseCount, 1, SMPI_INT, 0,
+                           Stream->mpiComm);
                 if (Stream->ReleaseCount > 0)
                 {
                     SMPI_Bcast(Stream->ReleaseList,
-                           Stream->ReleaseCount *
-                               sizeof(*(Stream->ReleaseList)),
-                           SMPI_BYTE, 0, Stream->mpiComm);
+                               Stream->ReleaseCount *
+                                   sizeof(*(Stream->ReleaseList)),
+                               SMPI_BYTE, 0, Stream->mpiComm);
                     Stream->ReleaseCount = 0;
                     free(Stream->ReleaseList);
                     Stream->ReleaseList = NULL;
                 }
             }
         }
-        if(Stream->ConfigParams->CPCommPattern == SstCPCommMin) 
+        if (Stream->ConfigParams->CPCommPattern == SstCPCommMin)
         {
             Stream->ReleaseCount = -1;
             SMPI_Bcast(&Stream->ReleaseCount, 1, SMPI_INT, 0, Stream->mpiComm);

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -1491,7 +1491,6 @@ void SstWriterClose(SstStream Stream)
     if ((Stream->ConfigParams->CPCommPattern == SstCPCommPeer) ||
         (Stream->Rank == 0))
     {
-        STREAM_MUTEX_LOCK(Stream)
         if (Stream->ReleaseCount > 0)
         {
             SMPI_Bcast(&Stream->ReleaseCount, 1, SMPI_INT, 0, Stream->mpiComm);
@@ -1580,7 +1579,9 @@ void SstWriterClose(SstStream Stream)
                                ReleaseData->ReleaseCount *
                                    sizeof(*(ReleaseData->ReleaseList)),
                                SMPI_BYTE, 0, Stream->mpiComm);
+                    STREAM_MUTEX_UNLOCK(Stream);
                     ProcessReleaseList(Stream, ReleaseData);
+                    STREAM_MUTEX_LOCK(Stream);
                     free(ReleaseData->ReleaseList);
                     ReleaseData->ReleaseList = NULL;
                 }

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -1554,7 +1554,6 @@ void SstWriterClose(SstStream Stream)
         Stream->ReleaseCount = -1;
         SMPI_Bcast(&Stream->ReleaseCount, 1, SMPI_INT, 0, Stream->mpiComm);
         Stream->ReleaseCount = 0;
-        STREAM_MUTEX_UNLOCK(Stream);
     }
 
     if (Stream->ConfigParams->CPCommPattern == SstCPCommMin)


### PR DESCRIPTION
Perform normal release operations on queued Release notices from the readers at writer close, rather than just dumping them. The push-based RDMA data plane needs this because it needs to perform data transfer operations in response to release messages.