### PR TITLE
bindings: Restore public adios2::GetType function name

### DIFF
--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -311,18 +311,18 @@ public:
 
     /**
      * Inspects variable type. This function can be used in conjunction with
-     * MACROS in an else if (type == adios2::GetDataType<T>() ) {} loop
+     * MACROS in an else if (type == adios2::GetType<T>() ) {} loop
      * @param name unique variable name identifier in current IO
-     * @return type as in adios2::GetDataType<T>() (e.g. "double", "float"),
+     * @return type as in adios2::GetType<T>() (e.g. "double", "float"),
      * empty std::string if variable not found
      */
     std::string VariableType(const std::string &name) const;
 
     /**
      * Inspects attribute type. This function can be used in conjunction with
-     * MACROS in an else if (type == adios2::GetDataType<T>() ) {} loop
+     * MACROS in an else if (type == adios2::GetType<T>() ) {} loop
      * @param name unique attribute name identifier in current IO
-     * @return type as in adios2::GetDataType<T>() (e.g. "double", "float"),
+     * @return type as in adios2::GetType<T>() (e.g. "double", "float"),
      * empty std::string if attribute not found
      */
     std::string AttributeType(const std::string &name) const;

--- a/bindings/CXX11/adios2/cxx11/Types.cpp
+++ b/bindings/CXX11/adios2/cxx11/Types.cpp
@@ -14,7 +14,7 @@ namespace adios2
 {
 
 #define declare_template_instantiation(T)                                      \
-    template std::string GetDataType<T>() noexcept;
+    template std::string GetType<T>() noexcept;
 
 ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/bindings/CXX11/adios2/cxx11/Types.h
+++ b/bindings/CXX11/adios2/cxx11/Types.h
@@ -20,12 +20,12 @@ namespace adios2
 {
 
 template <class T>
-std::string GetDataType() noexcept;
+std::string GetType() noexcept;
 
-// LIMIT TEMPLATE TYPES FOR adios2::GetDataType
+// LIMIT TEMPLATE TYPES FOR adios2::GetType
 #define declare_template_instantiation(T)                                      \
                                                                                \
-    extern template std::string GetDataType<T>() noexcept;
+    extern template std::string GetType<T>() noexcept;
 
 ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/bindings/CXX11/adios2/cxx11/Types.tcc
+++ b/bindings/CXX11/adios2/cxx11/Types.tcc
@@ -19,7 +19,7 @@ namespace adios2
 {
 
 template <class T>
-std::string GetDataType() noexcept
+std::string GetType() noexcept
 {
     return ToString(helper::GetDataType<typename TypeInfo<T>::IOType>());
 }

--- a/docs/user_guide/source/advice/advice.rst
+++ b/docs/user_guide/source/advice/advice.rst
@@ -53,7 +53,7 @@ The goal is to provide specific advice and good practices about the use of ADIOS
 
 11. Prefer the high-level Python and C++ APIs for simple tasks that do not require performance. The more familiar Write/Read overloads for File I/O return native data constructs (``std::vector`` and ``numpy arrays``) immediately for a requested selection. ``open`` only explores the metadata index.
 
-12. C++: prefer templates to ``void*`` to increase compile-time safety. Use ``IO::InquireVariableType("variableName")`` and ``adios2::GetDataType<T>()`` to cast upfront to a ``Variable<T>``. C++17 has ``std::any`` as an alternative to ``void*``. ADIOS 2 follows closely the STL model.
+12. C++: prefer templates to ``void*`` to increase compile-time safety. Use ``IO::InquireVariableType("variableName")`` and ``adios2::GetType<T>()`` to cast upfront to a ``Variable<T>``. C++17 has ``std::any`` as an alternative to ``void*``. ADIOS 2 follows closely the STL model.
 
 13. Understand ``Put`` and ``Get`` memory contracts from :ref:`Engine`
 

--- a/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
+++ b/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
@@ -102,7 +102,7 @@ ProcessMetadata(int rank, const adios2::Engine &reader, adios2::IO &io,
             // not supported
         }
 #define declare_template_instantiation(T)                                      \
-    else if (type == adios2::GetDataType<T>())                                 \
+    else if (type == adios2::GetType<T>())                                     \
     {                                                                          \
         ProcessVariableMetadata<T>(rank, name, type, reader, io, varinfos);    \
     }

--- a/testing/adios2/engine/bp/TestBPWriteAppendReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteAppendReadADIOS2.cpp
@@ -425,121 +425,119 @@ TEST_F(BPWriteAppendReadTestADIOS2, ADIOS2BPWriteAppendRead2D2x4)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), s1_Single);
         ASSERT_EQ(attr_s1.Data().size() == 1, true);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
         ASSERT_EQ(attr_s1.Data().front(), attributeTestData.S1);
 
         EXPECT_TRUE(attr_s1a);
         ASSERT_EQ(attr_s1a.Name(), s1_Array);
         ASSERT_EQ(attr_s1a.Data().size() == 1, true);
-        ASSERT_EQ(attr_s1a.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1a.Type(), adios2::GetType<std::string>());
         ASSERT_EQ(attr_s1a.Data()[0], attributeTestData.S1array[0]);
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), i8_Single);
         ASSERT_EQ(attr_i8.Data().size() == 1, true);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
         ASSERT_EQ(attr_i8.Data().front(), attributeTestData.I8.front());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), i16_Single);
         ASSERT_EQ(attr_i16.Data().size() == 1, true);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
         ASSERT_EQ(attr_i16.Data().front(), attributeTestData.I16.front());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), i32_Single);
         ASSERT_EQ(attr_i32.Data().size() == 1, true);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
         ASSERT_EQ(attr_i32.Data().front(), attributeTestData.I32.front());
 
         EXPECT_TRUE(attr_i32a);
         ASSERT_EQ(attr_i32a.Name(), i32_Array);
         ASSERT_EQ(attr_i32a.Data().size() == attributeTestData.I32.size(),
                   true);
