### PR TITLE
utils: Avoid unnamed struct in adios_reorganize

### DIFF
--- a/source/utils/adios_reorganize/Reorganize.h
+++ b/source/utils/adios_reorganize/Reorganize.h
@@ -20,7 +20,7 @@ namespace adios2
 namespace utils
 {
 
-typedef struct
+struct VarInfo
 {
     core::VariableBase *v = nullptr;
     std::string type;
@@ -28,7 +28,7 @@ typedef struct
     Dims count;
     size_t writesize = 0; // size of subset this process writes, 0: do not write
     void *readbuf = nullptr; // read in buffer
-} VarInfo;
+};
 
 class Reorganize : public Utils
 {


### PR DESCRIPTION
MSVC now warns:

    warning C5208: unnamed class used in typedef name cannot declare
    members other than non-static data members, member enumerations,
    or member classes