### PR TITLE
Add FileIME transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ adios_option(Table     "Enable support for Table" AUTO)
 adios_option(SST       "Enable support for SST" AUTO)
 adios_option(ZeroMQ    "Enable support for ZeroMQ" AUTO)
 adios_option(HDF5      "Enable support for the HDF5 engine" AUTO)
+adios_option(IME       "Enable support for DDN IME transport" AUTO)
 adios_option(Python    "Enable support for Python bindings" AUTO)
 adios_option(Fortran   "Enable support for Fortran bindings" AUTO)
 adios_option(SysVShMem "Enable support for SysV Shared Memory IPC on *NIX" AUTO)
@@ -148,7 +149,7 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 set(ADIOS2_CONFIG_OPTS
-    Blosc BZip2 ZFP SZ MGARD PNG MPI DataMan Table SSC SST DataSpaces ZeroMQ HDF5 Python Fortran SysVShMem Profiling Endian_Reverse
+    Blosc BZip2 ZFP SZ MGARD PNG MPI DataMan Table SSC SST DataSpaces ZeroMQ HDF5 IME Python Fortran SysVShMem Profiling Endian_Reverse
 )
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})
 configure_file(

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -224,6 +224,17 @@ elseif(ADIOS2_USE_HDF5)
   set(ADIOS2_HAVE_HDF5 TRUE)
 endif()
 
+# IME
+if(ADIOS2_USE_IME STREQUAL AUTO)
+  find_package(IME)
+elseif(ADIOS2_USE_IME)
+  find_package(IME REQUIRED)
+endif()
+if(IME_FOUND)
+  set(ADIOS2_HAVE_IME TRUE)
+endif()
+
+
 # Python
 
 # Not supported on PGI

--- a/cmake/FindIME.cmake
+++ b/cmake/FindIME.cmake
@@ -1,0 +1,60 @@
+#------------------------------------------------------------------------------#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#------------------------------------------------------------------------------#
+#
+# FindIME
+# -----------
+#
+# Try to find the IME library
+#
+# This module defines the following variables:
+#
+#   IME_FOUND        - System has IME
+#   IME_INCLUDE_DIRS - The IME include directory
+#   IME_LIBRARIES    - Link these to use IME
+#
+# and the following imported targets:
+#   IME::IME - The DDN IME library target
+#
+# You can also set the following variable to help guide the search:
+#   IME_ROOT - The install prefix for IME containing the
+#              include and lib folders
+#              Note: this can be set as a CMake variable or an
+#                    environment variable.  If specified as a CMake
+#                    variable, it will override any setting specified
+#                    as an environment variable.
+
+if(NOT IME_FOUND)
+  if((NOT IME_ROOT) AND (NOT (ENV{IME_ROOT} STREQUAL "")))
+    set(IME_ROOT "$ENV{IME_ROOT}")
+  endif()
+  if(IME_ROOT)
+    set(IME_INCLUDE_OPTS HINTS ${IME_ROOT}/include NO_DEFAULT_PATHS)
+    set(IME_LIBRARY_OPTS
+      HINTS ${IME_ROOT}/lib ${IME_ROOT}/lib64
+      NO_DEFAULT_PATHS
+    )
+  endif()
+
+  find_path(IME_INCLUDE_DIR im_client_native2.h ${IME_INCLUDE_OPTS})
+  find_library(IME_LIBRARY NAMES im_client ${IME_LIBRARY_OPTS})
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(IME
+    FOUND_VAR IME_FOUND
+    REQUIRED_VARS IME_LIBRARY IME_INCLUDE_DIR
+  )
+  if(IME_FOUND)
+    set(IME_INCLUDE_DIRS ${IME_INCLUDE_DIR})
+    set(IME_LIBRARIES ${IME_LIBRARY})
+    if(IME_FOUND AND NOT TARGET IME::IME)
+      add_library(IME::IME UNKNOWN IMPORTED)
+      set_target_properties(IME::IME PROPERTIES
+        IMPORTED_LOCATION             "${IME_LIBRARY}"
+        INTERFACE_LINK_LIBRARIES      "${IME_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${IME_INCLUDE_DIR}"
+      )
+    endif()
+  endif()
+endif()

--- a/docs/user_guide/source/engines/bp3.rst
+++ b/docs/user_guide/source/engines/bp3.rst
@@ -75,7 +75,7 @@ Only file transport types are supported. Optional parameters for ``IO::AddTransp
 ============= ================= ================================================
  **Key**       **Value Format**  **Default** and Examples
 ============= ================= ================================================
- Library           string        **POSIX** (UNIX), **FStream** (Windows), stdio
+ Library           string        **POSIX** (UNIX), **FStream** (Windows), stdio, IME
 ============= ================= ================================================
 
 

--- a/docs/user_guide/source/engines/bp4.rst
+++ b/docs/user_guide/source/engines/bp4.rst
@@ -108,7 +108,13 @@ Only file transport types are supported. Optional parameters for ``IO::AddTransp
 ============= ================= ================================================
  **Key**       **Value Format**  **Default** and Examples
 ============= ================= ================================================
- Library           string        **POSIX** (UNIX), **FStream** (Windows), stdio
+ Library           string        **POSIX** (UNIX), **FStream** (Windows), stdio, IME
 ============= ================= ================================================
 
-
+The IME transport directly reads and writes files stored on DDN's IME burst
+buffer using the IME native API. To use the IME transport, IME must be
+avaiable on the target system and ADIOS2 needs to be configured with
+``ADIOS2_USE_IME``. By default, data written to the IME is automatically
+flushed to the parallel filesystem at every ``EndStep()`` call. You can
+disable this automaic flush by setting the transport parameter ``SyncToPFS``
+to ``OFF``.

--- a/docs/user_guide/source/setting_up/source/cmake.rst
+++ b/docs/user_guide/source/setting_up/source/cmake.rst
@@ -99,6 +99,7 @@ VAR                            VALUE                     Description
 ``ADIOS2_USE_PNG``             **ON**/OFF      `PNG <https://libpng.org>`_ compression (experimental).
 ``ADIOS2_USE_Blosc``           **ON**/OFF      `Blosc <http://blosc.org/>`_ compression (experimental).
 ``ADIOS2_USE_Endian_Reverse``  ON/**OFF**      Enable endian conversion if a different endianness is detected between write and read.
+``ADIOS2_USE_IME``             ON/**OFF**      DDN IME transport.
 ============================= ================ ==========================================================================================================================================================================================================================
 
 In addition to the ``ADIOS2_USE_Feature`` options, the following options are also available to control how the library gets built:

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -318,6 +318,11 @@ if(ADIOS2_HAVE_HDF5)
 
 endif()
 
+if(ADIOS2_HAVE_IME)
+  target_sources(adios2_core PRIVATE toolkit/transport/file/FileIME.cpp)
+  target_link_libraries(adios2_core PRIVATE IME::IME)
+endif()
+
 if(ADIOS2_HAVE_MPI)
   set(maybe_adios2_c_mpi adios2_c_mpi)
   set(maybe_adios2_cxx11_mpi adios2_cxx11_mpi)

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -72,6 +72,9 @@ void Transport::InitProfiler(const Mode openMode, const TimeUnit timeUnit)
         "close", profiling::Timer("close", TimeUnit::Microseconds));
 }
 
+
+void Transport::SetParameters(const Params &parameters) {}
+
 void Transport::SetBuffer(char * /*buffer*/, size_t /*size*/)
 {
     std::invalid_argument("ERROR: " + m_Name + " transport type " + m_Type +

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -72,7 +72,6 @@ void Transport::InitProfiler(const Mode openMode, const TimeUnit timeUnit)
         "close", profiling::Timer("close", TimeUnit::Microseconds));
 }
 
