### PR TITLE
Identify via mode

### DIFF
--- a/docs/user_guide/source/engines/inline.rst
+++ b/docs/user_guide/source/engines/inline.rst
@@ -13,12 +13,10 @@ To use this engine, you can either specify it in your XML config file, with tag 
 
     adios2::IO inlineIO = adios.DeclareIO("ioName");
     inlineIO.SetEngine("Inline");
-    inlineIO.SetParameters({{"writerID", "inline_write"}, {"readerID", "inline_read"}});
     adios2::Engine inlineWriter = inlineIO.Open("inline_write", adios2::Mode::Write);
     adios2::Engine inlineReader = inlineIO.Open("inline_read", adios2::Mode::Read);
 
 Notice that unlike other engines, the reader and writer share an IO instance.
-Also, the ``writerID`` parameter allows the reader to connect to the writer, and ``readerID`` allows writer to connect to the reader.
 Both the writer and reader must be opened before either tries to call ``BeginStep()``/``PerformPuts()``/``PerformGets()``.
 There must be exactly one writer, and exactly one reader.
 
@@ -69,16 +67,3 @@ Typical access pattern:
     // use info.Data() to get the pointer for each element in blocksInfo
 
     // After any desired analysis is finished, writer can now reuse data pointer
-
-
-Parameters:
-
-1. **writerID**: Match the string passed to the ``IO::Open()`` call when creating the writer. The reader uses this parameter to fetch the correct writer.
-2. **readerID**: Match the string passed to the ``IO::Open()`` call when creating the reader. The writer uses this parameter to fetch the correct reader.
-
-===========  ===================== ===============================
- **Key**        **Value Type**       **Default** and Examples
-===========  ===================== ===============================
- writerID         string             none, match the writer name
- readerID         string             none, match the reader name
-===========  ===================== ===============================

--- a/docs/user_guide/source/engines/inline.rst
+++ b/docs/user_guide/source/engines/inline.rst
@@ -2,9 +2,10 @@
 Inline for zero-copy
 ********************
 
-The Inline engine provides in-process communication between the writer and reader, and seeks to avoid copying data buffers.
+The ``Inline`` engine provides in-process communication between the writer and reader, and seeks to avoid copying data buffers.
 
-This engine is experimental, and is focused on the N -> N case: N writers share a process with N readers, and the analysis happens 'inline' without writing the data to a file or copying to another buffer. It has similar considerations to the streaming SST engine, since analysis must happen per step.
+This engine is focused on the N -> N case: N writers share a process with N readers, and the analysis happens 'inline' without writing the data to a file or copying to another buffer.
+It has similar considerations to the streaming SST engine, since analysis must happen per step.
 
 To use this engine, you can either specify it in your XML config file, with tag ``<engine type=Inline>`` or set it in your application code:
 
@@ -16,22 +17,31 @@ To use this engine, you can either specify it in your XML config file, with tag 
     adios2::Engine inlineWriter = inlineIO.Open("inline_write", adios2::Mode::Write);
     adios2::Engine inlineReader = inlineIO.Open("inline_read", adios2::Mode::Read);
 
-Notice that unlike other engines, the reader and writer share an IO instance. Also, the ``writerID`` parameter allows the reader to connect to the writer, and ``readerID`` allows writer to connect to the reader. Both the writer and reader must be opened before either tries to call BeginStep/PerformPuts/PeformGets.
+Notice that unlike other engines, the reader and writer share an IO instance.
+Also, the ``writerID`` parameter allows the reader to connect to the writer, and ``readerID`` allows writer to connect to the reader.
+Both the writer and reader must be opened before either tries to call ``BeginStep()``/``PerformPuts()``/``PerformGets()``.
+There must be exactly one writer, and exactly one reader.
 
