### PR TITLE
BP4 metadata format fix

### DIFF
--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
@@ -1330,7 +1330,7 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
                                       serialized.begin() + start + length,
                                       buffer.begin() + position);
                             position += length - headerSize;
-                            setsCount++;
+                            setsCount += header.CharacteristicsSetsCount;
                         }
                         const uint32_t entryLength = static_cast<uint32_t>(
                             position - entryLengthPosition - 4);

--- a/source/utils/bp4dbg/adios2/bp4dbg/metadata.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/metadata.py
@@ -425,7 +425,7 @@ def ReadVarMD(buf, idx, pos, limit, varStartOffset):
     pos = pos + 8
     print("        # of blocks     : {0}".format(cSets))
 
-##  This loop only reads the number of reported blocks
+#   This loop only reads the number of reported blocks
 #     for i in range(cSets):
 #         # one characteristics block
 #         newlimit = limit - (pos - varStartPosition)
@@ -435,7 +435,7 @@ def ReadVarMD(buf, idx, pos, limit, varStartOffset):
 #         if not status:
 #             return False
 
-##  This loop reads blocks until the reported length of variable index length
+#   This loop reads blocks until the reported length of variable index length
     i = 0
     while pos < varStartPosition + varLength:
         # one characteristics block
@@ -452,7 +452,7 @@ def ReadVarMD(buf, idx, pos, limit, varStartOffset):
             "ERROR: reported # of blocks (={0}) != # of encoded blocks "
             " (={1})".format(
                 cSets, i))
-        
+
     return True, pos
 
 

--- a/source/utils/bp4dbg/adios2/bp4dbg/metadata.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/metadata.py
@@ -425,7 +425,19 @@ def ReadVarMD(buf, idx, pos, limit, varStartOffset):
     pos = pos + 8
     print("        # of blocks     : {0}".format(cSets))
 
-    for i in range(cSets):
+##  This loop only reads the number of reported blocks
+#     for i in range(cSets):
+#         # one characteristics block
+#         newlimit = limit - (pos - varStartPosition)
+#         fileOffset = varStartOffset + (pos - varStartPosition)
+#         status, pos = ReadCharacteristicsFromMetaData(
+#             buf, i, pos, newlimit, typeID, fileOffset, True)
+#         if not status:
+#             return False
+
+##  This loop reads blocks until the reported length of variable index length
+    i = 0
+    while pos < varStartPosition + varLength:
         # one characteristics block
         newlimit = limit - (pos - varStartPosition)
         fileOffset = varStartOffset + (pos - varStartPosition)
@@ -433,7 +445,14 @@ def ReadVarMD(buf, idx, pos, limit, varStartOffset):
             buf, i, pos, newlimit, typeID, fileOffset, True)
         if not status:
             return False
+        i = i + 1
 
+    if (i != cSets):
+        print(
+            "ERROR: reported # of blocks (={0}) != # of encoded blocks "
+            " (={1})".format(
+                cSets, i))
+        
     return True, pos
 
 


### PR DESCRIPTION
Fix the reported number of blocks in the BP4 metadata for a variable. When one rank wrote multiple blocks in a step, it was only counted as one block in the last step of collecting metadata (sort-merge step on rank 0). 

This number in the metadata was not used by BP4 reader so it did not cause reading problems. 

Also modified bp4dbg that caught this error, now it reads like BP4 (based on length of index, not based on reported number of blocks). It prints an error now if discrepancy is found between these two ways of reading.