### PR TITLE
Update documentation

### DIFF
--- a/docs/user_guide/source/components/attribute.rst
+++ b/docs/user_guide/source/components/attribute.rst
@@ -6,11 +6,11 @@ Attributes are extra information associated with a particular IO component.
 They can be thought of as a very simplified ``Variable``, but with the goal of adding extra metadata.
 The most common use is the addition of human-readable metadata (*e.g.* ``"experiment name"``, ``"date and time"``, ``"04,27,2017"``, or a schema).
 
-Currently, ADIOS2 supports single values and arrays of primitive types (excluding ``complex<T>``) for the template type in the ``IO::DefineAttribute<T>`` and ``IO::InquireAttribute<T>`` function (in C++).  
+Currently, ADIOS2 supports single values and arrays of primitive types (excluding ``complex<T>``) for the template type in the ``IO::DefineAttribute<T>`` and ``IO::InquireAttribute<T>`` function (in C++).
+
+The data types supported for ADIOS2 ``Attributes`` are
 
 .. code-block:: c++
-
-   Data types Attributes supported by ADIOS2:
 
    std::string
    char

--- a/docs/user_guide/source/components/io.rst
+++ b/docs/user_guide/source/components/io.rst
@@ -2,7 +2,7 @@
 IO
 **
 
-The ``IO`` component is the connection between how applications set up their input/output options by selecting an ``Engine`` and its specific parameters, subscribing variables to self-describe the data, and setting supported transport modes to a particular Engine.
+The ``IO`` component is the connection between how applications set up their input/output options by selecting an ``Engine`` and its specific parameters, subscribing variables to data, and setting supported transport modes to a particular ``Engine``.
 Think of ``IO`` as a control panel for all the user-defined parameters that applications would like to fine tune.
 None of the ``IO`` operations are heavyweight until the ``Open`` function that generates an ``Engine`` is called.
 Its API allows
@@ -163,7 +163,7 @@ Keep in mind that Attributes apply to all Engines created by the ``IO`` object a
                                   const size_t elements);
 
 In situations in which a variable and attribute has been previously defined:
-1) a variable/attribute reference goes out of scope, or 2) when reading from an incoming stream, IO can inquire the current variables and attributes and return a pointer acting as reference.
+1) a variable/attribute reference goes out of scope, or 2) when reading from an incoming stream, the ``IO`` can inquire about the status of variables and attributes.
 If the inquired variable/attribute is not found, then the overloaded ``bool()`` operator of returns ``false``.
 
 .. code-block:: c++
@@ -186,26 +186,6 @@ If the inquired variable/attribute is not found, then the overloaded ``bool()`` 
 .. caution::
 
    Since ``InquireVariable`` and ``InquireAttribute`` are template functions, both the name and type must match the data you are looking for.
-
-
-Removing Variables and Attributes can be done one at a time or by removing all existing variables or attributes in an ``IO``.
-
-.. code-block:: c++
-
-    /** Signature */
-    bool IO::RemoveVariable(const std::string &name) noexcept;
-    void IO::RemoveAllVariables( ) noexcept;
-
-    bool IO::RemoveAttribute(const std::string &name) noexcept;
-    void IO::RemoveAllAttributes( ) noexcept;
-
-.. caution::
-
-   Remove functions must be used with caution as they generate dangling Variable/Attributes references if they didn't go out of scope.
-
-.. tip::
-
-   It is good practice to check the ``bool`` flag returned by ``RemoveVariable`` or ``RemoveAttribute``.
 
 
 Opening an Engine

--- a/docs/user_guide/source/components/variable.rst
+++ b/docs/user_guide/source/components/variable.rst
@@ -58,7 +58,7 @@ Shapes
 
 ADIOS2 is designed for MPI applications.
 Thus different application data shapes must be supported depending on their scope within a particular MPI communicator.
-The shape is defined at creation from the ``IO`` object by providing the dimensions: shape, start, count in the ``IO::DeclareVariable<T>`` template function.
+The shape is defined at creation from the ``IO`` object by providing the dimensions: shape, start, count in the ``IO::DefineVariable<T>``.
 The supported shapes are described below.
 
 
