### PR TITLE
Compile C code with CC

### DIFF
--- a/cmake/install/post/generate-adios2-config.sh.in
+++ b/cmake/install/post/generate-adios2-config.sh.in
@@ -103,7 +103,7 @@ fi
 
 for variant in $variants
 do
-  echo "Extacting ADIOS flags for C bindings (${variant})"
+  echo "Extracting ADIOS flags for C bindings (${variant})"
   echo "  Without ADIOS"
   make_target_flags ${variant}_without_C
   without_C_CFLAGS=$(head -1 ${variant}_without_C.flags)
@@ -119,7 +119,7 @@ do
   echo ADIOS2_C_CFLAGS_${variant}=\"${ADIOS2_C_CFLAGS}\" >> adios2.flags
   echo ADIOS2_C_LDFLAGS_${variant}=\"${ADIOS2_C_LDFLAGS}\" >> adios2.flags
 
-  echo "Extacting ADIOS flags for C++ bindings (${variant})"
+  echo "Extracting ADIOS flags for C++ bindings (${variant})"
   echo "  Without ADIOS"
   make_target_flags ${variant}_without_CXX
   without_CXX_CXXFLAGS=$(head -1 ${variant}_without_CXX.flags)
@@ -137,7 +137,7 @@ do
 
   if [ @ADIOS2_CONFIG_FORTRAN@ -eq 1 ]
   then
-    echo "Extacting ADIOS flags for Fortran bindings (${variant})"
+    echo "Extracting ADIOS flags for Fortran bindings (${variant})"
     echo "  Without ADIOS"
     make_target_flags ${variant}_without_Fortran
     without_Fortran_FFLAGS=$(head -1 ${variant}_without_Fortran.flags)

--- a/scripts/conda/adios2/superbuild/CMakeLists.txt
+++ b/scripts/conda/adios2/superbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 project(ADIOS2_SUPERBUILD C CXX)
 
 include(ExternalProject)

--- a/scripts/dashboard/common.cmake
+++ b/scripts/dashboard/common.cmake
@@ -65,7 +65,7 @@
 #   set(ENV{FC}  /path/to/fc)   # Fortran compiler (optional)
 #   set(ENV{LD_LIBRARY_PATH} /path/to/vendor/lib) # (if necessary)
 
-cmake_minimum_required(VERSION 2.8.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12)
 
 if(NOT DEFINED dashboard_full)
   set(dashboard_full TRUE)

--- a/source/utils/bpls/bpls.cmake.gen.in
+++ b/source/utils/bpls/bpls.cmake.gen.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 
 if(OUTPUT_FILE)
   set(output_arg OUTPUT_FILE "${OUTPUT_FILE}")

--- a/testing/install/C/CMakeLists.txt
+++ b/testing/install/C/CMakeLists.txt
@@ -3,7 +3,7 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 project(adios_c_test C)
 enable_testing()
 

--- a/testing/install/C/Makefile
+++ b/testing/install/C/Makefile
@@ -20,13 +20,13 @@ test: adios_c_test adios_c_test_2
 	$(mpiexec) ./adios_c_test_2
 
 adios_c_test: main.o
-	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o adios_c_test main.o $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) --c-libs)
+	$(CC) $(LDFLAGS) $(CFLAGS) -o adios_c_test main.o $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) --c-libs)
 
 main.o: $(main_c)
 	$(CC) $(CFLAGS) $(ISYSROOT) -o main.o -c $(main_c) $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) --c-flags)
 
 adios_c_test_2: $(main_c)
-	$(CXX) $(LDFLAGS) $(CXXFLAGS) $(ISYSROOT) -o adios_c_test_2 $(main_c) $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) -c)
+	$(CC) $(LDFLAGS) $(CFLAGS) $(ISYSROOT) -o adios_c_test_2 $(main_c) $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) -c)
 
 
 test_serial: adios_c_serial_test adios_c_serial_test_2
@@ -34,13 +34,13 @@ test_serial: adios_c_serial_test adios_c_serial_test_2
 	./adios_c_serial_test_2
 
 adios_c_serial_test: main_nompi.o
-	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o adios_c_serial_test main_nompi.o $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) --serial --c-libs)
+	$(CC) $(LDFLAGS) $(CFLAGS) -o adios_c_serial_test main_nompi.o $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) --serial --c-libs)
 
 main_nompi.o: main_nompi.c
 	$(CC) $(CFLAGS) $(ISYSROOT) -o main_nompi.o -c main_nompi.c $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) -s --c-flags)
 
 adios_c_serial_test_2: main_nompi.o
-	$(CXX) $(LDFLAGS) $(CXXFLAGS) $(ISYSROOT) -o adios_c_serial_test_2 main_nompi.c $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) -s -c)
+	$(CC) $(LDFLAGS) $(CFLAGS) $(ISYSROOT) -o adios_c_serial_test_2 main_nompi.c $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) -s -c)
 
 
 test_mpi: adios_c_mpi_test adios_c_mpi_test_2
@@ -48,10 +48,10 @@ test_mpi: adios_c_mpi_test adios_c_mpi_test_2
 	$(MPIEXEC) ./adios_c_mpi_test_2
 
 adios_c_mpi_test: main_mpi.o
-	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o adios_c_mpi_test main_mpi.o $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) --mpi --c-libs)
+	$(CC) $(LDFLAGS) $(CFLAGS) -o adios_c_mpi_test main_mpi.o $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) --mpi --c-libs)
 
 main_mpi.o: main_mpi.c
 	$(CC) $(CFLAGS) $(ISYSROOT) -o main_mpi.o -c main_mpi.c $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) -m --c-flags)
 
 adios_c_mpi_test_2: main_mpi.o
-	$(CXX) $(LDFLAGS) $(CXXFLAGS) $(ISYSROOT) -o adios_c_mpi_test_2 main_mpi.c $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) -m -c)
+	$(CC) $(LDFLAGS) $(CFLAGS) $(ISYSROOT) -o adios_c_mpi_test_2 main_mpi.c $(shell adios2-config$(ADIOS2_EXECUTABLE_SUFFIX) -m -c)

--- a/testing/install/CXX11/CMakeLists.txt
+++ b/testing/install/CXX11/CMakeLists.txt
@@ -3,7 +3,7 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 project(adios_cxx11_test CXX)
 enable_testing()
 

--- a/testing/install/Fortran/CMakeLists.txt
+++ b/testing/install/Fortran/CMakeLists.txt
@@ -3,7 +3,7 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 project(adios_fortran_test Fortran)
 enable_testing()
 


### PR DESCRIPTION
Compiling C code with the CXX compiler is deprecated and will be an error.
Also, use a uniform minimum CMake version throughout the project.