### PR TITLE
Added 3 64-bit MPI_Gatherv implementations

### DIFF
--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -400,6 +400,26 @@ public:
                          Datatype recvtype, int root,
                          const std::string &hint) const = 0;
 
+    virtual void Gatherv64(const void *sendbuf, size_t sendcount,
+                           Datatype sendtype, void *recvbuf,
+                           const size_t *recvcounts, const size_t *displs,
+                           Datatype recvtype, int root,
+                           const std::string &hint) const = 0;
+
+    virtual void Gatherv64OneSidedPush(const void *sendbuf, size_t sendcount,
+                                       Datatype sendtype, void *recvbuf,
+                                       const size_t *recvcounts,
+                                       const size_t *displs, Datatype recvtype,
+                                       int root,
+                                       const std::string &hint) const = 0;
+
+    virtual void Gatherv64OneSidedPull(const void *sendbuf, size_t sendcount,
+                                       Datatype sendtype, void *recvbuf,
+                                       const size_t *recvcounts,
+                                       const size_t *displs, Datatype recvtype,
+                                       int root,
+                                       const std::string &hint) const = 0;
+
     virtual void Reduce(const void *sendbuf, void *recvbuf, size_t count,
                         Datatype datatype, Comm::Op op, int root,
                         const std::string &hint) const = 0;

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -218,6 +218,23 @@ public:
                  const size_t *recvcounts, const size_t *displs, int root,
                  const std::string &hint = std::string()) const;
 
+    template <typename TSend, typename TRecv>
+    void Gatherv64(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
+                   const size_t *recvcounts, const size_t *displs, int root,
+                   const std::string &hint = std::string()) const;
+
+    template <typename TSend, typename TRecv>
+    void Gatherv64OneSidedPush(const TSend *sendbuf, size_t sendcount,
+                               TRecv *recvbuf, const size_t *recvcounts,
+                               const size_t *displs, int root,
+                               const std::string &hint = std::string()) const;
+
+    template <typename TSend, typename TRecv>
+    void Gatherv64OneSidedPull(const TSend *sendbuf, size_t sendcount,
+                               TRecv *recvbuf, const size_t *recvcounts,
+                               const size_t *displs, int root,
+                               const std::string &hint = std::string()) const;
+
     template <typename T>
     void Reduce(const T *sendbuf, T *recvbuf, size_t count, Op op, int root,
                 const std::string &hint = std::string()) const;

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -217,6 +217,38 @@ void Comm::Gatherv(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
                            CommImpl::GetDatatype<TRecv>(), root, hint);
 }
 
+template <typename TSend, typename TRecv>
+void Comm::Gatherv64(const TSend *sendbuf, size_t sendcount, TRecv *recvbuf,
+                     const size_t *recvcounts, const size_t *displs, int root,
+                     const std::string &hint) const
+{
+    return m_Impl->Gatherv64(sendbuf, sendcount, CommImpl::GetDatatype<TSend>(),
+                             recvbuf, recvcounts, displs,
+                             CommImpl::GetDatatype<TRecv>(), root, hint);
+}
+
+template <typename TSend, typename TRecv>
+void Comm::Gatherv64OneSidedPush(const TSend *sendbuf, size_t sendcount,
+                                 TRecv *recvbuf, const size_t *recvcounts,
+                                 const size_t *displs, int root,
+                                 const std::string &hint) const
+{
+    return m_Impl->Gatherv64OneSidedPush(
+        sendbuf, sendcount, CommImpl::GetDatatype<TSend>(), recvbuf, recvcounts,
+        displs, CommImpl::GetDatatype<TRecv>(), root, hint);
+}
+
+template <typename TSend, typename TRecv>
+void Comm::Gatherv64OneSidedPull(const TSend *sendbuf, size_t sendcount,
+                                 TRecv *recvbuf, const size_t *recvcounts,
+                                 const size_t *displs, int root,
+                                 const std::string &hint) const
+{
+    return m_Impl->Gatherv64OneSidedPush(
+        sendbuf, sendcount, CommImpl::GetDatatype<TSend>(), recvbuf, recvcounts,
+        displs, CommImpl::GetDatatype<TRecv>(), root, hint);
+}
+
 template <typename T>
 void Comm::Reduce(const T *sendbuf, T *recvbuf, size_t count, Op op, int root,
                   const std::string &hint) const

--- a/source/adios2/helper/adiosCommDummy.cpp
+++ b/source/adios2/helper/adiosCommDummy.cpp
@@ -80,6 +80,23 @@ public:
                  Datatype recvtype, int root,
                  const std::string &hint) const override;
 
+    void Gatherv64(const void *sendbuf, size_t sendcount, Datatype sendtype,
+                   void *recvbuf, const size_t *recvcounts,
+                   const size_t *displs, Datatype recvtype, int root,
+                   const std::string &hint) const override;
+
+    void Gatherv64OneSidedPush(const void *sendbuf, size_t sendcount,
+                               Datatype sendtype, void *recvbuf,
+                               const size_t *recvcounts, const size_t *displs,
+                               Datatype recvtype, int root,
+                               const std::string &hint) const override;
+
+    void Gatherv64OneSidedPull(const void *sendbuf, size_t sendcount,
+                               Datatype sendtype, void *recvbuf,
+                               const size_t *recvcounts, const size_t *displs,
+                               Datatype recvtype, int root,
+                               const std::string &hint) const override;
+
     void Reduce(const void *sendbuf, void *recvbuf, size_t count,
                 Datatype datatype, Comm::Op op, int root,
                 const std::string &hint) const override;