-        ASSERT_EQ(attr_i32a.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32a.Type(), adios2::GetType<int32_t>());
         ASSERT_EQ(attr_i32a.Data()[0], attributeTestData.I32[0]);
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), i64_Single);
         ASSERT_EQ(attr_i64.Data().size() == 1, true);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
         ASSERT_EQ(attr_i64.Data().front(), attributeTestData.I64.front());
 
         EXPECT_TRUE(attr_u8);
         ASSERT_EQ(attr_u8.Name(), u8_Single);
         ASSERT_EQ(attr_u8.Data().size() == 1, true);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetDataType<uint8_t>());
+        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
         ASSERT_EQ(attr_u8.Data().front(), attributeTestData.U8.front());
 
         EXPECT_TRUE(attr_u16);
         ASSERT_EQ(attr_u16.Name(), u16_Single);
         ASSERT_EQ(attr_u16.Data().size() == 1, true);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetDataType<uint16_t>());
+        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
         ASSERT_EQ(attr_u16.Data().front(), attributeTestData.U16.front());
 
         EXPECT_TRUE(attr_u32);
         ASSERT_EQ(attr_u32.Name(), u32_Single);
         ASSERT_EQ(attr_u32.Data().size() == 1, true);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
         ASSERT_EQ(attr_u32.Data().front(), attributeTestData.U32.front());
 
         EXPECT_TRUE(attr_u32a);
         ASSERT_EQ(attr_u32a.Name(), u32_Array);
         ASSERT_EQ(attr_u32a.Data().size() == attributeTestData.U32.size(),
                   true);
-        ASSERT_EQ(attr_u32a.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32a.Type(), adios2::GetType<uint32_t>());
         ASSERT_EQ(attr_u32a.Data()[0], attributeTestData.U32[0]);
 
         EXPECT_TRUE(attr_u64);
         ASSERT_EQ(attr_u64.Name(), u64_Single);
         ASSERT_EQ(attr_u64.Data().size() == 1, true);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetDataType<uint64_t>());
+        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
         ASSERT_EQ(attr_u64.Data().front(), attributeTestData.U64.front());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), r32_Single);
         ASSERT_EQ(attr_r32.Data().size() == 1, true);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
         ASSERT_EQ(attr_r32.Data().front(), attributeTestData.R32.front());
 
         EXPECT_TRUE(attr_r32a);
         ASSERT_EQ(attr_r32a.Name(), r32_Array);
         ASSERT_EQ(attr_r32a.Data().size() == attributeTestData.R32.size(),
                   true);
-        ASSERT_EQ(attr_r32a.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32a.Type(), adios2::GetType<float>());
         ASSERT_EQ(attr_r32a.Data()[0], attributeTestData.R32[0]);
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), r64_Single);
         ASSERT_EQ(attr_r64.Data().size() == 1, true);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
         ASSERT_EQ(attr_r64.Data().front(), attributeTestData.R64.front());
 
         EXPECT_TRUE(attr_r128);
         ASSERT_EQ(attr_r128.Name(), r128_Single);
         ASSERT_EQ(attr_r128.Data().size() == 1, true);
-        ASSERT_EQ(attr_r128.Type(), adios2::GetDataType<long double>());
+        ASSERT_EQ(attr_r128.Type(), adios2::GetType<long double>());
         ASSERT_EQ(attr_r128.Data().front(), attributeTestData.R128.front());
 
         EXPECT_TRUE(attr_cr32);
         ASSERT_EQ(attr_cr32.Name(), cr32_Single);
         ASSERT_EQ(attr_cr32.Data().size() == 1, true);
-        ASSERT_EQ(attr_cr32.Type(), adios2::GetDataType<std::complex<float>>());
+        ASSERT_EQ(attr_cr32.Type(), adios2::GetType<std::complex<float>>());
         ASSERT_EQ(attr_cr32.Data().front(), attributeTestData.CR32.front());
 
         EXPECT_TRUE(attr_cr32a);
         ASSERT_EQ(attr_cr32a.Name(), cr32_Array);
         ASSERT_EQ(attr_cr32a.Data().size() == attributeTestData.CR32.size(),
                   true);
-        ASSERT_EQ(attr_cr32a.Type(),
-                  adios2::GetDataType<std::complex<float>>());
+        ASSERT_EQ(attr_cr32a.Type(), adios2::GetType<std::complex<float>>());
         ASSERT_EQ(attr_cr32a.Data()[0], attributeTestData.CR32[0]);
 
         EXPECT_TRUE(attr_cr64);
         ASSERT_EQ(attr_cr64.Name(), cr64_Single);
         ASSERT_EQ(attr_cr64.Data().size() == 1, true);
-        ASSERT_EQ(attr_cr64.Type(),
-                  adios2::GetDataType<std::complex<double>>());
+        ASSERT_EQ(attr_cr64.Type(), adios2::GetType<std::complex<double>>());
         ASSERT_EQ(attr_cr64.Data().front(), attributeTestData.CR64.front());
 
         EXPECT_EQ(bpReader.Steps(), 2 * NSteps);

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
@@ -140,92 +140,91 @@ TEST_F(BPWriteReadAttributes, WriteReadSingleTypes)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), s1_Single);
         ASSERT_EQ(attr_s1.Data().size() == 1, true);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
         ASSERT_EQ(attr_s1.Data().front(), currentTestData.S1);
 
         EXPECT_TRUE(attr_s1a);
         ASSERT_EQ(attr_s1a.Name(), s1_Array);
         ASSERT_EQ(attr_s1a.Data().size() == 1, true);
