### PR TITLE
SSC now works with flexible IO pattern

### DIFF
--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -38,9 +38,6 @@ SscReader::SscReader(IO &io, const std::string &name, const Mode mode,
     m_ReaderSize = m_Comm.Size();
     MPI_Comm_rank(m_StreamComm, &m_StreamRank);
     MPI_Comm_size(m_StreamComm, &m_StreamSize);
-
-    m_Buffer.resize(1, 0);
-    m_GlobalWritePattern.resize(m_StreamSize);
 }
 
 SscReader::~SscReader() { TAU_SCOPED_TIMER_FUNC(); }
@@ -52,10 +49,27 @@ StepStatus SscReader::BeginStep(const StepMode stepMode,
 
     ++m_CurrentStep;
 
+    if (m_Verbosity >= 5)
+    {
+        std::cout << "SscReader::BeginStep, World Rank " << m_StreamRank
+                  << ", Reader Rank " << m_ReaderRank << ", Step "
+                  << m_CurrentStep << std::endl;
+    }
+
     if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
         m_ReaderSelectionsLocked == false)
     {
-        SyncWritePattern();
+        m_Buffer.resize(1, 0);
+        m_GlobalWritePattern.clear();
+        m_GlobalWritePattern.resize(m_StreamSize);
+        m_LocalReadPattern.clear();
+        m_GlobalWritePatternJson.clear();
+        bool finalStep = SyncWritePattern();
+        if (finalStep)
+        {
+            return StepStatus::EndOfStream;
+        }
+
         MPI_Win_create(NULL, 0, 1, MPI_INFO_NULL, m_StreamComm, &m_MpiWin);
     }
     else
@@ -92,7 +106,8 @@ StepStatus SscReader::BeginStep(const StepMode stepMode,
                 v.shapeId == ShapeID::LocalValue)
             {
                 std::vector<char> value(v.bufferCount);
-                if (m_CurrentStep == 0)
+                if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
+                    m_ReaderSelectionsLocked == false)
                 {
                     std::memcpy(value.data(), v.value.data(), v.value.size());
                 }
@@ -136,13 +151,6 @@ StepStatus SscReader::BeginStep(const StepMode stepMode,
         }
     }
 
-    if (m_Verbosity >= 5)
-    {
-        std::cout << "SscReader::BeginStep, World Rank " << m_StreamRank
-                  << ", Reader Rank " << m_ReaderRank << ", Step "
-                  << m_CurrentStep << std::endl;
-    }
-
     if (m_Buffer[0] == 1)
     {
         return StepStatus::EndOfStream;
@@ -159,7 +167,15 @@ void SscReader::EndStep()
 {
     TAU_SCOPED_TIMER_FUNC();
 
-    if (m_WriterDefinitionsLocked && m_ReaderSelectionsLocked)
+    if (m_Verbosity >= 5)
+    {
+        std::cout << "SscReader::EndStep, World Rank " << m_StreamRank
+                  << ", Reader Rank " << m_ReaderRank << ", Step "
+                  << m_CurrentStep << std::endl;
+    }
+
+    if (m_WriterDefinitionsLocked &&
+        m_ReaderSelectionsLocked) // fixed IO pattern
     {
         if (m_CurrentStep == 0)
         {
@@ -207,9 +223,13 @@ void SscReader::EndStep()
             }
         }
     }
-    else
+    else // flexible IO pattern
     {
         MPI_Win_free(&m_MpiWin);
+        if (m_CurrentStep == 0)
+        {
+            SyncReadPattern();
+        }
     }
 }
 
@@ -234,13 +254,14 @@ void SscReader::SyncMpiPattern()
     MPI_Comm_create_group(MPI_COMM_WORLD, streamGroup, 0, &m_StreamComm);
 }
 
-void SscReader::SyncWritePattern()
+bool SscReader::SyncWritePattern()
 {
     TAU_SCOPED_TIMER_FUNC();
     if (m_Verbosity >= 5)
     {
         std::cout << "SscReader::SyncWritePattern, World Rank " << m_StreamRank
-                  << ", Reader Rank " << m_ReaderRank << std::endl;
+                  << ", Reader Rank " << m_ReaderRank << ", Step "
+                  << m_CurrentStep << std::endl;
     }
 
     // aggregate global write pattern
@@ -255,6 +276,22 @@ void SscReader::SyncWritePattern()
 
     ssc::LocalJsonToGlobalJson(globalVec, maxLocalSize, m_StreamSize,
                                m_GlobalWritePatternJson);
+
+    for (int i = 0; i < m_StreamSize; ++i)
+    {
+        if (m_GlobalWritePatternJson[i] == nullptr)
+        {
+            continue;
+        }
+        auto &patternJson = m_GlobalWritePatternJson[i]["FinalStep"];
+        if (patternJson != nullptr)
+        {
+            if (patternJson.get<bool>())
+            {
+                return true;
+            }
+        }
+    }
 
     ssc::JsonToBlockVecVec(m_GlobalWritePatternJson, m_GlobalWritePattern);
 
@@ -354,11 +391,19 @@ void SscReader::SyncWritePattern()
 #undef declare_type
         }
     }
