### PR TITLE
core: Simplify IO variable and attribute storage

### DIFF
--- a/bindings/C/adios2/c/adios2_c_io.cpp
+++ b/bindings/C/adios2/c/adios2_c_io.cpp
@@ -250,7 +250,7 @@ adios2_variable *adios2_inquire_variable(adios2_io *io, const char *name)
             io, "for adios2_io, in call to adios2_inquire_variable");
 
         adios2::core::IO &ioCpp = *reinterpret_cast<adios2::core::IO *>(io);
-        const auto &dataMap = ioCpp.GetVariablesDataMap();
+        const auto &dataMap = ioCpp.GetVariables();
 
         auto itVariable = dataMap.find(name);
         if (itVariable == dataMap.end()) // not found
@@ -292,7 +292,7 @@ adios2_error adios2_inquire_all_variables(adios2_variable ***variables,
             io, "for adios2_io, in call to adios2_inquire_all_variables");
 
         adios2::core::IO &ioCpp = *reinterpret_cast<adios2::core::IO *>(io);
-        const auto &dataMap = ioCpp.GetVariablesDataMap();
+        const auto &dataMap = ioCpp.GetVariables();
 
         *size = dataMap.size();
         adios2_variable **list =
@@ -308,7 +308,7 @@ adios2_error adios2_inquire_all_variables(adios2_variable ***variables,
         for (auto &name : names)
         {
             auto it = dataMap.find(name);
-            const adios2::DataType type(it->second.first);
+            const adios2::DataType type(it->second->m_Type);
             adios2::core::VariableBase *variable = nullptr;
 
             if (type == adios2::DataType::Compound)
@@ -498,7 +498,7 @@ adios2_attribute *adios2_inquire_attribute(adios2_io *io, const char *name)
             io, "for adios2_io, in call to adios2_inquire_attribute");
 
         adios2::core::IO &ioCpp = *reinterpret_cast<adios2::core::IO *>(io);
-        const auto &dataMap = ioCpp.GetAttributesDataMap();
+        const auto &dataMap = ioCpp.GetAttributes();
 
         auto itAttribute = dataMap.find(name);
         if (itAttribute == dataMap.end()) // not found
@@ -506,7 +506,7 @@ adios2_attribute *adios2_inquire_attribute(adios2_io *io, const char *name)
             return attribute;
         }
 
-        const adios2::DataType type(itAttribute->second.first);
+        const adios2::DataType type(itAttribute->second->m_Type);
         adios2::core::AttributeBase *attributeCpp = nullptr;
 
         if (type == adios2::DataType::Compound)
@@ -551,7 +551,7 @@ adios2_error adios2_inquire_all_attributes(adios2_attribute ***attributes,
             io, "for adios2_io, in call to adios2_inquire_all_attributes");
 
         adios2::core::IO &ioCpp = *reinterpret_cast<adios2::core::IO *>(io);
-        const auto &dataMap = ioCpp.GetAttributesDataMap();
+        const auto &dataMap = ioCpp.GetAttributes();
 
         *size = dataMap.size();
         adios2_attribute **list =
@@ -567,7 +567,7 @@ adios2_error adios2_inquire_all_attributes(adios2_attribute ***attributes,
         for (auto &name : names)
         {
             auto it = dataMap.find(name);
-            const adios2::DataType type(it->second.first);
+            const adios2::DataType type(it->second->m_Type);
             adios2::core::AttributeBase *attribute = nullptr;
 
             if (type == adios2::DataType::Compound)

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -123,7 +123,9 @@ IO &ADIOS::DeclareIO(const std::string name)
         }
     }
 
-    auto ioPair = m_IOs.emplace(name, IO(*this, name, false, m_HostLanguage));
+    auto ioPair = m_IOs.emplace(
+        std::piecewise_construct, std::forward_as_tuple(name),
+        std::forward_as_tuple(*this, name, false, m_HostLanguage));
     IO &io = ioPair.first->second;
     io.SetDeclared();
     return io;

--- a/source/adios2/core/Attribute.cpp
+++ b/source/adios2/core/Attribute.cpp
@@ -64,12 +64,6 @@ struct RequiresZeroPadding<long double> : std::true_type
         if (RequiresZeroPadding<T>::value)                                     \
             std::memset(&m_DataSingleValue, 0, sizeof(m_DataSingleValue));     \
         m_DataSingleValue = value;                                             \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
-    Params Attribute<T>::GetInfo() const noexcept                              \
-    {                                                                          \
-        return DoGetInfo();                                                    \
     }
 
 ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)

--- a/source/adios2/core/Attribute.h
+++ b/source/adios2/core/Attribute.h
@@ -51,10 +51,8 @@ public:
 
     ~Attribute<T>() = default;
 