-        ASSERT_EQ(attr_s1a.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1a.Type(), adios2::GetType<std::string>());
         ASSERT_EQ(attr_s1a.Data()[0], currentTestData.S1array[0]);
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), i8_Single);
         ASSERT_EQ(attr_i8.Data().size() == 1, true);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
         ASSERT_EQ(attr_i8.Data().front(), currentTestData.I8.front());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), i16_Single);
         ASSERT_EQ(attr_i16.Data().size() == 1, true);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
         ASSERT_EQ(attr_i16.Data().front(), currentTestData.I16.front());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), i32_Single);
         ASSERT_EQ(attr_i32.Data().size() == 1, true);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
         ASSERT_EQ(attr_i32.Data().front(), currentTestData.I32.front());
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), i64_Single);
         ASSERT_EQ(attr_i64.Data().size() == 1, true);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
         ASSERT_EQ(attr_i64.Data().front(), currentTestData.I64.front());
 
         EXPECT_TRUE(attr_u8);
         ASSERT_EQ(attr_u8.Name(), u8_Single);
         ASSERT_EQ(attr_u8.Data().size() == 1, true);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetDataType<uint8_t>());
+        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
         ASSERT_EQ(attr_u8.Data().front(), currentTestData.U8.front());
 
         EXPECT_TRUE(attr_u16);
         ASSERT_EQ(attr_u16.Name(), u16_Single);
         ASSERT_EQ(attr_u16.Data().size() == 1, true);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetDataType<uint16_t>());
+        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
         ASSERT_EQ(attr_u16.Data().front(), currentTestData.U16.front());
 
         EXPECT_TRUE(attr_u32);
         ASSERT_EQ(attr_u32.Name(), u32_Single);
         ASSERT_EQ(attr_u32.Data().size() == 1, true);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
         ASSERT_EQ(attr_u32.Data().front(), currentTestData.U32.front());
 
         EXPECT_TRUE(attr_u64);
         ASSERT_EQ(attr_u64.Name(), u64_Single);
         ASSERT_EQ(attr_u64.Data().size() == 1, true);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetDataType<uint64_t>());
+        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
         ASSERT_EQ(attr_u64.Data().front(), currentTestData.U64.front());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), r32_Single);
         ASSERT_EQ(attr_r32.Data().size() == 1, true);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
         ASSERT_EQ(attr_r32.Data().front(), currentTestData.R32.front());
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), r64_Single);
         ASSERT_EQ(attr_r64.Data().size() == 1, true);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
         ASSERT_EQ(attr_r64.Data().front(), currentTestData.R64.front());
 
         EXPECT_TRUE(attr_r128);
         ASSERT_EQ(attr_r128.Name(), r128_Single);
         ASSERT_EQ(attr_r128.Data().size() == 1, true);
-        ASSERT_EQ(attr_r128.Type(), adios2::GetDataType<long double>());
+        ASSERT_EQ(attr_r128.Type(), adios2::GetType<long double>());
         ASSERT_EQ(attr_r128.Data().front(), currentTestData.R128.front());
 
         EXPECT_TRUE(attr_cr32);
         ASSERT_EQ(attr_cr32.Name(), cr32_Single);
         ASSERT_EQ(attr_cr32.Data().size() == 1, true);
-        ASSERT_EQ(attr_cr32.Type(), adios2::GetDataType<std::complex<float>>());
+        ASSERT_EQ(attr_cr32.Type(), adios2::GetType<std::complex<float>>());
         ASSERT_EQ(attr_cr32.Data().front(), currentTestData.CR32.front());
 
         EXPECT_TRUE(attr_cr64);
         ASSERT_EQ(attr_cr64.Name(), cr64_Single);
         ASSERT_EQ(attr_cr64.Data().size() == 1, true);
-        ASSERT_EQ(attr_cr64.Type(),
-                  adios2::GetDataType<std::complex<double>>());
+        ASSERT_EQ(attr_cr64.Type(), adios2::GetType<std::complex<double>>());
         ASSERT_EQ(attr_cr64.Data().front(), currentTestData.CR64.front());
 
         bpRead.Close();
@@ -361,73 +360,72 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypes)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), s1_Array);
         ASSERT_EQ(attr_s1.Data().size() == 1, false);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), i8_Array);
         ASSERT_EQ(attr_i8.Data().size() == 1, false);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), i16_Array);
         ASSERT_EQ(attr_i16.Data().size() == 1, false);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), i32_Array);
         ASSERT_EQ(attr_i32.Data().size() == 1, false);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), i64_Array);
         ASSERT_EQ(attr_i64.Data().size() == 1, false);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
 
         EXPECT_TRUE(attr_u8);
         ASSERT_EQ(attr_u8.Name(), u8_Array);
         ASSERT_EQ(attr_u8.Data().size() == 1, false);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetDataType<uint8_t>());
+        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
 
         EXPECT_TRUE(attr_u16);
         ASSERT_EQ(attr_u16.Name(), u16_Array);
         ASSERT_EQ(attr_u16.Data().size() == 1, false);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetDataType<uint16_t>());
+        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
 
         EXPECT_TRUE(attr_u32);
         ASSERT_EQ(attr_u32.Name(), u32_Array);
         ASSERT_EQ(attr_u32.Data().size() == 1, false);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
 
         EXPECT_TRUE(attr_u64);
         ASSERT_EQ(attr_u64.Name(), u64_Array);
         ASSERT_EQ(attr_u64.Data().size() == 1, false);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetDataType<uint64_t>());
+        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), r32_Array);
         ASSERT_EQ(attr_r32.Data().size() == 1, false);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), r64_Array);
         ASSERT_EQ(attr_r64.Data().size() == 1, false);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
 
         EXPECT_TRUE(attr_r128);
         ASSERT_EQ(attr_r128.Name(), r128_Array);
         ASSERT_EQ(attr_r128.Data().size() == 1, false);
-        ASSERT_EQ(attr_r128.Type(), adios2::GetDataType<long double>());
+        ASSERT_EQ(attr_r128.Type(), adios2::GetType<long double>());
 
         EXPECT_TRUE(attr_cr32);
         ASSERT_EQ(attr_cr32.Name(), cr32_Array);
         ASSERT_EQ(attr_cr32.Data().size() == 1, false);