@@ -201,6 +218,53 @@ void CommImplDummy::Gatherv(const void *sendbuf, size_t sendcount,
                             const size_t *recvcounts, const size_t *displs,
                             Datatype recvtype, int root,
                             const std::string &hint) const
+{
+    const size_t recvcount = recvcounts[0];
+    if (recvcount != sendcount)
+    {
+        return CommDummyError("send and recv counts differ");
+    }
+    CommImplDummy::Gather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                          recvtype, root, hint);
+}
+
+void CommImplDummy::Gatherv64(const void *sendbuf, size_t sendcount,
+                              Datatype sendtype, void *recvbuf,
+                              const size_t *recvcounts, const size_t *displs,
+                              Datatype recvtype, int root,
+                              const std::string &hint) const
+{
+    const size_t recvcount = recvcounts[0];
+    if (recvcount != sendcount)
+    {
+        return CommDummyError("send and recv counts differ");
+    }
+    CommImplDummy::Gather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                          recvtype, root, hint);
+}
+
+void CommImplDummy::Gatherv64OneSidedPush(const void *sendbuf, size_t sendcount,
+                                          Datatype sendtype, void *recvbuf,
+                                          const size_t *recvcounts,
+                                          const size_t *displs,
+                                          Datatype recvtype, int root,
+                                          const std::string &hint) const
+{
+    const size_t recvcount = recvcounts[0];
+    if (recvcount != sendcount)
+    {
+        return CommDummyError("send and recv counts differ");
+    }
+    CommImplDummy::Gather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                          recvtype, root, hint);
+}
+
+void CommImplDummy::Gatherv64OneSidedPull(const void *sendbuf, size_t sendcount,
+                                          Datatype sendtype, void *recvbuf,
+                                          const size_t *recvcounts,
+                                          const size_t *displs,
+                                          Datatype recvtype, int root,
+                                          const std::string &hint) const
 {
     const size_t recvcount = recvcounts[0];
     if (recvcount != sendcount)

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -462,7 +462,6 @@ void CommImplMPI::Gatherv64OneSidedPush(const void *sendbuf, size_t sendcount,
     MPI_Win win;
     MPI_Win_create(recvbuf, recvsize * recvTypeSize, recvTypeSize,
                    MPI_INFO_NULL, m_MPIComm, &win);
-    MPI_Win_fence(0, win);
 
     uint64_t sendcountvar = sendcount;
 
@@ -488,7 +487,6 @@ void CommImplMPI::Gatherv64OneSidedPush(const void *sendbuf, size_t sendcount,
         }
     }
 
-    MPI_Win_fence(0, win);
     MPI_Win_free(&win);
 }
 
@@ -515,7 +513,6 @@ void CommImplMPI::Gatherv64OneSidedPull(const void *sendbuf, size_t sendcount,
     MPI_Win win;
     MPI_Win_create(const_cast<void *>(sendbuf), sendcount * sendTypeSize,
                    sendTypeSize, MPI_INFO_NULL, m_MPIComm, &win);
-    MPI_Win_fence(0, win);
 
     if (mpiRank == root)
     {
@@ -548,7 +545,6 @@ void CommImplMPI::Gatherv64OneSidedPull(const void *sendbuf, size_t sendcount,
         }
     }
 
-    MPI_Win_fence(0, win);
     MPI_Win_free(&win);
 }
 

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -484,7 +484,7 @@ void CommImplMPI::Gatherv64OneSidedPush(const void *sendbuf, size_t sendcount,
                     static_cast<int>(sendcountvar), ToMPI(sendtype), root,
                     static_cast<int>(displs[mpiRank]) + sendcount -
                         sendcountvar,
-                    sendcountvar, ToMPI(sendtype), win);
+                    static_cast<int>(sendcountvar), ToMPI(sendtype), win);
             sendcountvar = 0;
         }
     }


### PR DESCRIPTION
We have had problems for aggregating metadata larger than 2GB. This PR tries to provide a few 64-bit MPI_Gatherv implementations which can handle gather operations larger than 2GB. 

There are three subroutines:

**Gatherv64**

This uses two-sided MPI, nonblocking Isend and Irecv underneath. The send count on each rank must match the receive counts on the root rank, otherwise it will cause unmatched Isend and Irecv paris and therefore it will run into deadlock. 

**Gatherv64OneSidedPush**

This uses one-sided MPI, MPI_Put. It allows the send count on each rank and the receive counts on the root rank to be unmatched. When they are unmatched, the send count on each rank will be effective.

**Gatherv64OneSidedPull**

This uses one-sided MPI, MPI_Get. It allows the send count on each rank and the receive counts on the root rank to be unmatched. When they are unmatched, the receive counts on the root rank will be effective.