-    Params GetInfo() const noexcept;
-
 private:
-    Params DoGetInfo() const noexcept;
+    std::string DoGetInfoValue() const noexcept override;
 };
 
 } // end namespace core

--- a/source/adios2/core/Attribute.tcc
+++ b/source/adios2/core/Attribute.tcc
@@ -13,7 +13,6 @@
 
 #include "Attribute.h"
 
-#include "adios2/helper/adiosFunctions.h"
 #include "adios2/helper/adiosType.h"
 
 namespace adios2
@@ -22,21 +21,18 @@ namespace core
 {
 
 template <class T>
-Params Attribute<T>::DoGetInfo() const noexcept
+std::string Attribute<T>::DoGetInfoValue() const noexcept
 {
-    Params info;
-    info["Type"] = ToString(m_Type);
-    info["Elements"] = std::to_string(m_Elements);
-
+    std::string value;
     if (m_IsSingleValue)
     {
-        info["Value"] = helper::ValueToString(m_DataSingleValue);
+        value = helper::ValueToString(m_DataSingleValue);
     }
     else
     {
-        info["Value"] = "{ " + helper::VectorToCSV(m_DataArray) + " }";
+        value = "{ " + helper::VectorToCSV(m_DataArray) + " }";
     }
-    return info;
+    return value;
 }
 
 } // end namespace core

--- a/source/adios2/core/AttributeBase.cpp
+++ b/source/adios2/core/AttributeBase.cpp
@@ -26,5 +26,14 @@ AttributeBase::AttributeBase(const std::string &name, const DataType type,
 {
 }
 
+Params AttributeBase::GetInfo() const noexcept
+{
+    Params info;
+    info["Type"] = ToString(m_Type);
+    info["Elements"] = std::to_string(m_Elements);
+    info["Value"] = this->DoGetInfoValue();
+    return info;
+}
+
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/core/AttributeBase.h
+++ b/source/adios2/core/AttributeBase.h
@@ -49,6 +49,11 @@ public:
                   const size_t elements);
 
     virtual ~AttributeBase() = default;
+
+    Params GetInfo() const noexcept;
+
+private:
+    virtual std::string DoGetInfoValue() const noexcept = 0;
 };
 
 } // end namespace core

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -179,6 +179,8 @@ IO::IO(ADIOS &adios, const std::string name, const bool inConfigFile,
 {
 }
 
+IO::~IO() = default;
+
 void IO::SetEngine(const std::string engineType) noexcept
 {
     auto lf_InsertParam = [&](const std::string &key,

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -326,8 +326,6 @@ bool IO::RemoveVariable(const std::string &name) noexcept
 
         if (type == DataType::Compound)
         {
-            auto variableMap = m_Compound;
-            variableMap.erase(index);
         }
 #define declare_type(T)                                                        \
     else if (type == helper::GetDataType<T>())                                 \
@@ -355,7 +353,6 @@ void IO::RemoveAllVariables() noexcept
 #define declare_type(T) GetVariableMap<T>().clear();
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
-    m_Compound.clear();
 }
 
 bool IO::RemoveAttribute(const std::string &name) noexcept

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -329,15 +329,11 @@ bool IO::RemoveVariable(const std::string &name) noexcept
         if (type == DataType::Compound)
         {
         }
-#define declare_type(T)                                                        \
-    else if (type == helper::GetDataType<T>())                                 \
-    {                                                                          \
-        auto &variableMap = GetVariableMap<T>();                               \
-        variableMap.erase(index);                                              \
-        isRemoved = true;                                                      \
-    }
-        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
-#undef declare_type
+        else
+        {
+            m_VariableMap.erase(index);
+            isRemoved = true;
+        }
     }
 
     if (isRemoved)
@@ -352,9 +348,7 @@ void IO::RemoveAllVariables() noexcept
 {
     TAU_SCOPED_TIMER("IO::RemoveAllVariables");
     m_Variables.clear();
-#define declare_type(T) GetVariableMap<T>().clear();
-    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
-#undef declare_type
+    m_VariableMap.clear();
 }
 
 bool IO::RemoveAttribute(const std::string &name) noexcept
@@ -437,16 +431,13 @@ IO::GetAvailableAttributes(const std::string &variableName,
         if (type == DataType::Compound)
         {
         }
-#define declare_template_instantiation(T)                                      \
-    else if (type == helper::GetDataType<T>())                                 \
-    {                                                                          \
-        Variable<T> &variable =                                                \
-            GetVariableMap<T>().at(itVariable->second.second);                 \
-        attributesInfo =                                                       \
-            variable.GetAttributesInfo(*this, separator, fullNameKeys);        \
-    }
-        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
+        else
+        {
+            VariableBase &variable =
+                *m_VariableMap.at(itVariable->second.second);
+            attributesInfo =
+                variable.GetAttributesInfo(*this, separator, fullNameKeys);
+        }
 
         return attributesInfo;
     }
@@ -492,19 +483,15 @@ DataType IO::InquireVariableType(const DataMap::const_iterator itVariable) const
         if (type == DataType::Compound)
         {
         }
-#define declare_template_instantiation(T)                                      \
-    else if (type == helper::GetDataType<T>())                                 \
-    {                                                                          \
-        const Variable<T> &variable =                                          \
-            const_cast<IO *>(this)->GetVariableMap<T>().at(                    \
-                itVariable->second.second);                                    \
-        if (!variable.IsValidStep(m_EngineStep + 1))                           \
-        {                                                                      \
-            return DataType::None;                                             \
-        }                                                                      \
-    }
-        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
+        else
+        {
+            VariableBase &variable =
+                *m_VariableMap.at(itVariable->second.second);
+            if (!variable.IsValidStep(m_EngineStep + 1))
+            {
+                return DataType::None;
+            }
+        }
     }
 
     return type;
