### PR TITLE
Fortran GCC 10 compat: -fallow-argument-mismatch for

### DIFF
--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -11,6 +11,10 @@ FortranCInterface_VERIFY(CXX QUIET)
 # Check whether the compiler supports Fortran submodule constructs we need.
 adios2_check_fortran_submodules(ADIOS2_HAVE_FORTRAN_SUBMODULES)
 
+if(ADIOS2_USE_Fortran_flag_argument_mismatch)
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
+endif()
+
 add_library(adios2_fortran
   f2c/adios2_f2c_adios.cpp
   f2c/adios2_f2c_attribute.cpp

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -352,4 +352,7 @@ if(ADIOS2_USE_Fortran)
   check_float_type_representation("real(kind=4)" REAL4_TYPE_Fortran LANGUAGE Fortran)
   check_float_type_representation("real(kind=8)" REAL8_TYPE_Fortran LANGUAGE Fortran)
   check_float_type_representation("real(kind=16)" REAL16_TYPE_Fortran LANGUAGE Fortran)
+
+  include(CheckFortranCompilerFlag)
+  check_fortran_compiler_flag("-fallow-argument-mismatch" ADIOS2_USE_Fortran_flag_argument_mismatch)
 endif()


### PR DESCRIPTION
Resolves #2228 by replacing errors with warnings. There was no way to fix it without API-breaking changes. These warnings *can't* be silenced with `-Wno-argument-mismatch` since GCC 10 removed that.

Current warnings:
```bash
/Users/usr/Downloads/ADIOS23/bindings/Fortran/modules/adios2_attribute_data_mod.f90:225:43:

  225 |             call adios2_attribute_data_f2c(data, length, attribute%f2c, ierr)
      |                                           1
......
  240 |             call adios2_attribute_data_f2c(data, length, attribute%f2c, ierr)
      |                                           2
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
/Users/usr/Downloads/ADIOS23/bindings/Fortran/modules/adios2_attribute_data_mod.f90:114:44:

  114 |             call adios2_attribute_value_f2c(data, attribute%f2c, ierr)
      |                                            1
......
  127 |             call adios2_attribute_value_f2c(data, attribute%f2c, ierr)
      |                                            2
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
contains/adios2_engine_get_deferred_by_name.f90:742:41:

......
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
contains/adios2_engine_get_deferred_by_name.f90:125:41:

......
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
contains/adios2_engine_get_deferred.f90:909:54:

......
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
contains/adios2_engine_get_deferred.f90:151:54:

......
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
contains/adios2_engine_get_by_name.f90:141:32:

Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
contains/adios2_engine_get.f90:151:54:

Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
contains/adios2_engine_put_deferred_by_name.f90:744:41:

......
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
contains/adios2_engine_put_deferred_by_name.f90:127:41:

......
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
contains/adios2_engine_put_deferred.f90:910:54:

......
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
contains/adios2_engine_put_deferred.f90:152:54:

......
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
contains/adios2_engine_put_by_name.f90:140:32:

Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
contains/adios2_engine_put.f90:152:54:

Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
/Users/usr/Downloads/ADIOS23/bindings/Fortran/modules/adios2_io_define_attribute_mod.f90:1162:65:

 1162 |                                            adios2_type_integer4, data, length, &
      |                                                                 1
......
 1194 |                                            data, length, &
      |                                           2                      
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
/Users/usr/Downloads/ADIOS23/bindings/Fortran/modules/adios2_io_define_attribute_mod.f90:935:59:

  935 |                                      adios2_type_integer4, value, &
      |                                                           1
......
  963 |                                      adios2_type_integer8, value, &
      |                                                           2
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
/Users/usr/Downloads/ADIOS23/bindings/Fortran/modules/adios2_variable_max_mod.f90:117:41:

  117 |             call adios2_variable_max_f2c(maximum, variable%f2c, ierr)
      |                                         1
......
  130 |             call adios2_variable_max_f2c(maximum, variable%f2c, ierr)
      |                                         2
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
/Users/usr/Downloads/ADIOS23/bindings/Fortran/modules/adios2_variable_min_mod.f90:117:41:

  117 |             call adios2_variable_min_f2c(minimum, variable%f2c, ierr)
      |                                         1
......
  130 |             call adios2_variable_min_f2c(minimum, variable%f2c, ierr)
      |                                         2
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/INTEGER(8)).
```