-        ASSERT_EQ(attr_cr32.Type(), adios2::GetDataType<std::complex<float>>());
+        ASSERT_EQ(attr_cr32.Type(), adios2::GetType<std::complex<float>>());
 
         EXPECT_TRUE(attr_cr64);
         ASSERT_EQ(attr_cr64.Name(), cr64_Array);
         ASSERT_EQ(attr_cr64.Data().size() == 1, false);
-        ASSERT_EQ(attr_cr64.Type(),
-                  adios2::GetDataType<std::complex<double>>());
+        ASSERT_EQ(attr_cr64.Type(), adios2::GetType<std::complex<double>>());
 
         auto I8 = attr_i8.Data();
         auto I16 = attr_i16.Data();
@@ -581,86 +579,85 @@ TEST_F(BPWriteReadAttributes, BPWriteReadSingleTypesVar)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), var.Name() + separator + s1_Single);
         ASSERT_EQ(attr_s1.Data().size() == 1, true);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
         ASSERT_EQ(attr_s1.Data().front(), currentTestData.S1);
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), var.Name() + separator + i8_Single);
         ASSERT_EQ(attr_i8.Data().size() == 1, true);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
         ASSERT_EQ(attr_i8.Data().front(), currentTestData.I8.front());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), var.Name() + separator + i16_Single);
         ASSERT_EQ(attr_i16.Data().size() == 1, true);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
         ASSERT_EQ(attr_i16.Data().front(), currentTestData.I16.front());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), var.Name() + separator + i32_Single);
         ASSERT_EQ(attr_i32.Data().size() == 1, true);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
         ASSERT_EQ(attr_i32.Data().front(), currentTestData.I32.front());
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), var.Name() + separator + i64_Single);
         ASSERT_EQ(attr_i64.Data().size() == 1, true);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
         ASSERT_EQ(attr_i64.Data().front(), currentTestData.I64.front());
 
         EXPECT_TRUE(attr_u8);
         ASSERT_EQ(attr_u8.Name(), var.Name() + separator + u8_Single);
         ASSERT_EQ(attr_u8.Data().size() == 1, true);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetDataType<uint8_t>());
+        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
         ASSERT_EQ(attr_u8.Data().front(), currentTestData.U8.front());
 
         EXPECT_TRUE(attr_u16);
         ASSERT_EQ(attr_u16.Name(), var.Name() + separator + u16_Single);
         ASSERT_EQ(attr_u16.Data().size() == 1, true);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetDataType<uint16_t>());
+        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
         ASSERT_EQ(attr_u16.Data().front(), currentTestData.U16.front());
 
         EXPECT_TRUE(attr_u32);
         ASSERT_EQ(attr_u32.Name(), var.Name() + separator + u32_Single);
         ASSERT_EQ(attr_u32.Data().size() == 1, true);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
         ASSERT_EQ(attr_u32.Data().front(), currentTestData.U32.front());
 
         EXPECT_TRUE(attr_u64);
         ASSERT_EQ(attr_u64.Name(), var.Name() + separator + u64_Single);
         ASSERT_EQ(attr_u64.Data().size() == 1, true);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetDataType<uint64_t>());
+        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
         ASSERT_EQ(attr_u64.Data().front(), currentTestData.U64.front());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), var.Name() + separator + r32_Single);
         ASSERT_EQ(attr_r32.Data().size() == 1, true);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
         ASSERT_EQ(attr_r32.Data().front(), currentTestData.R32.front());
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), var.Name() + separator + r64_Single);
         ASSERT_EQ(attr_r64.Data().size() == 1, true);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
         ASSERT_EQ(attr_r64.Data().front(), currentTestData.R64.front());
 
         EXPECT_TRUE(attr_r128);
         ASSERT_EQ(attr_r128.Name(), var.Name() + separator + r128_Single);
         ASSERT_EQ(attr_r128.Data().size() == 1, true);
-        ASSERT_EQ(attr_r128.Type(), adios2::GetDataType<long double>());
+        ASSERT_EQ(attr_r128.Type(), adios2::GetType<long double>());
         ASSERT_EQ(attr_r128.Data().front(), currentTestData.R128.front());
 
         EXPECT_TRUE(attr_cr32);
         ASSERT_EQ(attr_cr32.Name(), var.Name() + separator + cr32_Single);
         ASSERT_EQ(attr_cr32.Data().size() == 1, true);
-        ASSERT_EQ(attr_cr32.Type(), adios2::GetDataType<std::complex<float>>());
+        ASSERT_EQ(attr_cr32.Type(), adios2::GetType<std::complex<float>>());
         ASSERT_EQ(attr_cr32.Data().front(), currentTestData.CR32.front());
 
         EXPECT_TRUE(attr_cr64);
         ASSERT_EQ(attr_cr64.Name(), var.Name() + separator + cr64_Single);
         ASSERT_EQ(attr_cr64.Data().size() == 1, true);
-        ASSERT_EQ(attr_cr64.Type(),
-                  adios2::GetDataType<std::complex<double>>());
+        ASSERT_EQ(attr_cr64.Type(), adios2::GetType<std::complex<double>>());
         ASSERT_EQ(attr_cr64.Data().front(), currentTestData.CR64.front());
 
         bpRead.Close();
@@ -803,73 +800,72 @@ TEST_F(BPWriteReadAttributes, WriteReadArrayTypesVar)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), var.Name() + separator + s1_Array);
         ASSERT_EQ(attr_s1.Data().size() == 1, false);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), var.Name() + separator + i8_Array);
         ASSERT_EQ(attr_i8.Data().size() == 1, false);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), var.Name() + separator + i16_Array);
         ASSERT_EQ(attr_i16.Data().size() == 1, false);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), var.Name() + separator + i32_Array);
         ASSERT_EQ(attr_i32.Data().size() == 1, false);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), var.Name() + separator + i64_Array);
         ASSERT_EQ(attr_i64.Data().size() == 1, false);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
 
         EXPECT_TRUE(attr_u8);
         ASSERT_EQ(attr_u8.Name(), var.Name() + separator + u8_Array);
         ASSERT_EQ(attr_u8.Data().size() == 1, false);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetDataType<uint8_t>());