@@ -711,18 +698,14 @@ void IO::ResetVariablesStepSelection(const bool zeroStart,
         if (type == DataType::Compound)
         {
         }
-// using relative start
-#define declare_type(T)                                                        \
-    else if (type == helper::GetDataType<T>())                                 \
-    {                                                                          \
-        Variable<T> &variable =                                                \
-            GetVariableMap<T>().at(itVariable->second.second);                 \
-        variable.CheckRandomAccessConflict(hint);                              \
-        variable.ResetStepsSelection(zeroStart);                               \
-        variable.m_RandomAccess = false;                                       \
-    }
-        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
-#undef declare_type
+        else
+        {
+            VariableBase &variable =
+                *m_VariableMap.at(itVariable->second.second);
+            variable.CheckRandomAccessConflict(hint);
+            variable.ResetStepsSelection(zeroStart);
+            variable.m_RandomAccess = false;
+        }
     }
 }
 
@@ -748,18 +731,15 @@ void IO::SetPrefixedNames(const bool isStep) noexcept
         if (type == DataType::Compound)
         {
         }
-#define declare_type(T)                                                        \
-    else if (type == helper::GetDataType<T>())                                 \
-    {                                                                          \
-        Variable<T> &variable =                                                \
-            GetVariableMap<T>().at(itVariable->second.second);                 \
-        variable.m_PrefixedVariables =                                         \
-            helper::PrefixMatches(variable.m_Name, variables);                 \
-        variable.m_PrefixedAttributes =                                        \
-            helper::PrefixMatches(variable.m_Name, attributes);                \
-    }
-        ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
-#undef declare_type
+        else
+        {
+            VariableBase &variable =
+                *m_VariableMap.at(itVariable->second.second);
+            variable.m_PrefixedVariables =
+                helper::PrefixMatches(variable.m_Name, variables);
+            variable.m_PrefixedAttributes =
+                helper::PrefixMatches(variable.m_Name, attributes);
+        }
     }
 
     m_IsPrefixedNames = true;

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -373,15 +373,11 @@ bool IO::RemoveAttribute(const std::string &name) noexcept
         {
             // nothing to do
         }
-#define declare_type(T)                                                        \
-    else if (type == helper::GetDataType<T>())                                 \
-    {                                                                          \
-        auto &attributeMap = GetAttributeMap<T>();                             \
-        attributeMap.erase(index);                                             \
-        isRemoved = true;                                                      \
-    }
-        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
-#undef declare_type
+        else
+        {
+            m_AttributeMap.erase(index);
+            isRemoved = true;
+        }
     }
 
     if (isRemoved)
@@ -396,10 +392,7 @@ void IO::RemoveAllAttributes() noexcept
 {
     TAU_SCOPED_TIMER("IO::RemoveAllAttributes");
     m_Attributes.clear();
-
-#define declare_type(T) GetAttributeMap<T>().clear();
-    ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_type)
-#undef declare_type
+    m_AttributeMap.clear();
 }
 
 std::map<std::string, Params>
@@ -467,15 +460,12 @@ IO::GetAvailableAttributes(const std::string &variableName,
         if (type == DataType::Compound)
         {
         }
-#define declare_template_instantiation(T)                                      \
-    else if (type == helper::GetDataType<T>())                                 \
-    {                                                                          \
-        Attribute<T> &attribute =                                              \
-            GetAttributeMap<T>().at(attributePair.second.second);              \
-        attributesInfo[name] = attribute.GetInfo();                            \
-    }
-        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
+        else
+        {
+            AttributeBase &attribute =
+                *m_AttributeMap.at(attributePair.second.second);
+            attributesInfo[name] = attribute.GetInfo();
+        }
     }
     return attributesInfo;
 }