-For successful operation, the writer will perform a step, then the reader will perform a step in the same process. Data is decomposed between processes, and the writer can write its portion of the data like other ADIOS engines. When the reader starts its step, the only data it has available is that written by the writer in its process. To select this data in ADIOS, use a block selection. The reader then can retrieve whatever data was written by the writer. The reader does require the use of a new ``Get()`` call that was added to the API:
+For successful operation, the writer will perform a step, then the reader will perform a step in the same process.
+Data is decomposed between processes, and the writer can write its portion of the data like other ADIOS2 engines.
+When the reader starts its step, the only data it has available is that written by the writer in its process.
+To select this data in ADIOS2, use a block selection.
+The reader then can retrieve whatever data was written by the writer.
+The reader requires the use of a new ``Get()`` call that was added to the API:
 
 .. code-block:: c++
 
     void Engine::Get<T>(                                       \
         Variable<T>, typename Variable<T>::Info & info, const Mode);
 
-This version of ``Get`` is only used for the inline engine and requires passing a ``Variable<T>::Info`` object, which can be obtained from calling the reader's ``BlocksInfo()``. See the example below for details.
+This version of ``Get`` is only used for the inline engine and requires passing a ``Variable<T>::Info`` object, which can be obtained from calling the reader's ``BlocksInfo()``.
+See the example below for details.
 
 .. note::
  This ``Get()`` method is preliminary and may be removed in the future when the span interface on the read side becomes available.
 
 .. note::
- The inline engine does not support Sync mode for writing. In addition, since the inline engine does not do any data copy, the writer should avoid changing the data contents before the reader has read the data.
+ The inline engine does not support ``Sync`` mode for writing. In addition, since the inline engine does not do any data copy, the writer should avoid changing the data contents before the reader has read the data.
 
 Typical access pattern:
 

--- a/examples/hello/inlineReaderWriter/helloInlineReaderWriter.cpp
+++ b/examples/hello/inlineReaderWriter/helloInlineReaderWriter.cpp
@@ -22,84 +22,61 @@
 void DoAnalysis(adios2::IO &inlineIO, adios2::Engine &inlineReader, int rank,
                 unsigned int step)
 {
-    try
+    inlineReader.BeginStep();
+    /////////////////////READ
+    adios2::Variable<float> inlineFloats000 =
+        inlineIO.InquireVariable<float>("inlineFloats000");
+
+    adios2::Variable<std::string> inlineString =
+        inlineIO.InquireVariable<std::string>("inlineString");
+
+    if (inlineFloats000)
     {
-        inlineReader.BeginStep();
-        /////////////////////READ
-        adios2::Variable<float> inlineFloats000 =
-            inlineIO.InquireVariable<float>("inlineFloats000");
+        auto blocksInfo = inlineReader.BlocksInfo(inlineFloats000, step);
 
-        adios2::Variable<std::string> inlineString =
-            inlineIO.InquireVariable<std::string>("inlineString");
-
-        if (inlineFloats000)
+        std::cout << "Data StepsStart " << inlineFloats000.StepsStart()
+                  << " from rank " << rank << ": ";
+        for (auto &info : blocksInfo)
         {
-            auto blocksInfo = inlineReader.BlocksInfo(inlineFloats000, step);
+            // bp file reader would see all blocks, inline only sees local
+            // writer's block(s).
+            size_t myBlock = info.BlockID;
+            inlineFloats000.SetBlockSelection(myBlock);
 
-            std::cout << "Data StepsStart " << inlineFloats000.StepsStart()
-                      << " from rank " << rank << ": ";
-            for (auto &info : blocksInfo)
+            // info passed by reference
+            // engine must remember data pointer (or info) to fill it out at
+            // PerformGets()
+            inlineReader.Get<float>(inlineFloats000, info,
+                                    adios2::Mode::Deferred);
+        }
+        inlineReader.PerformGets();
+
+        for (const auto &info : blocksInfo)
+        {
+            adios2::Dims count = info.Count;
+            const float *vectData = info.Data();
+            for (size_t i = 0; i < count[0]; ++i)
             {
-                // bp file reader would see all blocks, inline only sees local
-                // writer's block(s).
-                size_t myBlock = info.BlockID;
-                inlineFloats000.SetBlockSelection(myBlock);
-
-                // info passed by reference
-                // engine must remember data pointer (or info) to fill it out at
-                // PerformGets()
-                inlineReader.Get<float>(inlineFloats000, info,
-                                        adios2::Mode::Deferred);
+                float datum = vectData[i];
+                std::cout << datum << " ";
             }
-            inlineReader.PerformGets();
-
-            for (const auto &info : blocksInfo)
-            {
-                adios2::Dims count = info.Count;
-                const float *vectData = info.Data();
-                for (size_t i = 0; i < count[0]; ++i)
-                {
-                    float datum = vectData[i];
-                    std::cout << datum << " ";
-                }
-                std::cout << "\n";
-            }
+            std::cout << "\n";
         }
-        else
-        {
-            std::cout << "Variable inlineFloats000 not found\n";
-        }
+    }
+    else
+    {
+        std::cout << "Variable inlineFloats000 not found\n";
+    }
 
-        if (inlineString && rank == 0)
-        {
-            // inlineString.SetStepSelection({step, 1});
-
-            std::string myString;
-            inlineReader.Get(inlineString, myString, adios2::Mode::Sync);
-            std::cout << "inlineString: " << myString << "\n";
-        }
-        inlineReader.EndStep();
-        // all deferred block info are now valid - need data pointers to be
-        // valid, filled with data
-    }
-    catch (std::invalid_argument &e)
+    if (inlineString && rank == 0)
     {
-        std::cout << "Invalid argument exception, STOPPING PROGRAM from rank "
-                  << rank << "\n";
-        std::cout << e.what() << "\n";
+        std::string myString;
+        inlineReader.Get(inlineString, myString, adios2::Mode::Sync);
+        std::cout << "inlineString: " << myString << "\n";
     }