@@ -70,8 +70,8 @@ These variables are helpful for storing global information, preferably managed b
 
       if( rank == 0 )
       {
-         adios2::Variable<uint32_t> varNodes = adios2::DefineVariable<uint32_t>("Nodes");
-         adios2::Variable<std::string> varFlag = adios2::DefineVariable<std::string>("Nodes flag");
+         adios2::Variable<uint32_t> varNodes = io.DefineVariable<uint32_t>("Nodes");
+         adios2::Variable<std::string> varFlag = io.DefineVariable<std::string>("Nodes flag");
          // ...
          engine.Put( varNodes, nodes );
          engine.Put( varFlag, "increased" );
@@ -81,11 +81,11 @@ These variables are helpful for storing global information, preferably managed b
    .. note::
 
       Variables of type ``string`` are defined just like global single values.
-      In the current ADIOS2 version multidimensional strings are supported for fixed size strings through variables of type ``char``.
+      Multidimensional strings are supported for fixed size strings through variables of type ``char``.
 
 
 2. **Global Array**:
-The most common shape used for storing data that lives in several MPI processes.
+This is the most common shape used for storing data that lives in several MPI processes.
 The image below illustrates the definitions of the dimension components in a global array: shape, start, and count.
 
    .. image:: https://i.imgur.com/MKwNe5e.png

--- a/docs/user_guide/source/conf.py
+++ b/docs/user_guide/source/conf.py
@@ -66,7 +66,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'ADIOS2'
-copyright = u'2018, Oak Ridge National Laboratory'
+copyright = u'2020, Oak Ridge National Laboratory'
 author = u'Oak Ridge National Laboratory'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/user_guide/source/ecosystem/visualization.rst
+++ b/docs/user_guide/source/ecosystem/visualization.rst
@@ -2,11 +2,7 @@
 Visualizing Data
 ################
 
-.. note::
+Certain ADIOS2 bp files can be recognized by third party visualization tools.
+This section describes how to create an ADIOS2 bp file to accomodate the visualization product requirements.
 
-   As of version 2.6.0 this work is experimental. As it builds on top of the library in third party ecosystems, and doesn't ship with ADIOS 2 source code.
-
-Certain ADIOS 2 bp files, and in-memory streams in the future), can be recognized by third party products to enable data visualization. The expectation is to keep adding support to the list of products enabling ADIOS 2 for visualization purposes. The goal of this section is to describe the currently cover cases and how to create an ADIOS 2 BP file to accomodate the visualization product requirements.
-
- 
 .. include:: visualization/vtk.rst

--- a/docs/user_guide/source/ecosystem/visualization/vtk.rst
+++ b/docs/user_guide/source/ecosystem/visualization/vtk.rst
@@ -2,25 +2,27 @@
 Using VTK and Paraview
 **********************
 
-ADIOS BP files can now be seamlessly integrated into the `Visualization Toolkit <https://vtk.org/>`_ (VTK) and `Paraview <https://www.paraview.org/>`_. Datasets can be described with an additional attribute that conforms to the `VTK XML data model formats <https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf>`_ as high-level descriptors that will allow interpretation of ADIOS 2 variables into a hierarchy understood by the VTK infrastructure. This XML data format is saved in ADIOS as either an attribute, and optionally, as an additional vtk.xml file inside file.bp.dir/vtk.xml from the default engine. For more details, see :ref:`BP3 (Default)`.
+ADIOS BP files can now be seamlessly integrated into the `Visualization Toolkit <https://vtk.org/>`_ and `Paraview <https://www.paraview.org/>`_.
+Datasets can be described with an additional attribute that conforms to the `VTK XML data model formats <https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf>`_ as high-level descriptors that will allow interpretation of ADIOS2 variables into a hierarchy understood by the VTK infrastructure.
+This XML data format is saved in ADIOS2 as either an attribute or as an additional ``vtk.xml`` file inside the ``file.bp.dir`` directory.
 
+There are currently a number of limitations:
 
-Current limitations:
-
-* Only works with MPI builds of VTK and Paraview
-* Support only one Block per ADIOS dataset
+* It only works with MPI builds of VTK and Paraview
+* Support only one block per ADIOS dataset
 * Only supports BP Files, streams are not supported
 * Currently working up to 3D (and linearized 1D) variables for scalars and vectors.
 * Image Data, vti, is supported with ADIOS2 Global Array Variables only
 * Unstructured Grid, vtu, is supported with ADIOS2 Local Arrays Variables only
  
 
-Two "VTK File" types are supported:
+Two VTK file types are supported:
 
 1. Image data (.vti)
 2. Unstructured Grid (.vtu)
 
-The main idea is to populate the above XML format contents describing the extent and the data arrays with ADIOS variables in the BP data set. The result is a more-than-compact typical VTK data file since extra information about the variable, such as dimensions and type, as they already exist in the BP data set.
+The main idea is to populate the above XML format contents describing the extent and the data arrays with ADIOS variables in the BP data set.
+The result is a more-than-compact typical VTK data file since extra information about the variable, such as dimensions and type, as they already exist in the BP data set.
 
 A typical VTK image data XML descriptor (.vti):
 
@@ -64,13 +66,14 @@ A typical VTK unstructured grid XML descriptor (.vtu):
    </VTKFile>
    
 
-In addition, VTK can interpret physical-time or output-step varying data stored with ADIOS by resusing the special "TIME" tag. This is better illustrated in the following section.
+In addition, VTK can interpret physical-time or output-step varying data stored with ADIOS by reusing the special "TIME" tag.
+This is better illustrated in the following section.
 
 
 Saving the vtk.xml data model
 -----------------------------
 
-For the full source code of the following illustration example see the `gray-scott adios2 tutorial <https://github.com/pnorbert/adiosvm/tree/master/Tutorial/gray-scott>`_
+For the full source code of the following illustration example see the `gray-scott adios2 tutorial <https://github.com/pnorbert/adiosvm/tree/master/Tutorial/gray-scott>`_.
 
 To incorporate the data model in a BP data file, the application has two options: 
 
@@ -99,7 +102,7 @@ To incorporate the data model in a BP data file, the application has two options
 
 .. tip::
 