@@ -773,6 +763,12 @@ void IO::SetPrefixedNames(const bool isStep) noexcept
     }
 
     m_IsPrefixedNames = true;
+}
+
+std::map<unsigned int, std::unique_ptr<AttributeBase>> &
+IO::GetAttributeMap() noexcept
+{
+    return m_AttributeMap;
 }
 
 // PRIVATE

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -454,10 +454,6 @@ public:
 
     void SetPrefixedNames(const bool isStep) noexcept;
 
-    /** Gets the internal reference to a variable map for type T */
-    template <class T>
-    std::map<unsigned int, Variable<T>> &GetVariableMap() noexcept;
-
     /** Gets the internal reference to the attribute map. */
     std::map<unsigned int, std::unique_ptr<AttributeBase>> &
     GetAttributeMap() noexcept;
@@ -512,10 +508,7 @@ private:
     /** Independent (default) or Collective */
     adios2::IOMode m_IOMode = adios2::IOMode::Independent;
 
-/** Variable containers based on fixed-size type */
-#define declare_map(T, NAME) std::map<unsigned int, Variable<T>> m_##NAME;
-    ADIOS2_FOREACH_STDTYPE_2ARGS(declare_map)
-#undef declare_map
+    std::map<unsigned int, std::unique_ptr<VariableBase>> m_VariableMap;
 
     std::map<unsigned int, std::unique_ptr<AttributeBase>> m_AttributeMap;
 

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -123,7 +123,7 @@ public:
     IO(ADIOS &adios, const std::string name, const bool inConfigFile,
        const std::string hostLanguage);
 
-    ~IO() = default;
+    ~IO();
 
     /**
      * @brief Sets the engine type for this IO class object

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -458,9 +458,9 @@ public:
     template <class T>
     std::map<unsigned int, Variable<T>> &GetVariableMap() noexcept;
 
-    /** Gets the internal reference to an attribute map for type T */
-    template <class T>
-    std::map<unsigned int, Attribute<T>> &GetAttributeMap() noexcept;
+    /** Gets the internal reference to the attribute map. */
+    std::map<unsigned int, std::unique_ptr<AttributeBase>> &
+    GetAttributeMap() noexcept;
 
     using MakeEngineFunc = std::function<std::shared_ptr<Engine>(
         IO &, const std::string &, const Mode, helper::Comm)>;
@@ -517,9 +517,7 @@ private:
     ADIOS2_FOREACH_STDTYPE_2ARGS(declare_map)
 #undef declare_map
 
-#define declare_map(T, NAME) std::map<unsigned int, Attribute<T>> m_##NAME##A;
-    ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(declare_map)
-#undef declare_map
+    std::map<unsigned int, std::unique_ptr<AttributeBase>> m_AttributeMap;
 
     std::map<std::string, std::shared_ptr<Engine>> m_Engines;
 

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -518,8 +518,6 @@ private:
     ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(declare_map)
 #undef declare_map
 
-    std::map<unsigned int, VariableCompound> m_Compound;
-
     std::map<std::string, std::shared_ptr<Engine>> m_Engines;
 
     /**

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -125,6 +125,9 @@ public:
 
     ~IO();
 
+    IO(IO const &) = delete;
+    IO &operator=(IO const &) = delete;
+
     /**
      * @brief Sets the engine type for this IO class object
      * @param engine predefined engine type, default is bpfile

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -34,9 +34,8 @@ namespace adios2
 namespace core
 {
 
-/** used for Variables and Attributes, name, type, type-index */
-using DataMap =
-    std::unordered_map<std::string, std::pair<DataType, unsigned int>>;
+using VarMap = std::unordered_map<std::string, std::unique_ptr<VariableBase>>;
+using AttrMap = std::unordered_map<std::string, std::unique_ptr<AttributeBase>>;
 
 // forward declaration needed as IO is passed to Engine derived
 // classes
@@ -55,27 +54,6 @@ public:
 
     /** from ADIOS class passed to Engine created with Open */
     const std::string m_HostLanguage = "C++";
-
-    /**
-     * Map holding variable identifiers
-     * <pre>
-     * key: unique variable name,
-     * value: pair.first = type as string GetDataType<T> from adiosTemplates.h
-     *        pair.second = index in fixed size map (e.g. m_Int8, m_Double)
-     * </pre>
-     */
-    DataMap m_Variables;
-
-    /**
-     * Map holding attribute identifiers
-     * <pre>
-     * key: unique attribute name,
-     * value: pair.first = type as string GetDataType<T> from
-     *                     helper/adiosTemplates.h
-     *        pair.second = index in fixed size map (e.g. m_Int8, m_Double)
-     * </pre>
-     */
-    DataMap m_Attributes;
 
     /** From SetParameter, parameters for a particular engine from m_Type */
     Params m_Parameters;