-    catch (std::ios_base::failure &e)
-    {
-        std::cout << "IO System base failure exception, STOPPING PROGRAM "
-                     "from rank "
-                  << rank << "\n";
-        std::cout << e.what() << "\n";
-    }
-    catch (std::exception &e)
-    {
-        std::cout << "Exception, STOPPING PROGRAM from rank " << rank << "\n";
-        std::cout << e.what() << "\n";
-    }
+    inlineReader.EndStep();
+    // all deferred block info are now valid - need data pointers to be
+    // valid, filled with data
 }
 
 int main(int argc, char *argv[])
@@ -109,6 +86,9 @@ int main(int argc, char *argv[])
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+    adios2::ADIOS adios;
 #endif
 
     // Application variable
@@ -117,114 +97,88 @@ int main(int argc, char *argv[])
 
     try
     {
-#if ADIOS2_USE_MPI
-        /** ADIOS class factory of IO class objects */
-        adios2::ADIOS adios(MPI_COMM_WORLD);
-#else
-        adios2::ADIOS adios;
-#endif
-        /*** IO class object: settings and factory of Settings: Variables,
-         * Parameters, Transports, and Execution: Engines
-         * Inline uses single IO for write/read */
+        // Inline uses single IO for write/read
         adios2::IO inlineIO = adios.DeclareIO("InlineReadWrite");
         /// WRITE
+        inlineIO.SetEngine("Inline");
+        inlineIO.SetParameter("verbose", "4");
+
+        /** global array: name, { shape (total dimensions) }, { start
+         * (local) },
+         * { count (local) }, all are constant dimensions */
+        const unsigned int variablesSize = 10;
+        std::vector<adios2::Variable<float>> inlineFloats(variablesSize);
+
+        adios2::Variable<std::string> inlineString =
+            inlineIO.DefineVariable<std::string>("inlineString");
+
+        for (unsigned int v = 0; v < variablesSize; ++v)
         {
-            inlineIO.SetEngine("Inline");
-            inlineIO.SetParameters({{"verbose", "4"},
-                                    {"writerID", "myWriteID"},
-                                    {"readerID", "myReadID"}});
+            std::string namev("inlineFloats");
+            if (v < 10)
+            {
+                namev += "00";
+            }
+            else if (v < 100)
+            {
+                namev += "0";
+            }
+            namev += std::to_string(v);
 
-            /** global array: name, { shape (total dimensions) }, { start
-             * (local) },
-             * { count (local) }, all are constant dimensions */
-            const unsigned int variablesSize = 10;
-            std::vector<adios2::Variable<float>> inlineFloats(variablesSize);
+            inlineFloats[v] = inlineIO.DefineVariable<float>(
+                namev, {size * Nx}, {rank * Nx}, {Nx}, adios2::ConstantDims);
+        }
 
-            adios2::Variable<std::string> inlineString =
-                inlineIO.DefineVariable<std::string>("inlineString");
+        /** global single value variable: name */
+        adios2::Variable<unsigned int> inlineTimeStep =
+            inlineIO.DefineVariable<unsigned int>("timeStep");
 
+        adios2::Engine inlineWriter =
+            inlineIO.Open("myWriteID", adios2::Mode::Write);
+
+        adios2::Engine inlineReader =
+            inlineIO.Open("myReadID", adios2::Mode::Read);
+
+        for (unsigned int timeStep = 0; timeStep < 3; ++timeStep)
+        {
+            inlineWriter.BeginStep();
+            if (rank == 0) // global single value, only saved by rank 0
+            {
+                inlineWriter.Put<unsigned int>(inlineTimeStep, timeStep);
+            }
+
+            // template type is optional, but recommended
             for (unsigned int v = 0; v < variablesSize; ++v)
             {
-                std::string namev("inlineFloats");
-                if (v < 10)
-                {
-                    namev += "00";
-                }
-                else if (v < 100)
-                {
-                    namev += "0";
-                }
-                namev += std::to_string(v);
-
-                inlineFloats[v] = inlineIO.DefineVariable<float>(
-                    namev, {size * Nx}, {rank * Nx}, {Nx},
-                    adios2::ConstantDims);
+                // Note: Put is deferred, so all variables will see v == 9
+                // and myFloats[0] == 9, 10, or 11
+                myFloats[rank] = static_cast<float>(v + timeStep + rank);
+                inlineWriter.Put(inlineFloats[v], myFloats.data());
             }
 
-            /** global single value variable: name */
-            adios2::Variable<unsigned int> inlineTimeStep =
-                inlineIO.DefineVariable<unsigned int>("timeStep");
+            const std::string myString(
+                "Hello from rank: " + std::to_string(rank) +
+                " and timestep: " + std::to_string(timeStep));
 
-            /** Engine derived class, spawned to start IO operations */
-            adios2::Engine inlineWriter =
-                inlineIO.Open("myWriteID", adios2::Mode::Write);
-
-            adios2::Engine inlineReader =
-                inlineIO.Open("myReadID", adios2::Mode::Read);
-
-            for (unsigned int timeStep = 0; timeStep < 3; ++timeStep)
+            if (rank == 0)
             {
-                inlineWriter.BeginStep();
-                if (rank == 0) // global single value, only saved by rank 0
-                {
-                    inlineWriter.Put<unsigned int>(inlineTimeStep, timeStep);
-                }
-
-                // template type is optional, but recommended
-                for (unsigned int v = 0; v < variablesSize; ++v)
-                {
-                    // Note: Put is deferred, so all variables will see v == 9
-                    // and myFloats[0] == 9, 10, or 11
-                    myFloats[rank] = static_cast<float>(v + timeStep + rank);
-                    inlineWriter.Put(inlineFloats[v], myFloats.data());
-                }
-
-                const std::string myString(
-                    "Hello from rank: " + std::to_string(rank) +
-                    " and timestep: " + std::to_string(timeStep));
-
-                if (rank == 0)
-                {
-                    inlineWriter.Put(inlineString, myString);
-                }
-
-                inlineWriter.EndStep();
-
-                DoAnalysis(inlineIO, inlineReader, rank, timeStep);
+                inlineWriter.Put(inlineString, myString);
             }
 
-            inlineWriter.Close();
-            inlineReader.Close();
+            inlineWriter.EndStep();
+
+            DoAnalysis(inlineIO, inlineReader, rank, timeStep);
         }
-        // MPI_Barrier(MPI_COMM_WORLD);
     }
