### PR TITLE
Enforce invariants for inline engine

### DIFF
--- a/docs/user_guide/source/engines/inline.rst
+++ b/docs/user_guide/source/engines/inline.rst
@@ -2,9 +2,10 @@
 Inline for zero-copy
 ********************
 
-The Inline engine provides in-process communication between the writer and reader, and seeks to avoid copying data buffers.
+The ``Inline`` engine provides in-process communication between the writer and reader, and seeks to avoid copying data buffers.
 
-This engine is experimental, and is focused on the N -> N case: N writers share a process with N readers, and the analysis happens 'inline' without writing the data to a file or copying to another buffer. It has similar considerations to the streaming SST engine, since analysis must happen per step.
+This engine is focused on the N -> N case: N writers share a process with N readers, and the analysis happens 'inline' without writing the data to a file or copying to another buffer.
+It has similar considerations to the streaming SST engine, since analysis must happen per step.
 
 To use this engine, you can either specify it in your XML config file, with tag ``<engine type=Inline>`` or set it in your application code:
 
@@ -16,22 +17,31 @@ To use this engine, you can either specify it in your XML config file, with tag 
     adios2::Engine inlineWriter = inlineIO.Open("inline_write", adios2::Mode::Write);
     adios2::Engine inlineReader = inlineIO.Open("inline_read", adios2::Mode::Read);
 
-Notice that unlike other engines, the reader and writer share an IO instance. Also, the ``writerID`` parameter allows the reader to connect to the writer, and ``readerID`` allows writer to connect to the reader. Both the writer and reader must be opened before either tries to call BeginStep/PerformPuts/PeformGets.
+Notice that unlike other engines, the reader and writer share an IO instance.
+Also, the ``writerID`` parameter allows the reader to connect to the writer, and ``readerID`` allows writer to connect to the reader.
+Both the writer and reader must be opened before either tries to call ``BeginStep()``/``PerformPuts()``/``PerformGets()``.
+There must be exactly one writer, and exactly one reader.
 
-For successful operation, the writer will perform a step, then the reader will perform a step in the same process. Data is decomposed between processes, and the writer can write its portion of the data like other ADIOS engines. When the reader starts its step, the only data it has available is that written by the writer in its process. To select this data in ADIOS, use a block selection. The reader then can retrieve whatever data was written by the writer. The reader does require the use of a new ``Get()`` call that was added to the API:
+For successful operation, the writer will perform a step, then the reader will perform a step in the same process.
+Data is decomposed between processes, and the writer can write its portion of the data like other ADIOS2 engines.
+When the reader starts its step, the only data it has available is that written by the writer in its process.
+To select this data in ADIOS2, use a block selection.
+The reader then can retrieve whatever data was written by the writer.
+The reader requires the use of a new ``Get()`` call that was added to the API:
 
 .. code-block:: c++
 
     void Engine::Get<T>(                                       \
         Variable<T>, typename Variable<T>::Info & info, const Mode);
 
-This version of ``Get`` is only used for the inline engine and requires passing a ``Variable<T>::Info`` object, which can be obtained from calling the reader's ``BlocksInfo()``. See the example below for details.
+This version of ``Get`` is only used for the inline engine and requires passing a ``Variable<T>::Info`` object, which can be obtained from calling the reader's ``BlocksInfo()``.
+See the example below for details.
 
 .. note::
  This ``Get()`` method is preliminary and may be removed in the future when the span interface on the read side becomes available.
 
 .. note::
- The inline engine does not support Sync mode for writing. In addition, since the inline engine does not do any data copy, the writer should avoid changing the data contents before the reader has read the data.
+ The inline engine does not support ``Sync`` mode for writing. In addition, since the inline engine does not do any data copy, the writer should avoid changing the data contents before the reader has read the data.
 
 Typical access pattern:
 

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -572,7 +572,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         }
     }
 
-    // For the inline engine, there must be exactly 1 reader, and exactly 2
+    // For the inline engine, there must be exactly 1 reader, and exactly 1
     // writer.
     if (engineTypeLC == "inline")
     {

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -572,6 +572,51 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         }
     }
 
+    // For the inline engine, there must be exactly 1 reader, and exactly 2
+    // writer.
+    if (engineTypeLC == "inline")
+    {
+        if (mode == Mode::Append)
+        {
+            throw std::runtime_error(
+                "Append mode is not supported for the inline engine.");
+        }
+
+        // See inline.rst:44
+        if (mode == Mode::Sync)
+        {
+            throw std::runtime_error(
+                "Sync mode is not supported for the inline engine.");
+        }
+
+        if (m_Engines.size() >= 2)
+        {
+            std::string msg =
+                "Failed to add engine " + name + " to IO \'" + m_Name + "\'. ";
+            msg += "An inline engine must have exactly one writer, and one "
+                   "reader. ";
+            msg += "There are already two engines declared, so no more can be "
+                   "added.";
+            throw std::runtime_error(msg);
+        }
+        // Now protect against declaration of two writers, or declaration of two
+        // readers:
+        if (m_Engines.size() == 1)
+        {
+            auto engine_ptr = m_Engines.begin()->second;
+            if (engine_ptr->OpenMode() == mode)
+            {
+                std::string msg =
+                    "The previously added engine " + engine_ptr->m_Name +
+                    " is already opened in same mode requested for " + name +
+                    ". ";
+                msg += "The inline engine requires exactly one writer and one "
+                       "reader.";
+                throw std::runtime_error(msg);
+            }
+        }
+    }
+
     auto f = FactoryLookup(engineTypeLC);
     if (f != Factory.end())
     {

--- a/testing/adios2/engine/inline/TestInlineWriteRead.cpp
+++ b/testing/adios2/engine/inline/TestInlineWriteRead.cpp
@@ -860,13 +860,10 @@ TEST_F(InlineWriteRead, InlineWriteReadContracts2)
 
 TEST_F(InlineWriteRead, IOInvariants)
 {
-    int mpiRank = 0, mpiSize = 1;
 #if ADIOS2_USE_MPI
+    int mpiRank = 0, mpiSize = 1;
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
-#endif
-
-#if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);
 #else
     adios2::ADIOS adios;


### PR DESCRIPTION
The inline engine must have exactly one writer, and exactly one reader.
If a user attempts to add multiple readers or multiple writers, throw an exception.
This is a first step towards unifying the engine APIs, since currently we require
the user to specify which engine is the reader with a key.

Enforcing this invariant will allow us to remove the parameter keys, since we will
be able to uniquely identify the reader and writer via their respective modes.

As a bit of unrelated cleanup: throw exceptions when users request unsupported features,
like append mode or sync mode for the inline engine.