### PR TITLE
let ssc use pgi compiler

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -179,7 +179,7 @@ endif()
 
 # SSC
 # SSC currently breaks the PGI compiler
-if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "PGI") AND NOT MSVC)
+if(NOT MSVC)
     if(ADIOS2_HAVE_MPI)
         if(ADIOS2_USE_SSC STREQUAL AUTO)
             set(ADIOS2_HAVE_SSC TRUE)

--- a/source/adios2/engine/ssc/SscHelper.cpp
+++ b/source/adios2/engine/ssc/SscHelper.cpp
@@ -48,11 +48,7 @@ size_t TotalDataSize(const Dims &dims, DataType type, const ShapeID &shapeId)
     {
         return GetTypeSize(type);
     }
-    else
-    {
-        throw(std::runtime_error("ShapeID not supported"));
-    }
-    return 0;
+    throw(std::runtime_error("ShapeID not supported"));
 }
 
 size_t TotalDataSize(const BlockVec &bv)

--- a/thirdparty/nlohmann_json/nlohmann_json/src/single_include/nlohmann/json.hpp
+++ b/thirdparty/nlohmann_json/nlohmann_json/src/single_include/nlohmann/json.hpp
@@ -11410,6 +11410,14 @@ class serializer
         }
     }
 
+    template<typename NumberType, detail::enable_if_t<
+        std::is_same<NumberType, number_unsigned_t>::value, int> = 0>
+        bool is_negative_integer(NumberType x) { return false; }
+
+    template<typename NumberType, detail::enable_if_t<
+        std::is_same<NumberType, number_integer_t>::value, int> = 0>
+        bool is_negative_integer(NumberType x) { return x<0; }
+
     /*!
     @brief dump an integer
 
@@ -11432,7 +11440,7 @@ class serializer
             return;
         }
 
-        const bool is_negative = std::is_same<NumberType, number_integer_t>::value and not (x >= 0);  // see issue #755
+        const bool is_negative = is_negative_integer(x); // see issue #755
         std::size_t i = 0;
 
         while (x != 0)


### PR DESCRIPTION
An urgent request from HBPS project. XGC has been compiled only using PGI compiler, but SSC never tried that because nlohmann::json used to break PGI. 

I just tried on Summit using PGI, and it actually worked. Now let's see if it works with CI. 