### PR TITLE
Convert internal data type ids from std::string to an enumeration

### DIFF
--- a/bindings/C/adios2/c/adios2_c_attribute.cpp
+++ b/bindings/C/adios2/c/adios2_c_attribute.cpp
@@ -84,7 +84,7 @@ adios2_error adios2_attribute_type_string(char *type, size_t *size,
 
         const adios2::core::AttributeBase *attributeBase =
             reinterpret_cast<const adios2::core::AttributeBase *>(attribute);
-        return String2CAPI(attributeBase->m_Type, type, size);
+        return String2CAPI(ToString(attributeBase->m_Type), type, size);
     }
     catch (...)
     {
@@ -146,9 +146,9 @@ adios2_error adios2_attribute_data(void *data, size_t *size,
         const adios2::core::AttributeBase *attributeBase =
             reinterpret_cast<const adios2::core::AttributeBase *>(attribute);
 
-        const std::string type(attributeBase->m_Type);
+        const adios2::Type type(attributeBase->m_Type);
 
-        if (type == "")
+        if (type == adios2::Type::None)
         {
             // not supported
         }

--- a/bindings/C/adios2/c/adios2_c_engine.cpp
+++ b/bindings/C/adios2/c/adios2_c_engine.cpp
@@ -241,13 +241,13 @@ adios2_error adios2_put(adios2_engine *engine, adios2_variable *variable,
 
         adios2::core::VariableBase *variableBase =
             reinterpret_cast<adios2::core::VariableBase *>(variable);
-        const std::string type(variableBase->m_Type);
+        const adios2::Type type(variableBase->m_Type);
 
         const adios2::Mode modeCpp = adios2_ToMode(
             mode, "only adios2_mode_deferred or adios2_mode_sync are valid, "
                   "in call to adios2_put");
 
-        if (type == "compound")
+        if (type == adios2::Type::Compound)
         {
             // not supported
         }
@@ -302,10 +302,10 @@ adios2_error adios2_put_by_name(adios2_engine *engine,
             mode, "only adios2_mode_deferred or adios2_mode_sync are valid, "
                   "in call to adios2_put_by_name");
 
-        const std::string type(
+        const adios2::Type type(
             engineCpp->m_IO.InquireVariableType(variable_name));
 
-        if (type == "compound")
+        if (type == adios2::Type::Compound)
         {
             // not supported
         }
@@ -379,9 +379,9 @@ adios2_error adios2_get(adios2_engine *engine, adios2_variable *variable,
         adios2::core::VariableBase *variableBase =
             reinterpret_cast<adios2::core::VariableBase *>(variable);
 
-        const std::string type(variableBase->m_Type);
+        const adios2::Type type(variableBase->m_Type);
 
-        if (type == "compound")
+        if (type == adios2::Type::Compound)
         {
             // not supported
         }
@@ -438,10 +438,10 @@ adios2_error adios2_get_by_name(adios2_engine *engine,
         const adios2::Mode modeCpp = adios2_ToMode(
             mode, "only adios2_mode_deferred or adios2_mode_sync are valid, "
                   "in call to adios2_get_by_name");
-        const std::string type(
+        const adios2::Type type(
             engineCpp->m_IO.InquireVariableType(variable_name));
 
-        if (type == "compound")
+        if (type == adios2::Type::Compound)
         {
             // not supported
         }

--- a/bindings/C/adios2/c/adios2_c_io.cpp
+++ b/bindings/C/adios2/c/adios2_c_io.cpp
@@ -258,10 +258,10 @@ adios2_variable *adios2_inquire_variable(adios2_io *io, const char *name)
             return variable;
         }
 
-        const std::string type(ioCpp.InquireVariableType(name));
+        const adios2::Type type(ioCpp.InquireVariableType(name));
         adios2::core::VariableBase *variableCpp = nullptr;
 
-        if (type == "compound")
+        if (type == adios2::Type::Compound)
         {
             // not supported
         }
@@ -308,10 +308,10 @@ adios2_error adios2_inquire_all_variables(adios2_variable ***variables,
         for (auto &name : names)
         {
             auto it = dataMap.find(name);
-            const std::string type(it->second.first);
+            const adios2::Type type(it->second.first);
             adios2::core::VariableBase *variable = nullptr;
 
-            if (type == "compound")
+            if (type == adios2::Type::Compound)
             {
                 // not supported
             }
@@ -506,10 +506,10 @@ adios2_attribute *adios2_inquire_attribute(adios2_io *io, const char *name)
             return attribute;
         }
 
-        const std::string type(itAttribute->second.first);
+        const adios2::Type type(itAttribute->second.first);
         adios2::core::AttributeBase *attributeCpp = nullptr;
 
-        if (type == "compound")
+        if (type == adios2::Type::Compound)
         {
             // not supported
         }
@@ -567,10 +567,10 @@ adios2_error adios2_inquire_all_attributes(adios2_attribute ***attributes,
         for (auto &name : names)
         {
             auto it = dataMap.find(name);
-            const std::string type(it->second.first);
+            const adios2::Type type(it->second.first);
             adios2::core::AttributeBase *attribute = nullptr;
 
-            if (type == "compound")
+            if (type == adios2::Type::Compound)
             {
                 // not supported
             }

--- a/bindings/C/adios2/c/adios2_c_variable.cpp
+++ b/bindings/C/adios2/c/adios2_c_variable.cpp
@@ -219,7 +219,7 @@ adios2_error adios2_variable_type(adios2_type *type,
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
 
-        const std::string typeCpp = variableBase->m_Type;
+        const adios2::Type typeCpp = variableBase->m_Type;
         if (typeCpp == adios2::helper::GetType<std::string>())
         {
             *type = adios2_type_string;
@@ -254,7 +254,7 @@ adios2_error adios2_variable_type_string(char *type, size_t *size,
 
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
-        return String2CAPI(variableBase->m_Type, type, size);
+        return String2CAPI(ToString(variableBase->m_Type), type, size);
     }
     catch (...)
     {
@@ -319,8 +319,8 @@ adios2_error adios2_variable_shape(size_t *shape,
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
 
-        const std::string typeCpp = variableBase->m_Type;
-        if (typeCpp == "compound")
+        const adios2::Type typeCpp = variableBase->m_Type;
+        if (typeCpp == adios2::Type::Compound)
         {
             // not supported
         }
@@ -382,8 +382,8 @@ adios2_error adios2_variable_count(size_t *count,
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
 
-        const std::string typeCpp = variableBase->m_Type;
-        if (typeCpp == "compound")
+        const adios2::Type typeCpp = variableBase->m_Type;
+        if (typeCpp == adios2::Type::Compound)
         {
             // not supported
         }
@@ -458,9 +458,9 @@ adios2_error adios2_selection_size(size_t *size,
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
 
-        const std::string typeCpp = variableBase->m_Type;
+        const adios2::Type typeCpp = variableBase->m_Type;
 
-        if (typeCpp == "compound")
+        if (typeCpp == adios2::Type::Compound)
         {
             // not supported
         }
@@ -552,9 +552,9 @@ adios2_error adios2_variable_min(void *min, const adios2_variable *variable)
 
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
-        const std::string type(variableBase->m_Type);
+        const adios2::Type type(variableBase->m_Type);
 
-        if (type == "compound")
+        if (type == adios2::Type::Compound)
         {
             // not supported
         }
@@ -589,9 +589,9 @@ adios2_error adios2_variable_max(void *max, const adios2_variable *variable)
 
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
-        const std::string type(variableBase->m_Type);
+        const adios2::Type type(variableBase->m_Type);
 
-        if (type == "compound")
+        if (type == adios2::Type::Compound)
         {
             // not supported
         }

--- a/bindings/CXX11/adios2/cxx11/Attribute.cpp
+++ b/bindings/CXX11/adios2/cxx11/Attribute.cpp
@@ -44,7 +44,7 @@ namespace adios2
     {                                                                          \
         helper::CheckForNullptr(m_Attribute,                                   \
                                 "in call to Attribute<T>::Type()");            \
-        return m_Attribute->m_Type;                                            \
+        return ToString(m_Attribute->m_Type);                                  \
     }                                                                          \
                                                                                \
     template <>                                                                \

--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -133,13 +133,13 @@ IO::AvailableAttributes(const std::string &variableName,
 std::string IO::VariableType(const std::string &name) const
 {
     helper::CheckForNullptr(m_IO, "in call to IO::VariableType");
-    return m_IO->InquireVariableType(name);
+    return ToString(m_IO->InquireVariableType(name));
 }
 
 std::string IO::AttributeType(const std::string &name) const
 {
     helper::CheckForNullptr(m_IO, "in call to IO::AttributeType");
-    return m_IO->InquireAttributeType(name);
+    return ToString(m_IO->InquireAttributeType(name));
 }
 
 size_t IO::AddOperation(const Operator op, const Params &parameters)

--- a/bindings/CXX11/adios2/cxx11/Types.tcc
+++ b/bindings/CXX11/adios2/cxx11/Types.tcc
@@ -21,7 +21,7 @@ namespace adios2
 template <class T>
 std::string GetType() noexcept
 {
-    return helper::GetType<typename TypeInfo<T>::IOType>();
+    return ToString(helper::GetType<typename TypeInfo<T>::IOType>());
 }
 
 } // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/Variable.cpp
+++ b/bindings/CXX11/adios2/cxx11/Variable.cpp
@@ -90,7 +90,7 @@ namespace adios2
     std::string Variable<T>::Type() const                                      \
     {                                                                          \
         helper::CheckForNullptr(m_Variable, "in call to Variable<T>::Type");   \
-        return m_Variable->m_Type;                                             \
+        return ToString(m_Variable->m_Type);                                   \
     }                                                                          \
     template <>                                                                \
     size_t Variable<T>::Sizeof() const                                         \

--- a/bindings/Python/py11Attribute.cpp
+++ b/bindings/Python/py11Attribute.cpp
@@ -36,13 +36,13 @@ std::string Attribute::Name() const
 std::string Attribute::Type() const
 {
     helper::CheckForNullptr(m_Attribute, "in call to Attribute::Type");
-    return m_Attribute->m_Type;
+    return ToString(m_Attribute->m_Type);
 }
 
 std::vector<std::string> Attribute::DataString()
 {
     helper::CheckForNullptr(m_Attribute, "in call to Attribute::DataStrings");
-    const std::string type = m_Attribute->m_Type;
+    const adios2::Type type = m_Attribute->m_Type;
 
     std::vector<std::string> data;
 
@@ -73,9 +73,9 @@ std::vector<std::string> Attribute::DataString()
 pybind11::array Attribute::Data()
 {
     helper::CheckForNullptr(m_Attribute, "in call to Attribute::Data");
-    const std::string type = m_Attribute->m_Type;
+    const adios2::Type type = m_Attribute->m_Type;
 
-    if (type == "compound")
+    if (type == adios2::Type::Compound)
     {
         // not supported
     }

--- a/bindings/Python/py11Engine.cpp
+++ b/bindings/Python/py11Engine.cpp
@@ -67,9 +67,9 @@ void Engine::Put(Variable variable, const pybind11::array &array,
     helper::CheckForNullptr(variable.m_VariableBase,
                             "for variable, in call to Engine::Put numpy array");
 
-    const std::string type = variable.Type();
+    const adios2::Type type = helper::GetTypeFromString(variable.Type());
 
-    if (type == "compound")
+    if (type == adios2::Type::Compound)
     {
         // not supported
     }
@@ -103,7 +103,8 @@ void Engine::Put(Variable variable, const std::string &string)
     helper::CheckForNullptr(variable.m_VariableBase,
                             "for variable, in call to Engine::Put string");
 
-    if (variable.Type() != helper::GetType<std::string>())
+    if (helper::GetTypeFromString(variable.Type()) !=
+        helper::GetType<std::string>())
     {
         throw std::invalid_argument(
             "ERROR: variable " + variable.Name() +
@@ -138,9 +139,9 @@ void Engine::Get(Variable variable, pybind11::array &array, const Mode launch)
         variable.m_VariableBase,
         "for variable, in call to Engine::Get a numpy array");
 
-    const std::string type = variable.Type();
+    const adios2::Type type = helper::GetTypeFromString(variable.Type());
 
-    if (type == "compound")
+    if (type == adios2::Type::Compound)
     {
         // not supported
     }
@@ -176,7 +177,7 @@ void Engine::Get(Variable variable, std::string &string, const Mode launch)
     helper::CheckForNullptr(variable.m_VariableBase,
                             "for variable, in call to Engine::Get a string");
 
-    const std::string type = variable.Type();
+    const adios2::Type type = helper::GetTypeFromString(variable.Type());
 
     if (type == helper::GetType<std::string>())
     {
@@ -287,7 +288,7 @@ Engine::BlocksInfo(std::string &var_name, const size_t step) const
     std::vector<std::map<std::string, std::string>> rv;
 
     // Grab the specified variable object and get its type string
-    std::string var_type = m_Engine->GetIO().InquireVariableType(var_name);
+    adios2::Type var_type = m_Engine->GetIO().InquireVariableType(var_name);
 
     // Use the macro incantation to call the right instantiation of
     // core::BlocksInfo<>() Note that we are flatting the Dims type items, and

--- a/bindings/Python/py11File.cpp
+++ b/bindings/Python/py11File.cpp
@@ -208,7 +208,7 @@ pybind11::array File::Read(const std::string &name, const size_t blockID)
 pybind11::array File::Read(const std::string &name, const Dims &start,
                            const Dims &count, const size_t blockID)
 {
-    const std::string type = m_Stream->m_IO->InquireVariableType(name);
+    const Type type = m_Stream->m_IO->InquireVariableType(name);
 
     if (type == helper::GetType<std::string>())
     {
@@ -226,9 +226,9 @@ pybind11::array File::Read(const std::string &name, const Dims &start,
                            const Dims &count, const size_t stepStart,
                            const size_t stepCount, const size_t blockID)
 {
-    const std::string type = m_Stream->m_IO->InquireVariableType(name);
+    const Type type = m_Stream->m_IO->InquireVariableType(name);
 
-    if (type.empty())
+    if (type == Type::None)
     {
     }
 #define declare_type(T)                                                        \
@@ -251,10 +251,10 @@ pybind11::array File::ReadAttribute(const std::string &name,
                                     const std::string &variableName,
                                     const std::string separator)
 {
-    const std::string type =
+    const Type type =
         m_Stream->m_IO->InquireAttributeType(name, variableName, separator);
 
-    if (type.empty())
+    if (type == Type::None)
     {
     }
 #define declare_type(T)                                                        \

--- a/bindings/Python/py11IO.cpp
+++ b/bindings/Python/py11IO.cpp
@@ -111,10 +111,10 @@ Variable IO::InquireVariable(const std::string &name)
     helper::CheckForNullptr(m_IO, "for variable " + name +
                                       ", in call to IO::InquireVariable");
 
-    const std::string type(m_IO->InquireVariableType(name));
+    const Type type(m_IO->InquireVariableType(name));
     core::VariableBase *variable = nullptr;
 
-    if (type == "unknown")
+    if (type == Type::None)
     {
     }
 #define declare_template_instantiation(T)                                      \
@@ -193,9 +193,9 @@ Attribute IO::InquireAttribute(const std::string &name)
                                       ", in call to IO::InquireAttribute");
 
     core::AttributeBase *attribute = nullptr;
-    const std::string type(m_IO->InquireAttributeType(name));
+    const Type type(m_IO->InquireAttributeType(name));
 
-    if (type == "unknown")
+    if (type == Type::None)
     {
     }
 #define declare_template_instantiation(T)                                      \
@@ -264,14 +264,14 @@ std::string IO::VariableType(const std::string &name) const
 {
     helper::CheckForNullptr(m_IO, "for variable " + name +
                                       " in call to IO::VariableType");
-    return m_IO->InquireVariableType(name);
+    return ToString(m_IO->InquireVariableType(name));
 }
 
 std::string IO::AttributeType(const std::string &name) const
 {
     helper::CheckForNullptr(m_IO, "for attribute " + name +
                                       " in call to IO::AttributeType");
-    return m_IO->InquireAttributeType(name);
+    return ToString(m_IO->InquireAttributeType(name));
 }
 
 std::string IO::EngineType() const

--- a/bindings/Python/py11Variable.cpp
+++ b/bindings/Python/py11Variable.cpp
@@ -56,10 +56,10 @@ size_t Variable::SelectionSize() const
     helper::CheckForNullptr(m_VariableBase,
                             "in call to Variable::SelectionSize");
 
-    const std::string typeCpp = m_VariableBase->m_Type;
+    const adios2::Type typeCpp = m_VariableBase->m_Type;
     size_t size = 0;
 
-    if (typeCpp == "compound")
+    if (typeCpp == adios2::Type::Compound)
     {
         // not supported
     }
@@ -106,7 +106,7 @@ std::string Variable::Name() const
 std::string Variable::Type() const
 {
     helper::CheckForNullptr(m_VariableBase, "in call to Variable::Type");
-    return m_VariableBase->m_Type;
+    return ToString(m_VariableBase->m_Type);
 }
 
 size_t Variable::Sizeof() const
@@ -125,10 +125,10 @@ Dims Variable::Shape(const size_t step) const
 {
     helper::CheckForNullptr(m_VariableBase, "in call to Variable::Shape");
 
-    const std::string typeCpp = m_VariableBase->m_Type;
+    const adios2::Type typeCpp = m_VariableBase->m_Type;
     Dims shape;
 
-    if (typeCpp == "compound")
+    if (typeCpp == adios2::Type::Compound)
     {
         // not supported
     }
@@ -155,10 +155,10 @@ Dims Variable::Count() const
 {
     helper::CheckForNullptr(m_VariableBase, "in call to Variable::Count");
 
-    const std::string typeCpp = m_VariableBase->m_Type;
+    const adios2::Type typeCpp = m_VariableBase->m_Type;
     Dims count;
 
-    if (typeCpp == "compound")
+    if (typeCpp == adios2::Type::Compound)
     {
         // not supported
     }

--- a/source/adios2/common/ADIOSTypes.cpp
+++ b/source/adios2/common/ADIOSTypes.cpp
@@ -180,4 +180,45 @@ std::string ToString(SelectionType value)
     }
 }
 
+std::string ToString(Type type)
+{
+    // Keep in sync with helper::GetTypeFromString
+    switch (type)
+    {
+    case Type::None:
+        break;
+    case Type::Int8:
+        return "int8_t";
+    case Type::Int16:
+        return "int16_t";
+    case Type::Int32:
+        return "int32_t";
+    case Type::Int64:
+        return "int64_t";
+    case Type::UInt8:
+        return "uint8_t";
+    case Type::UInt16:
+        return "uint16_t";
+    case Type::UInt32:
+        return "uint32_t";
+    case Type::UInt64:
+        return "uint64_t";
+    case Type::Float:
+        return "float";
+    case Type::Double:
+        return "double";
+    case Type::LongDouble:
+        return "long double";
+    case Type::FloatComplex:
+        return "float complex";
+    case Type::DoubleComplex:
+        return "double complex";
+    case Type::String:
+        return "string";
+    case Type::Compound:
+        return "compound";
+    }
+    return std::string();
+}
+
 } // end namespace adios2

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -119,6 +119,27 @@ enum class SelectionType
     Auto         ///< Let the engine decide what to return
 };
 
+// Data types.
+enum class Type
+{
+    None,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Float,
+    Double,
+    LongDouble,
+    FloatComplex,
+    DoubleComplex,
+    String,
+    Compound
+};
+
 // Types
 using std::size_t;
 
@@ -215,6 +236,7 @@ std::string ToString(StepMode value);
 std::string ToString(StepStatus value);
 std::string ToString(TimeUnit value);
 std::string ToString(SelectionType value);
+std::string ToString(Type type);
 
 /**
  * os << [adios2_type] enables output of adios2 enums/classes directly

--- a/source/adios2/core/Attribute.tcc
+++ b/source/adios2/core/Attribute.tcc
@@ -14,6 +14,7 @@
 #include "Attribute.h"
 
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2/helper/adiosType.h"
 
 namespace adios2
 {
@@ -24,7 +25,7 @@ template <class T>
 Params Attribute<T>::DoGetInfo() const noexcept
 {
     Params info;
-    info["Type"] = m_Type;
+    info["Type"] = ToString(m_Type);
     info["Elements"] = std::to_string(m_Elements);
 
     if (m_IsSingleValue)

--- a/source/adios2/core/AttributeBase.cpp
+++ b/source/adios2/core/AttributeBase.cpp
@@ -15,12 +15,12 @@ namespace adios2
 namespace core
 {
 
-AttributeBase::AttributeBase(const std::string &name, const std::string type)
+AttributeBase::AttributeBase(const std::string &name, const Type type)
 : m_Name(name), m_Type(type), m_Elements(1), m_IsSingleValue(true)
 {
 }
 
-AttributeBase::AttributeBase(const std::string &name, const std::string type,
+AttributeBase::AttributeBase(const std::string &name, const Type type,
                              const size_t elements)
 : m_Name(name), m_Type(type), m_Elements(elements), m_IsSingleValue(false)
 {

--- a/source/adios2/core/AttributeBase.h
+++ b/source/adios2/core/AttributeBase.h
@@ -28,7 +28,7 @@ class AttributeBase
 
 public:
     const std::string m_Name;
-    const std::string m_Type;
+    const Type m_Type;
     const size_t m_Elements;
     const bool m_IsSingleValue;
 
@@ -37,7 +37,7 @@ public:
      * @param name
      * @param type
      */
-    AttributeBase(const std::string &name, const std::string type);
+    AttributeBase(const std::string &name, const Type type);
 
     /**
      * Array constructor used by Attribute<T> derived class
@@ -45,7 +45,7 @@ public:
      * @param type
      * @param elements
      */
-    AttributeBase(const std::string &name, const std::string type,
+    AttributeBase(const std::string &name, const Type type,
                   const size_t elements);
 
     virtual ~AttributeBase() = default;

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -321,10 +321,10 @@ bool IO::RemoveVariable(const std::string &name) noexcept
     if (itVariable != m_Variables.end())
     {
         // first remove the Variable object
-        const std::string type(itVariable->second.first);
+        const Type type(itVariable->second.first);
         const unsigned int index(itVariable->second.second);
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
             auto variableMap = m_Compound;
             variableMap.erase(index);
@@ -367,10 +367,10 @@ bool IO::RemoveAttribute(const std::string &name) noexcept
     if (itAttribute != m_Attributes.end())
     {
         // first remove the Attribute object
-        const std::string type(itAttribute->second.first);
+        const Type type(itAttribute->second.first);
         const unsigned int index(itAttribute->second.second);
 
-        if (type.empty())
+        if (type == Type::None)
         {
             // nothing to do
         }
@@ -412,9 +412,9 @@ IO::GetAvailableVariables(const std::set<std::string> &keys) noexcept
     for (const auto &variablePair : m_Variables)
     {
         const std::string variableName = variablePair.first;
-        const std::string type = InquireVariableType(variableName);
+        const Type type = InquireVariableType(variableName);
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_template_instantiation(T)                                      \
@@ -440,9 +440,9 @@ IO::GetAvailableAttributes(const std::string &variableName,
     if (!variableName.empty())
     {
         auto itVariable = m_Variables.find(variableName);
-        const std::string type = InquireVariableType(itVariable);
+        const Type type = InquireVariableType(itVariable);
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_template_instantiation(T)                                      \
@@ -463,9 +463,9 @@ IO::GetAvailableAttributes(const std::string &variableName,
     for (const auto &attributePair : m_Attributes)
     {
         const std::string &name = attributePair.first;
-        const std::string type = attributePair.second.first;
+        const Type type = attributePair.second.first;
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_template_instantiation(T)                                      \
@@ -481,26 +481,26 @@ IO::GetAvailableAttributes(const std::string &variableName,
     return attributesInfo;
 }
 
-std::string IO::InquireVariableType(const std::string &name) const noexcept
+Type IO::InquireVariableType(const std::string &name) const noexcept
 {
     TAU_SCOPED_TIMER("IO::other");
     auto itVariable = m_Variables.find(name);
     return InquireVariableType(itVariable);
 }
 
-std::string
-IO::InquireVariableType(const DataMap::const_iterator itVariable) const noexcept
+Type IO::InquireVariableType(const DataMap::const_iterator itVariable) const
+    noexcept
 {
     if (itVariable == m_Variables.end())
     {
-        return "";
+        return Type::None;
     }
 
-    const std::string type = itVariable->second.first;
+    const Type type = itVariable->second.first;
 
     if (m_ReadStreaming)
     {
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_template_instantiation(T)                                      \
@@ -511,7 +511,7 @@ IO::InquireVariableType(const DataMap::const_iterator itVariable) const noexcept
                 itVariable->second.second);                                    \
         if (!variable.IsValidStep(m_EngineStep + 1))                           \
         {                                                                      \
-            return "";                                                         \
+            return Type::None;                                                 \
         }                                                                      \
     }
         ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
@@ -521,9 +521,9 @@ IO::InquireVariableType(const DataMap::const_iterator itVariable) const noexcept
     return type;
 }
 
-std::string IO::InquireAttributeType(const std::string &name,
-                                     const std::string &variableName,
-                                     const std::string separator) const noexcept
+Type IO::InquireAttributeType(const std::string &name,
+                              const std::string &variableName,
+                              const std::string separator) const noexcept
 {
     TAU_SCOPED_TIMER("IO::other");
     const std::string globalName =
@@ -532,7 +532,7 @@ std::string IO::InquireAttributeType(const std::string &name,
     auto itAttribute = m_Attributes.find(globalName);
     if (itAttribute == m_Attributes.end())
     {
-        return "";
+        return Type::None;
     }
 
     return itAttribute->second.first;
@@ -712,14 +712,14 @@ void IO::ResetVariablesStepSelection(const bool zeroStart,
          ++itVariable)
     {
         const std::string &name = itVariable->first;
-        const std::string type = InquireVariableType(itVariable);
+        const Type type = InquireVariableType(itVariable);
 
-        if (type.empty())
+        if (type == Type::None)
         {
             continue;
         }
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 // using relative start
@@ -748,15 +748,15 @@ void IO::SetPrefixedNames(const bool isStep) noexcept
         const std::string &name = itVariable->first;
         // if for each step (BP4), check if variable type is not empty (means
         // variable exist in that step)
-        const std::string type =
+        const Type type =
             isStep ? InquireVariableType(itVariable) : itVariable->second.first;
 
-        if (type.empty())
+        if (type == Type::None)
         {
             continue;
         }
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_type(T)                                                        \

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -35,8 +35,7 @@ namespace core
 {
 
 /** used for Variables and Attributes, name, type, type-index */
-using DataMap =
-    std::unordered_map<std::string, std::pair<std::string, unsigned int>>;
+using DataMap = std::unordered_map<std::string, std::pair<Type, unsigned int>>;
 
 // forward declaration needed as IO is passed to Engine derived
 // classes
@@ -294,15 +293,14 @@ public:
      * @param name input variable name
      * @return type primitive type
      */
-    std::string InquireVariableType(const std::string &name) const noexcept;
+    Type InquireVariableType(const std::string &name) const noexcept;
 
     /**
      * Overload that accepts a const iterator into the m_Variables map if found
      * @param itVariable
      * @return type primitive type
      */
-    std::string
-    InquireVariableType(const DataMap::const_iterator itVariable) const
+    Type InquireVariableType(const DataMap::const_iterator itVariable) const
         noexcept;
 
     /**
@@ -343,10 +341,9 @@ public:
      * @param name input attribute name
      * @return type if found returns type as string, otherwise an empty string
      */
-    std::string InquireAttributeType(const std::string &name,
-                                     const std::string &variableName = "",
-                                     const std::string separator = "/") const
-        noexcept;
+    Type InquireAttributeType(const std::string &name,
+                              const std::string &variableName = "",
+                              const std::string separator = "/") const noexcept;
 
     /**
      * @brief Retrieve map with attributes info. Use when reading.

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -19,7 +19,8 @@
 /// \endcond
 
 #include "adios2/common/ADIOSMacros.h"
-#include "adios2/helper/adiosFunctions.h" //helper::GetType<T>
+#include "adios2/helper/adiosFunctions.h"
+#include "adios2/helper/adiosType.h"
 #include "adios2/toolkit/profiling/taustubs/tautimer.hpp"
 
 namespace adios2
@@ -102,7 +103,8 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T &value,
                                   const std::string separator)
 {
     TAU_SCOPED_TIMER("IO::DefineAttribute");
-    if (!variableName.empty() && InquireVariableType(variableName).empty())
+    if (!variableName.empty() &&
+        InquireVariableType(variableName) == Type::None)
     {
         throw std::invalid_argument(
             "ERROR: variable " + variableName +
@@ -149,7 +151,8 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T *array,
                                   const std::string separator)
 {
     TAU_SCOPED_TIMER("IO::DefineAttribute");
-    if (!variableName.empty() && InquireVariableType(variableName).empty())
+    if (!variableName.empty() &&
+        InquireVariableType(variableName) == Type::None)
     {
         throw std::invalid_argument(
             "ERROR: variable " + variableName +
@@ -256,7 +259,7 @@ Params IO::GetVariableInfo(const std::string &variableName,
 
     if (keys.empty() || keysLC.count("type") == 1)
     {
-        info["Type"] = variable.m_Type;
+        info["Type"] = ToString(variable.m_Type);
     }
 
     if (keys.empty() || keysLC.count("availablestepscount") == 1)

--- a/source/adios2/core/Operator.cpp
+++ b/source/adios2/core/Operator.cpp
@@ -70,9 +70,9 @@ ADIOS2_FOREACH_ZFP_TYPE_1ARG(declare_type)
 #undef declare_type
 
 size_t Operator::Compress(const void * /*dataIn*/, const Dims & /*dimensions*/,
-                          const size_t /*elementSize*/,
-                          const std::string /*type*/, void * /*bufferOut*/,
-                          const Params & /*params*/, Params & /*info*/) const
+                          const size_t /*elementSize*/, Type /*type*/,
+                          void * /*bufferOut*/, const Params & /*params*/,
+                          Params & /*info*/) const
 {
     throw std::invalid_argument("ERROR: signature (const void*, const "
                                 "Dims, const size_t, const std::string, "
@@ -93,8 +93,7 @@ size_t Operator::Decompress(const void *bufferIn, const size_t sizeIn,
 
 size_t Operator::Decompress(const void * /*bufferIn*/, const size_t /*sizeIn*/,
                             void * /*dataOut*/, const Dims & /*dimensions*/,
-                            const std::string /*type*/,
-                            const Params & /*parameters*/) const
+                            Type /*type*/, const Params & /*parameters*/) const
 {
     throw std::invalid_argument("ERROR: signature (const void*, const "
                                 "size_t, void*, const Dims&, const "
@@ -105,8 +104,7 @@ size_t Operator::Decompress(const void * /*bufferIn*/, const size_t /*sizeIn*/,
 
 // PROTECTED
 size_t Operator::DoBufferMaxSize(const void *dataIn, const Dims &dimensions,
-                                 const std::string type,
-                                 const Params &parameters) const
+                                 Type type, const Params &parameters) const
 {
     throw std::invalid_argument("ERROR: signature (const void*, const Dims& "
                                 "std::string ) not supported "

--- a/source/adios2/core/Operator.h
+++ b/source/adios2/core/Operator.h
@@ -86,7 +86,7 @@ public:
      * @return size of compressed buffer
      */
     virtual size_t Compress(const void *dataIn, const Dims &dimensions,
-                            const size_t elementSize, const std::string type,
+                            const size_t elementSize, Type type,
                             void *bufferOut, const Params &parameters,
                             Params &info) const;
 
@@ -104,8 +104,7 @@ public:
      * @return
      */
     virtual size_t Decompress(const void *bufferIn, const size_t sizeIn,
-                              void *dataOut, const Dims &dimensions,
-                              const std::string type,
+                              void *dataOut, const Dims &dimensions, Type type,
                               const Params &parameters) const;
 
 protected:
@@ -121,8 +120,7 @@ protected:
      * @return conservative buffer size for allocation
      */
     virtual size_t DoBufferMaxSize(const void *dataIn, const Dims &dimensions,
-                                   const std::string type,
-                                   const Params &parameters) const;
+                                   Type type, const Params &parameters) const;
 
 private:
     void CheckCallbackType(const std::string type) const;

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -28,7 +28,7 @@ namespace adios2
 namespace core
 {
 
-VariableBase::VariableBase(const std::string &name, const std::string type,
+VariableBase::VariableBase(const std::string &name, const Type type,
                            const size_t elementSize, const Dims &shape,
                            const Dims &start, const Dims &count,
                            const bool constantDims)
@@ -305,12 +305,12 @@ VariableBase::GetAttributesInfo(core::IO &io, const std::string separator,
         }
 
         auto itAttribute = io.m_Attributes.find(attributeName);
-        const std::string type = itAttribute->second.first;
+        const Type type = itAttribute->second.first;
 
         const std::string key =
             fullNameKeys ? attributeName : attributeName.substr(prefix.size());
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_template_instantiation(T)                                      \
@@ -521,7 +521,7 @@ void VariableBase::CheckDimensionsCommon(const std::string hint) const
 
 Dims VariableBase::GetShape(const size_t step)
 {
-    if (m_Type == "compound")
+    if (m_Type == Type::Compound)
     {
         // not supported
     }

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -41,7 +41,7 @@ public:
     const std::string m_Name;
 
     /** primitive from <T> or compound from struct */
-    const std::string m_Type;
+    const Type m_Type;
 
     /** Variable -> sizeof(T),
      *  VariableCompound -> from constructor sizeof(struct) */
@@ -112,7 +112,7 @@ public:
     std::set<std::string> m_PrefixedVariables;
     std::set<std::string> m_PrefixedAttributes;
 
-    VariableBase(const std::string &name, const std::string type,
+    VariableBase(const std::string &name, const Type type,
                  const size_t elementSize, const Dims &shape, const Dims &start,
                  const Dims &count, const bool constantShape);
 

--- a/source/adios2/core/VariableCompound.cpp
+++ b/source/adios2/core/VariableCompound.cpp
@@ -22,7 +22,8 @@ VariableCompound::VariableCompound(const std::string &name,
                                    const size_t structSize, const Dims &shape,
                                    const Dims &start, const Dims &count,
                                    const bool constantDims)
-: VariableBase(name, "compound", structSize, shape, start, count, constantDims)
+: VariableBase(name, Type::Compound, structSize, shape, start, count,
+               constantDims)
 {
 }
 

--- a/source/adios2/core/VariableCompound.h
+++ b/source/adios2/core/VariableCompound.h
@@ -14,6 +14,7 @@
 #include "VariableBase.h"
 
 #include "adios2/common/ADIOSMacros.h"
+#include "adios2/common/ADIOSTypes.h"
 
 namespace adios2
 {
@@ -34,8 +35,8 @@ public:
     struct Element
     {
         const std::string Name;
-        const std::string Type; ///< from GetType<T>
-        const size_t Offset;    ///< element offset in struct
+        const adios2::Type Type; ///< from GetType<T>
+        const size_t Offset;     ///< element offset in struct
     };
 
     /** vector of primitve element types defining compound struct */

--- a/source/adios2/engine/bp3/BP3Reader.cpp
+++ b/source/adios2/engine/bp3/BP3Reader.cpp
@@ -92,9 +92,9 @@ void BP3Reader::PerformGets()
 
     for (const std::string &name : m_BP3Deserializer.m_DeferredVariables)
     {
-        const std::string type = m_IO.InquireVariableType(name);
+        const Type type = m_IO.InquireVariableType(name);
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -62,8 +62,8 @@ void BP3Writer::PerformPuts()
 
     for (const std::string &variableName : m_BP3Serializer.m_DeferredVariables)
     {
-        const std::string type = m_IO.InquireVariableType(variableName);
-        if (type == "compound")
+        const Type type = m_IO.InquireVariableType(variableName);
+        if (type == Type::Compound)
         {
             // not supported
         }

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -115,9 +115,9 @@ void BP4Reader::PerformGets()
 
     for (const std::string &name : m_BP4Deserializer.m_DeferredVariables)
     {
-        const std::string type = m_IO.InquireVariableType(name);
+        const Type type = m_IO.InquireVariableType(name);
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -67,8 +67,8 @@ void BP4Writer::PerformPuts()
 
     for (const std::string &variableName : m_BP4Serializer.m_DeferredVariables)
     {
-        const std::string type = m_IO.InquireVariableType(variableName);
-        if (type == "compound")
+        const Type type = m_IO.InquireVariableType(variableName);
+        if (type == Type::Compound)
         {
             // not supported
         }

--- a/source/adios2/engine/dataman/DataManReader.cpp
+++ b/source/adios2/engine/dataman/DataManReader.cpp
@@ -183,7 +183,7 @@ StepStatus DataManReader::BeginStep(StepMode stepMode,
     {
         if (i.step == m_CurrentStep)
         {
-            if (i.type.empty())
+            if (i.type == Type::None)
             {
                 throw("unknown data type");
             }

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -310,7 +310,7 @@ void HDF5ReaderP::PerformGets()
 #define declare_type(T)                                                        \
     for (std::string variableName : m_DeferredStack)                           \
     {                                                                          \
-        const std::string type = m_IO.InquireVariableType(variableName);       \
+        const Type type = m_IO.InquireVariableType(variableName);              \
         if (type == helper::GetType<T>())                                      \
         {                                                                      \
             Variable<T> *var = m_IO.InquireVariable<T>(variableName);          \

--- a/source/adios2/engine/inline/InlineReader.cpp
+++ b/source/adios2/engine/inline/InlineReader.cpp
@@ -223,8 +223,8 @@ void InlineReader::SetDeferredVariablePointers()
     // this will make Variable::Info::Data() work correctly for the user
     for (const auto &varName : m_DeferredVariables)
     {
-        const std::string type = m_IO.InquireVariableType(varName);
-        if (type == "compound")
+        const Type type = m_IO.InquireVariableType(varName);
+        if (type == Type::Compound)
         {
         }
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/inline/InlineWriter.cpp
+++ b/source/adios2/engine/inline/InlineWriter.cpp
@@ -82,9 +82,9 @@ void InlineWriter::ResetVariables()
     for (auto &varPair : availVars)
     {
         const auto &name = varPair.first;
-        const std::string type = m_IO.InquireVariableType(name);
+        const Type type = m_IO.InquireVariableType(name);
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -488,9 +488,9 @@ void InSituMPIReader::AsyncRecvAllVariables()
     for (const auto &variablePair : m_ReadScheduleMap)
     {
         // AsyncRecvVariable(variablePair.first, variablePair.second);
-        const std::string type(m_IO.InquireVariableType(variablePair.first));
+        const Type type(m_IO.InquireVariableType(variablePair.first));
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
             // not supported
         }

--- a/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIWriter.cpp
@@ -281,9 +281,9 @@ void InSituMPIWriter::PerformPuts()
 void InSituMPIWriter::AsyncSendVariable(std::string variableName)
 {
     TAU_SCOPED_TIMER("InSituMPIWriter::AsyncSendVariable");
-    const std::string type(m_IO.InquireVariableType(variableName));
+    const Type type(m_IO.InquireVariableType(variableName));
 
-    if (type == "compound")
+    if (type == Type::Compound)
     {
         // not supported
     }

--- a/source/adios2/engine/ssc/SscHelper.h
+++ b/source/adios2/engine/ssc/SscHelper.h
@@ -28,7 +28,7 @@ namespace ssc
 struct BlockInfo
 {
     std::string name;
-    std::string type;
+    Type type;
     ShapeID shapeId;
     Dims shape;
     Dims start;
@@ -54,8 +54,7 @@ void PrintMpiInfo(const MpiInfo &writersInfo, const MpiInfo &readersInfo);
 
 size_t GetTypeSize(const std::string &type);
 
-size_t TotalDataSize(const Dims &dims, const std::string &type,
-                     const ShapeID &shapeId);
+size_t TotalDataSize(const Dims &dims, Type type, const ShapeID &shapeId);
 size_t TotalDataSize(const BlockVec &bv);
 
 RankPosMap CalculateOverlap(BlockVecVec &globalPattern,

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -158,11 +158,11 @@ StepStatus SscReader::BeginStep(const StepMode stepMode,
                     std::memcpy(value.data(), m_Buffer.data() + v.bufferStart,
                                 v.bufferCount);
                 }
-                if (v.type.empty())
+                if (v.type == Type::None)
                 {
                     throw(std::runtime_error("unknown data type"));
                 }
-                else if (v.type == "string")
+                else if (v.type == Type::String)
                 {
                     auto variable = m_IO.InquireVariable<std::string>(v.name);
                     if (variable)
@@ -313,7 +313,7 @@ void SscReader::SyncWritePattern()
     {
         for (const auto &b : blockVec)
         {
-            if (b.type.empty())
+            if (b.type == Type::None)
             {
                 throw(std::runtime_error("unknown data type"));
             }
@@ -367,8 +367,9 @@ void SscReader::SyncWritePattern()
         }
         for (const auto &attributeJson : attributesJson)
         {
-            const std::string type(attributeJson["Type"].get<std::string>());
-            if (type.empty())
+            const Type type(helper::GetTypeFromString(
+                attributeJson["Type"].get<std::string>()));
+            if (type == Type::None)
             {
             }
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/ssc/SscReader.tcc
+++ b/source/adios2/engine/ssc/SscReader.tcc
@@ -37,12 +37,12 @@ void SscReader::GetDeferredCommon(Variable<std::string> &variable,
         b.count = variable.m_Count;
         b.start = variable.m_Start;
         b.shape = variable.m_Shape;
-        b.type = "string";
+        b.type = Type::String;
 
         m_LocalReadPatternJson["Variables"].emplace_back();
         auto &jref = m_LocalReadPatternJson["Variables"].back();
         jref["Name"] = b.name;
-        jref["Type"] = b.type;
+        jref["Type"] = ToString(b.type);
         jref["ShapeID"] = variable.m_ShapeID;
         jref["Start"] = b.start;
         jref["Count"] = b.count;
@@ -128,7 +128,7 @@ void SscReader::GetDeferredCommon(Variable<T> &variable, T *data)
         m_LocalReadPatternJson["Variables"].emplace_back();
         auto &jref = m_LocalReadPatternJson["Variables"].back();
         jref["Name"] = variable.m_Name;
-        jref["Type"] = helper::GetType<T>();
+        jref["Type"] = ToString(helper::GetType<T>());
         jref["ShapeID"] = variable.m_ShapeID;
         jref["Start"] = vStart;
         jref["Count"] = vCount;

--- a/source/adios2/engine/ssc/SscWriter.tcc
+++ b/source/adios2/engine/ssc/SscWriter.tcc
@@ -52,7 +52,7 @@ void SscWriter::PutDeferredCommon(Variable<std::string> &variable,
             m_GlobalWritePattern[m_StreamRank].emplace_back();
             auto &b = m_GlobalWritePattern[m_StreamRank].back();
             b.name = variable.m_Name;
-            b.type = "string";
+            b.type = Type::String;
             b.shapeId = variable.m_ShapeID;
             b.shape = variable.m_Shape;
             b.start = variable.m_Start;

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -52,10 +52,10 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
 
     auto varFFSCallback = [](void *reader, const char *variableName,
                              const char *type, void *data) {
-        std::string Type(type);
+        adios2::Type Type(helper::GetTypeFromString(type));
         class SstReader::SstReader *Reader =
             reinterpret_cast<class SstReader::SstReader *>(reader);
-        if (Type == "compound")
+        if (Type == adios2::Type::Compound)
         {
             return (void *)NULL;
         }
@@ -85,10 +85,10 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
             Reader->m_IO.RemoveAllAttributes();
             return;
         }
-        std::string Type(type);
+        adios2::Type Type(helper::GetTypeFromString(type));
         try
         {
-            if (Type == "compound")
+            if (Type == adios2::Type::Compound)
             {
                 return;
             }
@@ -107,8 +107,8 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
 #undef declare_type
             else
             {
-                std::cout << "Loading attribute matched no type " << Type
-                          << std::endl;
+                std::cout << "Loading attribute matched no type "
+                          << ToString(Type) << std::endl;
             }
         }
         catch (...)
@@ -125,7 +125,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
         std::vector<size_t> VecShape;
         std::vector<size_t> VecStart;
         std::vector<size_t> VecCount;
-        std::string Type(type);
+        adios2::Type Type(helper::GetTypeFromString(type));
         class SstReader::SstReader *Reader =
             reinterpret_cast<class SstReader::SstReader *>(reader);
         /*
@@ -151,7 +151,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
             }
         }
 
-        if (Type == "compound")
+        if (Type == adios2::Type::Compound)
         {
             return (void *)NULL;
         }
@@ -174,7 +174,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
             std::vector<size_t> VecShape;
             std::vector<size_t> VecStart;
             std::vector<size_t> VecCount;
-            std::string Type(type);
+            adios2::Type Type(helper::GetTypeFromString(type));
             class SstReader::SstReader *Reader =
                 reinterpret_cast<class SstReader::SstReader *>(reader);
             size_t currentStep = SstCurrentStep(Reader->m_Input);
@@ -201,7 +201,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
                 }
             }
 
-            if (Type == "compound")
+            if (Type == adios2::Type::Compound)
             {
                 return;
             }
@@ -548,9 +548,9 @@ void SstReader::PerformGets()
 
         for (const std::string &name : m_BP3Deserializer->m_DeferredVariables)
         {
-            const std::string type = m_IO.InquireVariableType(name);
+            const Type type = m_IO.InquireVariableType(name);
 
-            if (type == "compound")
+            if (type == Type::Compound)
             {
             }
 #define declare_type(T)                                                        \
@@ -579,9 +579,9 @@ void SstReader::PerformGets()
 
         for (const std::string &name : m_BP3Deserializer->m_DeferredVariables)
         {
-            const std::string type = m_IO.InquireVariableType(name);
+            const Type type = m_IO.InquireVariableType(name);
 
-            if (type == "compound")
+            if (type == Type::Compound)
             {
             }
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -169,9 +169,9 @@ void SstWriter::FFSMarshalAttributes()
     for (const auto &attributePair : attributesDataMap)
     {
         const std::string name(attributePair.first);
-        const std::string type(attributePair.second.first);
+        const Type type(attributePair.second.first);
 
-        if (type == "unknown")
+        if (type == Type::None)
         {
         }
         else if (type == helper::GetType<std::string>())
@@ -185,8 +185,9 @@ void SstWriter::FFSMarshalAttributes()
                 //
             }
 
-            SstFFSMarshalAttribute(m_Output, name.c_str(), type.c_str(),
-                                   sizeof(char *), element_count, data_addr);
+            SstFFSMarshalAttribute(m_Output, name.c_str(),
+                                   ToString(type).c_str(), sizeof(char *),
+                                   element_count, data_addr);
         }
 #define declare_type(T)                                                        \
     else if (type == helper::GetType<T>())                                     \
@@ -200,8 +201,8 @@ void SstWriter::FFSMarshalAttributes()
             data_addr = attribute.m_DataArray.data();                          \
         }                                                                      \
         SstFFSMarshalAttribute(m_Output, attribute.m_Name.c_str(),             \
-                               type.c_str(), sizeof(T), element_count,         \
-                               data_addr);                                     \
+                               ToString(type).c_str(), sizeof(T),              \
+                               element_count, data_addr);                      \
     }
 
         ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type)

--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -56,8 +56,8 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
             Count = variable.m_Count.data();
         }
         SstFFSMarshal(m_Output, (void *)&variable, variable.m_Name.c_str(),
-                      variable.m_Type.c_str(), variable.m_ElementSize, DimCount,
-                      Shape, Count, Start, values);
+                      ToString(variable.m_Type).c_str(), variable.m_ElementSize,
+                      DimCount, Shape, Count, Start, values);
     }
     else if (m_MarshalMethod == SstMarshalBP)
     {

--- a/source/adios2/engine/table/TableWriter.cpp
+++ b/source/adios2/engine/table/TableWriter.cpp
@@ -287,7 +287,7 @@ void TableWriter::PutAggregatorBuffer()
         m_VarInfoMap[v.name].type = v.type;
         m_VarInfoMap[v.name].shape = v.shape;
         size_t elementSize;
-        if (v.type == "")
+        if (v.type == Type::None)
         {
         }
 #define declare_type(T)                                                        \
@@ -320,7 +320,7 @@ void TableWriter::PutAggregatorBuffer()
                 }
             }
 
-            if (v.type == "")
+            if (v.type == Type::None)
             {
             }
 #define declare_type(T)                                                        \
@@ -376,8 +376,8 @@ void TableWriter::PutSubEngine(bool finalPut)
                 {
                     count[0] = shape[0] - start[0];
                 }
-                const std::string &type = m_VarInfoMap[varPair.first].type;
-                if (type == "")
+                const Type type = m_VarInfoMap[varPair.first].type;
+                if (type == Type::None)
                 {
                 }
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/table/TableWriter.h
+++ b/source/adios2/engine/table/TableWriter.h
@@ -49,7 +49,7 @@ private:
     struct VarInfo
     {
         Dims shape;
-        std::string type;
+        Type type;
     };
     int m_Verbosity = 0;
     int m_Timeout = 5;

--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -24,7 +24,7 @@ namespace
 {
 
 void CopyPayloadStride(const char *src, const size_t payloadStride, char *dest,
-                       const bool endianReverse, const std::string destType)
+                       const bool endianReverse, const Type destType)
 {
 #ifdef ADIOS2_HAVE_ENDIAN_REVERSE
     if (endianReverse)
@@ -66,7 +66,7 @@ void ClipRowMajor(char *dest, const Dims &destStart, const Dims &destCount,
                   const Dims &srcStart, const Dims &srcCount,
                   const Dims & /*destMemStart*/, const Dims & /*destMemCount*/,
                   const Dims &srcMemStart, const Dims &srcMemCount,
-                  const bool endianReverse, const std::string destType)
+                  const bool endianReverse, const Type destType)
 {
     const Dims destStartFinal = DestDimsFinal(destStart, destRowMajor, true);
     const Dims destCountFinal = DestDimsFinal(destCount, destRowMajor, true);
@@ -163,7 +163,7 @@ void ClipColumnMajor(char *dest, const Dims &destStart, const Dims &destCount,
                      const Dims & /*destMemStart*/,
                      const Dims & /*destMemCount*/, const Dims &srcMemStart,
                      const Dims &srcMemCount, const bool endianReverse,
-                     const std::string destType)
+                     const Type destType)
 {
     const Dims destStartFinal = DestDimsFinal(destStart, destRowMajor, false);
     const Dims destCountFinal = DestDimsFinal(destCount, destRowMajor, false);
@@ -250,7 +250,7 @@ void CopyPayload(char *dest, const Dims &destStart, const Dims &destCount,
                  const Dims &srcCount, const bool srcRowMajor,
                  const Dims &destMemStart, const Dims &destMemCount,
                  const Dims &srcMemStart, const Dims &srcMemCount,
-                 const bool endianReverse, const std::string destType) noexcept
+                 const bool endianReverse, const Type destType) noexcept
 {
     if (srcStart.size() == 1) // 1D copy memory
     {

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -135,7 +135,7 @@ void CopyPayload(char *dest, const Dims &destStart, const Dims &destCount,
                  const Dims &srcMemStart = Dims(),
                  const Dims &srcMemCount = Dims(),
                  const bool endianReverse = false,
-                 const std::string destType = "") noexcept;
+                 const Type destType = Type::None) noexcept;
 
 /**
  * Clips the contiguous memory corresponding to an intersection and puts it in

--- a/source/adios2/helper/adiosType.cpp
+++ b/source/adios2/helper/adiosType.cpp
@@ -20,6 +20,72 @@ namespace adios2
 namespace helper
 {
 
+Type GetTypeFromString(std::string const &type) noexcept
+{
+    // Keep in sync with adios2::ToString(Type).
+    if (type == "int8_t")
+    {
+        return Type::Int8;
+    }
+    if (type == "int16_t")
+    {
+        return Type::Int16;
+    }
+    if (type == "int32_t")
+    {
+        return Type::Int32;
+    }
+    if (type == "int64_t")
+    {
+        return Type::Int64;
+    }
+    if (type == "uint8_t")
+    {
+        return Type::UInt8;
+    }
+    if (type == "uint16_t")
+    {
+        return Type::UInt16;
+    }
+    if (type == "uint32_t")
+    {
+        return Type::UInt32;
+    }
+    if (type == "uint64_t")
+    {
+        return Type::UInt64;
+    }
+    if (type == "float")
+    {
+        return Type::Float;
+    }
+    if (type == "double")
+    {
+        return Type::Double;
+    }
+    if (type == "long double")
+    {
+        return Type::LongDouble;
+    }
+    if (type == "float complex")
+    {
+        return Type::FloatComplex;
+    }
+    if (type == "double complex")
+    {
+        return Type::DoubleComplex;
+    }
+    if (type == "string")
+    {
+        return Type::String;
+    }
+    if (type == "compound")
+    {
+        return Type::Compound;
+    }
+    return Type::None;
+}
+
 std::string DimsToCSV(const Dims &dimensions) noexcept
 {
     std::string dimsCSV;

--- a/source/adios2/helper/adiosType.h
+++ b/source/adios2/helper/adiosType.h
@@ -98,10 +98,16 @@ struct SubStreamBoxInfo
 
 /**
  * Gets type from template parameter T
- * @return string with type
+ * @return Type enumeration value
  */
 template <class T>
-std::string GetType() noexcept;
+Type GetType() noexcept;
+
+/**
+ * Gets type from string, inversing ToString(Type)
+ * @return Type enumeration value, or Type::None on failure
+ */
+Type GetTypeFromString(std::string const &) noexcept;
 
 /**
  * Converts a vector of dimensions to a CSV string

--- a/source/adios2/helper/adiosType.h
+++ b/source/adios2/helper/adiosType.h
@@ -104,19 +104,6 @@ template <class T>
 std::string GetType() noexcept;
 
 /**
- * Check in types set if "type" is one of the aliases for a certain type,
- * (e.g. if type = integer is an accepted alias for "int", returning true)
- * @param type input to be compared with an alias
- * @param aliases set containing aliases to a certain type, typically
- * Support::DatatypesAliases from Support.h
- * @return true: is an alias, false: is not
- */
-template <class T>
-bool IsTypeAlias(
-    const std::string type,
-    const std::map<std::string, std::set<std::string>> &aliases) noexcept;
-
-/**
  * Converts a vector of dimensions to a CSV string
  * @param dims vector of dimensions
  * @return comma separate value (CSV)

--- a/source/adios2/helper/adiosType.inl
+++ b/source/adios2/helper/adiosType.inl
@@ -25,75 +25,75 @@ namespace helper
 {
 
 template <>
-inline std::string GetType<std::string>() noexcept
+inline Type GetType<std::string>() noexcept
 {
-    return "string";
+    return Type::String;
 }
 
 template <>
-inline std::string GetType<int8_t>() noexcept
+inline Type GetType<int8_t>() noexcept
 {
-    return "int8_t";
+    return Type::Int8;
 }
 template <>
-inline std::string GetType<uint8_t>() noexcept
+inline Type GetType<uint8_t>() noexcept
 {
-    return "uint8_t";
+    return Type::UInt8;
 }
 template <>
-inline std::string GetType<int16_t>() noexcept
+inline Type GetType<int16_t>() noexcept
 {
-    return "int16_t";
+    return Type::Int16;
 }
 template <>
-inline std::string GetType<uint16_t>() noexcept
+inline Type GetType<uint16_t>() noexcept
 {
-    return "uint16_t";
+    return Type::UInt16;
 }
 template <>
-inline std::string GetType<int32_t>() noexcept
+inline Type GetType<int32_t>() noexcept
 {
-    return "int32_t";
+    return Type::Int32;
 }
 template <>
-inline std::string GetType<uint32_t>() noexcept
+inline Type GetType<uint32_t>() noexcept
 {
-    return "uint32_t";
+    return Type::UInt32;
 }
 template <>
-inline std::string GetType<int64_t>() noexcept
+inline Type GetType<int64_t>() noexcept
 {
-    return "int64_t";
+    return Type::Int64;
 }
 template <>
-inline std::string GetType<uint64_t>() noexcept
+inline Type GetType<uint64_t>() noexcept
 {
-    return "uint64_t";
+    return Type::UInt64;
 }
 template <>
-inline std::string GetType<float>() noexcept
+inline Type GetType<float>() noexcept
 {
-    return "float";
+    return Type::Float;
 }
 template <>
-inline std::string GetType<double>() noexcept
+inline Type GetType<double>() noexcept
 {
-    return "double";
+    return Type::Double;
 }
 template <>
-inline std::string GetType<long double>() noexcept
+inline Type GetType<long double>() noexcept
 {
-    return "long double";
+    return Type::LongDouble;
 }
 template <>
-inline std::string GetType<std::complex<float>>() noexcept
+inline Type GetType<std::complex<float>>() noexcept
 {
-    return "float complex";
+    return Type::FloatComplex;
 }
 template <>
-inline std::string GetType<std::complex<double>>() noexcept
+inline Type GetType<std::complex<double>>() noexcept
 {
-    return "double complex";
+    return Type::DoubleComplex;
 }
 
 template <class T, class U>

--- a/source/adios2/helper/adiosType.inl
+++ b/source/adios2/helper/adiosType.inl
@@ -96,25 +96,6 @@ inline std::string GetType<std::complex<double>>() noexcept
     return "double complex";
 }
 
-template <class T>
-bool IsTypeAlias(
-    const std::string type,
-    const std::map<std::string, std::set<std::string>> &aliases) noexcept
-{
-    if (type == GetType<T>()) // is key itself
-    {
-        return true;
-    }
-
-    bool isAlias = false;
-    if (aliases.at(GetType<T>()).count(type) == 1)
-    {
-        isAlias = true;
-    }
-
-    return isAlias;
-}
-
 template <class T, class U>
 std::vector<U> NewVectorType(const std::vector<T> &in)
 {

--- a/source/adios2/operator/compress/CompressBZIP2.cpp
+++ b/source/adios2/operator/compress/CompressBZIP2.cpp
@@ -38,7 +38,7 @@ size_t CompressBZIP2::BufferMaxSize(const size_t sizeIn) const
 }
 
 size_t CompressBZIP2::Compress(const void *dataIn, const Dims &dimensions,
-                               const size_t elementSize, const std::string type,
+                               const size_t elementSize, Type type,
                                void *bufferOut, const Params &parameters,
                                Params &info) const
 {
@@ -49,8 +49,8 @@ size_t CompressBZIP2::Compress(const void *dataIn, const Dims &dimensions,
 
     if (!parameters.empty())
     {
-        const std::string hint(" in call to CompressBZIP2 Compress " + type +
-                               "\n");
+        const std::string hint(" in call to CompressBZIP2 Compress " +
+                               ToString(type) + "\n");
         helper::SetParameterValueInt("blockSize100k", parameters, blockSize100k,
                                      hint);
         helper::SetParameterValueInt("verbosity", parameters, verbosity, hint);

--- a/source/adios2/operator/compress/CompressBZIP2.h
+++ b/source/adios2/operator/compress/CompressBZIP2.h
@@ -43,9 +43,8 @@ public:
      * @return size of compressed buffer in bytes
      */
     size_t Compress(const void *dataIn, const Dims &dimensions,
-                    const size_t elementSize, const std::string type,
-                    void *bufferOut, const Params &parameters,
-                    Params &info) const final;
+                    const size_t elementSize, Type type, void *bufferOut,
+                    const Params &parameters, Params &info) const final;
 
     using Operator::Decompress;
     /**

--- a/source/adios2/operator/compress/CompressBlosc.cpp
+++ b/source/adios2/operator/compress/CompressBlosc.cpp
@@ -37,7 +37,7 @@ CompressBlosc::CompressBlosc(const Params &parameters)
 }
 
 size_t CompressBlosc::Compress(const void *dataIn, const Dims &dimensions,
-                               const size_t elementSize, const std::string type,
+                               const size_t elementSize, Type type,
                                void *bufferOut, const Params &parameters,
                                Params &info) const
 {

--- a/source/adios2/operator/compress/CompressBlosc.h
+++ b/source/adios2/operator/compress/CompressBlosc.h
@@ -44,9 +44,8 @@ public:
      * @return size of compressed buffer in bytes
      */
     size_t Compress(const void *dataIn, const Dims &dimensions,
-                    const size_t elementSize, const std::string type,
-                    void *bufferOut, const Params &parameters,
-                    Params &info) const final;
+                    const size_t elementSize, Type type, void *bufferOut,
+                    const Params &parameters, Params &info) const final;
 
     /**
      * Decompression signature for legacy libraries that use void*

--- a/source/adios2/operator/compress/CompressMGARD.cpp
+++ b/source/adios2/operator/compress/CompressMGARD.cpp
@@ -29,7 +29,7 @@ CompressMGARD::CompressMGARD(const Params &parameters)
 }
 
 size_t CompressMGARD::Compress(const void *dataIn, const Dims &dimensions,
-                               const size_t elementSize, const std::string type,
+                               const size_t elementSize, Type type,
                                void *bufferOut, const Params &parameters,
                                Params &info) const
 {
@@ -104,8 +104,7 @@ size_t CompressMGARD::Compress(const void *dataIn, const Dims &dimensions,
 
 size_t CompressMGARD::Decompress(const void *bufferIn, const size_t sizeIn,
                                  void *dataOut, const Dims &dimensions,
-                                 const std::string type,
-                                 const Params & /*parameters*/) const
+                                 Type type, const Params & /*parameters*/) const
 {
     int mgardType = -1;
     size_t elementSize = 0;

--- a/source/adios2/operator/compress/CompressMGARD.h
+++ b/source/adios2/operator/compress/CompressMGARD.h
@@ -41,9 +41,8 @@ public:
      * @return size of compressed buffer in bytes
      */
     size_t Compress(const void *dataIn, const Dims &dimensions,
-                    const size_t elementSize, const std::string type,
-                    void *bufferOut, const Params &parameters,
-                    Params &info) const final;
+                    const size_t elementSize, Type type, void *bufferOut,
+                    const Params &parameters, Params &info) const final;
 
     /**
      *
@@ -56,7 +55,7 @@ public:
      * @return
      */
     size_t Decompress(const void *bufferIn, const size_t sizeIn, void *dataOut,
-                      const Dims &dimensions, const std::string varType,
+                      const Dims &dimensions, Type varType,
                       const Params & /*parameters*/) const final;
 };
 

--- a/source/adios2/operator/compress/CompressPNG.cpp
+++ b/source/adios2/operator/compress/CompressPNG.cpp
@@ -48,9 +48,9 @@ CompressPNG::CompressPNG(const Params &parameters) : Operator("png", parameters)
 }
 
 size_t CompressPNG::Compress(const void *dataIn, const Dims &dimensions,
-                             const size_t elementSize,
-                             const std::string /*type*/, void *bufferOut,
-                             const Params &parameters, Params &info) const
+                             const size_t elementSize, Type /*type*/,
+                             void *bufferOut, const Params &parameters,
+                             Params &info) const
 {
     auto lf_Write = [](png_structp png_ptr, png_bytep data, png_size_t length) {
         DestInfo *pDestInfo =

--- a/source/adios2/operator/compress/CompressPNG.h
+++ b/source/adios2/operator/compress/CompressPNG.h
@@ -43,9 +43,8 @@ public:
      * @return size of compressed buffer in bytes
      */
     size_t Compress(const void *dataIn, const Dims &dimensions,
-                    const size_t elementSize, const std::string type,
-                    void *bufferOut, const Params &parameters,
-                    Params &info) const final;
+                    const size_t elementSize, Type type, void *bufferOut,
+                    const Params &parameters, Params &info) const final;
 
     /**
      * Decompression signature for legacy libraries that use void*

--- a/source/adios2/operator/compress/CompressSZ.cpp
+++ b/source/adios2/operator/compress/CompressSZ.cpp
@@ -35,7 +35,7 @@ size_t CompressSZ::BufferMaxSize(const size_t sizeIn) const
 }
 
 size_t CompressSZ::Compress(const void *dataIn, const Dims &dimensions,
-                            const size_t elementSize, const std::string varType,
+                            const size_t elementSize, Type varType,
                             void *bufferOut, const Params &parameters,
                             Params &info) const
 {
@@ -256,7 +256,7 @@ size_t CompressSZ::Compress(const void *dataIn, const Dims &dimensions,
     {
         throw std::invalid_argument("ERROR: ADIOS2 SZ Compression only support "
                                     "double or float, type: " +
-                                    varType + " is unsupported\n");
+                                    ToString(varType) + " is unsupported\n");
     }
 
     // r[0] is the fastest changing dimension and r[4] is the lowest changing
@@ -282,8 +282,7 @@ size_t CompressSZ::Compress(const void *dataIn, const Dims &dimensions,
 
 size_t CompressSZ::Decompress(const void *bufferIn, const size_t sizeIn,
                               void *dataOut, const Dims &dimensions,
-                              const std::string varType,
-                              const Params & /*parameters*/) const
+                              Type varType, const Params & /*parameters*/) const
 {
     if (dimensions.size() > 5)
     {

--- a/source/adios2/operator/compress/CompressSZ.h
+++ b/source/adios2/operator/compress/CompressSZ.h
@@ -43,9 +43,8 @@ public:
      * @return size of compressed buffer in bytes
      */
     size_t Compress(const void *dataIn, const Dims &dimensions,
-                    const size_t elementSize, const std::string type,
-                    void *bufferOut, const Params &parameters,
-                    Params &info) const final;
+                    const size_t elementSize, Type type, void *bufferOut,
+                    const Params &parameters, Params &info) const final;
 
     using Operator::Decompress;
 
@@ -59,7 +58,7 @@ public:
      * @return size of decompressed data in dataOut
      */
     size_t Decompress(const void *bufferIn, const size_t sizeIn, void *dataOut,
-                      const Dims &dimensions, const std::string type,
+                      const Dims &dimensions, Type type,
                       const Params &parameters) const final;
 };
 

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -23,8 +23,7 @@ CompressZFP::CompressZFP(const Params &parameters) : Operator("zfp", parameters)
 }
 
 size_t CompressZFP::DoBufferMaxSize(const void *dataIn, const Dims &dimensions,
-                                    const std::string type,
-                                    const Params &parameters) const
+                                    Type type, const Params &parameters) const
 {
     zfp_field *field = GetZFPField(dataIn, dimensions, type);
     zfp_stream *stream = GetZFPStream(dimensions, type, parameters);
@@ -35,7 +34,7 @@ size_t CompressZFP::DoBufferMaxSize(const void *dataIn, const Dims &dimensions,
 }
 
 size_t CompressZFP::Compress(const void *dataIn, const Dims &dimensions,
-                             const size_t elementSize, const std::string type,
+                             const size_t elementSize, Type type,
                              void *bufferOut, const Params &parameters,
                              Params &info) const
 {
@@ -63,8 +62,7 @@ size_t CompressZFP::Compress(const void *dataIn, const Dims &dimensions,
 }
 
 size_t CompressZFP::Decompress(const void *bufferIn, const size_t sizeIn,
-                               void *dataOut, const Dims &dimensions,
-                               const std::string type,
+                               void *dataOut, const Dims &dimensions, Type type,
                                const Params &parameters) const
 {
     auto lf_GetTypeSize = [](const zfp_type zfpType) -> size_t {
@@ -109,7 +107,7 @@ size_t CompressZFP::Decompress(const void *bufferIn, const size_t sizeIn,
 }
 
 // PRIVATE
-zfp_type CompressZFP::GetZfpType(const std::string type) const
+zfp_type CompressZFP::GetZfpType(Type type) const
 {
     zfp_type zfpType = zfp_type_none;
 
@@ -132,7 +130,7 @@ zfp_type CompressZFP::GetZfpType(const std::string type) const
     else
     {
         throw std::invalid_argument(
-            "ERROR: type " + type +
+            "ERROR: type " + ToString(type) +
             " not supported by zfp, only "
             "signed int32_t, signed int64_t, float, and "
             "double types are acceptable, from class "
@@ -143,16 +141,15 @@ zfp_type CompressZFP::GetZfpType(const std::string type) const
 }
 
 zfp_field *CompressZFP::GetZFPField(const void *data, const Dims &dimensions,
-                                    const std::string type) const
+                                    Type type) const
 {
     auto lf_CheckField = [](const zfp_field *field,
-                            const std::string zfpFieldFunction,
-                            const std::string type) {
+                            const std::string zfpFieldFunction, Type type) {
         if (field == nullptr || field == NULL)
         {
             throw std::invalid_argument(
                 "ERROR: " + zfpFieldFunction + " failed for data of type " +
-                type +
+                ToString(type) +
                 ", data pointer might be corrupted, from "
                 "class CompressZfp Transform\n");
         }
@@ -181,7 +178,7 @@ zfp_field *CompressZFP::GetZFPField(const void *data, const Dims &dimensions,
     else
     {
         throw std::invalid_argument(
-            "ERROR: zfp_field* failed for data of type " + type +
+            "ERROR: zfp_field* failed for data of type " + ToString(type) +
             ", only 1D, 2D and 3D dimensions are supported, from "
             "class CompressZfp Transform\n");
     }
@@ -189,8 +186,7 @@ zfp_field *CompressZFP::GetZFPField(const void *data, const Dims &dimensions,
     return field;
 }
 
-zfp_stream *CompressZFP::GetZFPStream(const Dims &dimensions,
-                                      const std::string type,
+zfp_stream *CompressZFP::GetZFPStream(const Dims &dimensions, Type type,
                                       const Params &parameters) const
 {
     auto lf_HasKey = [](Params::const_iterator itKey,

--- a/source/adios2/operator/compress/CompressZFP.h
+++ b/source/adios2/operator/compress/CompressZFP.h
@@ -46,9 +46,8 @@ public:
      * @return size of compressed buffer in bytes
      */
     size_t Compress(const void *dataIn, const Dims &dimensions,
-                    const size_t elementSize, const std::string type,
-                    void *bufferOut, const Params &parameters,
-                    Params &info) const final;
+                    const size_t elementSize, Type type, void *bufferOut,
+                    const Params &parameters, Params &info) const final;
 
     using Operator::Decompress;
 
@@ -62,7 +61,7 @@ public:
      * @return size of decompressed data in dataOut
      */
     size_t Decompress(const void *bufferIn, const size_t sizeIn, void *dataOut,
-                      const Dims &dimensions, const std::string type,
+                      const Dims &dimensions, Type type,
                       const Params &parameters) const final;
 
 private:
@@ -72,7 +71,7 @@ private:
      * helper/adiosType.inl
      * @return zfp_type
      */
-    zfp_type GetZfpType(const std::string type) const;
+    zfp_type GetZfpType(Type type) const;
 
     /**
      * Constructor Zfp zfp_field based on input information around the data
@@ -83,14 +82,13 @@ private:
      * @return zfp_field*
      */
     zfp_field *GetZFPField(const void *data, const Dims &shape,
-                           const std::string type) const;
+                           Type type) const;
 
-    zfp_stream *GetZFPStream(const Dims &dimensions, const std::string type,
+    zfp_stream *GetZFPStream(const Dims &dimensions, Type type,
                              const Params &parameters) const;
 
     size_t DoBufferMaxSize(const void *dataIn, const Dims &dimensions,
-                           const std::string type,
-                           const Params &parameters) const final;
+                           Type type, const Params &parameters) const final;
 
     /**
      * check status from BZip compression and decompression functions

--- a/source/adios2/toolkit/format/bp/BPSerializer.cpp
+++ b/source/adios2/toolkit/format/bp/BPSerializer.cpp
@@ -743,7 +743,7 @@ size_t BPSerializer::GetAttributesSizeInData(core::IO &io) const noexcept
 
     for (const auto &attribute : attributes)
     {
-        const std::string type = attribute.second.first;
+        const Type type = attribute.second.first;
 
         // each attribute is only written to output once
         // so filter out the ones already written
@@ -753,7 +753,7 @@ size_t BPSerializer::GetAttributesSizeInData(core::IO &io) const noexcept
             continue;
         }
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_type(T)                                                        \
@@ -796,7 +796,7 @@ void BPSerializer::PutAttributes(core::IO &io)
     for (const auto &attributePair : attributesDataMap)
     {
         const std::string name(attributePair.first);
-        const std::string type(attributePair.second.first);
+        const Type type(attributePair.second.first);
 
         // each attribute is only written to output once
         // so filter out the ones already written
@@ -806,7 +806,7 @@ void BPSerializer::PutAttributes(core::IO &io)
             continue;
         }
 
-        if (type == "unknown")
+        if (type == Type::None)
         {
         }
 #define declare_type(T)                                                        \

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
@@ -358,9 +358,9 @@ BP3Deserializer::PerformGetsVariablesSubFileInfo(core::IO &io)
     for (auto &subFileInfoPair : m_DeferredVariablesMap)
     {
         const std::string variableName(subFileInfoPair.first);
-        const std::string type(io.InquireVariableType(variableName));
+        const Type type(io.InquireVariableType(variableName));
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_type(T)                                                        \
@@ -380,9 +380,9 @@ void BP3Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
                                  const Box<Dims> &blockBox,
                                  const Box<Dims> &intersectionBox) const
 {
-    const std::string type(io.InquireVariableType(variableName));
+    const Type type(io.InquireVariableType(variableName));
 
-    if (type == "compound")
+    if (type == Type::Compound)
     {
     }
 #define declare_type(T)                                                        \

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
@@ -135,7 +135,7 @@ void BP3Deserializer::SetVariableBlockInfo(
         blockOperation.PreShape = bpOpInfo.PreShape;
         blockOperation.PreStart = bpOpInfo.PreStart;
         blockOperation.PreCount = bpOpInfo.PreCount;
-        blockOperation.Info["PreDataType"] = helper::GetType<T>();
+        blockOperation.Info["PreDataType"] = ToString(helper::GetType<T>());
         // TODO: need to verify it's a match with PreDataType
         // std::to_string(static_cast<size_t>(bp3OpInfo.PreDataType));
         blockOperation.Info["Type"] = bpOpInfo.Type;

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
@@ -589,9 +589,9 @@ BP4Deserializer::PerformGetsVariablesSubFileInfo(core::IO &io)
     for (auto &subFileInfoPair : m_DeferredVariablesMap)
     {
         const std::string variableName(subFileInfoPair.first);
-        const std::string type(io.InquireVariableType(variableName));
+        const Type type(io.InquireVariableType(variableName));
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
         }
 #define declare_type(T)                                                        \
@@ -611,9 +611,9 @@ void BP4Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
                                  const Box<Dims> &blockBox,
                                  const Box<Dims> &intersectionBox) const
 {
-    const std::string type(io.InquireVariableType(variableName));
+    const Type type(io.InquireVariableType(variableName));
 
-    if (type == "compound")
+    if (type == Type::Compound)
     {
     }
 #define declare_type(T)                                                        \

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -138,7 +138,7 @@ void BP4Deserializer::SetVariableBlockInfo(
         blockOperation.PreShape = bpOpInfo.PreShape;
         blockOperation.PreStart = bpOpInfo.PreStart;
         blockOperation.PreCount = bpOpInfo.PreCount;
-        blockOperation.Info["PreDataType"] = helper::GetType<T>();
+        blockOperation.Info["PreDataType"] = ToString(helper::GetType<T>());
         // TODO: need to verify it's a match with PreDataType
         // std::to_string(static_cast<size_t>(bp4OpInfo.PreDataType));
         blockOperation.Info["Type"] = bpOpInfo.Type;

--- a/source/adios2/toolkit/format/bp/bpOperation/compress/BPMGARD.cpp
+++ b/source/adios2/toolkit/format/bp/bpOperation/compress/BPMGARD.cpp
@@ -11,6 +11,7 @@
 #include "BPMGARD.h"
 
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2/helper/adiosType.h"
 
 #ifdef ADIOS2_HAVE_MGARD
 #include "adios2/operator/compress/CompressMGARD.h"
@@ -68,10 +69,11 @@ void BPMGARD::GetData(const char *input,
 {
 #ifdef ADIOS2_HAVE_MGARD
     core::compress::CompressMGARD op((Params()));
-    op.Decompress(input, blockOperationInfo.PayloadSize, dataOutput,
-                  blockOperationInfo.PreCount,
-                  blockOperationInfo.Info.at("PreDataType"),
-                  blockOperationInfo.Info);
+    op.Decompress(
+        input, blockOperationInfo.PayloadSize, dataOutput,
+        blockOperationInfo.PreCount,
+        helper::GetTypeFromString(blockOperationInfo.Info.at("PreDataType")),
+        blockOperationInfo.Info);
 
 #else
     throw std::runtime_error(

--- a/source/adios2/toolkit/format/bp/bpOperation/compress/BPSZ.cpp
+++ b/source/adios2/toolkit/format/bp/bpOperation/compress/BPSZ.cpp
@@ -11,6 +11,7 @@
 #include "BPSZ.h"
 
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2/helper/adiosType.h"
 
 #ifdef ADIOS2_HAVE_SZ
 #include "adios2/operator/compress/CompressSZ.h"
@@ -67,10 +68,11 @@ void BPSZ::GetData(const char *input,
 {
 #ifdef ADIOS2_HAVE_SZ
     core::compress::CompressSZ op((Params()));
-    op.Decompress(input, blockOperationInfo.PayloadSize, dataOutput,
-                  blockOperationInfo.PreCount,
-                  blockOperationInfo.Info.at("PreDataType"),
-                  blockOperationInfo.Info);
+    op.Decompress(
+        input, blockOperationInfo.PayloadSize, dataOutput,
+        blockOperationInfo.PreCount,
+        helper::GetTypeFromString(blockOperationInfo.Info.at("PreDataType")),
+        blockOperationInfo.Info);
 
 #else
     throw std::runtime_error("ERROR: current ADIOS2 library didn't compile "

--- a/source/adios2/toolkit/format/bp/bpOperation/compress/BPZFP.cpp
+++ b/source/adios2/toolkit/format/bp/bpOperation/compress/BPZFP.cpp
@@ -12,6 +12,7 @@
 #include "BPZFP.tcc"
 
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2/helper/adiosType.h"
 
 #ifdef ADIOS2_HAVE_ZFP
 #include "adios2/operator/compress/CompressZFP.h"
@@ -88,10 +89,11 @@ void BPZFP::GetData(const char *input,
 {
 #ifdef ADIOS2_HAVE_ZFP
     core::compress::CompressZFP op((Params()));
-    op.Decompress(input, blockOperationInfo.PayloadSize, dataOutput,
-                  blockOperationInfo.PreCount,
-                  blockOperationInfo.Info.at("PreDataType"),
-                  blockOperationInfo.Info);
+    op.Decompress(
+        input, blockOperationInfo.PayloadSize, dataOutput,
+        blockOperationInfo.PreCount,
+        helper::GetTypeFromString(blockOperationInfo.Info.at("PreDataType")),
+        blockOperationInfo.Info);
 #else
     throw std::runtime_error(
         "ERROR: current ADIOS2 library didn't compile "

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -61,7 +61,7 @@ struct DataManVar
     Dims start;
     std::string name;
     std::string doid;
-    std::string type;
+    Type type;
     std::vector<char> min;
     std::vector<char> max;
     std::vector<char> value;
@@ -193,8 +193,8 @@ private:
     template <class T>
     void PutAttribute(const core::Attribute<T> &attribute);
 
-    bool IsCompressionAvailable(const std::string &method,
-                                const std::string &type, const Dims &count);
+    bool IsCompressionAvailable(const std::string &method, Type type,
+                                const Dims &count);
 
     void JsonToVarMap(nlohmann::json &metaJ, VecPtr pack);
 

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
@@ -117,7 +117,7 @@ void DataManSerializer::PutData(const T *inputData, const std::string &varName,
     metaj["O"] = varStart;
     metaj["C"] = varCount;
     metaj["S"] = varShape;
-    metaj["Y"] = helper::GetType<T>();
+    metaj["Y"] = ToString(helper::GetType<T>());
     metaj["P"] = localBuffer->size();
 
     if (not address.empty())
@@ -371,7 +371,7 @@ void DataManSerializer::PutAttribute(const core::Attribute<T> &attribute)
     TAU_SCOPED_TIMER_FUNC();
     nlohmann::json staticVar;
     staticVar["N"] = attribute.m_Name;
-    staticVar["Y"] = attribute.m_Type;
+    staticVar["Y"] = ToString(attribute.m_Type);
     staticVar["V"] = attribute.m_IsSingleValue;
     if (attribute.m_IsSingleValue)
     {

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -1193,7 +1193,7 @@ void HDF5Common::CreateVarsFromIO(core::IO &io)
     for (const auto &vpair : variables)
     {
         const std::string &varName = vpair.first;
-        const std::string &varType = vpair.second.first;
+        const Type varType = vpair.second.first;
 #define declare_template_instantiation(T)                                      \
     if (varType == helper::GetType<T>())                                       \
     {                                                                          \
@@ -1229,7 +1229,7 @@ void HDF5Common::WriteAttrFromIO(core::IO &io)
     {
         std::string attrName = apair.first;
         Params temp = apair.second;
-        std::string attrType = temp["Type"];
+        Type attrType = helper::GetTypeFromString(temp["Type"]);
 
         hid_t parentID = m_FileId;
 #ifdef NO_ATTR_VAR_ASSOC
@@ -1254,7 +1254,7 @@ void HDF5Common::WriteAttrFromIO(core::IO &io)
             continue;
         }
 
-        if (attrType == "compound")
+        if (attrType == Type::Compound)
         {
             // not supported
         }

--- a/source/adios2/toolkit/query/JsonWorker.cpp
+++ b/source/adios2/toolkit/query/JsonWorker.cpp
@@ -94,8 +94,8 @@ void JsonWorker::ParseJson()
             throw std::ios_base::failure("No var name specified!!");
         auto varName = (varO)["name"];
         adios2::core::IO &currIO = m_SourceReader->m_IO;
-        const std::string varType = currIO.InquireVariableType(varName);
-        if (varType.size() == 0)
+        const Type varType = currIO.InquireVariableType(varName);
+        if (varType == Type::None)
         {
             std::cerr << "No such variable: " << varName << std::endl;
             return nullptr;

--- a/source/adios2/toolkit/query/Query.cpp
+++ b/source/adios2/toolkit/query/Query.cpp
@@ -186,7 +186,7 @@ void QueryVar::BlockIndexEvaluate(adios2::core::IO &io,
                                   adios2::core::Engine &reader,
                                   std::vector<Box<Dims>> &touchedBlocks)
 {
-    const std::string varType = io.InquireVariableType(m_VarName);
+    const Type varType = io.InquireVariableType(m_VarName);
 
     // Variable<int> var = io.InquireVariable<int>(m_VarName);
     // BlockIndex<int> idx(io, reader);

--- a/source/adios2/toolkit/query/Worker.cpp
+++ b/source/adios2/toolkit/query/Worker.cpp
@@ -20,8 +20,8 @@ Worker::~Worker()
 QueryVar *Worker::GetBasicVarQuery(adios2::core::IO &currentIO,
                                    const std::string &variableName)
 {
-    const std::string varType = currentIO.InquireVariableType(variableName);
-    if (varType.size() == 0)
+    const Type varType = currentIO.InquireVariableType(variableName);
+    if (varType == Type::None)
     {
         std::cerr << "No such variable: " << variableName << std::endl;
         return nullptr;

--- a/source/adios2/toolkit/query/XmlWorker.cpp
+++ b/source/adios2/toolkit/query/XmlWorker.cpp
@@ -136,8 +136,8 @@ QueryVar *XmlWorker::ParseVarNode(const pugi::xml_node &node,
         adios2::helper::XMLAttribute("name", node, "in query")->value());
 
     // const std::string varType = currentIO.VariableType(variableName);
-    const std::string varType = currentIO.InquireVariableType(variableName);
-    if (varType.size() == 0)
+    const Type varType = currentIO.InquireVariableType(variableName);
+    if (varType == Type::None)
     {
         std::cerr << "No such variable: " << variableName << std::endl;
         return nullptr;

--- a/source/utils/adios_reorganize/Reorganize.cpp
+++ b/source/utils/adios_reorganize/Reorganize.cpp
@@ -494,12 +494,12 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
     for (const auto &variablePair : variables)
     {
         const std::string &name(variablePair.first);
-        const std::string &type(variablePair.second.first);
+        const Type type(variablePair.second.first);
         core::VariableBase *variable = nullptr;
         print0("Get info on variable ", varidx, ": ", name);
         size_t nBlocks = 1;
 
-        if (type == "compound")
+        if (type == Type::Compound)
         {
             // not supported
         }
@@ -526,7 +526,7 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
             // print variable type and dimensions
             if (!m_Rank)
             {
-                std::cout << "    " << type << " " << name;
+                std::cout << "    " << ToString(type) << " " << name;
             }
             // if (variable->GetShape().size() > 0)
             if (variable->m_ShapeID == adios2::ShapeID::GlobalArray)
@@ -639,8 +639,8 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
                 // read variable subset
                 std::cout << "rank " << m_Rank << ": Read variable " << name
                           << std::endl;
-                const std::string &type = variables.at(name).first;
-                if (type == "compound")
+                const Type type = variables.at(name).first;
+                if (type == Type::Compound)
                 {
                     // not supported
                 }
@@ -683,8 +683,8 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
                 // Write variable subset
                 std::cout << "rank " << m_Rank << ": Write variable " << name
                           << std::endl;
-                const std::string &type = variables.at(name).first;
-                if (type == "compound")
+                const Type type = variables.at(name).first;
+                if (type == Type::Compound)
                 {
                     // not supported
                 }

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1698,10 +1698,6 @@ int getTypeInfo(enum ADIOS_DATATYPES adiosvartype, int *elemsize)
         *elemsize = 16;
         break;
 
-    case adios_long_double_complex:
-        *elemsize = 32;
-        break;
-
     case adios_long_double: // do not know how to print
     //*elemsize = 16;
     default:
@@ -2737,10 +2733,6 @@ int print_data(const void *data, int item, enum ADIOS_DATATYPES adiosvartype,
         fprintf(outf, (f ? fmt : "\"%s\""), dataStr[item].c_str());
         break;
     }
-    case adios_string_array:
-        // we expect one elemet of the array here
-        fprintf(outf, (f ? fmt : "\"%s\""), *((char **)data + item));
-        break;
 
     case adios_unsigned_short:
         fprintf(outf, (f ? fmt : "%hu"), ((unsigned short *)data)[item]);
@@ -2784,11 +2776,6 @@ int print_data(const void *data, int item, enum ADIOS_DATATYPES adiosvartype,
     case adios_double_complex:
         fprintf(outf, (f ? fmt : "(%g,i%g)"), ((double *)data)[2 * item],
                 ((double *)data)[2 * item + 1]);
-        break;
-
-    case adios_long_double_complex:
-        fprintf(outf, (f ? fmt : "(%Lg,i%Lg)"), ((long double *)data)[2 * item],
-                ((long double *)data)[2 * item + 1]);
         break;
 
     default:

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -820,7 +820,7 @@ template <class T>
 int printAttributeValue(core::Engine *fp, core::IO *io,
                         core::Attribute<T> *attribute)
 {
-    enum ADIOS_DATATYPES adiosvartype = type_to_enum(attribute->m_Type);
+    Type adiosvartype = attribute->m_Type;
     if (attribute->m_IsSingleValue)
     {
         print_data((void *)&attribute->m_DataSingleValue, 0, adiosvartype,
@@ -848,7 +848,7 @@ template <>
 int printAttributeValue(core::Engine *fp, core::IO *io,
                         core::Attribute<std::string> *attribute)
 {
-    enum ADIOS_DATATYPES adiosvartype = type_to_enum(attribute->m_Type);
+    Type adiosvartype = attribute->m_Type;
     bool xmlprint = helper::EndsWith(attribute->m_Name, "xml", false);
     bool printDataAnyway = true;
 
@@ -931,7 +931,7 @@ int doList_vars(core::Engine *fp, core::IO *io)
         int len = static_cast<int>(entrypair.first.size());
         if (len > maxlen)
             maxlen = len;
-        len = static_cast<int>(entrypair.second.typeName.size());
+        len = static_cast<int>(ToString(entrypair.second.typeName).size());
         if (len > maxtypelen)
             maxtypelen = len;
     }
@@ -949,14 +949,14 @@ int doList_vars(core::Engine *fp, core::IO *io)
 
             // print definition of variable
             fprintf(outf, "%c %-*s  %-*s", commentchar, maxtypelen,
-                    entry.typeName.c_str(), maxlen, name.c_str());
+                    ToString(entry.typeName).c_str(), maxlen, name.c_str());
             if (!entry.isVar)
             {
                 // list (and print) attribute
                 if (longopt || dump)
                 {
                     fprintf(outf, "  attr   = ");
-                    if (entry.typeName == "compound")
+                    if (entry.typeName == Type::Compound)
                     {
                         // not supported
                     }
@@ -979,7 +979,7 @@ int doList_vars(core::Engine *fp, core::IO *io)
             }
             else
             {
-                if (entry.typeName == "compound")
+                if (entry.typeName == Type::Compound)
                 {
                     // not supported
                 }
@@ -1007,7 +1007,7 @@ int printVariableInfo(core::Engine *fp, core::IO *io,
                       core::Variable<T> *variable)
 {
     size_t nsteps = variable->GetAvailableStepsCount();
-    enum ADIOS_DATATYPES adiosvartype = type_to_enum(variable->m_Type);
+    Type adiosvartype = variable->m_Type;
     int retval = 0;
 
     bool isGlobalValue = (nsteps == 1);
@@ -1128,11 +1128,11 @@ int printVariableInfo(core::Engine *fp, core::IO *io,
                 /* End - Print the headers of statistics first */
 
                 void *min, *max, *avg, *std_dev;
-                enum ADIOS_DATATYPES vt = vartype;
+                Type vt = vartype;
                 struct ADIOS_STAT_STEP *s = vi->statistics->steps;
-                if (vi->type == adios_complex ||
-                    vi->type == adios_double_complex)
-                    vt = adios_double;
+                if (vi->type == Type::FloatComplex ||
+                    vi->type == Type::DoubleComplex)
+                    vt = Type::Double;
                 fprintf(outf, "\n%-*sglobal:", indent_len, indent_char);
                 print_data_characteristics(
                     vi->statistics->min, vi->statistics->max,
@@ -1647,58 +1647,58 @@ void mergeLists(int nV, char **listV, int nA, char **listA, char **mlist,
     }
 }
 
-int getTypeInfo(enum ADIOS_DATATYPES adiosvartype, int *elemsize)
+int getTypeInfo(Type adiosvartype, int *elemsize)
 {
     switch (adiosvartype)
     {
-    case adios_unsigned_byte:
+    case Type::UInt8:
         *elemsize = 1;
         break;
-    case adios_byte:
+    case Type::Int8:
         *elemsize = 1;
         break;
-    case adios_string:
+    case Type::String:
         *elemsize = 1;
         break;
 
-    case adios_unsigned_short:
+    case Type::UInt16:
         *elemsize = 2;
         break;
-    case adios_short:
+    case Type::Int16:
         *elemsize = 2;
         break;
 
-    case adios_unsigned_integer:
+    case Type::UInt32:
         *elemsize = 4;
         break;
-    case adios_integer:
-        *elemsize = 4;
-        break;
-
-    case adios_unsigned_long:
-        *elemsize = 8;
-        break;
-    case adios_long:
-        *elemsize = 8;
-        break;
-
-    case adios_real:
+    case Type::Int32:
         *elemsize = 4;
         break;
 
-    case adios_double:
+    case Type::UInt64:
+        *elemsize = 8;
+        break;
+    case Type::Int64:
         *elemsize = 8;
         break;
 
-    case adios_complex:
+    case Type::Float:
+        *elemsize = 4;
+        break;
+
+    case Type::Double:
         *elemsize = 8;
         break;
 
-    case adios_double_complex:
+    case Type::FloatComplex:
+        *elemsize = 8;
+        break;
+
+    case Type::DoubleComplex:
         *elemsize = 16;
         break;
 
-    case adios_long_double: // do not know how to print
+    case Type::LongDouble: // do not know how to print
     //*elemsize = 16;
     default:
         return 1;
@@ -1875,7 +1875,7 @@ int readVar(core::Engine *fp, core::IO *io, core::Variable<T> *variable)
         maxreadn = nelems;
 
     // special case: string. Need to use different elemsize
-    /*if (vi->type == adios_string)
+    /*if (vi->type == Type::String)
     {
         if (vi->value)
             elemsize = strlen(vi->value) + 1;
@@ -2396,44 +2396,15 @@ void print_slice_info(core::VariableBase *variable, bool timed, uint64_t *s,
     }
 }
 
-const std::map<std::string, enum ADIOS_DATATYPES> adios_types_map = {
-    {"uint8_t", adios_unsigned_byte},
-    {"int32_t", adios_integer},
-    {"float", adios_real},
-    {"double", adios_double},
-    {"float complex", adios_complex},
-    {"double complex", adios_double_complex},
-    {"int8_t", adios_byte},
-    {"int16_t", adios_short},
-    {"int64_t", adios_long},
-    {"int64_t", adios_long},
-    {"string", adios_string},
-    {"uint8_t", adios_unsigned_byte},
-    {"uint16_t", adios_unsigned_short},
-    {"uint32_t", adios_unsigned_integer},
-    {"uint64_t", adios_unsigned_long},
-    {"uint64_t", adios_unsigned_long}};
-
-enum ADIOS_DATATYPES type_to_enum(std::string type)
-{
-    auto itType = adios_types_map.find(type);
-    if (itType == adios_types_map.end())
-    {
-        return adios_unknown;
-    }
-    return itType->second;
-}
-
-int print_data_as_string(const void *data, int maxlen,
-                         enum ADIOS_DATATYPES adiosvartype)
+int print_data_as_string(const void *data, int maxlen, Type adiosvartype)
 {
     const char *str = (const char *)data;
     int len = maxlen;
     switch (adiosvartype)
     {
-    case adios_unsigned_byte:
-    case adios_byte:
-    case adios_string:
+    case Type::UInt8:
+    case Type::Int8:
+    case Type::String:
         while (str[len - 1] == 0)
         {
             len--;
@@ -2466,8 +2437,7 @@ int print_data_as_string(const void *data, int maxlen,
 }
 
 int print_data_characteristics(void *min, void *max, double *avg,
-                               double *std_dev,
-                               enum ADIOS_DATATYPES adiosvartype,
+                               double *std_dev, Type adiosvartype,
                                bool allowformat)
 {
     bool f = format.size() && allowformat;
@@ -2475,7 +2445,7 @@ int print_data_characteristics(void *min, void *max, double *avg,
 
     switch (adiosvartype)
     {
-    case adios_unsigned_byte:
+    case Type::UInt8:
         if (min)
             fprintf(outf, (f ? fmt : "%10hhu  "), *((unsigned char *)min));
         else
@@ -2493,7 +2463,7 @@ int print_data_characteristics(void *min, void *max, double *avg,
         else
             fprintf(outf, "      null  ");
         break;
-    case adios_byte:
+    case Type::Int8:
         if (min)
             fprintf(outf, (f ? fmt : "%10hhd  "), *((char *)min));
         else
@@ -2511,10 +2481,10 @@ int print_data_characteristics(void *min, void *max, double *avg,
         else
             fprintf(outf, "      null  ");
         break;
-    case adios_string:
+    case Type::String:
         break;
 
-    case adios_unsigned_short:
+    case Type::UInt16:
         if (min)
             fprintf(outf, (f ? fmt : "%10hu  "), (*(unsigned short *)min));
         else
@@ -2532,7 +2502,7 @@ int print_data_characteristics(void *min, void *max, double *avg,
         else
             fprintf(outf, "      null  ");
         break;
-    case adios_short:
+    case Type::Int16:
         if (min)
             fprintf(outf, (f ? fmt : "%10hd  "), (*(short *)min));
         else
@@ -2551,7 +2521,7 @@ int print_data_characteristics(void *min, void *max, double *avg,
             fprintf(outf, "      null  ");
         break;
 
-    case adios_unsigned_integer:
+    case Type::UInt32:
         if (min)
             fprintf(outf, (f ? fmt : "%10u  "), (*(unsigned int *)min));
         else
@@ -2569,7 +2539,7 @@ int print_data_characteristics(void *min, void *max, double *avg,
         else
             fprintf(outf, "      null  ");
         break;
-    case adios_integer:
+    case Type::Int32:
         if (min)
             fprintf(outf, (f ? fmt : "%10d  "), (*(int *)min));
         else
@@ -2588,7 +2558,7 @@ int print_data_characteristics(void *min, void *max, double *avg,
             fprintf(outf, "      null  ");
         break;
 
-    case adios_unsigned_long:
+    case Type::UInt64:
         if (min)
             fprintf(outf, (f ? fmt : "%10llu  "), (*(unsigned long long *)min));
         else
@@ -2606,7 +2576,7 @@ int print_data_characteristics(void *min, void *max, double *avg,
         else
             fprintf(outf, "      null  ");
         break;
-    case adios_long:
+    case Type::Int64:
         if (min)
             fprintf(outf, (f ? fmt : "%10lld  "), (*(long long *)min));
         else
@@ -2625,7 +2595,7 @@ int print_data_characteristics(void *min, void *max, double *avg,
             fprintf(outf, "      null  ");
         break;
 
-    case adios_real:
+    case Type::Float:
         if (min)
             fprintf(outf, (f ? fmt : "%10.2g  "), (*(float *)min));
         else
@@ -2643,7 +2613,7 @@ int print_data_characteristics(void *min, void *max, double *avg,
         else
             fprintf(outf, "      null  ");
         break;
-    case adios_double:
+    case Type::Double:
         if (min)
             fprintf(outf, (f ? fmt : "%10.2g  "), (*(double *)min));
         else
@@ -2662,18 +2632,18 @@ int print_data_characteristics(void *min, void *max, double *avg,
             fprintf(outf, "      null  ");
         break;
 
-    case adios_long_double:
+    case Type::LongDouble:
         fprintf(outf, "????????");
         break;
 
     // TO DO
     /*
-       case adios_complex:
+       case Type::FloatComplex:
        fprintf(outf,(f ? format : "(%g,i%g) "), ((float *) data)[2*item],
        ((float *) data)[2*item+1]);
        break;
 
-       case adios_double_complex:
+       case Type::DoubleComplex:
        fprintf(outf,(f ? format : "(%g,i%g)" ), ((double *) data)[2*item],
        ((double *) data)[2*item+1]);
        break;
@@ -2705,8 +2675,7 @@ bool print_data_xml(const char *s, const size_t length)
     return false;
 }
 
-int print_data(const void *data, int item, enum ADIOS_DATATYPES adiosvartype,
-               bool allowformat)
+int print_data(const void *data, int item, Type adiosvartype, bool allowformat)
 {
     bool f = format.size() && allowformat;
     const char *fmt = format.c_str();
@@ -2718,14 +2687,14 @@ int print_data(const void *data, int item, enum ADIOS_DATATYPES adiosvartype,
     // print next data item
     switch (adiosvartype)
     {
-    case adios_unsigned_byte:
+    case Type::UInt8:
         fprintf(outf, (f ? fmt : "%hhu"), ((unsigned char *)data)[item]);
         break;
-    case adios_byte:
+    case Type::Int8:
         fprintf(outf, (f ? fmt : "%hhd"), ((signed char *)data)[item]);
         break;
 
-    case adios_string:
+    case Type::String:
     {
         // fprintf(outf, (f ? fmt : "\"%s\""), ((char *)data) + item);
         const std::string *dataStr =
@@ -2734,46 +2703,46 @@ int print_data(const void *data, int item, enum ADIOS_DATATYPES adiosvartype,
         break;
     }
 
-    case adios_unsigned_short:
+    case Type::UInt16:
         fprintf(outf, (f ? fmt : "%hu"), ((unsigned short *)data)[item]);
         break;
-    case adios_short:
+    case Type::Int16:
         fprintf(outf, (f ? fmt : "%hd"), ((signed short *)data)[item]);
         break;
 
-    case adios_unsigned_integer:
+    case Type::UInt32:
         fprintf(outf, (f ? fmt : "%u"), ((unsigned int *)data)[item]);
         break;
-    case adios_integer:
+    case Type::Int32:
         fprintf(outf, (f ? fmt : "%d"), ((signed int *)data)[item]);
         break;
 
-    case adios_unsigned_long:
+    case Type::UInt64:
         fprintf(outf, (f ? fmt : "%llu"), ((unsigned long long *)data)[item]);
         break;
-    case adios_long:
+    case Type::Int64:
         fprintf(outf, (f ? fmt : "%lld"), ((signed long long *)data)[item]);
         break;
 
-    case adios_real:
+    case Type::Float:
         fprintf(outf, (f ? fmt : "%g"), ((float *)data)[item]);
         break;
 
-    case adios_double:
+    case Type::Double:
         fprintf(outf, (f ? fmt : "%g"), ((double *)data)[item]);
         break;
 
-    case adios_long_double:
+    case Type::LongDouble:
         fprintf(outf, (f ? fmt : "%Lg"), ((long double *)data)[item]);
         // fprintf(outf,(f ? fmt : "????????"));
         break;
 
-    case adios_complex:
+    case Type::FloatComplex:
         fprintf(outf, (f ? fmt : "(%g,i%g)"), ((float *)data)[2 * item],
                 ((float *)data)[2 * item + 1]);
         break;
 
-    case adios_double_complex:
+    case Type::DoubleComplex:
         fprintf(outf, (f ? fmt : "(%g,i%g)"), ((double *)data)[2 * item],
                 ((double *)data)[2 * item + 1]);
         break;
@@ -2784,14 +2753,14 @@ int print_data(const void *data, int item, enum ADIOS_DATATYPES adiosvartype,
     return 0;
 }
 
-int print_dataset(const void *data, const std::string vartype, uint64_t *s,
+int print_dataset(const void *data, const Type vartype, uint64_t *s,
                   uint64_t *c, int tdims, int *ndigits)
 {
     int i, item, steps;
     char idxstr[128], buf[16];
     uint64_t ids[MAX_DIMS]; // current indices
     bool roll;
-    enum ADIOS_DATATYPES adiosvartype = type_to_enum(vartype);
+    Type adiosvartype = vartype;
 
     // init current indices
     steps = 1;
@@ -2825,7 +2794,7 @@ int print_dataset(const void *data, const std::string vartype, uint64_t *s,
         // print item
         fprintf(outf, "%s", idxstr);
         if (printByteAsChar &&
-            (adiosvartype == adios_byte || adiosvartype == adios_unsigned_byte))
+            (adiosvartype == Type::Int8 || adiosvartype == Type::UInt8))
         {
             /* special case: k-D byte array printed as (k-1)D array of
              * strings
@@ -3002,7 +2971,7 @@ template <class T>
 void print_decomp(core::Engine *fp, core::IO *io, core::Variable<T> *variable)
 {
     /* Print block info */
-    enum ADIOS_DATATYPES adiosvartype = type_to_enum(variable->m_Type);
+    Type adiosvartype = variable->m_Type;
     std::map<size_t, std::vector<typename core::Variable<T>::Info>> allblocks =
         fp->AllStepsBlocksInfo(*variable);
     if (allblocks.empty())

--- a/source/utils/bpls/bpls.h
+++ b/source/utils/bpls/bpls.h
@@ -7,6 +7,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSMacros.h"
+#include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/ADIOS.h"
 #include "adios2/core/Engine.h"
 #include "adios2/core/IO.h"
@@ -34,32 +35,12 @@ namespace utils
 #define MAX_MASKS 10
 #define MAX_BUFFERSIZE (10 * 1024 * 1024)
 
-/* global defines needed for the type creation/setup functions */
-enum ADIOS_DATATYPES
-{
-    adios_unknown = -1,
-    adios_byte = 0,
-    adios_short = 1,
-    adios_integer = 2,
-    adios_long = 4,
-    adios_unsigned_byte = 50,
-    adios_unsigned_short = 51,
-    adios_unsigned_integer = 52,
-    adios_unsigned_long = 54,
-    adios_real = 5,
-    adios_double = 6,
-    adios_long_double = 7,
-    adios_string = 9,
-    adios_complex = 10,
-    adios_double_complex = 11
-};
-
 struct Entry
 {
     bool isVar;
-    std::string typeName;
+    Type typeName;
     unsigned int typeIndex;
-    Entry(bool b, std::string name, unsigned idx)
+    Entry(bool b, Type name, unsigned idx)
     : isVar(b), typeName(name), typeIndex(idx)
     {
     }
@@ -77,8 +58,6 @@ void printSettings(void);
 int doList(const char *path);
 void mergeLists(int nV, char **listV, int nA, char **listA, char **mlist,
                 bool *isVar);
-
-enum ADIOS_DATATYPES type_to_enum(std::string type);
 
 template <class T>
 int printVariableInfo(core::Engine *fp, core::IO *io,
@@ -108,21 +87,20 @@ bool matchesAMask(const char *name);
 int print_start(const std::string &fnamestr);
 void print_slice_info(core::VariableBase *variable, bool timed, uint64_t *s,
                       uint64_t *c, Dims count);
-int print_data(const void *data, int item, enum ADIOS_DATATYPES adiosvartypes,
+int print_data(const void *data, int item, Type adiosvartypes,
                bool allowformat);
 
 /* s is a character array not necessarily null terminated.
  * return false on OK print, true if it not XML (not printed)*/
 bool print_data_xml(const char *s, const size_t length);
 
-int print_dataset(const void *data, const std::string vartype, uint64_t *s,
+int print_dataset(const void *data, const Type vartype, uint64_t *s,
                   uint64_t *c, int tdims, int *ndigits);
 void print_endline(void);
 void print_stop(void);
 int print_data_hist(core::VariableBase *vi, char *varname);
 int print_data_characteristics(void *min, void *max, double *avg,
-                               double *std_dev,
-                               enum ADIOS_DATATYPES adiosvartypes,
+                               double *std_dev, Type adiosvartypes,
                                bool allowformat);
 
 template <class T>

--- a/source/utils/bpls/bpls.h
+++ b/source/utils/bpls/bpls.h
@@ -51,9 +51,7 @@ enum ADIOS_DATATYPES
     adios_long_double = 7,
     adios_string = 9,
     adios_complex = 10,
-    adios_double_complex = 11,
-    adios_string_array = 12,
-    adios_long_double_complex = 13
+    adios_double_complex = 11
 };
 
 struct Entry


### PR DESCRIPTION
This improves type safety and reduces the runtime cost of comparisons.

The public bindings expose variable and attribute data types using string identifiers.  Preserve that by converting between the string and enumeration representations in the binding layer.
