### PR TITLE
Link to Software X paper in README.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,14 +12,17 @@
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/11116/badge.svg)](https://scan.coverity.com/projects/ornladios-adios2)
 
 
-# ADIOS 2 : The Adaptable Input Output System version 2
-This is ADIOS 2 : The Adaptable Input/Output (I/O) System, ADIOS 2 is developed as part of the United States Department of Energy's Exascale Computing Program.
+# ADIOS2 : The Adaptable Input Output System version 2
 
-ADIOS 2 is a framework designed for scientific data I/O to publish and subscribe (put/get) data when and where required. 
+This is ADIOS2: The Adaptable Input/Output (I/O) System.
 
-ADIOS 2 transports data as groups of self-describing variables and attributes across different media types (such as files, wide-area-networks, and remote direct memory access) using a common application programming interface for all transport modes. ADIOS 2 can be used on supercomputers, cloud systems, and personal computers.
+ADIOS2 is developed as part of the United States Department of Energy's Exascale Computing Project.
+It is a framework for scientific data I/O to publish and subscribe to data when and where required.
 
-ADIOS 2 focuses on:
+ADIOS2 transports data as groups of self-describing variables and attributes across different media types (such as files, wide-area-networks, and remote direct memory access) using a common application programming interface for all transport modes.
+ADIOS2 can be used on supercomputers, cloud systems, and personal computers.
+
+ADIOS2 focuses on:
 
 1. **Performance** I/O scalability in high performance computing (HPC) applications.
 2. **Adaptability** unified interfaces to allow for several modes of transport (files, memory-to-memory)  
@@ -27,23 +30,29 @@ ADIOS 2 focuses on:
     * Full APIs for HPC applications: C++11, Fortran 90, C 99, Python 2 and 3 
     * Simplified High-Level APIs for data analysis: Python 2 and 3, C++11, Matlab  
     
-In addition, ADIOS 2 APIs are based on:
+In addition, ADIOS2 APIs are based on:
 
-* **MPI** ADIOS 2 is MPI-based, it can be used in non-MPI serial code. Non-MPI 100% serial build is optional.
+* **MPI** Although ADIOS2 is MPI-based, it can also be used in non-MPI serial code.
 
-* **Data Groups** ADIOS 2 favors a deferred/prefetch/grouped variables transport mode by default to maximize data-per-request ratios. Sync mode, one variable at a time, is treated as the special case.
+* **Data Groups** ADIOS2 favors a deferred/prefetch/grouped variables transport mode by default to maximize data-per-request ratios.
+Sync mode, one variable at a time, is treated as the special case.
 
-* **Data Steps** ADIOS 2 follows the actual production/consumption of data using an I/O “steps” abstraction removing the need to manage extra indexing information.
+* **Data Steps** ADIOS2 follows the actual production/consumption of data using an I/O “steps” abstraction removing the need to manage extra indexing information.
 
-* **Data Engines** ADIOS 2 Engine abstraction allows for reusing the APIs for different transport modes removing the need for drastic code changes.
+* **Data Engines** ADIOS2 Engine abstraction allows for reusing the APIs for different transport modes removing the need for drastic code changes.
 
 ## Documentation
-Please find [The ADIOS 2 User Guide at readthedocs](https://adios2.readthedocs.io)
 
+Documentation is hosted at [readthedocs](https://adios2.readthedocs.io).
+
+## Citing
+
+If you find ADIOS2 useful, please cite our [SoftwareX paper](https://doi.org/10.1016/j.softx.2020.100561), which also gives a high-level overview to the motivation and goals of ADIOS; complementing the documentation.
 
 ## Getting ADIOS2
 
-* From source: [Install ADIOS 2 documentation](https://adios2.readthedocs.io/en/latest/setting_up/setting_up.html#) requires CMake v3.6 or above. For a cmake configuration example see [scripts/runconf/runconf.sh](https://github.com/ornladios/ADIOS2/blob/master/scripts/runconf/runconf.sh)
+* From source: [Install ADIOS2 documentation](https://adios2.readthedocs.io/en/latest/setting_up/setting_up.html#).
+For a `cmake` configuration example see [scripts/runconf/runconf.sh](https://github.com/ornladios/ADIOS2/blob/master/scripts/runconf/runconf.sh)
 
 
 * Conda packages: 
@@ -71,15 +80,15 @@ Once ADIOS 2 is installed refer to:
 
 ## Reporting Bugs
 
-If you found a bug, please open an [issue on ADIOS2 github repository](https://github.com/ornladios/ADIOS2/issues)
+If you find a bug, please open an [issue on ADIOS2 github repository](https://github.com/ornladios/ADIOS2/issues)
 
 ## Contributing
 
-We invite the community to contribute, see [Contributor's Guide to ADIOS 2](Contributing.md) for instructions on how to contribute. ADIOS 2 will always be free and open-source.
+See the [Contributor's Guide to ADIOS 2](Contributing.md) for instructions on how to contribute.
 
 ## License
-ADIOS >= 2.0 is licensed under the Apache License v2.0.  See the accompanying
-[Copyright.txt](Copyright.txt) for more details.
+ADIOS2 is licensed under the Apache License v2.0.
+See the accompanying [Copyright.txt](Copyright.txt) for more details.
 
 
 ## Directory layout


### PR DESCRIPTION
Also, use `ADIOS2` in preference to `ADIOS 2`, matching the `grep` findings of higher frequency occurrence of the former in the documentation.

Remove reference to required `cmake` version as this tends to go stale.