-
 void Transport::SetParameters(const Params &parameters) {}
 
 void Transport::SetBuffer(char * /*buffer*/, size_t /*size*/)

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -74,6 +74,12 @@ public:
     virtual void SetBuffer(char *buffer, size_t size);
 
     /**
+     * Set transport parameters
+     * @param parameters transport parameters to set
+     */
+    virtual void SetParameters(const Params &parameters);
+
+    /**
      * Writes to transport. Note that size is non-const due to the nature of
      * underlying transport libraries
      * @param buffer raw data to be written

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -1,0 +1,273 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * FileIME.cpp file I/O using IME Native library
+ *
+ *  Created on: Dec 1, 2019
+ *      Author: Keichi Takahashi keichi@is.naist.jp
+ */
+#include "FileIME.h"
+
+#include <iostream>
+
+#include <fcntl.h>          // O_* flags
+#include <unistd.h>         // getcwd
+#include <linux/limits.h>   // PATH_MAX
+
+extern "C" {
+#include <im_client_native2.h>
+}
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <ios> //std::ios_base::failure
+/// \endcond
+
+namespace adios2
+{
+namespace transport
+{
+
+FileIME::FileIME(helper::Comm const &comm, const bool debugMode)
+: Transport("File", "IME", comm, debugMode)
+{
+    ime_client_native2_init();
+}
+
+FileIME::~FileIME()
+{
+    if (m_IsOpen)
+    {
+        ime_client_native2_fsync(m_FileDescriptor);
+        ime_client_native2_bfs_sync(m_FileDescriptor, false);
+        ime_client_native2_close(m_FileDescriptor);
+    }
+
+   ime_client_native2_finalize();
+}
+
+void FileIME::Open(const std::string &name, const Mode openMode)
+{
+    m_Name = "ime://";
+    if (name[0] != '/') {
+        char tmp[PATH_MAX];
+        m_Name += std::string(getcwd(tmp, PATH_MAX)) + "/";
+    }
+    m_Name += name;
+
+    CheckName();
+    m_OpenMode = openMode;
+    switch (m_OpenMode)
+    {
+
+    case (Mode::Write):
+        ProfilerStart("open");
+        m_FileDescriptor =
+            ime_client_native2_open(m_Name.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
+        ProfilerStop("open");
+        break;
+
+    case (Mode::Append):
+        ProfilerStart("open");
+        // m_FileDescriptor = open(m_Name.c_str(), O_RDWR);
+        m_FileDescriptor = ime_client_native2_open(m_Name.c_str(), O_RDWR | O_CREAT, 0777);
+        lseek(m_FileDescriptor, 0, SEEK_END);
+        ProfilerStop("open");
+        break;
+
+    case (Mode::Read):
+        ProfilerStart("open");
+        m_FileDescriptor = ime_client_native2_open(m_Name.c_str(), O_RDONLY, 0000);
+        ProfilerStop("open");
+        break;
+
+    default:
+        CheckFile("unknown open mode for file " + m_Name +
+                  ", in call to IME open");
+    }
+
+    CheckFile("couldn't open file " + m_Name +
+              ", check permissions or path existence, in call to IME open");
+
+    m_IsOpen = true;
+}
+
+void FileIME::Write(const char *buffer, size_t size, size_t start)
+{
+    auto lf_Write = [&](const char *buffer, size_t size) {
+        while (size > 0)
+        {
+            ProfilerStart("write");
+            const auto writtenSize = ime_client_native2_write(m_FileDescriptor, buffer, size);
+            ProfilerStop("write");
+
+            if (writtenSize == -1)
+            {
+                if (errno == EINTR)
+                {
+                    continue;
+                }
+
+                throw std::ios_base::failure(
+                    "ERROR: couldn't write to file " + m_Name +
+                    ", in call to FileDescriptor Write\n");
+            }
+
+            buffer += writtenSize;
+            size -= writtenSize;
+        }
+    };
+
+    if (start != MaxSizeT)
+    {
+        const auto newPosition = ime_client_native2_lseek(m_FileDescriptor, start, SEEK_SET);
+
+        if (static_cast<size_t>(newPosition) != start)
+        {
+            throw std::ios_base::failure(
+                "ERROR: couldn't move to start position " +
+                std::to_string(start) + " in file " + m_Name +
+                ", in call to IME lseek\n");
+        }
+    }
+
+    if (size > DefaultMaxFileBatchSize)
+    {
+        const size_t batches = size / DefaultMaxFileBatchSize;
+        const size_t remainder = size % DefaultMaxFileBatchSize;
+
+        size_t position = 0;
+        for (size_t b = 0; b < batches; ++b)
+        {
+            lf_Write(&buffer[position], DefaultMaxFileBatchSize);
+            position += DefaultMaxFileBatchSize;
+        }
+        lf_Write(&buffer[position], remainder);
+    }
+    else
+    {
+        lf_Write(buffer, size);
+    }
+}
+
+void FileIME::Read(char *buffer, size_t size, size_t start)
+{
+    auto lf_Read = [&](char *buffer, size_t size) {
+        while (size > 0)
+        {
+            ProfilerStart("read");
+            const auto readSize = ime_client_native2_read(m_FileDescriptor, buffer, size);
+            ProfilerStop("read");
+
+            if (readSize == -1)
+            {
+                if (errno == EINTR)
+                {
+                    continue;
+                }
+
+                throw std::ios_base::failure("ERROR: couldn't read from file " +
+                                             m_Name +
+                                             ", in call to IME IO read\n");
+            }
+
+            buffer += readSize;
+            size -= readSize;
+        }
+    };
+
+    if (start != MaxSizeT)
+    {
+        const auto newPosition = ime_client_native2_lseek(m_FileDescriptor, start, SEEK_SET);
+
+        if (static_cast<size_t>(newPosition) != start)
+        {
+            throw std::ios_base::failure(
+                "ERROR: couldn't move to start position " +
+                std::to_string(start) + " in file " + m_Name +
+                ", in call to IME lseek errno " + std::to_string(errno) +
+                "\n");
+        }
+    }
+
+    if (size > DefaultMaxFileBatchSize)
+    {
+        const size_t batches = size / DefaultMaxFileBatchSize;
+        const size_t remainder = size % DefaultMaxFileBatchSize;
+
+        size_t position = 0;
+        for (size_t b = 0; b < batches; ++b)
+        {
+            lf_Read(&buffer[position], DefaultMaxFileBatchSize);
+            position += DefaultMaxFileBatchSize;
+        }
+        lf_Read(&buffer[position], remainder);
+    }
+    else
+    {
+        lf_Read(buffer, size);
+    }
+}
+
+size_t FileIME::GetSize()
+{
+    struct stat fileStat;
+    if (fstat(m_FileDescriptor, &fileStat) == -1)
+    {
+        throw std::ios_base::failure("ERROR: couldn't get size of file " +
+                                     m_Name + "\n");
+    }
+    return static_cast<size_t>(fileStat.st_size);
+}
+
+void FileIME::Flush() {}
+
+void FileIME::Close()
+{
+    ProfilerStart("close");
+    ime_client_native2_fsync(m_FileDescriptor);
+    ime_client_native2_bfs_sync(m_FileDescriptor, false);
+    const int status = ime_client_native2_close(m_FileDescriptor);
+    ProfilerStop("close");
+
+    if (status == -1)
+    {
+        throw std::ios_base::failure("ERROR: couldn't close file " + m_Name +
+                                     ", in call to IME IO close\n");
+    }
+
+    m_IsOpen = false;
+}
+
+void FileIME::CheckFile(const std::string hint) const
+{
+    if (m_FileDescriptor == -1)
+    {
+        throw std::ios_base::failure("ERROR: " + hint + "\n");
+    }
+}
+
+void FileIME::SeekToEnd()
+{
+    const int status = ime_client_native2_lseek(m_FileDescriptor, 0, SEEK_END);
+    if (status == -1)
+    {
+        throw std::ios_base::failure(
+            "ERROR: couldn't seek to the end of file " + m_Name +
+            ", in call to IME IO lseek\n");
+    }
+}
+
+void FileIME::SeekToBegin()
+{
+    const int status = ime_client_native2_lseek(m_FileDescriptor, 0, SEEK_SET);
+    if (status == -1)
+    {
+        throw std::ios_base::failure(
+            "ERROR: couldn't seek to the begin of file " + m_Name +
+            ", in call to IME IO lseek\n");
+    }
+}
+
+} // end namespace transport
+} // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -13,9 +13,9 @@
 
 #include <iostream>
 
-#include <fcntl.h>          // O_* flags
-#include <unistd.h>         // getcwd
-#include <linux/limits.h>   // PATH_MAX
+#include <fcntl.h>        // O_* flags
+#include <linux/limits.h> // PATH_MAX
+#include <unistd.h>       // getcwd
 
 extern "C" {
 #include <im_client_native2.h>
@@ -47,7 +47,8 @@ FileIME::~FileIME()
 {
     if (m_IsOpen)
     {
-        if (m_SyncToPFS) {
+        if (m_SyncToPFS)
+        {
             ime_client_native2_fsync(m_FileDescriptor);
             ime_client_native2_bfs_sync(m_FileDescriptor, true);
         }
@@ -65,7 +66,8 @@ FileIME::~FileIME()
 void FileIME::Open(const std::string &name, const Mode openMode)
 {
     m_Name = "ime://";
-    if (name[0] != '/') {
+    if (name[0] != '/')
+    {
         char tmp[PATH_MAX];
         m_Name += std::string(getcwd(tmp, PATH_MAX)) + "/";
     }
@@ -78,22 +80,24 @@ void FileIME::Open(const std::string &name, const Mode openMode)
 
     case (Mode::Write):
         ProfilerStart("open");
-        m_FileDescriptor =
-            ime_client_native2_open(m_Name.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
+        m_FileDescriptor = ime_client_native2_open(
+            m_Name.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
         ProfilerStop("open");
         break;
 
     case (Mode::Append):
         ProfilerStart("open");
         // m_FileDescriptor = open(m_Name.c_str(), O_RDWR);
-        m_FileDescriptor = ime_client_native2_open(m_Name.c_str(), O_RDWR | O_CREAT, 0777);
+        m_FileDescriptor =
+            ime_client_native2_open(m_Name.c_str(), O_RDWR | O_CREAT, 0777);
         lseek(m_FileDescriptor, 0, SEEK_END);
         ProfilerStop("open");
         break;
 
     case (Mode::Read):
         ProfilerStart("open");
-        m_FileDescriptor = ime_client_native2_open(m_Name.c_str(), O_RDONLY, 0000);
+        m_FileDescriptor =
+            ime_client_native2_open(m_Name.c_str(), O_RDONLY, 0000);
         ProfilerStop("open");
         break;
 
@@ -108,15 +112,17 @@ void FileIME::Open(const std::string &name, const Mode openMode)
     m_IsOpen = true;
 }
 
-void FileIME::SetParameters(const Params& parameters)
+void FileIME::SetParameters(const Params &parameters)
 {
-    for (const auto &pair : parameters) {
+    for (const auto &pair : parameters)
+    {
         const std::string key = helper::LowerCase(pair.first);
         const std::string value = helper::LowerCase(pair.second);
 
-        if (key == "synctopfs") {
+        if (key == "synctopfs")
+        {
             m_SyncToPFS = helper::StringTo<bool>(value, m_DebugMode,
-                    " in Parameter key=SyncToPFS");
+                                                 " in Parameter key=SyncToPFS");
         }
     }
 }
@@ -127,7 +133,8 @@ void FileIME::Write(const char *buffer, size_t size, size_t start)
         while (size > 0)
         {
             ProfilerStart("write");
-            const auto writtenSize = ime_client_native2_write(m_FileDescriptor, buffer, size);
+            const auto writtenSize =
+                ime_client_native2_write(m_FileDescriptor, buffer, size);
             ProfilerStop("write");
 
             if (writtenSize == -1)
@@ -149,7 +156,8 @@ void FileIME::Write(const char *buffer, size_t size, size_t start)
 
     if (start != MaxSizeT)
     {
-        const auto newPosition = ime_client_native2_lseek(m_FileDescriptor, start, SEEK_SET);
+        const auto newPosition =
+            ime_client_native2_lseek(m_FileDescriptor, start, SEEK_SET);
 
         if (static_cast<size_t>(newPosition) != start)
         {
@@ -185,7 +193,8 @@ void FileIME::Read(char *buffer, size_t size, size_t start)
         while (size > 0)
         {
             ProfilerStart("read");
-            const auto readSize = ime_client_native2_read(m_FileDescriptor, buffer, size);
+            const auto readSize =
+                ime_client_native2_read(m_FileDescriptor, buffer, size);
             ProfilerStop("read");
 
             if (readSize == -1)
@@ -207,15 +216,15 @@ void FileIME::Read(char *buffer, size_t size, size_t start)
 
     if (start != MaxSizeT)
     {
-        const auto newPosition = ime_client_native2_lseek(m_FileDescriptor, start, SEEK_SET);
+        const auto newPosition =
+            ime_client_native2_lseek(m_FileDescriptor, start, SEEK_SET);
 
         if (static_cast<size_t>(newPosition) != start)
         {
             throw std::ios_base::failure(
                 "ERROR: couldn't move to start position " +
                 std::to_string(start) + " in file " + m_Name +
-                ", in call to IME lseek errno " + std::to_string(errno) +
-                "\n");
+                ", in call to IME lseek errno " + std::to_string(errno) + "\n");
         }
     }
 
@@ -249,8 +258,10 @@ size_t FileIME::GetSize()
     return static_cast<size_t>(fileStat.st_size);
 }
 
-void FileIME::Flush() {
-    if (m_SyncToPFS) {
+void FileIME::Flush()
+{
+    if (m_SyncToPFS)
+    {
         ime_client_native2_fsync(m_FileDescriptor);
         ime_client_native2_bfs_sync(m_FileDescriptor, true);
     }
@@ -259,7 +270,8 @@ void FileIME::Flush() {
 void FileIME::Close()
 {
     ProfilerStart("close");
-    if (m_SyncToPFS) {
+    if (m_SyncToPFS)
+    {
         ime_client_native2_fsync(m_FileDescriptor);
         ime_client_native2_bfs_sync(m_FileDescriptor, true);
     }

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -232,7 +232,10 @@ size_t FileIME::GetSize()
     return static_cast<size_t>(fileStat.st_size);
 }
 
-void FileIME::Flush() {}
+void FileIME::Flush() {
+    ime_client_native2_fsync(m_FileDescriptor);
+    ime_client_native2_bfs_sync(m_FileDescriptor, true);
+}
 
 void FileIME::Close()
 {

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -11,6 +11,8 @@
 #ifndef ADIOS2_TOOLKIT_TRANSPORT_FILE_IME_H_
 #define ADIOS2_TOOLKIT_TRANSPORT_FILE_IME_H_
 
+#include <atomic>
+
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/toolkit/transport/Transport.h"
 
@@ -58,6 +60,9 @@ private:
      * @param hint exception message
      */
     void CheckFile(const std::string hint) const;
+
+    /** Number of existing FileIME instances */
+    static std::atomic_uint client_refcount;
 };
 
 } // end namespace transport

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -2,10 +2,10 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * FileDescriptor.h wrapper of POSIX library functions for file I/O
+ * FileIME.h file I/O using IME Native library
  *
- *  Created on: Oct 6, 2016
- *      Author: William F Godoy godoywf@ornl.gov
+ *  Created on: Dec 1, 2019
+ *      Author: Keichi Takahashi keichi@is.naist.jp
  */
 
 #ifndef ADIOS2_TOOLKIT_TRANSPORT_FILE_IME_H_
@@ -30,11 +30,13 @@ class FileIME : public Transport
 {
 
 public:
-    FileIME(helper::Comm const &comm, const bool debugMode);
+    FileIME(helper::Comm const &comm);
 
     ~FileIME();
 
-    void Open(const std::string &name, const Mode openMode) final;
+    /** Async option is ignored in FileIME transport */
+    void Open(const std::string &name, const Mode openMode,
+              const bool async = false) final;
 
     void SetParameters(const Params &parameters) final;
 
@@ -44,10 +46,12 @@ public:
 
     size_t GetSize() final;
 
-    /** Does nothing, each write is supposed to flush */
+    /** Triggers a flush from IME to PFS if SyncToPFS=ON */
     void Flush() final;
 
     void Close() final;
+
+    void Delete() final;
 
     void SeekToEnd() final;
 
@@ -63,7 +67,8 @@ private:
      */
     void CheckFile(const std::string hint) const;
 
-    /** Number of existing FileIME instances */
+    /** Number of existing FileIME instances. We use atomic type for thread
+     * safety but it is unclear if the IME client itself is thread safe. */
     static std::atomic_uint client_refcount;
 
     bool m_SyncToPFS = true;

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -36,7 +36,7 @@ public:
 
     void Open(const std::string &name, const Mode openMode) final;
 
-    void SetParameters(const Params& parameters) final;
+    void SetParameters(const Params &parameters) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
 

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -1,0 +1,66 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * FileDescriptor.h wrapper of POSIX library functions for file I/O
+ *
+ *  Created on: Oct 6, 2016
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
+#ifndef ADIOS2_TOOLKIT_TRANSPORT_FILE_IME_H_
+#define ADIOS2_TOOLKIT_TRANSPORT_FILE_IME_H_
+
+#include "adios2/common/ADIOSConfig.h"
+#include "adios2/toolkit/transport/Transport.h"
+
+namespace adios2
+{
+namespace helper
+{
+class Comm;
+}
+namespace transport
+{
+
+/** File descriptor transport using the IME Native library */
+class FileIME : public Transport
+{
+
+public:
+    FileIME(helper::Comm const &comm, const bool debugMode);
+
+    ~FileIME();
+
+    void Open(const std::string &name, const Mode openMode) final;
+
+    void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
+
+    void Read(char *buffer, size_t size, size_t start = MaxSizeT) final;
+
+    size_t GetSize() final;
+
+    /** Does nothing, each write is supposed to flush */
+    void Flush() final;
+
+    void Close() final;
+
+    void SeekToEnd() final;
+
+    void SeekToBegin() final;
+
+private:
+    /** POSIX file handle returned by Open */
+    int m_FileDescriptor = -1;
+
+    /**
+     * Check if m_FileDescriptor is -1 after an operation
+     * @param hint exception message
+     */
+    void CheckFile(const std::string hint) const;
+};
+
+} // end namespace transport
+} // end namespace adios2
+
+#endif /* ADIOS2_TRANSPORT_FILE_FILEDESCRIPTOR_H_ */

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -36,6 +36,8 @@ public:
 
     void Open(const std::string &name, const Mode openMode) final;
 
+    void SetParameters(const Params& parameters) final;
+
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
 
     void Read(char *buffer, size_t size, size_t start = MaxSizeT) final;
@@ -63,6 +65,8 @@ private:
 
     /** Number of existing FileIME instances */
     static std::atomic_uint client_refcount;
+
+    bool m_SyncToPFS = true;
 };
 
 } // end namespace transport

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -392,8 +392,7 @@ TransportMan::OpenFileTransport(const std::string &fileName,
 #ifdef ADIOS2_HAVE_IME
         else if (library == "IME" || library == "ime")
         {
-            transport =
-                std::make_shared<transport::FileIME>(m_Comm, m_DebugMode);
+            transport = std::make_shared<transport::FileIME>(m_Comm);
         }
 #endif
         else if (library == "NULL" || library == "null")

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -449,6 +449,8 @@ TransportMan::OpenFileTransport(const std::string &fileName,
                                 lf_GetTimeUnits(DefaultTimeUnit, parameters));
     }
 
+    transport->SetParameters(parameters);
+
     // open
     transport->Open(fileName, openMode, lf_GetAsync("false", parameters));
     return transport;

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -19,6 +19,9 @@
 #ifndef _WIN32
 #include "adios2/toolkit/transport/file/FilePOSIX.h"
 #endif
+#ifdef ADIOS2_HAVE_IME
+#include "adios2/toolkit/transport/file/FileIME.h"
+#endif
 
 #ifdef _WIN32
 #pragma warning(disable : 4503) // length of std::function inside std::async
@@ -384,6 +387,13 @@ TransportMan::OpenFileTransport(const std::string &fileName,
                     "ERROR: " + library +
                     " transport does not support buffered I/O.");
             }
+        }
+#endif
+#ifdef ADIOS2_HAVE_IME
+        else if (library == "IME" || library == "ime")
+        {
+            transport =
+                std::make_shared<transport::FileIME>(m_Comm, m_DebugMode);
         }
 #endif
         else if (library == "NULL" || library == "null")


### PR DESCRIPTION
FileIME is an alternative to FilePOSIX that directly reads and writes files stored on DDN's IME burst buffer using the IME native API (kernel's VFS is bypassed). This has been tested on Oakforest-PACS installed at the University of Tsukuba.