### PR TITLE
Remove superfluous check on CMake version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,14 +88,12 @@ mark_as_advanced(ADIOS2_LIBRARY_SUFFIX ADIOS2_EXECUTABLE_SUFFIX)
 
 # Use meta-compile features if available, otherwise use specific language
 # features
-if(CMAKE_VERSION VERSION_LESS 3.9 OR
-   CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Intel|Clang|AppleClang|MSVC)$")
+if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Intel|Clang|AppleClang|MSVC)$")
   set(ADIOS2_CXX11_FEATURES cxx_auto_type cxx_nullptr)
 else()
   set(ADIOS2_CXX11_FEATURES cxx_std_11)
 endif()
-if(CMAKE_VERSION VERSION_LESS 3.9 OR
-   CMAKE_C_COMPILER_ID MATCHES "^(GNU|Intel|Clang|AppleClang|MSVC)$")
+if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Intel|Clang|AppleClang|MSVC)$")
   set(ADIOS2_C99_FEATURES c_restrict)
 else()
   set(ADIOS2_C99_FEATURES c_std_99)


### PR DESCRIPTION
The top line requires a `cmake_minimum_required(VERSION 3.12)`.