### PR TITLE
Add rank decomposition by dimensional ratio to iotest

### DIFF
--- a/source/utils/adios_iotest/settings.cpp
+++ b/source/utils/adios_iotest/settings.cpp
@@ -130,8 +130,6 @@ int Settings::rescaleDecomp()
 
     throw std::invalid_argument(
         "decomposition ratios must scale up to process count");
-
-    return (0);
 }
 
 int Settings::processArgs(int argc, char *argv[])

--- a/source/utils/adios_iotest/settings.cpp
+++ b/source/utils/adios_iotest/settings.cpp
@@ -88,9 +88,10 @@ size_t Settings::stringToNumber(const std::string &varName,
 
 int Settings::parseRatios(const char *arg)
 {
-    char *argCopy = strdup(arg);
+    char *argCopy = malloc(strlen(arg) * sizeof(*argCopy));
     char *ratio;
 
+    strcpy(argCopy, arg);
     ratio = strtok(argCopy, ",");
     while (ratio)
     {

--- a/source/utils/adios_iotest/settings.cpp
+++ b/source/utils/adios_iotest/settings.cpp
@@ -88,7 +88,7 @@ size_t Settings::stringToNumber(const std::string &varName,
 
 int Settings::parseRatios(const char *arg)
 {
-    char *argCopy = malloc(strlen(arg) * sizeof(*argCopy));
+    char *argCopy = (char *)malloc(strlen(arg) * sizeof(*argCopy));
     char *ratio;
 
     strcpy(argCopy, arg);

--- a/source/utils/adios_iotest/settings.h
+++ b/source/utils/adios_iotest/settings.h
@@ -40,6 +40,7 @@ public:
     bool isStrongScaling = true; // strong or weak scaling
     bool ioTimer = false;        // used to measure io time
     bool fixedPattern = false;   // should Lock definitions?
+    bool isRatioDecomp = false;
     IOLib iolib = IOLib::ADIOS;
     //   process decomposition
     std::vector<size_t> processDecomp = {1, 1, 1, 1, 1, 1, 1, 1,
@@ -57,6 +58,8 @@ public:
     int processArguments(int argc, char *argv[], MPI_Comm worldComm);
     int extraArgumentChecks();
     size_t stringToNumber(const std::string &varName, const char *arg) const;
+    int parseRatios(const char *arg);
+    int rescaleDecomp();
     size_t ndigits(size_t n) const;
 
 private:

--- a/source/utils/adios_iotest/settings.h
+++ b/source/utils/adios_iotest/settings.h
@@ -58,7 +58,7 @@ public:
     int processArguments(int argc, char *argv[], MPI_Comm worldComm);
     int extraArgumentChecks();
     size_t stringToNumber(const std::string &varName, const char *arg) const;
-    int parseRatios(const char *arg);
+    int parseCSDecomp(const char *arg);
     int rescaleDecomp();
     size_t ndigits(size_t n) const;
 


### PR DESCRIPTION
Currently, the iotest x y z rank decomposition is done with the -d flag, using literal dimensions; so `-d 2 4 2 `defines a 2x4x2 decomposition, and the number of ranks for the application must be 16. This PR adds the option to specify the ratio of the dimensions of ranks by providing a comma-separated list to the -d flag, so that `-d 1,2,1` would have the same results ad `-d 2 4 2` if 16 ranks were provided, but would also work for a scaled up or scaled down number of ranks (for example, `-d 1,2,1` with 2 ranks would be equivalent to `-d 1 2 1`; `-d 1,2,1` with 54 ranks would be equivalent to `-d  3 6 3`; with 128 ranks, `-d 4 8 4`; etc.)

The reason for this change is to work better with Cheetah. It is not possible to correlate options that are separated by spaces inside a sweep in Cheetah, and it does not seem to be possible to correlate process count with different option values without defining a sweep for each valid combination (at least this is my understanding after some correspondence with @kshitij-v-mehta.) I wrote this issue up more [here](https://github.com/philip-davis/adios-patterns-planar/issues/1).

This change is backwards compatible.