### PR TITLE
bindings: Fix Python serial program init when ADIOS2 has MPI enabled

### DIFF
--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -229,6 +229,15 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
                  const bool opBool = adios ? true : false;
                  return opBool;
              })
+        .def(pybind11::init<const bool>(),
+             "adios2 module starting point "
+             "non-MPI, constructs an ADIOS class "
+             "object",
+             pybind11::arg("debugMode") = true)
+        .def(pybind11::init<const std::string &, const bool>(),
+             "adios2 module starting point non-MPI, constructs an ADIOS class "
+             "object",
+             pybind11::arg("configFile"), pybind11::arg("debugMode") = true)
 #if ADIOS2_USE_MPI
         .def(pybind11::init<const adios2::py11::MPI4PY_Comm, const bool>(),
              "adios2 module starting point, constructs an ADIOS class object",
@@ -239,15 +248,6 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
              pybind11::arg("configFile"), pybind11::arg("comm"),
              pybind11::arg("debugMode") = true)
 #endif
-        .def(pybind11::init<const bool>(),
-             "adios2 module starting point "
-             "non-MPI, constructs an ADIOS class "
-             "object",
-             pybind11::arg("debugMode") = true)
-        .def(pybind11::init<const std::string &, const bool>(),
-             "adios2 module starting point non-MPI, constructs an ADIOS class "
-             "object",
-             pybind11::arg("configFile"), pybind11::arg("debugMode") = true)
         .def("DeclareIO", &adios2::py11::ADIOS::DeclareIO,
              "spawn IO object component returning a IO object with a unique "
              "name, throws an exception if IO with the same name is declared "

--- a/testing/adios2/bindings/python/CMakeLists.txt
+++ b/testing/adios2/bindings/python/CMakeLists.txt
@@ -4,21 +4,17 @@
 #------------------------------------------------------------------------------#
 
 function(add_python_mpi_test testname)
-  python_add_test(NAME Bindings.Python.${testname} SCRIPT Test${testname}.py
+  python_add_test(NAME Bindings.Python.${testname}.MPI SCRIPT Test${testname}.py
     EXEC_WRAPPER ${MPIEXEC_COMMAND}
   )
-  set_tests_properties(Bindings.Python.${testname} PROPERTIES
+  set_tests_properties(Bindings.Python.${testname}.MPI PROPERTIES
     PROCESSORS "${MPIEXEC_MAX_NUMPROCS}"
   )
 endfunction()
 
-python_add_test(NAME Bindings.Python.HighLevelAPI SCRIPT TestHighLevelAPI.py) 
+python_add_test(NAME Bindings.Python.HighLevelAPI.Serial SCRIPT TestHighLevelAPI.py)
 
-if(NOT ADIOS2_HAVE_MPI)
-  python_add_test(NAME Bindings.Python.BPWriteReadTypes
-    SCRIPT TestBPWriteReadTypes_nompi.py
-  )
-endif()
+python_add_test(NAME Bindings.Python.BPWriteReadTypes.Serial SCRIPT TestBPWriteReadTypes_nompi.py)
 
 if(ADIOS2_HAVE_MPI)
   add_python_mpi_test(BPWriteReadTypes)


### PR DESCRIPTION
The one-argument `adios2.ADIOS(...)` constructor has two overloads when MPI is enabled: `ADIOS(bool)` and `ADIOS(MPI4PY_Comm)`.  The representation of `MPI4PY_Comm` is just an integer, so a call with a `bool` may try to convert it (and fail).  Re-order the pybind11 definitions of these signatures so that the `ADIOS(bool)` is tried first.  That way a call with a `bool` will use it and a call with a `MPI4PY_Comm` will not convert and fall back to the proper variant.

Also update the test suite to always add the Serial variant of the tests and additionally enable the MPI variants when possible.  The `Bindings.Python.BPWriteReadTypes.Serial` test in particular covers the overload selection problem fixed here.

Fixes: #2233  
