### PR TITLE
Use pip3 for Python files.

### DIFF
--- a/scripts/travis/run-format.sh
+++ b/scripts/travis/run-format.sh
@@ -20,7 +20,9 @@ git config --global clangformat.binary ${HOME}/clang+llvm-7.0.1-x86_64-linux-gnu
 popd
 
 # Install flake8
-pip install --user flake8
+sudo apt update -y
+sudo apt install -y python3-pip
+python3 -m pip install flake8
 
 cd ${SOURCE_DIR}
 
@@ -39,7 +41,7 @@ then
 fi
 
 # Check python code with flake8
-if ! ~/.local/bin/flake8 --config=flake8.cfg .
+if ! flake8 --config=flake8.cfg .
 then
   exit 3
 fi


### PR DESCRIPTION
Although we may want to retain Python2 compatibility in the ADIOS package, there is no harm in running `pip3` on the files, and also, we have Python3 files which require `pip3`. So just use `pip3` everywhere.