-    catch (std::invalid_argument &e)
+    catch (std::exception const &e)
     {
-        std::cout << "Invalid argument exception, STOPPING PROGRAM from rank "
-                  << rank << "\n";
+        std::cout << "Caught exception from rank " << rank << "\n";
         std::cout << e.what() << "\n";
-    }
-    catch (std::ios_base::failure &e)
-    {
-        std::cout << "IO System base failure exception, STOPPING PROGRAM "
-                     "from rank "
-                  << rank << "\n";
-        std::cout << e.what() << "\n";
-    }
-    catch (std::exception &e)
-    {
-        std::cout << "Exception, STOPPING PROGRAM from rank " << rank << "\n";
-        std::cout << e.what() << "\n";
+#if ADIOS2_USE_MPI
+        return MPI_Abort(MPI_COMM_WORLD, 1);
+#else
+        return 1;
+#endif
     }
 
 #if ADIOS2_USE_MPI

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -572,7 +572,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         }
     }
 
-    // For the inline engine, there must be exactly 1 reader, and exactly 2
+    // For the inline engine, there must be exactly 1 reader, and exactly 1
     // writer.
     if (engineTypeLC == "inline")
     {

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -572,6 +572,51 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         }
     }
 
+    // For the inline engine, there must be exactly 1 reader, and exactly 2
+    // writer.
+    if (engineTypeLC == "inline")
+    {
+        if (mode == Mode::Append)
+        {
+            throw std::runtime_error(
+                "Append mode is not supported for the inline engine.");
+        }
+
+        // See inline.rst:44
+        if (mode == Mode::Sync)
+        {
+            throw std::runtime_error(
+                "Sync mode is not supported for the inline engine.");
+        }
+
+        if (m_Engines.size() >= 2)
+        {
+            std::string msg =
+                "Failed to add engine " + name + " to IO \'" + m_Name + "\'. ";
+            msg += "An inline engine must have exactly one writer, and one "
+                   "reader. ";
+            msg += "There are already two engines declared, so no more can be "
+                   "added.";
+            throw std::runtime_error(msg);
+        }
+        // Now protect against declaration of two writers, or declaration of two
+        // readers:
+        if (m_Engines.size() == 1)
+        {
+            auto engine_ptr = m_Engines.begin()->second;
+            if (engine_ptr->OpenMode() == mode)
+            {
+                std::string msg =
+                    "The previously added engine " + engine_ptr->m_Name +
+                    " is already opened in same mode requested for " + name +
+                    ". ";
+                msg += "The inline engine requires exactly one writer and one "
+                       "reader.";
+                throw std::runtime_error(msg);
+            }
+        }
+    }
+
     auto f = FactoryLookup(engineTypeLC);
     if (f != Factory.end())
     {

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -471,6 +471,15 @@ public:
     static void RegisterEngine(const std::string &engineType,
                                EngineFactoryEntry entry);
 
+    /*
+     * Return list of all engines associated with this IO.
+     */
+
+    const std::map<std::string, std::shared_ptr<Engine>> &GetEngines() const
+    {
+        return m_Engines;
+    }
+
 private:
     /** true: exist in config file (XML) */
     const bool m_InConfigFile = false;

--- a/source/adios2/engine/inline/InlineReader.h
+++ b/source/adios2/engine/inline/InlineReader.h
@@ -25,6 +25,10 @@ namespace core
 namespace engine
 {
 
+// The inline reader needs to know about the writer, and vice versa.
+// Break cyclic dependency via a forward declaration:
+class InlineWriter;
+
 class InlineReader : public Engine
 {
 public:
@@ -51,6 +55,7 @@ public:
     bool IsInsideStep() const;
 
 private:
+    const InlineWriter *GetWriter() const;
     int m_Verbosity = 0;
     int m_ReaderRank; // my rank in the readers' comm
 
@@ -58,8 +63,6 @@ private:
     size_t m_CurrentStep = static_cast<size_t>(-1);
     bool m_InsideStep = false;
     std::vector<std::string> m_DeferredVariables;
-
-    std::string m_WriterID;
 
     void Init() final; ///< called from constructor, gets the selected Inline
                        /// transport method from settings

--- a/source/adios2/engine/inline/InlineReader.tcc
+++ b/source/adios2/engine/inline/InlineReader.tcc
@@ -55,8 +55,6 @@ template <class T>
 inline typename Variable<T>::Info *
 InlineReader::GetBlockSyncCommon(Variable<T> &variable)
 {
-    InlineWriter &writer =
-        dynamic_cast<InlineWriter &>(m_IO.GetEngine(m_WriterID));
     if (variable.m_BlockID >= variable.m_BlocksInfo.size())
     {
         throw std::invalid_argument(
@@ -79,8 +77,6 @@ template <class T>
 inline typename Variable<T>::Info *
 InlineReader::GetBlockDeferredCommon(Variable<T> &variable)
 {
-    InlineWriter &writer =
-        dynamic_cast<InlineWriter &>(m_IO.GetEngine(m_WriterID));
     if (variable.m_BlockID >= variable.m_BlocksInfo.size())
     {
         throw std::invalid_argument(

--- a/source/adios2/engine/inline/InlineWriter.cpp
+++ b/source/adios2/engine/inline/InlineWriter.cpp
@@ -39,6 +39,30 @@ InlineWriter::InlineWriter(IO &io, const std::string &name, const Mode mode,
     }
 }
 
+const InlineReader *InlineWriter::GetReader() const
+{
+    const auto &engine_map = m_IO.GetEngines();
+    if (engine_map.size() != 2)
+    {
+        throw std::runtime_error("There must be exactly one reader and one "
+                                 "writer for the inline engine.");
+    }
+
+    std::shared_ptr<Engine> e = engine_map.begin()->second;
+    if (e->OpenMode() == adios2::Mode::Write)
+    {
+        e = engine_map.rbegin()->second;
+    }
+
+    const auto reader = dynamic_cast<InlineReader *>(e.get());
+    if (!reader)
+    {
+        throw std::runtime_error(
+            "dynamic_cast<InlineReader*> failed; this is very likely a bug.");
+    }
+    return reader;
+}
+
 StepStatus InlineWriter::BeginStep(StepMode mode, const float timeoutSeconds)
 {
     TAU_SCOPED_TIMER("InlineWriter::BeginStep");
@@ -47,9 +71,9 @@ StepStatus InlineWriter::BeginStep(StepMode mode, const float timeoutSeconds)
         throw std::runtime_error("InlineWriter::BeginStep was called but the "
                                  "writer is already inside a step");
     }
-    const auto &reader =
-        dynamic_cast<InlineReader &>(m_IO.GetEngine(m_ReaderID));
-    if (reader.IsInsideStep())
+
+    auto reader = GetReader();
+    if (reader->IsInsideStep())
     {
         m_InsideStep = false;
         return StepStatus::NotReady;
@@ -177,15 +201,6 @@ void InlineWriter::InitParameters()
                     "ERROR: Method verbose argument must be an "
                     "integer in the range [0,5], in call to "
                     "Open or Engine constructor\n");
-        }
-        else if (key == "readerid")
-        {
-            m_ReaderID = value;
-            if (m_Verbosity == 5)
-            {
-                std::cout << "Inline Writer " << m_WriterRank
-                          << " Init() readerID " << m_ReaderID << "\n";
-            }
         }
     }
 }

--- a/source/adios2/engine/inline/InlineWriter.h
+++ b/source/adios2/engine/inline/InlineWriter.h
@@ -23,6 +23,10 @@ namespace core
 namespace engine
 {
 
+// The inline reader needs to know about the writer, and vice versa.
+// Break cyclic dependency via a forward declaration:
+class InlineReader;
+
 class InlineWriter : public Engine
 {
 
@@ -55,11 +59,10 @@ private:
     bool m_InsideStep = false;
     bool m_ResetVariables = false; // used when PerformPuts is being used
 
-    std::string m_ReaderID;
-
     void Init() final;
     void InitParameters() final;
     void InitTransports() final;
+    const InlineReader *GetReader() const;
 
 #define declare_type(T)                                                        \
     void DoPutSync(Variable<T> &, const T *) final;                            \

--- a/testing/adios2/engine/inline/TestInlineWriteRead.cpp
+++ b/testing/adios2/engine/inline/TestInlineWriteRead.cpp
@@ -67,9 +67,6 @@ TEST_F(InlineWriteRead, InlineWriteRead1D8)
 #if ADIOS2_USE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
-#endif
-
-#if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);
 #else
     adios2::ADIOS adios;
@@ -113,9 +110,7 @@ TEST_F(InlineWriteRead, InlineWriteRead1D8)
         io.SetEngine("Inline");
 
         // writerID parameter makes sure the reader can find the writer.
-        io.SetParameters({{"verbose", "4"},
-                          {"writerID", fname + "_write"},
-                          {"readerID", fname + "_read"}});
+        io.SetParameter("verbose", "4");
 
         adios2::Engine inlineWriter =
             io.Open(fname + "_write", adios2::Mode::Write);
@@ -357,9 +352,6 @@ TEST_F(InlineWriteRead, InlineWriteRead2D2x4)
 #if ADIOS2_USE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
-#endif
-
-#if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);
 #else
     adios2::ADIOS adios;
@@ -403,9 +395,7 @@ TEST_F(InlineWriteRead, InlineWriteRead2D2x4)
         io.SetEngine("Inline");
 
         // writerID parameter makes sure the reader can find the writer.
-        io.SetParameters({{"verbose", "4"},
-                          {"writerID", fname + "_write"},
-                          {"readerID", fname + "_read"}});
+        io.SetParameter("verbose", "4");
 
         adios2::Engine inlineWriter =
             io.Open(fname + "_write", adios2::Mode::Write);
@@ -630,12 +620,9 @@ TEST_F(InlineWriteRead, InlineWriteReadContracts)
 #if ADIOS2_USE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
-#endif
-
-#if ADIOS2_USE_MPI
-    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+    adios2::ADIOS adios(MPI_COMM_WORLD);
 #else
-    adios2::ADIOS adios(adios2::DebugON);
+    adios2::ADIOS adios;
 #endif
     {
         adios2::IO io = adios.DeclareIO("TestIO");
@@ -657,9 +644,7 @@ TEST_F(InlineWriteRead, InlineWriteReadContracts)
         io.SetEngine("Inline");
 
         // writerID parameter makes sure the reader can find the writer.
-        io.SetParameters({{"verbose", "4"},
-                          {"writerID", fname + "_write"},
-                          {"readerID", fname + "_read"}});
+        io.SetParameter("verbose", "4");
 
         adios2::Engine inlineWriter =
             io.Open(fname + "_write", adios2::Mode::Write);
@@ -757,12 +742,9 @@ TEST_F(InlineWriteRead, InlineWriteReadContracts2)
 #if ADIOS2_USE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
-#endif
-
-#if ADIOS2_USE_MPI
-    adios2::ADIOS adios(MPI_COMM_WORLD, adios2::DebugON);
+    adios2::ADIOS adios(MPI_COMM_WORLD);
 #else
-    adios2::ADIOS adios(adios2::DebugON);
+    adios2::ADIOS adios;
 #endif
     {
         adios2::IO io = adios.DeclareIO("TestIO");
@@ -784,9 +766,7 @@ TEST_F(InlineWriteRead, InlineWriteReadContracts2)
         io.SetEngine("Inline");
 
         // writerID parameter makes sure the reader can find the writer.
-        io.SetParameters({{"verbose", "4"},
-                          {"writerID", fname + "_write"},
-                          {"readerID", fname + "_read"}});
+        io.SetParameter("verbose", "4");
 
         adios2::Engine inlineWriter =
             io.Open(fname + "_write", adios2::Mode::Write);

--- a/testing/adios2/engine/inline/TestInlineWriteRead.cpp
+++ b/testing/adios2/engine/inline/TestInlineWriteRead.cpp
@@ -860,13 +860,10 @@ TEST_F(InlineWriteRead, InlineWriteReadContracts2)
 
 TEST_F(InlineWriteRead, IOInvariants)
 {
-    int mpiRank = 0, mpiSize = 1;
 #if ADIOS2_USE_MPI
+    int mpiRank = 0, mpiSize = 1;
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
-#endif
-
-#if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);
 #else
     adios2::ADIOS adios;


### PR DESCRIPTION
The inline engine now uses the requested mode to identify the correct reader and writer.
This streamlines the API so that users can more easily swap between engines.

Note: It is not obvious from the diff, but no backwards incompatible changes were made.