+        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
 
         EXPECT_TRUE(attr_u16);
         ASSERT_EQ(attr_u16.Name(), var.Name() + separator + u16_Array);
         ASSERT_EQ(attr_u16.Data().size() == 1, false);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetDataType<uint16_t>());
+        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
 
         EXPECT_TRUE(attr_u32);
         ASSERT_EQ(attr_u32.Name(), var.Name() + separator + u32_Array);
         ASSERT_EQ(attr_u32.Data().size() == 1, false);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
 
         EXPECT_TRUE(attr_u64);
         ASSERT_EQ(attr_u64.Name(), var.Name() + separator + u64_Array);
         ASSERT_EQ(attr_u64.Data().size() == 1, false);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetDataType<uint64_t>());
+        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), var.Name() + separator + r32_Array);
         ASSERT_EQ(attr_r32.Data().size() == 1, false);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), var.Name() + separator + r64_Array);
         ASSERT_EQ(attr_r64.Data().size() == 1, false);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
 
         EXPECT_TRUE(attr_r128);
         ASSERT_EQ(attr_r128.Name(), var.Name() + separator + r128_Array);
         ASSERT_EQ(attr_r128.Data().size() == 1, false);
-        ASSERT_EQ(attr_r128.Type(), adios2::GetDataType<long double>());
+        ASSERT_EQ(attr_r128.Type(), adios2::GetType<long double>());
 
         EXPECT_TRUE(attr_cr32);
         ASSERT_EQ(attr_cr32.Name(), var.Name() + separator + cr32_Array);
         ASSERT_EQ(attr_cr32.Data().size() == 1, false);
-        ASSERT_EQ(attr_cr32.Type(), adios2::GetDataType<std::complex<float>>());
+        ASSERT_EQ(attr_cr32.Type(), adios2::GetType<std::complex<float>>());
 
         EXPECT_TRUE(attr_cr64);
         ASSERT_EQ(attr_cr64.Name(), var.Name() + separator + cr64_Array);
         ASSERT_EQ(attr_cr64.Data().size() == 1, false);
-        ASSERT_EQ(attr_cr64.Type(),
-                  adios2::GetDataType<std::complex<double>>());
+        ASSERT_EQ(attr_cr64.Type(), adios2::GetType<std::complex<double>>());
 
         auto I8 = attr_i8.Data();
         auto I16 = attr_i16.Data();

--- a/testing/adios2/engine/common/TestEngineCommon.cpp
+++ b/testing/adios2/engine/common/TestEngineCommon.cpp
@@ -236,7 +236,7 @@ TEST_F(Common, NewAttributeEveryStep)
             uint64_t expectedAttributeValue = step + 1;
             EXPECT_TRUE(aStep);
             ASSERT_EQ(aStep.Data().size() == 1, true);
-            ASSERT_EQ(aStep.Type(), adios2::GetDataType<uint64_t>());
+            ASSERT_EQ(aStep.Type(), adios2::GetType<uint64_t>());
             ASSERT_EQ(aStep.Data().front(), expectedAttributeValue);
 
             if (!rank)

--- a/testing/adios2/engine/hdf5/TestHDF5WriteReadAttributesADIOS2.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteReadAttributesADIOS2.cpp
@@ -111,73 +111,73 @@ TEST_F(BPWriteReadAttributeTestADIOS2, ADIOS2BPWriteReadSingleTypes)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), s1_Single);
         ASSERT_EQ(attr_s1.Data().size() == 1, true);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
         ASSERT_EQ(attr_s1.Data().front(), currentTestData.S1);
 
         EXPECT_TRUE(attr_s1a);
         ASSERT_EQ(attr_s1a.Name(), s1_Array);
         ASSERT_EQ(attr_s1a.Data().size() == 1, true);
-        ASSERT_EQ(attr_s1a.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1a.Type(), adios2::GetType<std::string>());
         ASSERT_EQ(attr_s1a.Data()[0], currentTestData.S1array[0]);
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), i8_Single);
         ASSERT_EQ(attr_i8.Data().size() == 1, true);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
         ASSERT_EQ(attr_i8.Data().front(), currentTestData.I8.front());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), i16_Single);
         ASSERT_EQ(attr_i16.Data().size() == 1, true);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
         ASSERT_EQ(attr_i16.Data().front(), currentTestData.I16.front());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), i32_Single);
         ASSERT_EQ(attr_i32.Data().size() == 1, true);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
         ASSERT_EQ(attr_i32.Data().front(), currentTestData.I32.front());
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), i64_Single);
         ASSERT_EQ(attr_i64.Data().size() == 1, true);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
         ASSERT_EQ(attr_i64.Data().front(), currentTestData.I64.front());
 
         EXPECT_TRUE(attr_u8);
         ASSERT_EQ(attr_u8.Name(), u8_Single);
         ASSERT_EQ(attr_u8.Data().size() == 1, true);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetDataType<uint8_t>());
+        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
         ASSERT_EQ(attr_u8.Data().front(), currentTestData.U8.front());
 
         EXPECT_TRUE(attr_u16);
         ASSERT_EQ(attr_u16.Name(), u16_Single);
         ASSERT_EQ(attr_u16.Data().size() == 1, true);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetDataType<uint16_t>());
+        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
         ASSERT_EQ(attr_u16.Data().front(), currentTestData.U16.front());
 
         EXPECT_TRUE(attr_u32);
         ASSERT_EQ(attr_u32.Name(), u32_Single);
         ASSERT_EQ(attr_u32.Data().size() == 1, true);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
         ASSERT_EQ(attr_u32.Data().front(), currentTestData.U32.front());
 
         EXPECT_TRUE(attr_u64);
         ASSERT_EQ(attr_u64.Name(), u64_Single);
         ASSERT_EQ(attr_u64.Data().size() == 1, true);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetDataType<uint64_t>());
