### PR TITLE
HDF5P: Signed/Unsigned Warnings

### DIFF
--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -129,10 +129,10 @@ size_t HDF5ReaderP::ReadDataset(hid_t dataSetId, hid_t h5Type,
         return 0;
     }
 
-    size_t slabsize = 1;
+    size_t slabsize = 1u;
 
-    int ndims = std::max(variable.m_Shape.size(), variable.m_Count.size());
-    if (0 == ndims)
+    size_t ndims = std::max(variable.m_Shape.size(), variable.m_Count.size());
+    if (0u == ndims)
     { // is scalar
         hid_t myclass = H5Tget_class(h5Type);
         if (H5Tget_class(h5Type) == H5T_STRING)
@@ -150,7 +150,7 @@ size_t HDF5ReaderP::ReadDataset(hid_t dataSetId, hid_t h5Type,
         std::vector<hsize_t> start(ndims), count(ndims), stride(ndims);
         bool isOrderC = helper::IsRowMajor(m_IO.m_HostLanguage);
 
-        for (int i = 0; i < ndims; i++)
+        for (size_t i = 0u; i < ndims; i++)
         {
             if (isOrderC)
             {
@@ -159,8 +159,8 @@ size_t HDF5ReaderP::ReadDataset(hid_t dataSetId, hid_t h5Type,
             }
             else
             {
-                count[i] = variable.m_Count[ndims - 1 - i];
-                start[i] = variable.m_Start[ndims - 1 - i];
+                count[i] = variable.m_Count[ndims - 1u - i];
+                start[i] = variable.m_Start[ndims - 1u - i];
             }
             slabsize *= count[i];
             stride[i] = 1;
@@ -174,7 +174,7 @@ size_t HDF5ReaderP::ReadDataset(hid_t dataSetId, hid_t h5Type,
         interop::HDF5TypeGuard g_mds(memDataSpace, interop::E_H5_SPACE);
 
         int elementsRead = 1;
-        for (int i = 0; i < ndims; i++)
+        for (size_t i = 0u; i < ndims; i++)
         {
             elementsRead *= count[i];
         }
@@ -207,7 +207,7 @@ void HDF5ReaderP::UseHDFRead(Variable<T> &variable, T *data, hid_t h5Type)
     }
 
     T *values = data;
-    int ts = 0;
+    unsigned int ts = 0;
     // T *values = data;
     size_t variableStart = variable.m_StepsStart;
     /*
@@ -263,7 +263,7 @@ void HDF5ReaderP::UseHDFRead(Variable<T> &variable, T *data, hid_t h5Type)
 
 StepStatus HDF5ReaderP::BeginStep(StepMode mode, const float timeoutSeconds)
 {
-    int ts = m_H5File.GetNumAdiosSteps();
+    const unsigned int ts = m_H5File.GetNumAdiosSteps();
 
     if (m_StreamAt >= ts)
     {


### PR DESCRIPTION
Fix signed-unsigned conversion warnings seen on MSVC:
- `conversion from 'size_t' to 'int', possible loss of data`
- `'>=': signed/unsigned mismatch`