-   C++11 users should take advantage C++11 string literals (R"( xml_here )") to simplify escaping characters in the XML.
+   C++11 users should take advantage C++11 string literals (``R"( xml_here )"``) to simplify escaping characters in the XML.
    
 The resulting bpls output should contain the "vtk.xml" attribute and the variables in the model:
 
@@ -158,14 +161,14 @@ The resulting bpls output should contain the "vtk.xml" attribute and the variabl
      </VTKFile>
 
 
-The result is that the generated BP file should be recognize by a branch of Paraview/VTK that must be built from source:
+This BP file should be recognize by Paraview:
 
 .. image:: https://i.imgur.com/ap3l9Z5.png : alt: my-picture2
 
 
 Similarly, unstructured grid (.vtu) support can be added with the limitations of using specific labels for the variable names setting the "connectivity", "vertices", and cell "types".
 
-The following example is taken from example 2 of the `MFEM product examples website <https://mfem.org/examples/>`_ using ADIOS 2:
+The following example is taken from example 2 of the `MFEM product examples website <https://mfem.org/examples/>`_ using ADIOS2:
 
 The resulting `bpls` output for unstructured grid data types: 
 
@@ -207,20 +210,3 @@ The resulting `bpls` output for unstructured grid data types:
 and resulting visualization in Paraview for different "cell" types:
 
 .. image:: https://i.imgur.com/ke1xiNh.png : alt: my-picture3
-
-Build VTK and Paraview with ADIOS 2 Support
--------------------------------------------
-
-.. note::
-
-   Currently the implementation for ADIOS 2 readers exist in VTK and Paraview nightly releases and master branches. We expect this to be part of the VTK and Paraview release cycle with their upcoming releases. Users must build from source and point to these branches until formal merge into their master branches is done.
-
-
-Paraview and its VTK dependency must be built with the following CMake options:
-
-1. `-DVTK_MODULE_ENABLE_VTK_IOADIOS2=YES`
-2. `-DVTK_USE_MPI=ON`
-3. `-DPARAVIEW_USE_MPI=ON`
-
-For comprehensive build instructions see the documentation for `VTK <https://vtk.org/>`_ (VTK) and `Paraview <https://www.paraview.org/>`_.
-

--- a/docs/user_guide/source/engines/dataspaces.rst
+++ b/docs/user_guide/source/engines/dataspaces.rst
@@ -19,17 +19,17 @@ how to create an DataSpaces reader:
 
 .. code-block:: c++
 
- adios2::IO dspacesIO = adios.DeclareIO("SomeName");
- dspacesIO.SetEngine("DATASPACES");
- adios2::Engine dspacesReader = dspacesIO.Open(filename, adios2::Mode::Read);
+    adios2::IO dspacesIO = adios.DeclareIO("SomeName");
+    dspacesIO.SetEngine("DATASPACES");
+    adios2::Engine dspacesReader = dspacesIO.Open(filename, adios2::Mode::Read);
 
 and a sample code for DataSpaces writer is:
 
 .. code-block:: c++
 
- adios2::IO dspacesIO = adios.DeclareIO("SomeName");
- dspacesIO.SetEngine("DATASPACES");
- adios2::Engine dspacesWriter = dspacesIO.Open(filename, adios2::Mode::Write);
+    adios2::IO dspacesIO = adios.DeclareIO("SomeName");
+    dspacesIO.SetEngine("DATASPACES");
+    adios2::Engine dspacesWriter = dspacesIO.Open(filename, adios2::Mode::Write);
 
 To make use of the DataSpaces engine, an application job needs to also run the dataspaces_server
 component together with the application. The server should be configured and started 
@@ -52,9 +52,10 @@ How many output timesteps of the same dataset (called versions) should be kept i
 and served to readers should be specified in the file. If this file does not exist in the current directory, 
 the server will assume default values (only 1 timestep stored).
 .. code-block::
- ## Config file for DataSpaces
- max_versions = 5
- lock_type = 3
+
+    ## Config file for DataSpaces
+    max_versions = 5
+    lock_type = 3
 
 The dataspaces_server module is a stand-alone service that runs independently of a simulation 
 on a set of dedicated nodes in the staging area. It transfers data from the application through RDMA,  

--- a/docs/user_guide/source/setting_up/source.rst
+++ b/docs/user_guide/source/setting_up/source.rst
@@ -2,7 +2,7 @@
 Install from Source
 ###################
 
-ADIOS2 uses `CMake <https://cmake.org/>`_ version 3.12 or above, for building,
+ADIOS2 uses `CMake <https://cmake.org/>`_ for building,
 testing and installing the library and utilities.
 
 .. include:: source/cmake.rst


### PR DESCRIPTION
- Remove stale comments about needing to do a source build of Paraview for ADIOS support.
- Update copyright year.
- Spans are supported in BP4, so remove statement that they are only supported in BP3.
- Remove 'RemoveAllVariables()' from documentation as it can generate dangling references.
- Fix a few Sphinx formatting errors.
- Do not specify a required CMake version, as the CMakeLists.txt gives a very understandable error message.