+        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
         ASSERT_EQ(attr_u64.Data().front(), currentTestData.U64.front());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), r32_Single);
         ASSERT_EQ(attr_r32.Data().size() == 1, true);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
         ASSERT_EQ(attr_r32.Data().front(), currentTestData.R32.front());
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), r64_Single);
         ASSERT_EQ(attr_r64.Data().size() == 1, true);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
         ASSERT_EQ(attr_r64.Data().front(), currentTestData.R64.front());
 
         bpRead.Close();
@@ -284,57 +284,57 @@ TEST_F(BPWriteReadAttributeTestADIOS2, ADIOS2BPWriteReadArrayTypes)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), s1_Array);
         ASSERT_EQ(attr_s1.Data().size() == 1, false);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), i8_Array);
         ASSERT_EQ(attr_i8.Data().size() == 1, false);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), i16_Array);
         ASSERT_EQ(attr_i16.Data().size() == 1, false);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), i32_Array);
         ASSERT_EQ(attr_i32.Data().size() == 1, false);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), i64_Array);
         ASSERT_EQ(attr_i64.Data().size() == 1, false);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
 
         EXPECT_TRUE(attr_u8);
         ASSERT_EQ(attr_u8.Name(), u8_Array);
         ASSERT_EQ(attr_u8.Data().size() == 1, false);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetDataType<uint8_t>());
+        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
 
         EXPECT_TRUE(attr_u16);
         ASSERT_EQ(attr_u16.Name(), u16_Array);
         ASSERT_EQ(attr_u16.Data().size() == 1, false);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetDataType<uint16_t>());
+        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
 
         EXPECT_TRUE(attr_u32);
         ASSERT_EQ(attr_u32.Name(), u32_Array);
         ASSERT_EQ(attr_u32.Data().size() == 1, false);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
 
         EXPECT_TRUE(attr_u64);
         ASSERT_EQ(attr_u64.Name(), u64_Array);
         ASSERT_EQ(attr_u64.Data().size() == 1, false);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetDataType<uint64_t>());
+        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), r32_Array);
         ASSERT_EQ(attr_r32.Data().size() == 1, false);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), r64_Array);
         ASSERT_EQ(attr_r64.Data().size() == 1, false);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
 
         auto I8 = attr_i8.Data();
         auto I16 = attr_i16.Data();
@@ -465,67 +465,67 @@ TEST_F(BPWriteReadAttributeTestADIOS2, BPWriteReadSingleTypesVar)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), var.Name() + separator + s1_Single);
         ASSERT_EQ(attr_s1.Data().size() == 1, true);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
         ASSERT_EQ(attr_s1.Data().front(), currentTestData.S1);
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), var.Name() + separator + i8_Single);
         ASSERT_EQ(attr_i8.Data().size() == 1, true);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
         ASSERT_EQ(attr_i8.Data().front(), currentTestData.I8.front());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), var.Name() + separator + i16_Single);
         ASSERT_EQ(attr_i16.Data().size() == 1, true);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
         ASSERT_EQ(attr_i16.Data().front(), currentTestData.I16.front());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), var.Name() + separator + i32_Single);
         ASSERT_EQ(attr_i32.Data().size() == 1, true);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
         ASSERT_EQ(attr_i32.Data().front(), currentTestData.I32.front());
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), var.Name() + separator + i64_Single);
         ASSERT_EQ(attr_i64.Data().size() == 1, true);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
         ASSERT_EQ(attr_i64.Data().front(), currentTestData.I64.front());
 
         EXPECT_TRUE(attr_u8);
         ASSERT_EQ(attr_u8.Name(), var.Name() + separator + u8_Single);
         ASSERT_EQ(attr_u8.Data().size() == 1, true);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetDataType<uint8_t>());
+        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
         ASSERT_EQ(attr_u8.Data().front(), currentTestData.U8.front());
 
         EXPECT_TRUE(attr_u16);
         ASSERT_EQ(attr_u16.Name(), var.Name() + separator + u16_Single);
         ASSERT_EQ(attr_u16.Data().size() == 1, true);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetDataType<uint16_t>());
+        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
         ASSERT_EQ(attr_u16.Data().front(), currentTestData.U16.front());
 
         EXPECT_TRUE(attr_u32);
         ASSERT_EQ(attr_u32.Name(), var.Name() + separator + u32_Single);
         ASSERT_EQ(attr_u32.Data().size() == 1, true);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
         ASSERT_EQ(attr_u32.Data().front(), currentTestData.U32.front());
 
         EXPECT_TRUE(attr_u64);
         ASSERT_EQ(attr_u64.Name(), var.Name() + separator + u64_Single);
         ASSERT_EQ(attr_u64.Data().size() == 1, true);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetDataType<uint64_t>());
+        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
         ASSERT_EQ(attr_u64.Data().front(), currentTestData.U64.front());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), var.Name() + separator + r32_Single);
         ASSERT_EQ(attr_r32.Data().size() == 1, true);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
         ASSERT_EQ(attr_r32.Data().front(), currentTestData.R32.front());
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), var.Name() + separator + r64_Single);
         ASSERT_EQ(attr_r64.Data().size() == 1, true);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
         ASSERT_EQ(attr_r64.Data().front(), currentTestData.R64.front());
 
         bpRead.Close();
@@ -638,57 +638,57 @@ TEST_F(BPWriteReadAttributeTestADIOS2, ADIOS2BPWriteReadArrayTypesVar)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), var.Name() + separator + s1_Array);
         ASSERT_EQ(attr_s1.Data().size() == 1, false);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), var.Name() + separator + i8_Array);
         ASSERT_EQ(attr_i8.Data().size() == 1, false);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), var.Name() + separator + i16_Array);
         ASSERT_EQ(attr_i16.Data().size() == 1, false);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), var.Name() + separator + i32_Array);
         ASSERT_EQ(attr_i32.Data().size() == 1, false);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), var.Name() + separator + i64_Array);
         ASSERT_EQ(attr_i64.Data().size() == 1, false);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
 
         EXPECT_TRUE(attr_u8);
         ASSERT_EQ(attr_u8.Name(), var.Name() + separator + u8_Array);
         ASSERT_EQ(attr_u8.Data().size() == 1, false);
