### PR TITLE
Add stream reading mode for BP4 metadata processing. Read and parse o…

### DIFF
--- a/docs/user_guide/source/engines/bp4.rst
+++ b/docs/user_guide/source/engines/bp4.rst
@@ -76,7 +76,7 @@ This engine allows the user to fine tune the buffering operations through the fo
 
 16. **BurstBufferVerbose**: Verbose level 1 will cause each draining thread to print a one line report at the end (to standard output) about where it has spent its time and the number of bytes moved. Verbose level 2 will cause each thread to print a line for each draining operation (file creation, copy block, write block from memory, etc). 
 
-
+17. **StreamReader**: By default the BP4 engine parses all available metadata in Open(). An application may turn this flag on to parse a limited number of steps at once, and update metadata when those steps have been processed. If the flag is ON, reading only works in streaming mode (using BeginStep/EndStep); file reading mode will not work as there will be zero steps processed in Open().
 
 ============================== ===================== ===========================================================
  **Key**                       **Value Format**      **Default** and Examples
@@ -98,6 +98,7 @@ This engine allows the user to fine tune the buffering operations through the fo
  BurstBufferPath                string                **""**, /mnt/bb/norbert, /ssd
  BurstBufferDrain               string On/Off         **On**, Off
  BurstBufferVerbose             integer, 0-2          **0**, ``1``, ``2`` 
+ StreamReader                   string On/Off         On, **Off**
 ============================== ===================== ===========================================================
 
 

--- a/docs/user_guide/source/engines/virtual_engines.rst
+++ b/docs/user_guide/source/engines/virtual_engines.rst
@@ -55,6 +55,7 @@ These are the actual settings in ADIOS when a virtual engine is selected. The pa
 ============================== ===================== ===========================================================
  OpenTimeoutSecs                float                 **3600**  (wait for up to an hour)
  BeginStepPollingFrequencySecs  float                 **1**     (poll the file system with 1 second frequency
+ StreamReader                   bool                  **On**    (process metadata in streaming mode)
 ============================== ===================== ===========================================================
 
 3. ``InSituAnalysis``. The engine is ``SST``. The parameters are set to:

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -224,6 +224,7 @@ void IO::SetEngine(const std::string engineType) noexcept
     {
         finalEngineType = "BP4";
         lf_InsertParam("OpenTimeoutSecs", "3600");
+        lf_InsertParam("StreamReader", "true");
     }
     /* "file" is handled entirely in IO::Open() as it needs the name */
     else

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -157,17 +157,11 @@ void BP4Reader::Init()
     const Seconds timeoutSeconds =
         Seconds(m_BP4Deserializer.m_Parameters.OpenTimeoutSecs);
 
-    // set poll to 1/100 of timeout
-    Seconds pollSeconds = timeoutSeconds / 100.0;
-    static const auto pollSecondsMin = Seconds(1.0);
-    if (pollSeconds < pollSecondsMin)
+    Seconds pollSeconds =
+        Seconds(m_BP4Deserializer.m_Parameters.BeginStepPollingFrequencySecs);
+    if (pollSeconds > timeoutSeconds)
     {
-        pollSeconds = pollSecondsMin;
-    }
-    static const auto pollSecondsMax = Seconds(10.0);
-    if (pollSeconds > pollSecondsMax)
-    {
-        pollSeconds = pollSecondsMax;
+        pollSeconds = timeoutSeconds;
     }
 
     TimePoint timeoutInstant =

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -355,7 +355,7 @@ void MetadataCalculateMinFileSize(
             std::to_string(idxsize) + " bytes.");
     }
 
