### PR TITLE
ci: Disable mac builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-        entrypoint: /usr/bin/sh -c
     - name: Setup
       run: scripts/ci/gh-actions/linux-setup.sh
     - name: Update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,28 +45,28 @@ jobs:
     - bash: scripts/ci/azure/run.sh test
       name: Test
 
-- job: macos
-  timeoutInMinutes: 90
-  strategy:
-    matrix:
-      macos1014_xcode103_ninja:
-        hostImage: 'macOS-10.14'
-      macos1015_xcode111_make:
-        hostImage: 'macOS-10.15'
-
-  pool:
-    vmImage: $[ variables['hostImage'] ]
-  steps:
-    - bash: scripts/ci/azure/macos-setup.sh
-      name: Setup
-    - bash: scripts/ci/azure/run.sh update
-      name: Update
-    - bash: scripts/ci/azure/run.sh configure
-      name: Configure
-    - bash: scripts/ci/azure/run.sh build
-      name: Build
-    - bash: scripts/ci/azure/run.sh test
-      name: Test
+#- job: macos
+#  timeoutInMinutes: 90
+#  strategy:
+#    matrix:
+#      macos1014_xcode103_ninja:
+#        hostImage: 'macOS-10.14'
+#      macos1015_xcode111_make:
+#        hostImage: 'macOS-10.15'
+#
+#  pool:
+#    vmImage: $[ variables['hostImage'] ]
+#  steps:
+#    - bash: scripts/ci/azure/macos-setup.sh
+#      name: Setup
+#    - bash: scripts/ci/azure/run.sh update
+#      name: Update
+#    - bash: scripts/ci/azure/run.sh configure
+#      name: Configure
+#    - bash: scripts/ci/azure/run.sh build
+#      name: Build
+#    - bash: scripts/ci/azure/run.sh test
+#      name: Test
 
 - job: linux
   timeoutInMinutes: 90

--- a/source/utils/adios_reorganize/Reorganize.h
+++ b/source/utils/adios_reorganize/Reorganize.h
@@ -20,7 +20,7 @@ namespace adios2
 namespace utils
 {
 
-typedef struct
+struct VarInfo
 {
     core::VariableBase *v = nullptr;
     std::string type;
@@ -28,7 +28,7 @@ typedef struct
     Dims count;
     size_t writesize = 0; // size of subset this process writes, 0: do not write
     void *readbuf = nullptr; // read in buffer
-} VarInfo;
+};
 
 class Reorganize : public Utils
 {


### PR DESCRIPTION
The mac builds have been very flaky the past several days so I'm disabling them for now to allow other work to continue and we can re-enable them in a PR once the issue is resolve.