### PR TITLE
Process metadata really step-by-step in BP4 when StreamReader is on. …

### DIFF
--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -61,14 +61,26 @@ private:
     format::BP4Deserializer m_BP4Deserializer;
     /* transport manager for metadata file */
     transportman::TransportMan m_MDFileManager;
+    /* How many bytes of metadata have we already read in? */
+    size_t m_MDFileAlreadyReadSize = 0;
+    /* How many bytes of metadata have we already processed?
+     * It is <= m_MDFileAlreadyReadSize, at = we need to read more */
     size_t m_MDFileProcessedSize = 0;
+    /* The file position of the first byte that is currently
+     * residing in memory. Needed for skewing positions when
+     * processing metadata index.
+     */
+    size_t m_MDFileAbsolutePos = 0;
+    /* m_MDFileAbsolutePos <= m_MDFileProcessedSize <= m_MDFileAlreadyReadSize
+     */
 
     /* transport manager for managing data file(s) */
     transportman::TransportMan m_DataFileManager;
 
     /* transport manager for managing the metadata index file */
     transportman::TransportMan m_MDIndexFileManager;
-    size_t m_MDIndexFileProcessedSize = 0;
+    /* How many bytes of metadata index have we already read in? */
+    size_t m_MDIndexFileAlreadyReadSize = 0;
 
     /* transport manager for managing the active flag file */
     transportman::TransportMan m_ActiveFlagFileManager;
@@ -123,6 +135,14 @@ private:
      *  It sets m_WriterIsActive.
      */
     bool CheckWriterActive();
+
+    /** Check for a step that is already in memory but haven't
+     * been processed yet.
+     *  @return true: if new step has been found and processed, false otherwise
+     *  Used by CheckForNewSteps() to get the next step from memory if there is
+     * one.
+     */
+    bool ProcessNextStepInMemory();
 
     /** Check for new steps withing timeout and only if writer is active.
      *  @return the status flag

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
@@ -58,13 +58,13 @@ size_t BP4Deserializer::ParseMetadata(const BufferSTL &bufferSTL,
     return lastposition;
 }
 
-void BP4Deserializer::ParseMetadataIndex(const BufferSTL &bufferSTL,
+void BP4Deserializer::ParseMetadataIndex(BufferSTL &bufferSTL,
                                          const size_t absoluteStartPos,
-                                         const bool hasHeader)
+                                         const bool hasHeader,
+                                         const bool oneStepOnly)
 {
     const auto &buffer = bufferSTL.m_Buffer;
-    const size_t bufferSize = buffer.size();
-    size_t position = 0;
+    size_t &position = bufferSTL.m_Position;
 
     if (hasHeader)
     {
@@ -113,7 +113,7 @@ void BP4Deserializer::ParseMetadataIndex(const BufferSTL &bufferSTL,
     }
 
     // Read each record now
-    while (position < bufferSize)
+    do
     {
         std::vector<uint64_t> ptrs;
         const uint64_t currentStep = helper::ReadValue<uint64_t>(
@@ -137,7 +137,7 @@ void BP4Deserializer::ParseMetadataIndex(const BufferSTL &bufferSTL,
         ptrs.push_back(currentTimeStamp);
         m_MetadataIndexTable[mpiRank][currentStep] = ptrs;
         position += 8;
-    }
+    } while (!oneStepOnly && position < buffer.size());
 }
 
 const helper::BlockOperationInfo &BP4Deserializer::InitPostOperatorBlockData(

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
@@ -46,9 +46,8 @@ public:
 
     ~BP4Deserializer() = default;
 
-    void ParseMetadataIndex(const BufferSTL &bufferSTL,
-                            const size_t absoluteStartPos,
-                            const bool hasHeader);
+    void ParseMetadataIndex(BufferSTL &bufferSTL, const size_t absoluteStartPos,
+                            const bool hasHeader, const bool oneStepOnly);
 
     /* Return the position in the buffer where processing ends. The processing
      * is controlled by the number of records in the Index, which may be less


### PR DESCRIPTION
…So far, it was reading in metadata in chunks but it processed the whole chunk (multiple steps) at once. For true semantics, we want Variables and Attributes show up in their proper step and since the IO map holds all entries of all processed steps, the current processing can show variables in later steps too early. Now the chunks are kept in memory but only processed step by step.