-    const int nTotalRecords = idxsize / m_BP4Deserializer.m_IndexRecordSize;
+    const size_t nTotalRecords = idxsize / m_BP4Deserializer.m_IndexRecordSize;
     if (nTotalRecords == 0)
     {
         // no (new) step entry in the index, so no metadata is expected
@@ -364,12 +364,12 @@ void MetadataCalculateMinFileSize(
         return;
     }
 
-    int nRecords = 1;
+    size_t nRecords = 1;
     expectedMinFileSize = *(uint64_t *)&(
         buf[nRecords * m_BP4Deserializer.m_IndexRecordSize - 24]);
     while (nRecords < nTotalRecords)
     {
-        const int n = nRecords + 1;
+        const size_t n = nRecords + 1;
         const uint64_t mdEndPos =
             *(uint64_t *)&(buf[n * m_BP4Deserializer.m_IndexRecordSize - 24]);
         if (mdEndPos - mdStartPos > 16777216)
@@ -384,53 +384,6 @@ void MetadataCalculateMinFileSize(
     {
         newIdxSize += m_BP4Deserializer.m_IndexRecordSize;
     }
-}
-
-/* Count index records to minimum 1 and maximum of N records so that
- * expected metadata size is less then a predetermined constant
- */
-void MetadataCalculateMinFileSize2(
-    const format::BP4Deserializer &m_BP4Deserializer,
-    const std::string &IdxFileName, char *buf, const size_t idxsize,
-    size_t &newIdxSize, size_t &expectedMinFileSize)
-{
-    if (idxsize % m_BP4Deserializer.m_IndexRecordSize != 0)
-    {
-        throw std::runtime_error(
-            "FATAL CODING ERROR: ADIOS Index file " + IdxFileName +
-            " is assumed to always contain n*" +
-            std::to_string(m_BP4Deserializer.m_IndexRecordSize) +
-            " byte-length records. "
-            "The file size now is " +
-            std::to_string(idxsize + m_BP4Deserializer.m_IndexHeaderSize) +
-            " bytes.");
-    }
-
-    const int nTotalRecords = idxsize / m_BP4Deserializer.m_IndexRecordSize;
-    if (nTotalRecords == 0)
-    {
-        // no (new) step entry in the index, so no metadata is expected
-        newIdxSize = 0;
-        expectedMinFileSize = 0;
-        return;
-    }
-
-    int nRecords = 1;
-    expectedMinFileSize = *(uint64_t *)&(
-        buf[nRecords * m_BP4Deserializer.m_IndexRecordSize - 24]);
-    while (nRecords < nTotalRecords)
-    {
-        const int n = nRecords + 1;
-        const uint64_t mdsize =
-            *(uint64_t *)&(buf[n * m_BP4Deserializer.m_IndexRecordSize - 24]);
-        if (mdsize > 16777216)
-        {
-            break;
-        }
-        expectedMinFileSize = mdsize;
-        ++nRecords;
-    }
-    newIdxSize = nRecords * m_BP4Deserializer.m_IndexRecordSize;
 }
 
 uint64_t

--- a/source/adios2/toolkit/format/bp/BPBase.cpp
+++ b/source/adios2/toolkit/format/bp/BPBase.cpp
@@ -196,6 +196,11 @@ void BPBase::Init(const Params &parameters, const std::string hint,
                 static_cast<int>(helper::StringTo<int32_t>(
                     value, " in Parameter key=BurstBufferVerbose " + hint));
         }
+        else if (key == "streamreader")
+        {
+            parsedParameters.StreamReader = helper::StringTo<bool>(
+                value, " in Parameter key=StreamReader " + hint);
+        }
     }
     if (!engineType.empty())
     {

--- a/source/adios2/toolkit/format/bp/BPBase.h
+++ b/source/adios2/toolkit/format/bp/BPBase.h
@@ -210,6 +210,11 @@ public:
         bool BurstBufferDrain = true;
         /** Verbose level for burst buffer draining thread */
         int BurstBufferVerbose = 0;
+
+        /** Stream reader flag: process metadata step-by-step
+         * instead of parsing everything available
+         */
+        bool StreamReader = false;
     };
 
     /** Return type of the ResizeBuffer function. */

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.h
@@ -56,6 +56,8 @@ public:
     BufferSTL m_MetadataIndex;
 
     /** Positions of flags in Index Table Header that Reader uses */
+    static constexpr size_t m_IndexHeaderSize = 64;
+    static constexpr size_t m_IndexRecordSize = 64;
     static constexpr size_t m_EndianFlagPosition = 36;
     static constexpr size_t m_BPVersionPosition = 37;
     static constexpr size_t m_ActiveFlagPosition = 38;

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -5,8 +5,10 @@
 
 set(BP3_DIR ${CMAKE_CURRENT_BINARY_DIR}/bp3)
 set(BP4_DIR ${CMAKE_CURRENT_BINARY_DIR}/bp4)
+set(FS_DIR ${CMAKE_CURRENT_BINARY_DIR}/filestream)
 file(MAKE_DIRECTORY ${BP3_DIR})
 file(MAKE_DIRECTORY ${BP4_DIR})
+file(MAKE_DIRECTORY ${FS_DIR})
 
 macro(bp3_bp4_gtest_add_tests_helper testname mpi)
   gtest_add_tests_helper(${testname} ${mpi} BP Engine.BP. .BP3
@@ -66,5 +68,13 @@ gtest_add_tests_helper(StepsInSituGlobalArray MPI_ALLOW BP Engine.BP. .BP4
 )
 gtest_add_tests_helper(StepsInSituLocalArray MPI_ALLOW BP Engine.BP. .BP4
   WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4"
+)
+
+# FileStream is BP4 + StreamReader=true
+gtest_add_tests_helper(StepsInSituGlobalArray MPI_ALLOW BP Engine.BP. .FileStream
+  WORKING_DIRECTORY ${FS_DIR} EXTRA_ARGS "FileStream"
+)
+gtest_add_tests_helper(StepsInSituLocalArray MPI_ALLOW BP Engine.BP. .FileStream
+  WORKING_DIRECTORY ${FS_DIR} EXTRA_ARGS "FileStream"
 )
 

--- a/testing/adios2/engine/staging-common/CMakeLists.txt
+++ b/testing/adios2/engine/staging-common/CMakeLists.txt
@@ -12,6 +12,7 @@ if(ADIOS2_HAVE_SST)
   gtest_add_tests_helper(Threads MPI_NONE "" Engine.Staging. ".SST.FFS" EXTRA_ARGS "SST"  "MarshalMethod=FFS")
   gtest_add_tests_helper(Threads MPI_NONE "" Engine.Staging. ".SST.BP" EXTRA_ARGS "SST"  "MarshalMethod=BP")
   gtest_add_tests_helper(Threads MPI_NONE "" Engine.Staging. ".BP4_stream" EXTRA_ARGS "BP4"  "OpenTimeoutSecs=5")
+  gtest_add_tests_helper(Threads MPI_NONE "" Engine.Staging. ".FileStream" EXTRA_ARGS "FileStream")
 endif()
 
 foreach(helper
@@ -230,7 +231,7 @@ endif()
 if(NOT MSVC)    # not on windows
     # BP4 streaming tests start with all the simple tests, but with a timeout added on open
     LIST (APPEND BP4_STREAM_TESTS ${ALL_SIMPLE_TESTS} ${SPECIAL_TESTS})
-    MutateTestSet( BP4_STREAM_TESTS "BPS" reader "OpenTimeoutSecs=10" "${BP4_STREAM_TESTS}")
+    MutateTestSet( BP4_STREAM_TESTS "BPS" reader "OpenTimeoutSecs=10,BeginStepPollingFrequencySecs=0.1" "${BP4_STREAM_TESTS}")
     # SharedVars fail with BP4_streaming*
     list (FILTER BP4_STREAM_TESTS EXCLUDE REGEX ".*SharedVar.BPS$")
     # Discard not a feature of BP4
@@ -266,6 +267,37 @@ if(NOT MSVC)    # not on windows
         add_common_test(${test} BP4_stream)
     endforeach()
     
+endif()
+
+#
+#   Setup streaming tests for FileStream virtual engine (BP4+StreamReader=true)
+#
+if(NOT MSVC)    # not on windows
+    # FileStream streaming tests start with all the simple tests, but with a timeout added on open
+    LIST (APPEND FILESTREAM_TESTS ${SIMPLE_TESTS} ${SIMPLE_MPI_TESTS})
+    MutateTestSet( FILESTREAM_TESTS "FS" reader "OpenTimeoutSecs=10,BeginStepPollingFrequencySecs=0.1" "${FILESTREAM_TESTS}")
+    # SharedVars fail with file_streaming*
+    list (FILTER FILESTREAM_TESTS EXCLUDE REGEX ".*SharedVar.FS$")
+    # SharedVars fail with file_streaming*
+    list (FILTER FILESTREAM_TESTS EXCLUDE REGEX ".*SharedVar.FS$")
+    # Local fail with file_streaming*
+    list (FILTER FILESTREAM_TESTS EXCLUDE REGEX ".*Local.FS$")
+    # The nobody-writes-data-in-a-timestep tests don't work for any BP-file based engine
+    list (FILTER FILESTREAM_TESTS EXCLUDE REGEX ".*NoData.FS$")
+    # Don't need to repeat tests that are identical for BP4 and FileStream
+    list (FILTER FILESTREAM_TESTS EXCLUDE REGEX ".*NoReaderNoWait.FS$")
+    list (FILTER FILESTREAM_TESTS EXCLUDE REGEX ".*TimeoutOnOpen.FS$")
+    list (FILTER FILESTREAM_TESTS EXCLUDE REGEX ".*NoReaderNoWait.FS$")
+
+    foreach(test ${FILESTREAM_TESTS})
+        add_common_test(${test} FileStream)
+    endforeach()
+
+    MutateTestSet( FileStream_BBSTREAM_TESTS "BB" writer "BurstBufferPath=bb,BurstBufferVerbose=2" "${FILESTREAM_TESTS}")
+    foreach(test ${FileStream_BBSTREAM_TESTS})
+        add_common_test(${test} FileStream)
+    endforeach()
+
 endif()
 
 #


### PR DESCRIPTION
…nly a limited metadata at a time (max 16MB but min 1 step). FileStream turns this on automatically