### PR TITLE
u8 string literals are ill-formed in C++20

### DIFF
--- a/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
@@ -949,9 +949,9 @@ TEST_F(BPWriteReadAttributes, WriteReadStreamVar)
         io.DefineAttribute<std::string>("smile", "\u263A", var2.Name(),
                                         separator);
 
-        io.DefineAttribute<std::string>("utf8", std::string(u8"महसुस"),
+        io.DefineAttribute<std::string>("utf8", std::string("महसुस"),
                                         var1.Name(), separator);
-        io.DefineAttribute<std::string>("utf8", std::string(u8"महसुस"),
+        io.DefineAttribute<std::string>("utf8", std::string("महसुस"),
                                         var2.Name(), separator);
 #endif
         adios2::Engine bpWriter = io.Open(fName, adios2::Mode::Write);
@@ -1016,7 +1016,7 @@ TEST_F(BPWriteReadAttributes, WriteReadStreamVar)
             EXPECT_EQ(itUTF8->second.at("Type"), "string");
             EXPECT_EQ(itUTF8->second.at("Elements"), "1");
             EXPECT_EQ(itUTF8->second.at("Value"),
-                      "\"" + std::string(u8"महसुस") + "\"");
+                      "\"" + std::string("महसुस") + "\"");
 #endif
         };
 


### PR DESCRIPTION
See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r0.html