+    return false;
 }
 
 void SscReader::SyncReadPattern()
 {
     TAU_SCOPED_TIMER_FUNC();
+
+    if (m_Verbosity >= 5)
+    {
+        std::cout << "SscReader::SyncReadPattern, World Rank " << m_StreamRank
+                  << ", Reader Rank " << m_ReaderRank << ", Step "
+                  << m_CurrentStep << std::endl;
+    }
 
     if (m_ReaderRank == 0)
     {
@@ -479,7 +524,10 @@ void SscReader::DoClose(const int transportIndex)
         std::cout << "SscReader::DoClose, World Rank " << m_StreamRank
                   << ", Reader Rank " << m_ReaderRank << std::endl;
     }
-    MPI_Win_free(&m_MpiWin);
+    if (m_WriterDefinitionsLocked && m_ReaderSelectionsLocked)
+    {
+        MPI_Win_free(&m_MpiWin);
+    }
 }
 
 } // end namespace engine

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -51,15 +51,15 @@ StepStatus SscReader::BeginStep(const StepMode stepMode,
 {
     TAU_SCOPED_TIMER_FUNC();
 
-    if (m_InitialStep)
+    ++m_CurrentStep;
+
+    if (m_CurrentStep == 0)
     {
-        m_InitialStep = false;
         SyncWritePattern();
         MPI_Win_create(NULL, 0, 1, MPI_INFO_NULL, m_StreamComm, &m_MpiWin);
     }
     else
     {
-        ++m_CurrentStep;
         if (m_MpiMode == "twosided")
         {
             MPI_Status statuses[m_MpiRequests.size()];

--- a/source/adios2/engine/ssc/SscReader.h
+++ b/source/adios2/engine/ssc/SscReader.h
@@ -39,8 +39,7 @@ public:
     void EndStep() final;
 
 private:
-    size_t m_CurrentStep = 0;
-    bool m_InitialStep = true;
+    int64_t m_CurrentStep = -1;
 
     ssc::BlockVecVec m_GlobalWritePattern;
     ssc::BlockVec m_LocalReadPattern;

--- a/source/adios2/engine/ssc/SscReader.h
+++ b/source/adios2/engine/ssc/SscReader.h
@@ -60,7 +60,7 @@ private:
     int m_ReaderSize;
 
     void SyncMpiPattern();
-    void SyncWritePattern();
+    bool SyncWritePattern();
     void SyncReadPattern();
 
 #define declare_type(T)                                                        \

--- a/source/adios2/engine/ssc/SscReader.tcc
+++ b/source/adios2/engine/ssc/SscReader.tcc
@@ -29,7 +29,8 @@ void SscReader::GetDeferredCommon(Variable<std::string> &variable,
 {
     TAU_SCOPED_TIMER_FUNC();
     variable.SetData(data);
-    if (m_CurrentStep == 0)
+    if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
+        m_ReaderSelectionsLocked == false)
     {
         m_LocalReadPattern.emplace_back();
         auto &b = m_LocalReadPattern.back();
@@ -103,7 +104,8 @@ void SscReader::GetDeferredCommon(Variable<T> &variable, T *data)
         std::reverse(vShape.begin(), vShape.end());
     }
 
-    if (m_CurrentStep == 0)
+    if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
+        m_ReaderSelectionsLocked == false)
     {
         m_LocalReadPattern.emplace_back();
         auto &b = m_LocalReadPattern.back();

--- a/source/adios2/engine/ssc/SscReader.tcc
+++ b/source/adios2/engine/ssc/SscReader.tcc
@@ -217,7 +217,9 @@ SscReader::BlocksInfoCommon(const Variable<T> &variable,
                     v.shapeId == ShapeID::LocalValue)
                 {
                     b.IsValue = true;
-                    if (m_CurrentStep == 0)
+                    if (m_CurrentStep == 0 ||
+                        m_WriterDefinitionsLocked == false ||
+                        m_ReaderSelectionsLocked == false)
                     {
                         std::memcpy(&b.Value, v.value.data(), v.value.size());
                     }

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -36,10 +36,6 @@ SscWriter::SscWriter(IO &io, const std::string &name, const Mode mode,
     m_WriterSize = m_Comm.Size();
     MPI_Comm_rank(m_StreamComm, &m_StreamRank);
     MPI_Comm_size(m_StreamComm, &m_StreamSize);
-
-    m_Buffer.resize(1, 0);
-    m_GlobalWritePattern.resize(m_StreamSize);
-    m_GlobalReadPattern.resize(m_StreamSize);
 }
 
 StepStatus SscWriter::BeginStep(StepMode mode, const float timeoutSeconds)
@@ -47,6 +43,23 @@ StepStatus SscWriter::BeginStep(StepMode mode, const float timeoutSeconds)
     TAU_SCOPED_TIMER_FUNC();
 
     ++m_CurrentStep;
+
+    if (m_Verbosity >= 5)
+    {
+        std::cout << "SscWriter::BeginStep, World Rank " << m_StreamRank
+                  << ", Reader Rank " << m_WriterRank << ", Step "
+                  << m_CurrentStep << std::endl;
+    }
+
+    if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
+        m_ReaderSelectionsLocked == false)
+    {
+        m_Buffer.resize(1, 0);
+        m_GlobalWritePattern.clear();
+        m_GlobalWritePattern.resize(m_StreamSize);
+        m_GlobalReadPattern.clear();
+        m_GlobalReadPattern.resize(m_StreamSize);
+    }
 
     if (m_WriterDefinitionsLocked && m_ReaderSelectionsLocked)
     {
@@ -66,6 +79,13 @@ void SscWriter::PerformPuts() { TAU_SCOPED_TIMER_FUNC(); }
 void SscWriter::EndStep()
 {
     TAU_SCOPED_TIMER_FUNC();
+
+    if (m_Verbosity >= 5)
+    {
+        std::cout << "SscWriter::EndStep, World Rank " << m_StreamRank
+                  << ", Reader Rank " << m_WriterRank << ", Step "
+                  << m_CurrentStep << std::endl;
+    }
 
     if (m_CurrentStep == 0)
     {
@@ -124,11 +144,6 @@ void SscWriter::EndStep()
         }
         else
         {
-            m_Buffer.resize(1, 0);
-            m_GlobalWritePattern.clear();
-            m_GlobalWritePattern.resize(m_StreamSize);
-            m_GlobalReadPattern.clear();
-            m_GlobalReadPattern.resize(m_StreamSize);
             SyncWritePattern();
             MPI_Win_create(m_Buffer.data(), m_Buffer.size(), 1, MPI_INFO_NULL,
                            m_StreamComm, &m_MpiWin);
@@ -186,13 +201,14 @@ void SscWriter::SyncMpiPattern()
     MPI_Comm_create_group(MPI_COMM_WORLD, streamGroup, 0, &m_StreamComm);
 }
 
-void SscWriter::SyncWritePattern()
+void SscWriter::SyncWritePattern(bool finalStep)
 {
     TAU_SCOPED_TIMER_FUNC();
     if (m_Verbosity >= 5)
     {
         std::cout << "SscWriter::SyncWritePattern, World Rank " << m_StreamRank
-                  << ", Writer Rank " << m_WriterRank << std::endl;
+                  << ", Writer Rank " << m_WriterRank << ", Step "
+                  << m_CurrentStep << std::endl;
     }
 
     nlohmann::json localRankMetaJ;
@@ -203,6 +219,10 @@ void SscWriter::SyncWritePattern()
     {
         ssc::AttributeMapToJson(m_IO, localRankMetaJ);
         localRankMetaJ["Pattern"] = m_WriterDefinitionsLocked;
+    }
+    if (finalStep)
+    {
+        localRankMetaJ["FinalStep"] = true;
     }
 
     std::string localStr = localRankMetaJ.dump();
@@ -233,7 +253,8 @@ void SscWriter::SyncReadPattern()
     if (m_Verbosity >= 5)
     {
         std::cout << "SscWriter::SyncReadPattern, World Rank " << m_StreamRank
-                  << ", Writer Rank " << m_WriterRank << std::endl;
+                  << ", Writer Rank " << m_WriterRank << ", Step "
+                  << m_CurrentStep << std::endl;
     }
 
     size_t localSize = 0;
@@ -354,54 +375,58 @@ void SscWriter::DoClose(const int transportIndex)
         {
             MpiWait();
         }
-    }
 
-    m_Buffer[0] = 1;
+        m_Buffer[0] = 1;
 
-    if (m_MpiMode == "twosided")
-    {
-        std::vector<MPI_Request> requests;
-        for (const auto &i : m_AllSendingReaderRanks)
+        if (m_MpiMode == "twosided")
         {
-            requests.emplace_back();
-            MPI_Isend(m_Buffer.data(), 1, MPI_CHAR, i.first, 0, m_StreamComm,
-                      &requests.back());
+            std::vector<MPI_Request> requests;
+            for (const auto &i : m_AllSendingReaderRanks)
+            {
+                requests.emplace_back();
+                MPI_Isend(m_Buffer.data(), 1, MPI_CHAR, i.first, 0,
+                          m_StreamComm, &requests.back());
+            }
+            MPI_Status statuses[requests.size()];
+            MPI_Waitall(requests.size(), requests.data(), statuses);
         }
-        MPI_Status statuses[requests.size()];
-        MPI_Waitall(requests.size(), requests.data(), statuses);
-    }
-    else if (m_MpiMode == "onesidedfencepush")
-    {
-        MPI_Win_fence(0, m_MpiWin);
-        for (const auto &i : m_AllSendingReaderRanks)
+        else if (m_MpiMode == "onesidedfencepush")
         {
-            MPI_Put(m_Buffer.data(), 1, MPI_CHAR, i.first, 0, 1, MPI_CHAR,
-                    m_MpiWin);
+            MPI_Win_fence(0, m_MpiWin);
+            for (const auto &i : m_AllSendingReaderRanks)
+            {
+                MPI_Put(m_Buffer.data(), 1, MPI_CHAR, i.first, 0, 1, MPI_CHAR,
+                        m_MpiWin);
+            }
+            MPI_Win_fence(0, m_MpiWin);
         }
-        MPI_Win_fence(0, m_MpiWin);
-    }
-    else if (m_MpiMode == "onesidedpostpush")
-    {
-        MPI_Win_start(m_MpiAllReadersGroup, 0, m_MpiWin);
-        for (const auto &i : m_AllSendingReaderRanks)
+        else if (m_MpiMode == "onesidedpostpush")
         {
-            MPI_Put(m_Buffer.data(), 1, MPI_CHAR, i.first, 0, 1, MPI_CHAR,
-                    m_MpiWin);
+            MPI_Win_start(m_MpiAllReadersGroup, 0, m_MpiWin);
+            for (const auto &i : m_AllSendingReaderRanks)
+            {
+                MPI_Put(m_Buffer.data(), 1, MPI_CHAR, i.first, 0, 1, MPI_CHAR,
+                        m_MpiWin);
+            }
+            MPI_Win_complete(m_MpiWin);
         }
-        MPI_Win_complete(m_MpiWin);
-    }
-    else if (m_MpiMode == "onesidedfencepull")
-    {
-        MPI_Win_fence(0, m_MpiWin);
-        MPI_Win_fence(0, m_MpiWin);
-    }
-    else if (m_MpiMode == "onesidedpostpull")
-    {
-        MPI_Win_post(m_MpiAllReadersGroup, 0, m_MpiWin);
-        MPI_Win_wait(m_MpiWin);
-    }
+        else if (m_MpiMode == "onesidedfencepull")
+        {
+            MPI_Win_fence(0, m_MpiWin);
+            MPI_Win_fence(0, m_MpiWin);
+        }
+        else if (m_MpiMode == "onesidedpostpull")
+        {
+            MPI_Win_post(m_MpiAllReadersGroup, 0, m_MpiWin);
+            MPI_Win_wait(m_MpiWin);
+        }
 
-    MPI_Win_free(&m_MpiWin);
+        MPI_Win_free(&m_MpiWin);
+    }
+    else
+    {
+        SyncWritePattern(true);
+    }
 }
 
 } // end namespace engine

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -47,14 +47,7 @@ StepStatus SscWriter::BeginStep(StepMode mode, const float timeoutSeconds)
 {
     TAU_SCOPED_TIMER_FUNC();
 
-    if (m_InitialStep)
-    {
-        m_InitialStep = false;
-    }
-    else
-    {
-        ++m_CurrentStep;
-    }
+    ++m_CurrentStep;
 
     if (m_CurrentStep > 1 && m_WriterDefinitionsLocked &&
         m_ReaderSelectionsLocked)

--- a/source/adios2/engine/ssc/SscWriter.h
+++ b/source/adios2/engine/ssc/SscWriter.h
@@ -61,7 +61,7 @@ private:
     int m_WriterSize;
 
     void SyncMpiPattern();
-    void SyncWritePattern();
+    void SyncWritePattern(bool finalStep = false);
     void SyncReadPattern();
     void MpiWait();
 

--- a/source/adios2/engine/ssc/SscWriter.h
+++ b/source/adios2/engine/ssc/SscWriter.h
@@ -42,8 +42,7 @@ public:
     void Flush(const int transportIndex = -1) final;
 
 private:
-    size_t m_CurrentStep = 0;
-    bool m_InitialStep = true;
+    int64_t m_CurrentStep = -1;
 
     ssc::BlockVecVec m_GlobalWritePattern;
     ssc::BlockVecVec m_GlobalReadPattern;

--- a/source/adios2/engine/ssc/SscWriter.tcc
+++ b/source/adios2/engine/ssc/SscWriter.tcc
@@ -47,7 +47,8 @@ void SscWriter::PutDeferredCommon(Variable<std::string> &variable,
 
     if (!found)
     {
-        if (m_CurrentStep == 0)
+        if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
+            m_ReaderSelectionsLocked == false)
         {
             m_GlobalWritePattern[m_StreamRank].emplace_back();
             auto &b = m_GlobalWritePattern[m_StreamRank].back();
@@ -104,7 +105,8 @@ void SscWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
 
     if (!found)
     {
-        if (m_CurrentStep == 0)
+        if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
+            m_ReaderSelectionsLocked == false)
         {
             m_GlobalWritePattern[m_StreamRank].emplace_back();
             auto &b = m_GlobalWritePattern[m_StreamRank].back();
@@ -127,7 +129,7 @@ void SscWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
         }
         else
         {
-            throw std::runtime_error("ssc only accepts fixed IO pattern");
+            throw std::runtime_error("IO pattern changed after locking");
         }
     }
 }

--- a/testing/adios2/engine/ssc/CMakeLists.txt
+++ b/testing/adios2/engine/ssc/CMakeLists.txt
@@ -57,4 +57,7 @@ if(ADIOS2_HAVE_MPI)
   gtest_add_tests_helper(Xgc3Way MPI_ONLY Ssc Engine.SSC. "")
   SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscXgc3Way.MPI "" TRUE)
 
+  gtest_add_tests_helper(VaryingSteps MPI_ONLY Ssc Engine.SSC. "")
+  SetupTestPipeline(Engine.SSC.SscEngineTest.TestSscVaryingSteps.MPI "" TRUE)
+
 endif()

--- a/testing/adios2/engine/ssc/TestSscCommon.h
+++ b/testing/adios2/engine/ssc/TestSscCommon.h
@@ -40,7 +40,7 @@ void PrintData(const T *data, const size_t step, const Dims &start,
 template <class T>
 void GenDataRecursive(std::vector<size_t> start, std::vector<size_t> count,
                       std::vector<size_t> shape, size_t n0, size_t y,
-                      std::vector<T> &vec)
+                      std::vector<T> &vec, const size_t step)
 {
     for (size_t i = 0; i < count[0]; i++)
     {
@@ -59,12 +59,13 @@ void GenDataRecursive(std::vector<size_t> start, std::vector<size_t> count,
             for (size_t j = 0; j < count_next[0]; j++)
             {
                 vec[i0 * count_next[0] + j] =
-                    z * shape_next[0] + (j + start_next[0]);
+                    z * shape_next[0] + (j + start_next[0]) + step;
             }
         }
         else
         {
-            GenDataRecursive(start_next, count_next, shape_next, i0, z, vec);
+            GenDataRecursive(start_next, count_next, shape_next, i0, z, vec,
+                             step);
         }
     }
 }
@@ -77,7 +78,7 @@ void GenData(std::vector<T> &vec, const size_t step,
     size_t total_size = std::accumulate(count.begin(), count.end(), 1,
                                         std::multiplies<size_t>());
     vec.resize(total_size);
-    GenDataRecursive(start, count, shape, 0, 0, vec);
+    GenDataRecursive(start, count, shape, 0, 0, vec, step);
 }
 
 template <class T>

--- a/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
+++ b/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
@@ -1,0 +1,322 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+
+#include "TestSscCommon.h"
+#include <adios2.h>
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <numeric>
+#include <thread>
+
+using namespace adios2;
+int mpiRank = 0;
+int mpiSize = 1;
+MPI_Comm mpiComm;
+
+class SscEngineTest : public ::testing::Test
+{
+public:
+    SscEngineTest() = default;
+};
+
+void Writer(const Dims &shape, const Dims &start, const Dims &count,
+            const size_t steps, const adios2::Params &engineParams,
+            const std::string &name)
+{
+    size_t datasize = std::accumulate(count.begin(), count.end(), 1,
+                                      std::multiplies<size_t>());
+    adios2::ADIOS adios(mpiComm);
+    adios2::IO dataManIO = adios.DeclareIO("WAN");
+    dataManIO.SetEngine("ssc");
+    dataManIO.SetParameters(engineParams);
+    std::vector<char> myChars(datasize);
+    std::vector<unsigned char> myUChars(datasize);
+    std::vector<short> myShorts(datasize);
+    std::vector<unsigned short> myUShorts(datasize);
+    std::vector<int> myInts(datasize);
+    std::vector<unsigned int> myUInts(datasize);
+    std::vector<float> myFloats(datasize);
+    std::vector<double> myDoubles(datasize);
+    std::vector<std::complex<float>> myComplexes(datasize);
+    std::vector<std::complex<double>> myDComplexes(datasize);
+    auto bpChars =
+        dataManIO.DefineVariable<char>("bpChars", shape, start, count);
+    auto bpUChars = dataManIO.DefineVariable<unsigned char>("bpUChars", shape,
+                                                            start, count);
+    auto bpShorts =
+        dataManIO.DefineVariable<short>("bpShorts", shape, start, count);
+    auto bpUShorts = dataManIO.DefineVariable<unsigned short>(
+        "bpUShorts", shape, start, count);
+    auto bpInts = dataManIO.DefineVariable<int>("bpInts", shape, start, count);
+    auto bpUInts =
+        dataManIO.DefineVariable<unsigned int>("bpUInts", shape, start, count);
+    auto bpFloats =
+        dataManIO.DefineVariable<float>("bpFloats", shape, start, count);
+    auto bpDoubles =
+        dataManIO.DefineVariable<double>("bpDoubles", shape, start, count);
+    auto bpComplexes = dataManIO.DefineVariable<std::complex<float>>(
+        "bpComplexes", shape, start, count);
+    auto bpDComplexes = dataManIO.DefineVariable<std::complex<double>>(
+        "bpDComplexes", shape, start, count);
+    auto scalarInt = dataManIO.DefineVariable<int>("scalarInt");
+    auto stringVar = dataManIO.DefineVariable<std::string>("stringVar");
+    dataManIO.DefineAttribute<int>("AttInt", 110);
+    adios2::Engine engine = dataManIO.Open(name, adios2::Mode::Write);
+    //    engine.LockWriterDefinitions();
+    for (int i = 0; i < steps; ++i)
+    {
+        engine.BeginStep();
+
+        Dims vstart = {0, (size_t)mpiRank * 2};
+        //        Dims vcount = {(size_t)i+1, 2};
+        //        Dims vshape = {(size_t)i+1, (size_t)mpiSize * 2};
+        Dims vcount = {10, 2};
+        Dims vshape = {10, (size_t)mpiSize * 2};
+
+        bpChars.SetShape(vshape);
+        bpChars.SetSelection({vstart, vcount});
+        bpUChars.SetShape(vshape);
+        bpUChars.SetSelection({vstart, vcount});
+        bpShorts.SetShape(vshape);
+        bpShorts.SetSelection({vstart, vcount});
+        bpUShorts.SetShape(vshape);
+        bpUShorts.SetSelection({vstart, vcount});
+        bpInts.SetShape(vshape);
+        bpInts.SetSelection({vstart, vcount});
+        bpUInts.SetShape(vshape);
+        bpUInts.SetSelection({vstart, vcount});
+        bpFloats.SetShape(vshape);
+        bpFloats.SetSelection({vstart, vcount});
+        bpDoubles.SetShape(vshape);
+        bpDoubles.SetSelection({vstart, vcount});
+        bpComplexes.SetShape(vshape);
+        bpComplexes.SetSelection({vstart, vcount});
+        bpDComplexes.SetShape(vshape);
+        bpDComplexes.SetSelection({vstart, vcount});
+
+        GenData(myChars, i, vstart, vcount, vshape);
+        GenData(myUChars, i, vstart, vcount, vshape);
+        GenData(myShorts, i, vstart, vcount, vshape);
+        GenData(myUShorts, i, vstart, vcount, vshape);
+        GenData(myInts, i, vstart, vcount, vshape);
+        GenData(myUInts, i, vstart, vcount, vshape);
+        GenData(myFloats, i, vstart, vcount, vshape);
+        GenData(myDoubles, i, vstart, vcount, vshape);
+        GenData(myComplexes, i, vstart, vcount, vshape);
+        GenData(myDComplexes, i, vstart, vcount, vshape);
+
+        engine.Put(bpChars, myChars.data(), adios2::Mode::Sync);
+        engine.Put(bpUChars, myUChars.data(), adios2::Mode::Sync);
+        engine.Put(bpShorts, myShorts.data(), adios2::Mode::Sync);
+        engine.Put(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
+        engine.Put(bpInts, myInts.data(), adios2::Mode::Sync);
+        engine.Put(bpUInts, myUInts.data(), adios2::Mode::Sync);
+        engine.Put(bpFloats, myFloats.data(), adios2::Mode::Sync);
+        engine.Put(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
+        engine.Put(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
+        engine.Put(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
+        engine.Put(scalarInt, i);
+        std::string s = "sample string sample string sample string";
+        engine.Put(stringVar, s);
+        engine.EndStep();
+    }
+    engine.Close();
+}
+
+void Reader(const Dims &shape, const Dims &start, const Dims &count,
+            const size_t steps, const adios2::Params &engineParams,
+            const std::string &name)
+{
+    adios2::ADIOS adios(mpiComm);
+    adios2::IO dataManIO = adios.DeclareIO("Test");
+    dataManIO.SetEngine("ssc");
+    dataManIO.SetParameters(engineParams);
+    adios2::Engine engine = dataManIO.Open(name, adios2::Mode::Read);
+    //    engine.LockReaderSelections();
+
+    size_t datasize = std::accumulate(count.begin(), count.end(), 1,
+                                      std::multiplies<size_t>());
+    std::vector<char> myChars(datasize);
+    std::vector<unsigned char> myUChars(datasize);
+    std::vector<short> myShorts(datasize);
+    std::vector<unsigned short> myUShorts(datasize);
+    std::vector<int> myInts(datasize);
+    std::vector<unsigned int> myUInts(datasize);
+    std::vector<float> myFloats(datasize);
+    std::vector<double> myDoubles(datasize);
+    std::vector<std::complex<float>> myComplexes(datasize);
+    std::vector<std::complex<double>> myDComplexes(datasize);
+
+    while (true)
+    {
+        adios2::StepStatus status = engine.BeginStep(StepMode::Read, 5);
+        if (status == adios2::StepStatus::OK)
+        {
+            auto scalarInt = dataManIO.InquireVariable<int>("scalarInt");
+            auto blocksInfo =
+                engine.BlocksInfo(scalarInt, engine.CurrentStep());
+
+            for (const auto &bi : blocksInfo)
+            {
+                ASSERT_EQ(bi.IsValue, true);
+                ASSERT_EQ(bi.Value, engine.CurrentStep());
+                ASSERT_EQ(scalarInt.Min(), engine.CurrentStep());
+                ASSERT_EQ(scalarInt.Max(), engine.CurrentStep());
+            }
+
+            const auto &vars = dataManIO.AvailableVariables();
+            ASSERT_EQ(vars.size(), 12);
+            size_t currentStep = engine.CurrentStep();
+            adios2::Variable<char> bpChars =
+                dataManIO.InquireVariable<char>("bpChars");
+            adios2::Variable<unsigned char> bpUChars =
+                dataManIO.InquireVariable<unsigned char>("bpUChars");
+            adios2::Variable<short> bpShorts =
+                dataManIO.InquireVariable<short>("bpShorts");
+            adios2::Variable<unsigned short> bpUShorts =
+                dataManIO.InquireVariable<unsigned short>("bpUShorts");
+            adios2::Variable<int> bpInts =
+                dataManIO.InquireVariable<int>("bpInts");
+            adios2::Variable<unsigned int> bpUInts =
+                dataManIO.InquireVariable<unsigned int>("bpUInts");
+            adios2::Variable<float> bpFloats =
+                dataManIO.InquireVariable<float>("bpFloats");
+            adios2::Variable<double> bpDoubles =
+                dataManIO.InquireVariable<double>("bpDoubles");
+            adios2::Variable<std::complex<float>> bpComplexes =
+                dataManIO.InquireVariable<std::complex<float>>("bpComplexes");
+            adios2::Variable<std::complex<double>> bpDComplexes =
+                dataManIO.InquireVariable<std::complex<double>>("bpDComplexes");
+            adios2::Variable<std::string> stringVar =
+                dataManIO.InquireVariable<std::string>("stringVar");
+
+            auto vshape = bpChars.Shape();
+            myChars.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                           std::multiplies<size_t>()));
+            myUChars.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                            std::multiplies<size_t>()));
+            myShorts.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                            std::multiplies<size_t>()));
+            myUShorts.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                             std::multiplies<size_t>()));
+            myInts.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                          std::multiplies<size_t>()));
+            myUInts.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                           std::multiplies<size_t>()));
+            myFloats.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                            std::multiplies<size_t>()));
+            myDoubles.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                             std::multiplies<size_t>()));
+            myComplexes.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                               std::multiplies<size_t>()));
+            myDComplexes.resize(std::accumulate(vshape.begin(), vshape.end(), 1,
+                                                std::multiplies<size_t>()));
+
+            engine.Get(bpChars, myChars.data(), adios2::Mode::Sync);
+            engine.Get(bpUChars, myUChars.data(), adios2::Mode::Sync);
+            engine.Get(bpShorts, myShorts.data(), adios2::Mode::Sync);
+            engine.Get(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
+            engine.Get(bpInts, myInts.data(), adios2::Mode::Sync);
+            engine.Get(bpUInts, myUInts.data(), adios2::Mode::Sync);
+            engine.Get(bpFloats, myFloats.data(), adios2::Mode::Sync);
+            engine.Get(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
+            engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
+            engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
+            std::string s;
+            engine.Get(stringVar, s);
+            ASSERT_EQ(s, "sample string sample string sample string");
+            ASSERT_EQ(stringVar.Min(),
+                      "sample string sample string sample string");
+            ASSERT_EQ(stringVar.Max(),
+                      "sample string sample string sample string");
+
+            int i;
+            engine.Get(scalarInt, &i);
+            ASSERT_EQ(i, currentStep);
+
+            VerifyData(myChars.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            VerifyData(myUChars.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            VerifyData(myShorts.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            VerifyData(myUShorts.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            VerifyData(myInts.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            VerifyData(myUInts.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            VerifyData(myFloats.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            VerifyData(myDoubles.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            VerifyData(myComplexes.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            VerifyData(myDComplexes.data(), currentStep, {0, 0}, vshape, vshape,
+                       mpiRank);
+            engine.EndStep();
+        }
+        else if (status == adios2::StepStatus::EndOfStream)
+        {
+            std::cout << "[Rank " + std::to_string(mpiRank) +
+                             "] SscTest reader end of stream!"
+                      << std::endl;
+            break;
+        }
+    }
+    auto attInt = dataManIO.InquireAttribute<int>("AttInt");
+    std::cout << "[Rank " + std::to_string(mpiRank) + "] Attribute received "
+              << attInt.Data()[0] << ", expected 110" << std::endl;
+    ASSERT_EQ(110, attInt.Data()[0]);
+    ASSERT_NE(111, attInt.Data()[0]);
+    engine.Close();
+}
+
+TEST_F(SscEngineTest, TestSscVaryingSteps)
+{
+    std::string filename = "TestSscVaryingSteps";
+    adios2::Params engineParams = {};
+
+    int worldRank, worldSize;
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+    int mpiGroup = worldRank / (worldSize / 2);
+    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+    MPI_Comm_rank(mpiComm, &mpiRank);
+    MPI_Comm_size(mpiComm, &mpiSize);
+
+    Dims shape = {1, (size_t)mpiSize * 2};
+    Dims start = {0, (size_t)mpiRank * 2};
+    Dims count = {1, 2};
+    size_t steps = 100;
+
+    if (mpiGroup == 0)
+    {
+        Writer(shape, start, count, steps, engineParams, filename);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    if (mpiGroup == 1)
+    {
+        Reader(shape, start, count, steps, engineParams, filename);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    int worldRank, worldSize;
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+
+    MPI_Finalize();
+    return result;
+}


### PR DESCRIPTION
This has been requested by several applications, but I have been too lazy to implement. Part of the reason is because SSC is mainly designed and optimized for fixed IO patterns, and I really wanted to just focus on that. Now that unexpectedly more users are asking for it, so I finally decided to implement it. It's for sure not yet optimal performance wise, but at least it should work at scale. I will do optimizations in future PRs. 