### PR TITLE
Rework bp4 open

### DIFF
--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -170,11 +170,29 @@ void BP4Reader::Init()
         pollSeconds = pollSecondsMax;
     }
 
-    const TimePoint timeoutInstant =
+    TimePoint timeoutInstant =
         std::chrono::steady_clock::now() + timeoutSeconds;
 
     OpenFiles(timeoutInstant, pollSeconds, timeoutSeconds);
     InitBuffer(timeoutInstant, pollSeconds / 10, timeoutSeconds);
+}
+
+bool BP4Reader::SleepOrQuit(const TimePoint &timeoutInstant,
+                            const Seconds &pollSeconds)
+{
+    auto now = std::chrono::steady_clock::now();
+    if (now + pollSeconds >= timeoutInstant)
+    {
+        return false;
+    }
+    auto remainderTime = timeoutInstant - now;
+    auto sleepTime = pollSeconds;
+    if (remainderTime < sleepTime)
+    {
+        sleepTime = remainderTime;
+    }
+    std::this_thread::sleep_for(sleepTime);
+    return true;
 }
 
 size_t BP4Reader::OpenWithTimeout(transportman::TransportMan &tm,
@@ -209,24 +227,11 @@ size_t BP4Reader::OpenWithTimeout(transportman::TransportMan &tm,
                 break;
             }
         }
-        auto now = std::chrono::steady_clock::now();
-        if (now + pollSeconds >= timeoutInstant)
-        {
-            break;
-        }
-        auto remainderTime = timeoutInstant - now;
-        auto sleepTime = pollSeconds;
-        if (remainderTime < sleepTime)
-        {
-            sleepTime = remainderTime;
-        }
-        std::this_thread::sleep_for(sleepTime);
-    } while (1);
+    } while (SleepOrQuit(timeoutInstant, pollSeconds));
     return flag;
 }
 
-void BP4Reader::OpenFiles(const TimePoint &timeoutInstant,
-                          const Seconds &pollSeconds,
+void BP4Reader::OpenFiles(TimePoint &timeoutInstant, const Seconds &pollSeconds,
                           const Seconds &timeoutSeconds)
 {
     /* Poll */
@@ -251,14 +256,13 @@ void BP4Reader::OpenFiles(const TimePoint &timeoutInstant,
              * This slows down finding the error in file reading mode but
              * it will be more robust in streaming mode
              */
-            TimePoint endTime = timeoutInstant;
             if (timeoutSeconds == Seconds(0.0))
             {
-                endTime += Seconds(5.0);
+                timeoutInstant += Seconds(5.0);
             }
 
-            flag = OpenWithTimeout(m_MDFileManager, {metadataFile}, endTime,
-                                   pollSeconds, lasterrmsg);
+            flag = OpenWithTimeout(m_MDFileManager, {metadataFile},
+                                   timeoutInstant, pollSeconds, lasterrmsg);
             if (flag != 0)
             {
                 /* Close the metadata index table */
@@ -368,8 +372,7 @@ void BP4Reader::InitBuffer(const TimePoint &timeoutInstant,
                 {
                     break;
                 }
-                std::this_thread::sleep_for(pollSeconds);
-            } while (std::chrono::steady_clock::now() < timeoutInstant);
+            } while (SleepOrQuit(timeoutInstant, pollSeconds));
 
             if (fileSize >= expectedMinFileSize)
             {
@@ -466,8 +469,7 @@ size_t BP4Reader::UpdateBuffer(const TimePoint &timeoutInstant,
                 {
                     break;
                 }
-                std::this_thread::sleep_for(pollSeconds);
-            } while (std::chrono::steady_clock::now() < timeoutInstant);
+            } while (SleepOrQuit(timeoutInstant, pollSeconds));
 
             if (fileSize >= expectedMinFileSize)
             {
@@ -586,10 +588,10 @@ StepStatus BP4Reader::CheckForNewSteps(Seconds timeoutSeconds)
     // Hack: processing metadata for multiple new steps only works
     // when pretending not to be in streaming mode
     const bool saveReadStreaming = m_IO.m_ReadStreaming;
+    m_IO.m_ReadStreaming = false;
     size_t newIdxSize = 0;
 
-    m_IO.m_ReadStreaming = false;
-    while (m_WriterIsActive)
+    do
     {
         newIdxSize = UpdateBuffer(timeoutInstant, pollSeconds / 10);
         if (newIdxSize > 0)
@@ -605,12 +607,7 @@ StepStatus BP4Reader::CheckForNewSteps(Seconds timeoutSeconds)
             newIdxSize = UpdateBuffer(timeoutInstant, pollSeconds / 10);
             break;
         }
-        std::this_thread::sleep_for(pollSeconds);
-        if (std::chrono::steady_clock::now() >= timeoutInstant)
-        {
-            break;
-        }
-    }
+    } while (SleepOrQuit(timeoutInstant, pollSeconds));
 
     if (newIdxSize > 0)
     {

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -82,6 +82,12 @@ private:
     void Init();
     void InitTransports();
 
+    /* Sleep up to pollSeconds time if we have not reached timeoutInstant.
+     * Return true if slept
+     * return false if sleep was not needed because it was overtime
+     */
+    bool SleepOrQuit(const TimePoint &timeoutInstant,
+                     const Seconds &pollSeconds);
     /** Open one category of files within timeout.
      * @return: 0 = OK, 1 = timeout, 2 = error
      * lasterrmsg contains the error message in case of error
@@ -95,7 +101,7 @@ private:
     /** Open files within timeout.
      * @return True if files are opened, False in case of timeout
      */
-    void OpenFiles(const TimePoint &timeoutInstant, const Seconds &pollSeconds,
+    void OpenFiles(TimePoint &timeoutInstant, const Seconds &pollSeconds,
                    const Seconds &timeoutSeconds);
     void InitBuffer(const TimePoint &timeoutInstant, const Seconds &pollSeconds,
                     const Seconds &timeoutSeconds);

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -82,6 +82,16 @@ private:
     void Init();
     void InitTransports();
 
+    /** Open one category of files within timeout.
+     * @return: 0 = OK, 1 = timeout, 2 = error
+     * lasterrmsg contains the error message in case of error
+     */
+    size_t OpenWithTimeout(transportman::TransportMan &tm,
+                           const std::vector<std::string> &fileNames,
+                           const TimePoint &timeoutInstant,
+                           const Seconds &pollSeconds,
+                           std::string &lasterrmsg /*INOUT*/);
+
     /** Open files within timeout.
      * @return True if files are opened, False in case of timeout
      */

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -2430,7 +2430,7 @@ int print_data_as_string(const void *data, int maxlen, DataType adiosvartype)
         fprintf(stderr,
                 "Error in bpls code: cannot use print_data_as_string() "
                 "for type \"%d\"\n",
-                static_cast<typename std::underlying_type<Type>::type>(
+                static_cast<typename std::underlying_type<DataType>::type>(
                     adiosvartype));
         return -1;
     }

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -2430,7 +2430,8 @@ int print_data_as_string(const void *data, int maxlen, DataType adiosvartype)
         fprintf(stderr,
                 "Error in bpls code: cannot use print_data_as_string() "
                 "for type \"%d\"\n",
-                adiosvartype);
+                static_cast<typename std::underlying_type<Type>::type>(
+                    adiosvartype));
         return -1;
     }
     return 0;


### PR DESCRIPTION
Rework the timeout loops and separate timeout loops for opening md.idx and md.0.
Adds extra 5s wait for md.0 if md.idx is present but md.0 is not yet present. 