### PR TITLE
Fix compile warning:

### DIFF
--- a/bindings/C/adios2/c/adios2_c_types.h
+++ b/bindings/C/adios2/c/adios2_c_types.h
@@ -138,7 +138,7 @@ typedef enum
     adios2_shapeid_local_array = 4
 } adios2_shapeid;
 
-static size_t adios2_string_array_element_max_size = 4096;
+static const size_t adios2_string_array_element_max_size = 4096;
 
 static const uint64_t adios2_local_value_dim = ULLONG_MAX - 2;
 


### PR DESCRIPTION
```
In file included from /home/svcpetsc/petsc-hash-pkgs/577169/include/adios2/c/adios2_c_adios.h:14:0,
                 from /home/svcpetsc/petsc-hash-pkgs/577169/include/adios2_c.h:16,
                 from /scratch/svcpetsc/glci-builds/GXbQf6e_/1/petsc/petsc/src/sys/objects/pinit.c:649:
/home/svcpetsc/petsc-hash-pkgs/577169/include/adios2/c/adios2_c_types.h:141:15: error: ‘adios2_string_array_element_max_size’ defined but not used [-Werror=unused-variable]
 static size_t adios2_string_array_element_max_size = 4096;
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```