### PR TITLE
reduced data steps in dataman tests in order to prevent timeout

### DIFF
--- a/testing/adios2/engine/dataman/TestDataMan1D.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan1D.cpp
@@ -315,7 +315,7 @@ TEST_F(DataManEngineTest, 1D)
     Dims shape = {10};
     Dims start = {0};
     Dims count = {10};
-    size_t steps = 10000;
+    size_t steps = 5000;
     adios2::Params engineParams = {{"IPAddress", "127.0.0.1"},
                                    {"Port", "12300"}};
 

--- a/testing/adios2/engine/dataman/TestDataMan2DMemSelect.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan2DMemSelect.cpp
@@ -356,7 +356,7 @@ TEST_F(DataManEngineTest, 2D_MemSelect)
     memstart = {1, 1};
     memcount = {7, 9};
 
-    size_t steps = 10000;
+    size_t steps = 5000;
     adios2::Params engineParams = {
         {"IPAddress", "127.0.0.1"}, {"Port", "12320"}, {"Verbose", "0"}};
 

--- a/testing/adios2/engine/dataman/TestDataMan3DMemSelect.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan3DMemSelect.cpp
@@ -185,7 +185,7 @@ void DataManReaderP2PMemSelect(const Dims &shape, const Dims &start,
 TEST_F(DataManEngineTest, 3D_MemSelect)
 {
 
-    size_t steps = 10000;
+    size_t steps = 5000;
     adios2::Params engineParams = {{"IPAddress", "127.0.0.1"},
                                    {"Port", "12340"}};
     // run workflow

--- a/testing/adios2/engine/dataman/TestDataManReaderDoubleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManReaderDoubleBuffer.cpp
@@ -310,7 +310,7 @@ TEST_F(DataManEngineTest, ReaderDoubleBuffer)
     Dims shape = {10};
     Dims start = {0};
     Dims count = {10};
-    size_t steps = 10000;
+    size_t steps = 5000;
 
     // run workflow
     adios2::Params readerEngineParams = {{"IPAddress", "127.0.0.1"},

--- a/testing/adios2/engine/dataman/TestDataManReaderSingleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManReaderSingleBuffer.cpp
@@ -310,7 +310,7 @@ TEST_F(DataManEngineTest, ReaderSingleBuffer)
     Dims shape = {10};
     Dims start = {0};
     Dims count = {10};
-    size_t steps = 10000;
+    size_t steps = 5000;
 
     // run workflow
     adios2::Params readerEngineParams = {{"IPAddress", "127.0.0.1"},

--- a/testing/adios2/engine/dataman/TestDataManReliable.cpp
+++ b/testing/adios2/engine/dataman/TestDataManReliable.cpp
@@ -310,7 +310,7 @@ TEST_F(DataManEngineTest, Reliable)
     Dims shape = {10};
     Dims start = {0};
     Dims count = {10};
-    size_t steps = 10000;
+    size_t steps = 500;
 
     // run workflow
     adios2::Params readerEngineParams = {{"IPAddress", "127.0.0.1"},

--- a/testing/adios2/engine/dataman/TestDataManWriterDoubleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManWriterDoubleBuffer.cpp
@@ -315,7 +315,7 @@ TEST_F(DataManEngineTest, WriterDoubleBuffer)
     Dims shape = {10};
     Dims start = {0};
     Dims count = {10};
-    size_t steps = 10000;
+    size_t steps = 5000;
 
     // run workflow
     adios2::Params readerEngineParams = {{"IPAddress", "127.0.0.1"},

--- a/testing/adios2/engine/dataman/TestDataManWriterSingleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManWriterSingleBuffer.cpp
@@ -310,7 +310,7 @@ TEST_F(DataManEngineTest, WriterSingleBuffer)
     Dims shape = {10};
     Dims start = {0};
     Dims count = {10};
-    size_t steps = 10000;
+    size_t steps = 5000;
 
     // run workflow
     adios2::Params readerEngineParams = {{"IPAddress", "127.0.0.1"},


### PR DESCRIPTION
A random timeout error was seen in CI when running dataman reliable test. This PR tries to prevent similar errors from happening again.