### PR TITLE
Add -F option to iotest for Fixed IO patterns. Before the first EndSt…

### DIFF
--- a/source/utils/adios_iotest/adiosStream.cpp
+++ b/source/utils/adios_iotest/adiosStream.cpp
@@ -191,6 +191,19 @@ adios2::StepStatus adiosStream::readADIOS(CommandRead *cmdR, Config &cfg,
     {
         getADIOSArray(ov);
     }
+
+    if (step == 1 && settings.fixedPattern)
+    {
+        if (!settings.myRank && settings.verbose)
+        {
+            std::cout
+                << "        Lock Reader Selections for Fixed Pattern before "
+                   "first EndStep"
+                << std::endl;
+        }
+        engine.LockWriterDefinitions();
+    }
+
     engine.EndStep();
     timeEnd = MPI_Wtime();
     if (settings.ioTimer)
@@ -303,6 +316,19 @@ void adiosStream::writeADIOS(CommandWrite *cmdW, Config &cfg,
     {
         putADIOSArray(ov);
     }
+
+    if (step == 1 && settings.fixedPattern)
+    {
+        if (!settings.myRank && settings.verbose)
+        {
+            std::cout
+                << "        Lock Writer Definitions for Fixed Pattern before "
+                   "first EndStep"
+                << std::endl;
+        }
+        engine.LockWriterDefinitions();
+    }
+
     engine.EndStep();
     timeEnd = MPI_Wtime();
     if (settings.ioTimer)

--- a/source/utils/adios_iotest/settings.cpp
+++ b/source/utils/adios_iotest/settings.cpp
@@ -24,12 +24,13 @@ struct option options[] = {{"help", no_argument, NULL, 'h'},
                            {"strong-scaling", no_argument, NULL, 's'},
                            {"weak-scaling", no_argument, NULL, 'w'},
                            {"timer", no_argument, NULL, 't'},
+                           {"fixed", no_argument, NULL, 'F'},
 #ifdef ADIOS2_HAVE_HDF5_PARALLEL
                            {"hdf5", no_argument, NULL, 'H'},
 #endif
                            {NULL, 0, NULL, 0}};
 
-static const char *optstring = "-hvswtHa:c:d:x:";
+static const char *optstring = "-hvswtFHa:c:d:x:";
 
 size_t Settings::ndigits(size_t n) const
 {
@@ -58,6 +59,7 @@ void Settings::displayHelp()
 #endif
         << "  -v         increase verbosity\n"
         << "  -h         display this help\n"
+        << "  -F         turn on fixed I/O pattern explicitly\n"
         << "  -t         print and dump the timing measured by the I/O "
            "timer\n\n";
 }
@@ -98,6 +100,9 @@ int Settings::processArgs(int argc, char *argv[])
             processDecomp[nDecomp] =
                 stringToNumber("decomposition in dimension 1", optarg);
             ++nDecomp;
+            break;
+        case 'F':
+            fixedPattern = true;
             break;
         case 'h':
             if (!myRank)

--- a/source/utils/adios_iotest/settings.h
+++ b/source/utils/adios_iotest/settings.h
@@ -39,6 +39,7 @@ public:
     size_t appId = 0;
     bool isStrongScaling = true; // strong or weak scaling
     bool ioTimer = false;        // used to measure io time
+    bool fixedPattern = false;   // should Lock definitions?
     IOLib iolib = IOLib::ADIOS;
     //   process decomposition
     std::vector<size_t> processDecomp = {1, 1, 1, 1, 1, 1, 1, 1,


### PR DESCRIPTION
Add -F option to iotest for Fixed IO patterns. Before the first EndStep, writer definitions or reader selections will be locked in each engine. Iotest has only fixed IO patterns anyway, this option only makes the calls to engine.Lock*() functions. 

Engines that optimize its work for fixed IO patterns can use this explicit calls from the application to turn on those optimizations.
