### PR TITLE
Fix DataSpaces Engine Variable m_Type type mismatch

### DIFF
--- a/source/adios2/engine/dataspaces/DataSpacesWriter.tcc
+++ b/source/adios2/engine/dataspaces/DataSpacesWriter.tcc
@@ -87,7 +87,7 @@ void DataSpacesWriter::DoPutSyncCommon(Variable<T> &variable, const T *values)
     }
     gdims_vector.push_back(dims_vec);
     int varType;
-    auto itType = varType_to_ds.find(variable.m_Type);
+    auto itType = varType_to_ds.find(ToString(variable.m_Type));
     if (itType == varType_to_ds.end())
     {
         varType = 2;


### PR DESCRIPTION
The DataSpaces engine was failing to build because it expected VariableBase's m_type member to be a string, rather than an object. This uses ToString() the bridge this mismatch.