### PR TITLE
Go back using active flag in metadata index header instead of using a…

### DIFF
--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -60,8 +60,6 @@ private:
     /* transport manager for managing the metadata index file */
     transportman::TransportMan m_FileMetadataIndexManager;
 
-    transportman::TransportMan m_FileActiveFlagManager;
-
     /*
      *  Burst buffer variables
      */
@@ -87,7 +85,6 @@ private:
     std::vector<std::string> m_MetadataIndexFileNames;
     std::vector<std::string> m_DrainMetadataIndexFileNames;
     std::vector<std::string> m_ActiveFlagFileNames;
-    std::vector<std::string> m_DrainActiveFlagFileNames;
 
     void Init() final;
 
@@ -136,6 +133,8 @@ private:
         const uint64_t mpirank, const uint64_t pgIndexStart,
         const uint64_t variablesIndexStart, const uint64_t attributesIndexStart,
         const uint64_t currentStepEndPos, const uint64_t currentTimeStamp);
+
+    void UpdateActiveFlag(const bool active);
 
     void WriteCollectiveMetadataFile(const bool isFinal = false);
 

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
@@ -102,13 +102,11 @@ void BP4Deserializer::ParseMetadataIndex(const BufferSTL &bufferSTL,
                 std::to_string(m_Minifooter.Version) + " version \n");
         }
 
-        /* Writer active flag (not used anymore)
-            //
-            //position = m_ActiveFlagPosition;
-            //const char activeChar = helper::ReadValue<uint8_t>(
-            //    buffer, position, m_Minifooter.IsLittleEndian);
-            //m_WriterIsActive = (activeChar == '\1' ? true : false);
-        */
+        // Writer active flag
+        position = m_ActiveFlagPosition;
+        const char activeChar = helper::ReadValue<uint8_t>(
+            buffer, position, m_Minifooter.IsLittleEndian);
+        m_WriterIsActive = (activeChar == '\1' ? true : false);
 
         // move position to first row
         position = 64;
@@ -632,6 +630,21 @@ void BP4Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
     }
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
+}
+
+bool BP4Deserializer::ReadActiveFlag(std::vector<char> &buffer)
+{
+    if (buffer.size() < m_ActiveFlagPosition)
+    {
+        throw std::runtime_error("BP4Deserializer::ReadActiveFlag() is called "
+                                 "with a buffer smaller than required");
+    }
+    // Writer active flag
+    size_t position = m_ActiveFlagPosition;
+    const char activeChar = helper::ReadValue<uint8_t>(
+        buffer, position, m_Minifooter.IsLittleEndian);
+    m_WriterIsActive = (activeChar == '\1' ? true : false);
+    return m_WriterIsActive;
 }
 
 #define declare_template_instantiation(T)                                      \

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
@@ -36,6 +36,8 @@ public:
     /** BP Minifooter fields */
     Minifooter m_Minifooter;
 
+    bool m_WriterIsActive = false;
+
     /**
      * Unique constructor
      * @param comm multi-process communicator
@@ -175,6 +177,8 @@ public:
                     const std::vector<char> &contiguousMemory,
                     const Box<Dims> &blockBox,
                     const Box<Dims> &intersectionBox) const;
+
+    bool ReadActiveFlag(std::vector<char> &buffer);
 
     // TODO: will deprecate
     bool m_PerformedGets = false;


### PR DESCRIPTION
… separate 'active' file, which introduced race conditions. A separate file cannot guarantee the order of the following events: removal of active file (file system's metadata server operation), and arrival of content of metadata index file on disk (a storage operation). Index content may be en route to disk but held up to indefinite time while the active file disappears, so a reader may not get the last steps believing the file is not active anymore. In contrast, active flag is written to the same file after the last steps are written, so order is guaranteed as long as the file system guarantees the order of writes to the same file.