@@ -304,7 +282,7 @@ public:
      * @param itVariable
      * @return type primitive type
      */
-    DataType InquireVariableType(const DataMap::const_iterator itVariable) const
+    DataType InquireVariableType(const VarMap::const_iterator itVariable) const
         noexcept;
 
     /**
@@ -312,22 +290,20 @@ public:
      * @return
      * <pre>
      * key: unique variable name,
-     * value: pair.first = string type
-     *        pair.second = order in the type bucket
+     * value: pointer to VariableBase
      * </pre>
      */
-    const DataMap &GetVariablesDataMap() const noexcept;
+    const VarMap &GetVariables() const noexcept;
 
     /**
      * Retrieves hash holding internal Attributes identifiers
      * @return
      * <pre>
      * key: unique attribute name,
-     * value: pair.first = string type
-     *        pair.second = order in the type bucket
+     * value: pointer to AttributeBase
      * </pre>
      */
-    const DataMap &GetAttributesDataMap() const noexcept;
+    const AttrMap &GetAttributes() const noexcept;
 
     /**
      * Gets an existing attribute of primitive type by name
@@ -454,10 +430,6 @@ public:
 
     void SetPrefixedNames(const bool isStep) noexcept;
 
-    /** Gets the internal reference to the attribute map. */
-    std::map<unsigned int, std::unique_ptr<AttributeBase>> &
-    GetAttributeMap() noexcept;
-
     using MakeEngineFunc = std::function<std::shared_ptr<Engine>(
         IO &, const std::string &, const Mode, helper::Comm)>;
     struct EngineFactoryEntry
@@ -508,32 +480,15 @@ private:
     /** Independent (default) or Collective */
     adios2::IOMode m_IOMode = adios2::IOMode::Independent;
 
-    std::map<unsigned int, std::unique_ptr<VariableBase>> m_VariableMap;
+    VarMap m_Variables;
 
-    std::map<unsigned int, std::unique_ptr<AttributeBase>> m_AttributeMap;
+    AttrMap m_Attributes;
 
     std::map<std::string, std::shared_ptr<Engine>> m_Engines;
-
-    /**
-     * Gets map index for Variables or Attributes
-     * @param name
-     * @param dataMap m_Variables or m_Attributes
-     * @return index in type map, -1 if not found
-     */
-    int GetMapIndex(const std::string &name, const DataMap &dataMap) const
-        noexcept;
 
     /** Checks if attribute exists, called from DefineAttribute different
      *  signatures */
     void CheckAttributeCommon(const std::string &name) const;
-
-    /**
-     * Checks if iterator points to end. Used for Variables and Attributes.
-     * @param itDataMap iterator to be tested
-     * @param dataMap map
-     * @return true: itDataMap == dataMap.end(), false otherwise
-     */
-    bool IsEnd(DataMap::const_iterator itDataMap, const DataMap &dataMap) const;
 
     void CheckTransportType(const std::string type) const;
 

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -304,20 +304,17 @@ VariableBase::GetAttributesInfo(core::IO &io, const std::string separator,
             return;
         }
 
-        auto itAttribute = io.m_Attributes.find(attributeName);
-        const DataType type = itAttribute->second.first;
+        auto itAttribute = io.GetAttributes().find(attributeName);
 
         const std::string key =
             fullNameKeys ? attributeName : attributeName.substr(prefix.size());
 
-        if (type == DataType::Compound)
+        if (itAttribute->second->m_Type == DataType::Compound)
         {
         }
         else
         {
-            AttributeBase &attribute =
-                *io.GetAttributeMap().at(itAttribute->second.second);
-            attributesInfo[key] = attribute.GetInfo();
+            attributesInfo[key] = itAttribute->second->GetInfo();
         }
     };
 
