### PR TITLE
[SSC] Hide data transfer from application activities

### DIFF
--- a/source/adios2/engine/ssc/SscReader.h
+++ b/source/adios2/engine/ssc/SscReader.h
@@ -53,6 +53,7 @@ private:
     MPI_Group m_MpiAllWritersGroup;
     MPI_Comm m_StreamComm;
     std::string m_MpiMode = "twosided";
+    std::vector<MPI_Request> m_MpiRequests;
 
     int m_StreamRank;
     int m_StreamSize;

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -110,7 +110,7 @@ void SscWriter::PutOneSidedPostPull()
 {
     TAU_SCOPED_TIMER_FUNC();
     MPI_Win_post(m_MpiAllReadersGroup, 0, m_MpiWin);
-    MPI_Win_wait(m_MpiWin);
+    m_NeedWait = true;
 }
 
 void SscWriter::PutOneSidedFencePull()
@@ -147,7 +147,8 @@ void SscWriter::EndStep()
         SyncWritePattern();
         MPI_Win_create(m_Buffer.data(), m_Buffer.size(), 1, MPI_INFO_NULL,
                        m_StreamComm, &m_MpiWin);
-        PutOneSidedPostPull();
+        MPI_Win_post(m_MpiAllReadersGroup, 0, m_MpiWin);
+        MPI_Win_wait(m_MpiWin);
         MPI_Win_free(&m_MpiWin);
         SyncReadPattern();
         MPI_Win_create(m_Buffer.data(), m_Buffer.size(), 1, MPI_INFO_NULL,
@@ -206,6 +207,7 @@ void SscWriter::MpiWait()
         }
         else if (m_MpiMode == "onesidedpostpull")
         {
+            MPI_Win_wait(m_MpiWin);
         }
         m_NeedWait = false;
     }

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -91,7 +91,7 @@ void SscWriter::PutOneSidedPostPush()
         MPI_Put(m_Buffer.data(), m_Buffer.size(), MPI_CHAR, i.first,
                 i.second.first, m_Buffer.size(), MPI_CHAR, m_MpiWin);
     }
-    MPI_Win_complete(m_MpiWin);
+    m_NeedWait = true;
 }
 
 void SscWriter::PutOneSidedFencePush()
@@ -198,6 +198,7 @@ void SscWriter::MpiWait()
         }
         else if (m_MpiMode == "onesidedpostpush")
         {
+            MPI_Win_complete(m_MpiWin);
         }
         else if (m_MpiMode == "onesidedfencepull")
         {

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -103,7 +103,7 @@ void SscWriter::PutOneSidedFencePush()
         MPI_Put(m_Buffer.data(), m_Buffer.size(), MPI_CHAR, i.first,
                 i.second.first, m_Buffer.size(), MPI_CHAR, m_MpiWin);
     }
-    MPI_Win_fence(0, m_MpiWin);
+    m_NeedWait = true;
 }
 
 void SscWriter::PutOneSidedPostPull()
@@ -117,7 +117,7 @@ void SscWriter::PutOneSidedFencePull()
 {
     TAU_SCOPED_TIMER_FUNC();
     MPI_Win_fence(0, m_MpiWin);
-    MPI_Win_fence(0, m_MpiWin);
+    m_NeedWait = true;
 }
 
 void SscWriter::PutTwoSided()
@@ -194,12 +194,14 @@ void SscWriter::MpiWait()
         }
         else if (m_MpiMode == "onesidedfencepush")
         {
+            MPI_Win_fence(0, m_MpiWin);
         }
         else if (m_MpiMode == "onesidedpostpush")
         {
         }
         else if (m_MpiMode == "onesidedfencepull")
         {
+            MPI_Win_fence(0, m_MpiWin);
         }
         else if (m_MpiMode == "onesidedpostpull")
         {

--- a/source/adios2/engine/ssc/SscWriter.h
+++ b/source/adios2/engine/ssc/SscWriter.h
@@ -54,6 +54,8 @@ private:
     MPI_Group m_MpiAllReadersGroup;
     MPI_Comm m_StreamComm;
     std::string m_MpiMode = "twosided";
+    bool m_NeedWait = false;
+    std::vector<MPI_Request> m_MpiRequests;
 
     int m_StreamRank;
     int m_StreamSize;
@@ -70,6 +72,7 @@ private:
     void PutOneSidedFencePull();
     void PutOneSidedPostPull();
     void PutTwoSided();
+    void MpiWait();
 
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &, const T *) final;                            \


### PR DESCRIPTION
Previously, SSC writers block EndStep for sending data. This PR moves MPI_Wait and MPI_Win_fence from EndStep to BeginStep. Data transfers can then be overlapped with application algorithms that happen between EndStep(N) and BeginStep(N+1).