-        ASSERT_EQ(attr_u8.Type(), adios2::GetDataType<uint8_t>());
+        ASSERT_EQ(attr_u8.Type(), adios2::GetType<uint8_t>());
 
         EXPECT_TRUE(attr_u16);
         ASSERT_EQ(attr_u16.Name(), var.Name() + separator + u16_Array);
         ASSERT_EQ(attr_u16.Data().size() == 1, false);
-        ASSERT_EQ(attr_u16.Type(), adios2::GetDataType<uint16_t>());
+        ASSERT_EQ(attr_u16.Type(), adios2::GetType<uint16_t>());
 
         EXPECT_TRUE(attr_u32);
         ASSERT_EQ(attr_u32.Name(), var.Name() + separator + u32_Array);
         ASSERT_EQ(attr_u32.Data().size() == 1, false);
-        ASSERT_EQ(attr_u32.Type(), adios2::GetDataType<uint32_t>());
+        ASSERT_EQ(attr_u32.Type(), adios2::GetType<uint32_t>());
 
         EXPECT_TRUE(attr_u64);
         ASSERT_EQ(attr_u64.Name(), var.Name() + separator + u64_Array);
         ASSERT_EQ(attr_u64.Data().size() == 1, false);
-        ASSERT_EQ(attr_u64.Type(), adios2::GetDataType<uint64_t>());
+        ASSERT_EQ(attr_u64.Type(), adios2::GetType<uint64_t>());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), var.Name() + separator + r32_Array);
         ASSERT_EQ(attr_r32.Data().size() == 1, false);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), var.Name() + separator + r64_Array);
         ASSERT_EQ(attr_r64.Data().size() == 1, false);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
 
         auto I8 = attr_i8.Data();
         auto I16 = attr_i16.Data();

--- a/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
@@ -112,49 +112,49 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
         EXPECT_TRUE(attr_s1);
         ASSERT_EQ(attr_s1.Name(), s1_Single);
         ASSERT_EQ(attr_s1.Data().size() == 1, true);
-        ASSERT_EQ(attr_s1.Type(), adios2::GetDataType<std::string>());
+        ASSERT_EQ(attr_s1.Type(), adios2::GetType<std::string>());
         ASSERT_EQ(attr_s1.Data().front(), data_S1);
 
         // EXPECT_TRUE(attr_s1a);
         // ASSERT_EQ(attr_s1a.Name(), s1_Array);
         // ASSERT_EQ(attr_s1a.Data().size() == 1, true);
-        // ASSERT_EQ(attr_s1a.Type(), adios2::GetDataType<std::string>());
+        // ASSERT_EQ(attr_s1a.Type(), adios2::GetType<std::string>());
         // ASSERT_EQ(attr_s1a.Data()[0], currentTestData.S1array[0]);
 
         EXPECT_TRUE(attr_i8);
         ASSERT_EQ(attr_i8.Name(), i8_Single);
         ASSERT_EQ(attr_i8.Data().size() == 1, true);
-        ASSERT_EQ(attr_i8.Type(), adios2::GetDataType<int8_t>());
+        ASSERT_EQ(attr_i8.Type(), adios2::GetType<int8_t>());
         ASSERT_EQ(attr_i8.Data().front(), data_I8.front());
 
         EXPECT_TRUE(attr_i16);
         ASSERT_EQ(attr_i16.Name(), i16_Single);
         ASSERT_EQ(attr_i16.Data().size() == 1, true);
-        ASSERT_EQ(attr_i16.Type(), adios2::GetDataType<int16_t>());
+        ASSERT_EQ(attr_i16.Type(), adios2::GetType<int16_t>());
         ASSERT_EQ(attr_i16.Data().front(), data_I16.front());
 
         EXPECT_TRUE(attr_i32);
         ASSERT_EQ(attr_i32.Name(), i32_Single);
         ASSERT_EQ(attr_i32.Data().size() == 1, true);
-        ASSERT_EQ(attr_i32.Type(), adios2::GetDataType<int32_t>());
+        ASSERT_EQ(attr_i32.Type(), adios2::GetType<int32_t>());
         ASSERT_EQ(attr_i32.Data().front(), data_I32.front());
 
         EXPECT_TRUE(attr_i64);
         ASSERT_EQ(attr_i64.Name(), i64_Single);
         ASSERT_EQ(attr_i64.Data().size() == 1, true);
-        ASSERT_EQ(attr_i64.Type(), adios2::GetDataType<int64_t>());
+        ASSERT_EQ(attr_i64.Type(), adios2::GetType<int64_t>());
         ASSERT_EQ(attr_i64.Data().front(), data_I64.front());
 
         EXPECT_TRUE(attr_r32);
         ASSERT_EQ(attr_r32.Name(), r32_Single);
         ASSERT_EQ(attr_r32.Data().size() == 1, true);
-        ASSERT_EQ(attr_r32.Type(), adios2::GetDataType<float>());
+        ASSERT_EQ(attr_r32.Type(), adios2::GetType<float>());
         ASSERT_EQ(attr_r32.Data().front(), data_R32.front());
 
         EXPECT_TRUE(attr_r64);
         ASSERT_EQ(attr_r64.Name(), r64_Single);
         ASSERT_EQ(attr_r64.Data().size() == 1, true);
-        ASSERT_EQ(attr_r64.Type(), adios2::GetDataType<double>());
+        ASSERT_EQ(attr_r64.Type(), adios2::GetType<double>());
         ASSERT_EQ(attr_r64.Data().front(), data_R64.front());
 
         auto scalar_r64 = io.InquireVariable<double>("scalar_r64");

--- a/testing/adios2/interface/TestADIOSDefineAttribute.cpp
+++ b/testing/adios2/interface/TestADIOSDefineAttribute.cpp
@@ -712,17 +712,17 @@ TEST_F(ADIOSDefineAttributeTest, DefineCheckType)
     io.DefineAttribute<float>("r32", 32);
     io.DefineAttribute<double>("r64", 64);
 