@@ -336,7 +333,7 @@ VariableBase::GetAttributesInfo(core::IO &io, const std::string separator,
     }
     else
     { // get prefixed attributes on-the-fly (expensive)
-        for (const auto &attributePair : io.m_Attributes)
+        for (const auto &attributePair : io.GetAttributes())
         {
             const std::string &attributeName = attributePair.first;
             lf_GetAttributeInfo(prefix, attributeName, io, attributesInfo,

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -313,15 +313,12 @@ VariableBase::GetAttributesInfo(core::IO &io, const std::string separator,
         if (type == DataType::Compound)
         {
         }
-#define declare_template_instantiation(T)                                      \
-    else if (type == helper::GetDataType<T>())                                 \
-    {                                                                          \
-        Attribute<T> &attribute =                                              \
-            io.GetAttributeMap<T>().at(itAttribute->second.second);            \
-        attributesInfo[key] = attribute.GetInfo();                             \
-    }
-        ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
+        else
+        {
+            AttributeBase &attribute =
+                *io.GetAttributeMap().at(itAttribute->second.second);
+            attributesInfo[key] = attribute.GetInfo();
+        }
     };
 
     // BODY OF FUNCTION STARTS HERE

--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -265,8 +265,8 @@ StepStatus InSituMPIReader::BeginStep(const StepMode mode,
         if (m_Verbosity == 5)
         {
             std::cout << "InSituMPI Reader " << m_ReaderRank << " found "
-                      << m_IO.GetVariablesDataMap().size() << " variables and "
-                      << m_IO.GetAttributesDataMap().size()
+                      << m_IO.GetVariables().size() << " variables and "
+                      << m_IO.GetAttributes().size()
                       << " attributes in metadata. Is source row major = "
                       << m_BP3Deserializer.m_IsRowMajor << std::endl;
         }

--- a/source/adios2/engine/ssc/SscHelper.cpp
+++ b/source/adios2/engine/ssc/SscHelper.cpp
@@ -144,12 +144,12 @@ void BlockVecToJson(const BlockVec &input, nlohmann::json &output)
 
 void AttributeMapToJson(IO &input, nlohmann::json &output)
 {
-    const auto &attributeMap = input.GetAttributesDataMap();
+    const auto &attributeMap = input.GetAttributes();
     auto &attributesJson = output["Attributes"];
     for (const auto &attributePair : attributeMap)
     {
         const std::string name(attributePair.first);
-        const DataType type(attributePair.second.first);
+        const DataType type(attributePair.second->m_Type);
         if (type == DataType::None)
         {
         }

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -386,10 +386,9 @@ void SscReader::SyncWritePattern()
 #define declare_type(T)                                                        \
     else if (type == helper::GetDataType<T>())                                 \
     {                                                                          \
-        const auto &attributesDataMap = m_IO.GetAttributesDataMap();           \
-        auto it =                                                              \
-            attributesDataMap.find(attributeJson["Name"].get<std::string>());  \
-        if (it == attributesDataMap.end())                                     \
+        const auto &attributes = m_IO.GetAttributes();                         \
+        auto it = attributes.find(attributeJson["Name"].get<std::string>());   \
+        if (it == attributes.end())                                            \
         {                                                                      \
             if (attributeJson["IsSingleValue"].get<bool>())                    \
             {                                                                  \

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -157,19 +157,18 @@ StepStatus SstWriter::BeginStep(StepMode mode, const float timeout_sec)
 void SstWriter::FFSMarshalAttributes()
 {
     TAU_SCOPED_TIMER_FUNC();
-    const auto &attributesDataMap = m_IO.GetAttributesDataMap();
+    const auto &attributes = m_IO.GetAttributes();
 
-    const uint32_t attributesCount =
-        static_cast<uint32_t>(attributesDataMap.size());
+    const uint32_t attributesCount = static_cast<uint32_t>(attributes.size());
 
     // if there are no new attributes, nothing to do
     if (attributesCount == m_FFSMarshaledAttributesCount)
         return;
 
-    for (const auto &attributePair : attributesDataMap)
+    for (const auto &attributePair : attributes)
     {
         const std::string name(attributePair.first);
-        const DataType type(attributePair.second.first);
+        const DataType type(attributePair.second->m_Type);
 
         if (type == DataType::None)
         {

--- a/source/adios2/helper/adiosXML.cpp
+++ b/source/adios2/helper/adiosXML.cpp
@@ -147,9 +147,10 @@ void ParseConfigXML(
             helper::XMLAttribute("name", io, hint);
 
         // Build the IO object
-        auto itCurrentIO =
-            ios.emplace(ioName->value(), core::IO(adios, ioName->value(), true,
-                                                  adios.m_HostLanguage));
+        auto itCurrentIO = ios.emplace(
+            std::piecewise_construct, std::forward_as_tuple(ioName->value()),
+            std::forward_as_tuple(adios, ioName->value(), true,
+                                  adios.m_HostLanguage));
         core::IO &currentIO = itCurrentIO.first->second;
 
         // must be unique per io

--- a/source/adios2/helper/adiosYAML.cpp
+++ b/source/adios2/helper/adiosYAML.cpp
@@ -123,7 +123,8 @@ void ParseConfigYAML(
     auto lf_IOYAML = [&](const std::string &ioName, const YAML::Node &ioMap) {
         // Build the IO object
         auto itCurrentIO = ios.emplace(
-            ioName, core::IO(adios, ioName, true, adios.m_HostLanguage));
+            std::piecewise_construct, std::forward_as_tuple(ioName),
+            std::forward_as_tuple(adios, ioName, true, adios.m_HostLanguage));
         core::IO &currentIO = itCurrentIO.first->second;
 
         // Engine parameters

--- a/source/adios2/toolkit/format/bp/BPSerializer.cpp
+++ b/source/adios2/toolkit/format/bp/BPSerializer.cpp
@@ -739,11 +739,11 @@ size_t BPSerializer::GetAttributesSizeInData(core::IO &io) const noexcept
 {
     size_t attributesSizeInData = 0;
 
-    auto &attributes = io.GetAttributesDataMap();
+    auto &attributes = io.GetAttributes();
 
     for (const auto &attribute : attributes)
     {
-        const DataType type = attribute.second.first;
+        const DataType type = attribute.second->m_Type;
 
         // each attribute is only written to output once
         // so filter out the ones already written
@@ -772,7 +772,7 @@ size_t BPSerializer::GetAttributesSizeInData(core::IO &io) const noexcept
 
 void BPSerializer::PutAttributes(core::IO &io)
 {
-    const auto &attributesDataMap = io.GetAttributesDataMap();
+    const auto &attributes = io.GetAttributes();
 
     auto &buffer = m_Data.m_Buffer;
     auto &position = m_Data.m_Position;
@@ -781,8 +781,7 @@ void BPSerializer::PutAttributes(core::IO &io)
     const size_t attributesCountPosition = position;
 
     // count is known ahead of time
-    const uint32_t attributesCount =
-        static_cast<uint32_t>(attributesDataMap.size());
+    const uint32_t attributesCount = static_cast<uint32_t>(attributes.size());
     helper::CopyToBuffer(buffer, position, &attributesCount);
 
     // will go back
@@ -793,10 +792,10 @@ void BPSerializer::PutAttributes(core::IO &io)
 
     uint32_t memberID = 0;
 
-    for (const auto &attributePair : attributesDataMap)
+    for (const auto &attributePair : attributes)
     {
         const std::string name(attributePair.first);
-        const DataType type(attributePair.second.first);
+        const DataType type(attributePair.second->m_Type);
 
         // each attribute is only written to output once
         // so filter out the ones already written

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -332,12 +332,12 @@ bool DataManSerializer::IsCompressionAvailable(const std::string &method,
 void DataManSerializer::PutAttributes(core::IO &io)
 {
     TAU_SCOPED_TIMER_FUNC();
-    const auto &attributesDataMap = io.GetAttributesDataMap();
+    const auto &attributes = io.GetAttributes();
     bool attributePut = false;
-    for (const auto &attributePair : attributesDataMap)
+    for (const auto &attributePair : attributes)
     {
         const std::string name(attributePair.first);
-        const DataType type(attributePair.second.first);
+        const DataType type(attributePair.second->m_Type);
         if (type == DataType::None)
         {
         }
@@ -383,9 +383,9 @@ void DataManSerializer::GetAttributes(core::IO &io)
 #define declare_type(T)                                                        \
     else if (type == helper::GetDataType<T>())                                 \
     {                                                                          \
-        const auto &attributesDataMap = io.GetAttributesDataMap();             \
-        auto it = attributesDataMap.find(staticVar["N"].get<std::string>());   \
-        if (it == attributesDataMap.end())                                     \
+        const auto &attributes = io.GetAttributes();                           \
+        auto it = attributes.find(staticVar["N"].get<std::string>());          \
+        if (it == attributes.end())                                            \
         {                                                                      \
             if (staticVar["V"].get<bool>())                                    \
             {                                                                  \

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -1189,11 +1189,11 @@ void HDF5Common::LocateAttrParent(const std::string &attrName,
 void HDF5Common::CreateVarsFromIO(core::IO &io)
 {
     CheckWriteGroup();
-    const core::DataMap &variables = io.GetVariablesDataMap();
+    const core::VarMap &variables = io.GetVariables();
     for (const auto &vpair : variables)
     {
         const std::string &varName = vpair.first;
-        const DataType varType = vpair.second.first;
+        const DataType varType = vpair.second->m_Type;
 #define declare_template_instantiation(T)                                      \
     if (varType == helper::GetDataType<T>())                                   \
     {                                                                          \

--- a/source/utils/adios_reorganize/Reorganize.cpp
+++ b/source/utils/adios_reorganize/Reorganize.cpp
@@ -194,8 +194,8 @@ void Reorganize::Run()
         }
 
         curr_step = static_cast<int>(rStream.CurrentStep());
-        const core::DataMap &variables = io.GetVariablesDataMap();
-        const core::DataMap &attributes = io.GetAttributesDataMap();
+        const core::VarMap &variables = io.GetVariables();
+        const core::AttrMap &attributes = io.GetAttributes();
 
         print0("____________________\n\nFile info:");
         print0("  current step:   ", curr_step);
@@ -480,8 +480,8 @@ Reorganize::Decompose(int numproc, int rank, VarInfo &vi,
 }
 
 int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
-                                const core::DataMap &variables,
-                                const core::DataMap &attributes, int step)
+                                const core::VarMap &variables,
+                                const core::AttrMap &attributes, int step)
 {
     int retval = 0;
 
@@ -494,7 +494,7 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
     for (const auto &variablePair : variables)
     {
         const std::string &name(variablePair.first);
-        const DataType type(variablePair.second.first);
+        const DataType type(variablePair.second->m_Type);
         core::VariableBase *variable = nullptr;
         print0("Get info on variable ", varidx, ": ", name);
         size_t nBlocks = 1;
@@ -608,8 +608,7 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
 }
 
 int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
-                          core::IO &io, const core::DataMap &variables,
-                          int step)
+                          core::IO &io, const core::VarMap &variables, int step)
 {
     int retval = 0;
 
@@ -639,7 +638,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
                 // read variable subset
                 std::cout << "rank " << m_Rank << ": Read variable " << name
                           << std::endl;
-                const DataType type = variables.at(name).first;
+                const DataType type = variables.at(name)->m_Type;
                 if (type == DataType::Compound)
                 {
                     // not supported
@@ -683,7 +682,7 @@ int Reorganize::ReadWrite(core::Engine &rStream, core::Engine &wStream,
                 // Write variable subset
                 std::cout << "rank " << m_Rank << ": Write variable " << name
                           << std::endl;
-                const DataType type = variables.at(name).first;
+                const DataType type = variables.at(name)->m_Type;
                 if (type == DataType::Compound)
                 {
                     // not supported

--- a/source/utils/adios_reorganize/Reorganize.h
+++ b/source/utils/adios_reorganize/Reorganize.h
@@ -11,7 +11,7 @@
 #ifndef UTILS_REORGANIZE_REORGANIZE_H_
 #define UTILS_REORGANIZE_REORGANIZE_H_
 
-#include "adios2/core/IO.h" // DataMap
+#include "adios2/core/IO.h"
 #include "adios2/helper/adiosComm.h"
 #include "utils/Utils.h"
 
@@ -61,10 +61,10 @@ private:
                      const int *np // number of processes in each dimension
     );
     int ProcessMetadata(core::Engine &rStream, core::IO &io,
-                        const core::DataMap &variables,
-                        const core::DataMap &attributes, int step);
+                        const core::VarMap &variables,
+                        const core::AttrMap &attributes, int step);
     int ReadWrite(core::Engine &rStream, core::Engine &wStream, core::IO &io,
-                  const core::DataMap &variables, int step);
+                  const core::VarMap &variables, int step);
     Params parseParams(const std::string &param_str);
 
     // Input arguments

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -898,8 +898,8 @@ int nEntriesMatched = 0;
 int doList_vars(core::Engine *fp, core::IO *io)
 {
 
-    const core::DataMap &variables = io->GetVariablesDataMap();
-    const core::DataMap &attributes = io->GetAttributesDataMap();
+    const core::VarMap &variables = io->GetVariables();
+    const core::AttrMap &attributes = io->GetAttributes();
 
     // make a sorted list of all variables and attributes
     EntryMap entries;
@@ -907,7 +907,7 @@ int doList_vars(core::Engine *fp, core::IO *io)
     {
         for (const auto &vpair : variables)
         {
-            Entry e(true, vpair.second.first, vpair.second.second);
+            Entry e(true, vpair.second->m_Type);
             entries.emplace(vpair.first, e);
         }
     }
@@ -915,7 +915,7 @@ int doList_vars(core::Engine *fp, core::IO *io)
     {
         for (const auto &apair : attributes)
         {
-            Entry e(false, apair.second.first, apair.second.second);
+            Entry e(false, apair.second->m_Type);
             entries.emplace(apair.first, e);
         }
     }

--- a/source/utils/bpls/bpls.h
+++ b/source/utils/bpls/bpls.h
@@ -39,11 +39,7 @@ struct Entry
 {
     bool isVar;
     DataType typeName;
-    unsigned int typeIndex;
-    Entry(bool b, DataType name, unsigned idx)
-    : isVar(b), typeName(name), typeIndex(idx)
-    {
-    }
+    Entry(bool b, DataType type) : isVar(b), typeName(type) {}
 };
 
 // how to print one data item of an array


### PR DESCRIPTION
Flatten IO variable and attribute storage maps.  Replace each two-layer map (and intermediate index) with one direct map.  Map directly from the variable name (or attribute name) to the corresponding `Variable<T>` (or `Attribute<T>`) instance.  Avoid using per-type maps by mapping to `unique_ptr<VariableBase>` (or `unique_ptr<AttributeBase>`) and statically downcast as needed.

This removes several uses of `ADIOS2_FOREACH_*` macros and likely enables removal of many more in future work.
