### PR TITLE
Bpls -t: read as stream

### DIFF
--- a/source/utils/bpls/bpls.h
+++ b/source/utils/bpls/bpls.h
@@ -114,6 +114,9 @@ int print_data_characteristics(void *min, void *max, double *avg,
 template <class T>
 void print_decomp(core::Engine *fp, core::IO *io, core::Variable<T> *variable);
 
+template <class T>
+void print_decomp_singlestep(core::Engine *fp, core::IO *io,
+                             core::Variable<T> *variable);
 // close namespace
 }
 }

--- a/testing/utils/cwriter/TestUtilsCWriter.bplsh.expected.txt
+++ b/testing/utils/cwriter/TestUtilsCWriter.bplsh.expected.txt
@@ -10,7 +10,7 @@ The time dimension is the first dimension then.
   --attrs     | -a           List/match attributes too
   --attrsonly | -A           List attributes only
   --meshes    | -m           List meshes
-  --timestep  | -t           Print values of timestep elements
+  --timestep  | -t           Read content step by step (stream reading)
   --dump      | -d           Dump matched variables/attributes
                                To match attributes too, add option -a
   --regexp    | -e           Treat masks as extended regular expressions


### PR DESCRIPTION
Go over file content step by step using BeginStep/EndStep loop.
It works with BP3, BP4 and HDF5, and it works with actual producer concurrently but the main purpose is to be able to start listing content from an existing BP4 dataset with huge metadata file that cannot be opened otherwise.

Missing functionality is to print value or minmax of a variable in each step, as this information is not available in the engine/IO object.