-    EXPECT_EQ(io.AttributeType("iString"), adios2::GetDataType<std::string>());
-    EXPECT_EQ(io.AttributeType("i8"), adios2::GetDataType<int8_t>());
-    EXPECT_EQ(io.AttributeType("i16"), adios2::GetDataType<int16_t>());
-    EXPECT_EQ(io.AttributeType("i32"), adios2::GetDataType<int32_t>());
-    EXPECT_EQ(io.AttributeType("i64"), adios2::GetDataType<int64_t>());
-    EXPECT_EQ(io.AttributeType("u8"), adios2::GetDataType<uint8_t>());
-    EXPECT_EQ(io.AttributeType("u16"), adios2::GetDataType<uint16_t>());
-    EXPECT_EQ(io.AttributeType("u32"), adios2::GetDataType<uint32_t>());
-    EXPECT_EQ(io.AttributeType("u64"), adios2::GetDataType<uint64_t>());
-    EXPECT_EQ(io.AttributeType("r32"), adios2::GetDataType<float>());
-    EXPECT_EQ(io.AttributeType("r64"), adios2::GetDataType<double>());
+    EXPECT_EQ(io.AttributeType("iString"), adios2::GetType<std::string>());
+    EXPECT_EQ(io.AttributeType("i8"), adios2::GetType<int8_t>());
+    EXPECT_EQ(io.AttributeType("i16"), adios2::GetType<int16_t>());
+    EXPECT_EQ(io.AttributeType("i32"), adios2::GetType<int32_t>());
+    EXPECT_EQ(io.AttributeType("i64"), adios2::GetType<int64_t>());
+    EXPECT_EQ(io.AttributeType("u8"), adios2::GetType<uint8_t>());
+    EXPECT_EQ(io.AttributeType("u16"), adios2::GetType<uint16_t>());
+    EXPECT_EQ(io.AttributeType("u32"), adios2::GetType<uint32_t>());
+    EXPECT_EQ(io.AttributeType("u64"), adios2::GetType<uint64_t>());
+    EXPECT_EQ(io.AttributeType("r32"), adios2::GetType<float>());
+    EXPECT_EQ(io.AttributeType("r64"), adios2::GetType<double>());
 }
 
 TEST_F(ADIOSDefineAttributeTest, VariableException)

--- a/testing/adios2/interface/TestADIOSDefineVariable.cpp
+++ b/testing/adios2/interface/TestADIOSDefineVariable.cpp
@@ -637,24 +637,22 @@ TEST_F(ADIOSDefineVariableTest, DefineCheckType)
     io.DefineVariable<long>("l", shape, start, count);
     io.DefineVariable<unsigned long>("ul", shape, start, count);
 
-    EXPECT_EQ(io.VariableType("iString"), adios2::GetDataType<std::string>());
-    EXPECT_EQ(io.VariableType("i8"), adios2::GetDataType<int8_t>());
-    EXPECT_EQ(io.VariableType("i16"), adios2::GetDataType<int16_t>());
-    EXPECT_EQ(io.VariableType("i32"), adios2::GetDataType<int32_t>());
-    EXPECT_EQ(io.VariableType("i64"), adios2::GetDataType<int64_t>());
-    EXPECT_EQ(io.VariableType("u8"), adios2::GetDataType<uint8_t>());
-    EXPECT_EQ(io.VariableType("u16"), adios2::GetDataType<uint16_t>());
-    EXPECT_EQ(io.VariableType("u32"), adios2::GetDataType<uint32_t>());
-    EXPECT_EQ(io.VariableType("u64"), adios2::GetDataType<uint64_t>());
-    EXPECT_EQ(io.VariableType("r32"), adios2::GetDataType<float>());
-    EXPECT_EQ(io.VariableType("r64"), adios2::GetDataType<double>());
-    EXPECT_EQ(io.VariableType("c32"),
-              adios2::GetDataType<std::complex<float>>());
-    EXPECT_EQ(io.VariableType("c64"),
-              adios2::GetDataType<std::complex<double>>());
-    EXPECT_EQ(io.VariableType("char"), adios2::GetDataType<char>());
-    EXPECT_EQ(io.VariableType("l"), adios2::GetDataType<long>());
-    EXPECT_EQ(io.VariableType("ul"), adios2::GetDataType<unsigned long>());
+    EXPECT_EQ(io.VariableType("iString"), adios2::GetType<std::string>());
+    EXPECT_EQ(io.VariableType("i8"), adios2::GetType<int8_t>());
+    EXPECT_EQ(io.VariableType("i16"), adios2::GetType<int16_t>());
+    EXPECT_EQ(io.VariableType("i32"), adios2::GetType<int32_t>());
+    EXPECT_EQ(io.VariableType("i64"), adios2::GetType<int64_t>());
+    EXPECT_EQ(io.VariableType("u8"), adios2::GetType<uint8_t>());
+    EXPECT_EQ(io.VariableType("u16"), adios2::GetType<uint16_t>());
+    EXPECT_EQ(io.VariableType("u32"), adios2::GetType<uint32_t>());
+    EXPECT_EQ(io.VariableType("u64"), adios2::GetType<uint64_t>());
+    EXPECT_EQ(io.VariableType("r32"), adios2::GetType<float>());
+    EXPECT_EQ(io.VariableType("r64"), adios2::GetType<double>());
+    EXPECT_EQ(io.VariableType("c32"), adios2::GetType<std::complex<float>>());
+    EXPECT_EQ(io.VariableType("c64"), adios2::GetType<std::complex<double>>());
+    EXPECT_EQ(io.VariableType("char"), adios2::GetType<char>());
+    EXPECT_EQ(io.VariableType("l"), adios2::GetType<long>());
+    EXPECT_EQ(io.VariableType("ul"), adios2::GetType<unsigned long>());
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
In #2318 we accidentally renamed the public-facing `GetType` to `GetDataType` too.  Revert that part of the change.
