### PR TITLE
Rework SstVerbose to include levels (0-5)

### DIFF
--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -406,10 +406,6 @@ void SstReader::Init()
     SstParamParser Parser;
 
     Parser.ParseParams(m_IO, Params);
-
-#define set_params(Param, Type, Typedecl, Default) m_##Param = Params.Param;
-    SST_FOREACH_PARAMETER_TYPE_4ARGS(set_params);
-#undef set_params
 }
 
 #define declare_gets(T)                                                        \

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -75,10 +75,6 @@ private:
     /* --- Used only with BP marshaling --- */
 
     struct _SstParams Params;
-#define declare_locals(Param, Type, Typedecl, Default)                         \
-    Typedecl m_##Param = Default;
-    SST_FOREACH_PARAMETER_TYPE_4ARGS(declare_locals)
-#undef declare_locals
 
 #define declare_type(T)                                                        \
     void DoGetSync(Variable<T> &, T *) final;                                  \

--- a/source/adios2/engine/sst/SstWriter.h
+++ b/source/adios2/engine/sst/SstWriter.h
@@ -71,10 +71,6 @@ private:
     bool m_DefinitionsNotified = false;
     size_t m_FFSMarshaledAttributesCount = 0;
     struct _SstParams Params;
-#define declare_locals(Param, Type, Typedecl, Default)                         \
-    Typedecl m_##Param = Default;
-    SST_FOREACH_PARAMETER_TYPE_4ARGS(declare_locals)
-#undef declare_locals
 
     void FFSMarshalAttributes();
     void DoClose(const int transportIndex = -1) final;

--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -36,7 +36,7 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
                                "BeginStep/EndStep pairs");
     }
 
-    if (m_MarshalMethod == SstMarshalFFS)
+    if (Params.MarshalMethod == SstMarshalFFS)
     {
         size_t *Shape = NULL;
         size_t *Start = NULL;
@@ -59,7 +59,7 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
                       ToString(variable.m_Type).c_str(), variable.m_ElementSize,
                       DimCount, Shape, Count, Start, values);
     }
-    else if (m_MarshalMethod == SstMarshalBP)
+    else if (Params.MarshalMethod == SstMarshalBP)
     {
         auto &blockInfo = variable.SetBlockInfo(
             values, m_BP3Serializer->m_MetadataSet.CurrentStep);

--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -142,8 +142,8 @@ struct _SstStream
     SstRegistrationMethod RegistrationMethod;
 
     /* state */
-    int CPVerbose;
-    int DPVerbose;
+    int CPVerbosityLevel;
+    int DPVerbosityLevel;
     double OpenTimeSecs;
     struct timeval ValidStartTime;
     SstStats Stats;
@@ -524,7 +524,18 @@ extern void FFSFreeMarshalData(SstStream Stream);
 extern void getPeerArrays(int MySize, int MyRank, int PeerSize,
                           int **forwardArray, int **reverseArray);
 extern void AddToLastCallFreeList(void *Block);
-extern void CP_verbose(SstStream Stream, char *Format, ...);
+enum VerbosityLevel
+{
+    TraceVerbose = 5,
+    PerRankVerbose = 4,
+    PerStepVerbose = 3,
+    SummaryVerbose = 2,
+    CriticalVerbose = 1,
+    NoVerbose = 0,
+};
+
+extern void CP_verbose(SstStream Stream, enum VerbosityLevel Level,
+                       char *Format, ...);
 extern void CP_error(SstStream Stream, char *Format, ...);
 extern struct _CP_Services Svcs;
 extern void CP_dumpParams(SstStream Stream, struct _SstParams *Params,

--- a/source/adios2/toolkit/sst/cp/ffs_marshal.c
+++ b/source/adios2/toolkit/sst/cp/ffs_marshal.c
@@ -734,8 +734,6 @@ static FFSVarRec CreateVarRec(SstStream Stream, const char *ArrayName)
     return &Info->VarList[Info->VarCount++];
 }
 
-extern void CP_verbose(SstStream Stream, char *Format, ...);
-
 extern int SstFFSWriterBeginStep(SstStream Stream, int mode,
                                  const float timeout_sec)
 {
@@ -1015,13 +1013,14 @@ static SstStatusValue WaitForReadRequests(SstStream Stream)
             }
             else
             {
-                CP_verbose(Stream, "Wait for remote read completion failed, "
-                                   "returning failure\n");
+                CP_verbose(Stream, CriticalVerbose,
+                           "Wait for remote read completion failed, "
+                           "returning failure\n");
                 return Result;
             }
         }
     }
-    CP_verbose(Stream, "All remote memory reads completed\n");
+    CP_verbose(Stream, TraceVerbose, "All remote memory reads completed\n");
     return SstSuccess;
 }
 
@@ -1469,8 +1468,9 @@ extern SstStatusValue SstFFSPerformGets(SstStream Stream)
     }
     else
     {
-        CP_verbose(Stream, "Some memory read failed, not filling requests and "
-                           "returning failure\n");
+        CP_verbose(Stream, CriticalVerbose,
+                   "Some memory read failed, not filling requests and "
+                   "returning failure\n");
     }
     ClearReadRequests(Stream);
 
@@ -1485,7 +1485,7 @@ extern void SstFFSWriterEndStep(SstStream Stream, size_t Timestep)
 
     TAU_START("Marshaling overhead in SstFFSWriterEndStep");
 
-    CP_verbose(Stream, "Calling SstWriterEndStep\n");
+    CP_verbose(Stream, PerStepVerbose, "Calling SstWriterEndStep\n");
     // if field lists have changed, register formats with FFS local context, add
     // to format chain
     if (!Stream->WriterMarshalData)

--- a/source/adios2/toolkit/sst/dp/dp.c
+++ b/source/adios2/toolkit/sst/dp/dp.c
@@ -75,13 +75,14 @@ CP_DP_Interface SelectDP(CP_Services Svcs, void *CP_Stream,
     int FoundPreferred = 0;
     if (Params->DataTransport)
     {
-        Svcs->verbose(CP_Stream, "Prefered dataplane name is \"%s\"\n",
+        Svcs->verbose(CP_Stream, DPPerStepVerbose,
+                      "Prefered dataplane name is \"%s\"\n",
                       Params->DataTransport);
     }
     while (List[i].Interface)
     {
         Svcs->verbose(
-            CP_Stream,
+            CP_Stream, DPPerStepVerbose,
             "Considering DataPlane \"%s\" for possible use, priority is %d\n",
             List[i].Name, List[i].Priority);
         if (Params->DataTransport)
@@ -117,13 +118,13 @@ CP_DP_Interface SelectDP(CP_Services Svcs, void *CP_Stream,
     }
     if (SelectedDP != -1)
     {
-        Svcs->verbose(CP_Stream,
+        Svcs->verbose(CP_Stream, DPSummaryVerbose,
                       "Selecting DataPlane \"%s\" (preferred) for use\n",
                       List[SelectedDP].Name);
     }
     else
     {
-        Svcs->verbose(CP_Stream,
+        Svcs->verbose(CP_Stream, DPSummaryVerbose,
                       "Selecting DataPlane \"%s\", priority %d for use\n",
                       List[BestPrioDP].Name, List[BestPrioDP].Priority);
         SelectedDP = BestPrioDP;

--- a/source/adios2/toolkit/sst/dp/evpath_dp.c
+++ b/source/adios2/toolkit/sst/dp/evpath_dp.c
@@ -387,7 +387,7 @@ static void EvpathReadRequestHandler(CManager cm, CMConnection incoming_conn,
     CP_Services Svcs = (CP_Services)client_Data;
     int RequestingRank = ReadRequestMsg->RequestingRank;
 
-    Svcs->verbose(WS_Stream->CP_Stream,
+    Svcs->verbose(WS_Stream->CP_Stream, DPTraceVerbose,
                   "Got a request to read remote memory "
                   "from reader rank %d: timestep %d, "
                   "offset %d, length %d\n",
@@ -410,7 +410,7 @@ static void EvpathReadRequestHandler(CManager cm, CMConnection incoming_conn,
             ReadReplyMsg.RS_Stream = ReadRequestMsg->RS_Stream;
             ReadReplyMsg.NotifyCondition = ReadRequestMsg->NotifyCondition;
             Svcs->verbose(
-                WS_Stream->CP_Stream,
+                WS_Stream->CP_Stream, DPTraceVerbose,
                 "Sending a reply to reader rank %d for remote memory read\n",
                 RequestingRank);
             ReplyConn = WSR_Stream->ReaderContactInfo[RequestingRank].Conn;
@@ -491,9 +491,10 @@ static void EvpathReadReplyHandler(CManager cm, CMConnection conn, void *msg_v,
 
     if (CMCondition_has_signaled(cm, ReadReplyMsg->NotifyCondition))
     {
-        Svcs->verbose(RS_Stream->CP_Stream, "Got a reply to remote memory "
-                                            "read, but the condition is "
-                                            "already signalled, returning\n");
+        Svcs->verbose(RS_Stream->CP_Stream, DPTraceVerbose,
+                      "Got a reply to remote memory "
+                      "read, but the condition is "
+                      "already signalled, returning\n");
         TAU_STOP_FUNC();
         return;
     }
@@ -502,13 +503,13 @@ static void EvpathReadReplyHandler(CManager cm, CMConnection conn, void *msg_v,
     if (!Handle)
     {
         Svcs->verbose(
-            RS_Stream->CP_Stream,
+            RS_Stream->CP_Stream, DPCriticalVerbose,
             "Got a reply to remote memory read, but condition not found\n");
         TAU_STOP_FUNC();
         return;
     }
     Svcs->verbose(
-        RS_Stream->CP_Stream,
+        RS_Stream->CP_Stream, DPTraceVerbose,
         "Got a reply to remote memory read from rank %d, condition is %d\n",
         Handle->Rank, ReadReplyMsg->NotifyCondition);
 
@@ -572,7 +573,7 @@ static int HandleRequestWithPreloaded(CP_Services Svcs,
     {
         return 0;
     }
-    Svcs->verbose(RS_Stream->CP_Stream,
+    Svcs->verbose(RS_Stream->CP_Stream, DPTraceVerbose,
                   "Satisfying remote memory read with preload from writer rank "
                   "%d for timestep %ld, fprint %lx\n",
                   Rank, Timestep,
@@ -606,7 +607,7 @@ static void DiscardPriorPreloaded(CP_Services Svcs, Evpath_RS_Stream RS_Stream,
             /* free item */
             if (ItemToFree->Data)
             {
-                Svcs->verbose(RS_Stream->CP_Stream,
+                Svcs->verbose(RS_Stream->CP_Stream, DPPerRankVerbose,
                               "Discarding prior, TS %ld, data %p, fprint %lx\n",
                               ItemToFree->Timestep, ItemToFree->Data,
                               writeBlockFingerprint(ItemToFree->Data,
@@ -637,7 +638,7 @@ static void EvpathPreloadHandler(CManager cm, CMConnection conn, void *msg_v,
     RSTimestepList Entry = calloc(1, sizeof(*Entry));
 
     Svcs->verbose(
-        RS_Stream->CP_Stream,
+        RS_Stream->CP_Stream, DPPerStepVerbose,
         "Got a preload message from writer rank %d for timestep %ld, fprint "
         "%lx\n",
         PreloadMsg->WriterRank, PreloadMsg->Timestep,
@@ -787,7 +788,7 @@ static DP_WSR_Stream EvpathInitWriterPerReader(CP_Services Svcs,
         WSR_Stream->ReaderContactInfo[i].RS_Stream =
             providedReaderInfo[i]->RS_Stream;
         Svcs->verbose(
-            WS_Stream->CP_Stream,
+            WS_Stream->CP_Stream, DPTraceVerbose,
             "Received contact info \"%s\", RD_Stream %p for Reader Rank %d\n",
             WSR_Stream->ReaderContactInfo[i].ContactString,
             WSR_Stream->ReaderContactInfo[i].RS_Stream, i);
@@ -852,7 +853,7 @@ static void EvpathProvideWriterDataToReader(CP_Services Svcs,
         RS_Stream->WriterContactInfo[i].WS_Stream =
             providedWriterInfo[i]->WS_Stream;
         Svcs->verbose(
-            RS_Stream->CP_Stream,
+            RS_Stream->CP_Stream, DPTraceVerbose,
             "Received contact info \"%s\", WS_stream %p for WSR Rank %d\n",
             RS_Stream->WriterContactInfo[i].ContactString,
             RS_Stream->WriterContactInfo[i].WS_Stream, i);
@@ -899,7 +900,7 @@ static void FailRequestsToRank(CP_Services Svcs, CManager cm,
 {
     EvpathCompletionHandle Tmp;
     int FailedSomethingToRank = 0;
-    Svcs->verbose(Stream->CP_Stream,
+    Svcs->verbose(Stream->CP_Stream, DPTraceVerbose,
                   "Fail pending requests to rank %d on stream %p\n", FailedRank,
                   Stream);
     pthread_mutex_lock(&Stream->DataLock);
@@ -910,21 +911,22 @@ static void FailRequestsToRank(CP_Services Svcs, CManager cm,
         {
             Tmp->Failed = 1;
             FailedSomethingToRank = 1;
-            Svcs->verbose(Tmp->CPStream,
+            Svcs->verbose(Tmp->CPStream, DPTraceVerbose,
                           "Found a pending remote memory read "
                           "to writer rank %d, marking as "
                           "failed and signalling condition %d\n",
                           Tmp->Rank, Tmp->CMcondition);
             CMCondition_signal(cm, Tmp->CMcondition);
-            Svcs->verbose(Tmp->CPStream, "Did the signal of condition %d\n",
-                          Tmp->Rank, Tmp->CMcondition);
+            Svcs->verbose(Tmp->CPStream, DPTraceVerbose,
+                          "Did the signal of condition %d\n", Tmp->Rank,
+                          Tmp->CMcondition);
         }
         Tmp = Tmp->Next;
     }
     if (FailedSomethingToRank)
     {
         Tmp = Stream->PendingReadRequests;
-        Svcs->verbose(Stream->CP_Stream,
+        Svcs->verbose(Stream->CP_Stream, DPTraceVerbose,
                       "We were waiting for requests on rank %d, fail *all* "
                       "pending requests on stream %p\n",
                       FailedRank, Stream);
@@ -935,20 +937,21 @@ static void FailRequestsToRank(CP_Services Svcs, CManager cm,
             {
                 Tmp->Failed = 1;
                 FailedSomethingToRank = 1;
-                Svcs->verbose(Tmp->CPStream,
+                Svcs->verbose(Tmp->CPStream, DPTraceVerbose,
                               "Found a pending remote memory read "
                               "to writer rank %d, marking as "
                               "failed and signalling condition %d\n",
                               Tmp->Rank, Tmp->CMcondition);
                 CMCondition_signal(cm, Tmp->CMcondition);
-                Svcs->verbose(Tmp->CPStream, "Did the signal of condition %d\n",
-                              Tmp->Rank, Tmp->CMcondition);
+                Svcs->verbose(Tmp->CPStream, DPTraceVerbose,
+                              "Did the signal of condition %d\n", Tmp->Rank,
+                              Tmp->CMcondition);
             }
             Tmp = Tmp->Next;
         }
     }
     pthread_mutex_unlock(&Stream->DataLock);
-    Svcs->verbose(Stream->CP_Stream,
+    Svcs->verbose(Stream->CP_Stream, DPPerRankVerbose,
                   "Done Failing requests to writer %d from stream %p\n",
                   FailedRank, Stream);
 }
@@ -1034,14 +1037,14 @@ static void *EvpathReadRemoteMemory(CP_Services Svcs, DP_RS_Stream Stream_v,
     {
         // we're in some kind of preload mode, but we don't have the data yet,
         // wait for it without sending a request
-        Svcs->verbose(Stream->CP_Stream,
+        Svcs->verbose(Stream->CP_Stream, DPTraceVerbose,
                       "Adios waiting for preload data for Timestep %d "
                       "from Rank %d, WSR_Stream = %p, DP_TimestepInfo %p\n",
                       Timestep, Rank, Stream->WriterContactInfo[Rank].WS_Stream,
                       DP_TimestepInfo);
         return ret;
     }
-    Svcs->verbose(Stream->CP_Stream,
+    Svcs->verbose(Stream->CP_Stream, DPTraceVerbose,
                   "Adios requesting to read remote memory for Timestep %d "
                   "from Rank %d, WSR_Stream = %p, DP_TimestepInfo %p\n",
                   Timestep, Rank, Stream->WriterContactInfo[Rank].WS_Stream,
@@ -1074,7 +1077,7 @@ static int EvpathWaitForCompletion(CP_Services Svcs, void *Handle_v)
     int Ret = 1;
     if (Handle->CMcondition != -1)
         Svcs->verbose(
-            Handle->CPStream,
+            Handle->CPStream, DPTraceVerbose,
             "Waiting for completion of memory read to rank %d, condition %d\n",
             Handle->Rank, Handle->CMcondition);
     /*
@@ -1086,7 +1089,7 @@ static int EvpathWaitForCompletion(CP_Services Svcs, void *Handle_v)
         CMCondition_wait(Handle->cm, Handle->CMcondition);
     if (Handle->Failed)
     {
-        Svcs->verbose(Handle->CPStream,
+        Svcs->verbose(Handle->CPStream, DPTraceVerbose,
                       "Remote memory read to rank %d with "
                       "condition %d has FAILED because of "
                       "writer failure\n",
@@ -1096,7 +1099,7 @@ static int EvpathWaitForCompletion(CP_Services Svcs, void *Handle_v)
     else
     {
         if (Handle->CMcondition != -1)
-            Svcs->verbose(Handle->CPStream,
+            Svcs->verbose(Handle->CPStream, DPTraceVerbose,
                           "Remote memory read to rank %d with condition %d has "
                           "completed\n",
                           Handle->Rank, Handle->CMcondition);
@@ -1115,7 +1118,7 @@ static void EvpathNotifyConnFailure(CP_Services Svcs, DP_RS_Stream Stream_v,
     Evpath_RS_Stream Stream = (Evpath_RS_Stream)
         Stream_v; /* DP_RS_Stream is the return from InitReader */
     CManager cm = Svcs->getCManager(Stream->CP_Stream);
-    Svcs->verbose(Stream->CP_Stream,
+    Svcs->verbose(Stream->CP_Stream, DPPerRankVerbose,
                   "received notification that writer peer "
                   "%d has failed, failing any pending "
                   "requests\n",
@@ -1163,7 +1166,7 @@ static void EvpathWSReaderRegisterTimestep(CP_Services Svcs,
         return;
     }
 
-    Svcs->verbose(WS_Stream->CP_Stream,
+    Svcs->verbose(WS_Stream->CP_Stream, DPPerRankVerbose,
                   "Per reader registration for timestep %ld, preload mode %d\n",
                   Timestep, PreloadMode);
     if (PreloadMode == SstPreloadLearned)
@@ -1175,7 +1178,7 @@ static void EvpathWSReaderRegisterTimestep(CP_Services Svcs,
         if (WSR_Stream->ReaderRequestArray)
         {
             Svcs->verbose(
-                WS_Stream->CP_Stream,
+                WS_Stream->CP_Stream, DPPerRankVerbose,
                 "Sending Learned Preload messages, reader %p, timestep %ld, "
                 "fprint %lx\n",
                 WSR_Stream, Timestep,
@@ -1186,7 +1189,7 @@ static void EvpathWSReaderRegisterTimestep(CP_Services Svcs,
     else if (PreloadMode == SstPreloadSpeculative)
     {
         Svcs->verbose(
-            WS_Stream->CP_Stream,
+            WS_Stream->CP_Stream, DPPerRankVerbose,
             "Sending Speculative Preload messages, reader %p, timestep %ld\n",
             WSR_Stream, Timestep);
         SendSpeculativePreloadMsgs(Svcs, WSR_Stream, Entry);
@@ -1201,7 +1204,7 @@ static void EvpathRSTimestepArrived(CP_Services Svcs, DP_RS_Stream RS_Stream_v,
 {
     Evpath_RS_Stream RS_Stream = (Evpath_RS_Stream)RS_Stream_v;
     Svcs->verbose(
-        RS_Stream->CP_Stream,
+        RS_Stream->CP_Stream, DPPerRankVerbose,
         "EVPATH registering reader arrival of TS %ld metadata, preload mode "
         "%d\n",
         Timestep, PreloadMode);
@@ -1219,7 +1222,7 @@ static void SendPreloadMsgs(CP_Services Svcs, Evpath_WSR_Stream WSR_Stream,
     Evpath_WS_Stream WS_Stream =
         WSR_Stream->WS_Stream; /* pointer to writer struct */
     struct _EvpathPreloadMsg PreloadMsg;
-    Svcs->verbose(WS_Stream->CP_Stream,
+    Svcs->verbose(WS_Stream->CP_Stream, DPPerRankVerbose,
                   "EVPATH Sending preload messages for timestep %ld\n",
                   TS->Timestep);
     memset(&PreloadMsg, 0, sizeof(PreloadMsg));
@@ -1234,7 +1237,7 @@ static void SendPreloadMsgs(CP_Services Svcs, Evpath_WSR_Stream WSR_Stream,
         {
             PreloadMsg.RS_Stream = WSR_Stream->ReaderContactInfo[i].RS_Stream;
             Svcs->verbose(
-                WS_Stream->CP_Stream,
+                WS_Stream->CP_Stream, DPTraceVerbose,
                 "EVPATH Preload message for timestep %ld, going to rank %d\n",
                 TS->Timestep, i);
             CMwrite(WSR_Stream->ReaderContactInfo[i].Conn,
@@ -1268,7 +1271,7 @@ static void SendSpeculativePreloadMsgs(CP_Services Svcs,
             if (!Conn)
             {
                 Svcs->verbose(
-                    WS_Stream->CP_Stream,
+                    WS_Stream->CP_Stream, DPCriticalVerbose,
                     "Failed to connect to reader rank %d for response to "
                     "remote read, assume failure, no response sent\n",
                     i);
@@ -1295,7 +1298,7 @@ static void EvpathReaderReleaseTimestep(CP_Services Svcs,
     if ((!WSR_Stream->ReaderRequestArray) &&
         (Timestep == WSR_Stream->ReadPatternLockTimestep))
     {
-        Svcs->verbose(WS_Stream->CP_Stream,
+        Svcs->verbose(WS_Stream->CP_Stream, DPPerRankVerbose,
                       "EVPATH Saving the read pattern for timestep %ld\n",
                       Timestep);
         /* save the pattern */
@@ -1311,7 +1314,7 @@ static void EvpathReaderReleaseTimestep(CP_Services Svcs,
                         WSR_Stream->ReaderRequestArray = ReqList->RequestList;
                         /* so it doesn't get free'd */
                         ReqList->RequestList = NULL;
-                        Svcs->verbose(WS_Stream->CP_Stream,
+                        Svcs->verbose(WS_Stream->CP_Stream, DPTraceVerbose,
                                       "EVPATH Found timestep\n", Timestep);
                     }
                     ReqList = ReqList->Next;
@@ -1320,7 +1323,7 @@ static void EvpathReaderReleaseTimestep(CP_Services Svcs,
             tmp = tmp->Next;
         }
         /* send stored timesteps based on learned pattern */
-        Svcs->verbose(WS_Stream->CP_Stream,
+        Svcs->verbose(WS_Stream->CP_Stream, DPPerRankVerbose,
                       "EVPATH Sending learned preloads for queued messages\n");
         tmp = WS_Stream->Timesteps;
         while (tmp != NULL)
@@ -1360,7 +1363,7 @@ static void EvpathProvideTimestep(CP_Services Svcs, DP_WS_Stream Stream_v,
     Entry->Next = NULL;
 
     Svcs->verbose(
-        WS_Stream->CP_Stream,
+        WS_Stream->CP_Stream, DPPerRankVerbose,
         "ProvideTimestep, registering timestep %ld, data %p, fprint %lx\n",
         Timestep, Data->block,
         writeBlockFingerprint(Data->block, Data->DataSize));
@@ -1388,7 +1391,8 @@ static void EvpathReleaseTimestep(CP_Services Svcs, DP_WS_Stream Stream_v,
     Evpath_WS_Stream WS_Stream = (Evpath_WS_Stream)Stream_v;
     TimestepList List;
 
-    Svcs->verbose(WS_Stream->CP_Stream, "Releasing timestep %ld\n", Timestep);
+    Svcs->verbose(WS_Stream->CP_Stream, DPPerRankVerbose,
+                  "Releasing timestep %ld\n", Timestep);
     pthread_mutex_lock(&WS_Stream->DataLock);
     List = WS_Stream->Timesteps;
     if (WS_Stream->Timesteps && (WS_Stream->Timesteps->Timestep == Timestep))

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -374,7 +374,8 @@ static DP_RS_Stream RdmaInitReader(CP_Services Svcs, void *CP_Stream,
     if (!get_int_attr(WriterContact, attr_atom_from_string("RDMA_DRC_KEY"),
                       &protection_key))
     {
-        Svcs->verbose(CP_Stream, "Didn't find DRC credential\n");
+        Svcs->verbose(CP_Stream, DPCriticalVerbose,
+                      "Didn't find DRC credential for Cray RDMA\n");
         return NULL;
     }
     // do something with protection key?
@@ -414,14 +415,15 @@ static DP_WS_Stream RdmaInitWriter(CP_Services Svcs, void *CP_Stream,
         rc = drc_acquire(&Fabric->credential, DRC_FLAGS_FLEX_CREDENTIAL);
         if (rc != DRC_SUCCESS)
         {
-            Svcs->verbose(CP_Stream,
+            Svcs->verbose(CP_Stream, DPCriticalVerbose,
                           "Could not acquire DRC credential. Failed with %d.\n",
                           rc);
             goto err_out;
         }
         else
         {
-            Svcs->verbose(CP_Stream, "DRC acquired credential id %d.\n",
+            Svcs->verbose(CP_Stream, DPTraceVerbose,
+                          "DRC acquired credential id %d.\n",
                           Fabric->credential);
         }
     }
@@ -438,7 +440,7 @@ static DP_WS_Stream RdmaInitWriter(CP_Services Svcs, void *CP_Stream,
     }
     if (rc != DRC_SUCCESS)
     {
-        Svcs->verbose(CP_Stream,
+        Svcs->verbose(CP_Stream, DPCriticalVerbose,
                       "Could not access DRC credential. Last failed with %d.\n",
                       rc);
         goto err_out;
@@ -448,7 +450,7 @@ static DP_WS_Stream RdmaInitWriter(CP_Services Svcs, void *CP_Stream,
     Fabric->auth_key->type = GNIX_AKT_RAW;
     Fabric->auth_key->raw.protection_key =
         drc_get_first_cookie(Fabric->drc_info);
-    Svcs->verbose(CP_Stream, "Using protection key %08x.\n",
+    Svcs->verbose(CP_Stream, DPTraceVerbose, "Using protection key %08x.\n",
                   Fabric->auth_key->raw.protection_key);
 
     set_int_attr(DPAttrs, attr_atom_from_string("RDMA_DRC_KEY"),
@@ -460,11 +462,12 @@ static DP_WS_Stream RdmaInitWriter(CP_Services Svcs, void *CP_Stream,
     Fabric = Stream->Fabric;
     if (!Fabric->info)
     {
-        Svcs->verbose(CP_Stream, "Could not find a valid transport fabric.\n");
+        Svcs->verbose(CP_Stream, DPTraceVerbose,
+                      "Could not find a valid transport fabric.\n");
         goto err_out;
     }
 
-    Svcs->verbose(CP_Stream, "Fabric Parameters:\n%s\n",
+    Svcs->verbose(CP_Stream, DPTraceVerbose, "Fabric Parameters:\n%s\n",
                   fi_tostr(Fabric->info, FI_TYPE_INFO));
 
     /*
@@ -564,7 +567,7 @@ static void RdmaProvideWriterDataToReader(CP_Services Svcs,
     }
     else
     {
-        Svcs->verbose(CP_Stream,
+        Svcs->verbose(CP_Stream, DPCriticalVerbose,
                       "Writer contact info needed to access DRC credentials.\n",
                       rc);
     }
@@ -582,7 +585,7 @@ static void RdmaProvideWriterDataToReader(CP_Services Svcs,
     }
     if (rc != DRC_SUCCESS)
     {
-        Svcs->verbose(CP_Stream,
+        Svcs->verbose(CP_Stream, DPCriticalVerbose,
                       "Could not access DRC credential. Last failed with %d.\n",
                       rc);
     }
@@ -591,17 +594,18 @@ static void RdmaProvideWriterDataToReader(CP_Services Svcs,
     Fabric->auth_key->type = GNIX_AKT_RAW;
     Fabric->auth_key->raw.protection_key =
         drc_get_first_cookie(Fabric->drc_info);
-    Svcs->verbose(CP_Stream, "Using protection key %08x.\n",
+    Svcs->verbose(CP_Stream, DPTraceVerbose, "Using protection key %08x.\n",
                   Fabric->auth_key->raw.protection_key);
 #endif /* SST_HAVE_CRAY_DRC */
 
     init_fabric(RS_Stream->Fabric, RS_Stream->Params);
     if (!Fabric->info)
     {
-        Svcs->verbose(CP_Stream, "Could not find a valid transport fabric.\n");
+        Svcs->verbose(CP_Stream, DPTraceVerbose,
+                      "Could not find a valid transport fabric.\n");
     }
 
-    Svcs->verbose(CP_Stream, "Fabric Parameters:\n%s\n",
+    Svcs->verbose(CP_Stream, DPTraceVerbose, "Fabric Parameters:\n%s\n",
                   fi_tostr(Fabric->info, FI_TYPE_INFO));
 
     /*
@@ -616,7 +620,7 @@ static void RdmaProvideWriterDataToReader(CP_Services Svcs,
             providedWriterInfo[i]->WS_Stream;
         fi_av_insert(Fabric->av, providedWriterInfo[i]->Address, 1,
                      &RS_Stream->WriterAddr[i], 0, NULL);
-        Svcs->verbose(RS_Stream->CP_Stream,
+        Svcs->verbose(RS_Stream->CP_Stream, DPTraceVerbose,
                       "Received contact info for WS_stream %p, WSR Rank %d\n",
                       RS_Stream->WriterContactInfo[i].WS_Stream, i);
     }
@@ -636,18 +640,19 @@ static void *RdmaReadRemoteMemory(CP_Services Svcs, DP_RS_Stream Stream_v,
     uint8_t *Addr;
     ssize_t rc;
 
-    Svcs->verbose(RS_Stream->CP_Stream,
+    Svcs->verbose(RS_Stream->CP_Stream, DPPerRankVerbose,
                   "Performing remote read of Writer Rank %d\n", Rank);
 
     if (Info)
     {
-        Svcs->verbose(RS_Stream->CP_Stream,
+        Svcs->verbose(RS_Stream->CP_Stream, DPTraceVerbose,
                       "Block address is %p, with a key of %d\n", Info->Block,
                       Info->Key);
     }
     else
     {
-        Svcs->verbose(RS_Stream->CP_Stream, "Timestep info is null\n");
+        Svcs->verbose(RS_Stream->CP_Stream, DPTraceVerbose,
+                      "Timestep info is null\n");
     }
 
     ret->CPStream = RS_Stream;
@@ -668,7 +673,7 @@ static void *RdmaReadRemoteMemory(CP_Services Svcs, DP_RS_Stream Stream_v,
 
     Addr = Info->Block + Offset;
 
-    Svcs->verbose(RS_Stream->CP_Stream,
+    Svcs->verbose(RS_Stream->CP_Stream, DPTraceVerbose,
                   "Target of remote read on Writer Rank %d is %p\n", Rank,
                   Addr);
 
@@ -680,13 +685,13 @@ static void *RdmaReadRemoteMemory(CP_Services Svcs, DP_RS_Stream Stream_v,
 
     if (rc != 0)
     {
-        Svcs->verbose(RS_Stream->CP_Stream, "fi_read failed with code %d.\n",
-                      rc);
+        Svcs->verbose(RS_Stream->CP_Stream, DPCriticalVerbose,
+                      "fi_read failed with code %d.\n", rc);
         free(ret);
         return NULL;
     }
 
-    Svcs->verbose(RS_Stream->CP_Stream,
+    Svcs->verbose(RS_Stream->CP_Stream, DPTraceVerbose,
                   "Posted RDMA get for Writer Rank %d for handle %p\n", Rank,
                   (void *)ret);
 
@@ -699,7 +704,7 @@ static void RdmaNotifyConnFailure(CP_Services Svcs, DP_RS_Stream Stream_v,
     Rdma_RS_Stream Stream = (Rdma_RS_Stream)
         Stream_v; /* DP_RS_Stream is the return from InitReader */
     CManager cm = Svcs->getCManager(Stream->CP_Stream);
-    Svcs->verbose(Stream->CP_Stream,
+    Svcs->verbose(Stream->CP_Stream, DPTraceVerbose,
                   "received notification that writer peer "
                   "%d has failed, failing any pending "
                   "requests\n",
@@ -730,7 +735,7 @@ static int RdmaWaitForCompletion(CP_Services Svcs, void *Handle_v)
         }
         else
         {
-            Svcs->verbose(Stream->CP_Stream,
+            Svcs->verbose(Stream->CP_Stream, DPTraceVerbose,
                           "got completion for request with handle %p.\n",
                           CQEntry.op_context);
             Handle_t = (RdmaCompletionHandle)CQEntry.op_context;
@@ -774,7 +779,7 @@ static void RdmaProvideTimestep(CP_Services Svcs, DP_WS_Stream Stream_v,
     pthread_mutex_unlock(&ts_mutex);
     Info->Block = (uint8_t *)Data->block;
 
-    Svcs->verbose(Stream->CP_Stream,
+    Svcs->verbose(Stream->CP_Stream, DPTraceVerbose,
                   "Providing timestep data with block %p and access key %d\n",
                   Info->Block, Info->Key);
 
@@ -789,7 +794,8 @@ static void RdmaReleaseTimestep(CP_Services Svcs, DP_WS_Stream Stream_v,
     TimestepList ReleaseTSL;
     RdmaPerTimestepInfo Info;
 
-    Svcs->verbose(Stream->CP_Stream, "Releasing timestep %ld\n", Timestep);
+    Svcs->verbose(Stream->CP_Stream, DPTraceVerbose, "Releasing timestep %ld\n",
+                  Timestep);
 
     pthread_mutex_lock(&ts_mutex);
     while ((*List) && (*List)->Timestep != Timestep)
@@ -828,7 +834,8 @@ static void RdmaDestroyReader(CP_Services Svcs, DP_RS_Stream RS_Stream_v)
 {
     Rdma_RS_Stream RS_Stream = (Rdma_RS_Stream)RS_Stream_v;
 
-    Svcs->verbose(RS_Stream->CP_Stream, "Tearing down RDMA state on reader.\n");
+    Svcs->verbose(RS_Stream->CP_Stream, DPTraceVerbose,
+                  "Tearing down RDMA state on reader.\n");
     fini_fabric(RS_Stream->Fabric);
 
     free(RS_Stream->WriterContactInfo);
@@ -888,7 +895,8 @@ static void RdmaDestroyWriter(CP_Services Svcs, DP_WS_Stream WS_Stream_v)
     Credential = WS_Stream->Fabric->credential;
 #endif /* SST_HAVE_CRAY_DRC */
 
-    Svcs->verbose(WS_Stream->CP_Stream, "Tearing down RDMA state on writer.\n");
+    Svcs->verbose(WS_Stream->CP_Stream, DPTraceVerbose,
+                  "Tearing down RDMA state on writer.\n");
     fini_fabric(WS_Stream->Fabric);
 
 #ifdef SST_HAVE_CRAY_DRC
@@ -1000,7 +1008,7 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream,
 
     if (!info)
     {
-        Svcs->verbose(CP_Stream,
+        Svcs->verbose(CP_Stream, DPTraceVerbose,
                       "RDMA Dataplane could not find any viable fabrics.\n");
     }
 
@@ -1014,7 +1022,7 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream,
         domain_name = info->domain_attr->name;
         if (ifname && strcmp(ifname, domain_name) == 0)
         {
-            Svcs->verbose(CP_Stream,
+            Svcs->verbose(CP_Stream, DPPerStepVerbose,
                           "RDMA Dataplane found the requested "
                           "interface %s, provider type %s.\n",
                           ifname, prov_name);
@@ -1025,7 +1033,7 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream,
             strstr(prov_name, "gni") || strstr(prov_name, "psm2"))
         {
 
-            Svcs->verbose(CP_Stream,
+            Svcs->verbose(CP_Stream, DPPerStepVerbose,
                           "RDMA Dataplane sees interface %s, "
                           "provider type %s, which should work.\n",
                           domain_name, prov_name);
@@ -1037,7 +1045,7 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream,
     if (Ret == -1)
     {
         Svcs->verbose(
-            CP_Stream,
+            CP_Stream, DPPerStepVerbose,
             "RDMA Dataplane could not find an RDMA-compatible fabric.\n");
     }
 
@@ -1047,7 +1055,7 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream,
     }
 
     Svcs->verbose(
-        CP_Stream,
+        CP_Stream, DPPerStepVerbose,
         "RDMA Dataplane evaluating viability, returning priority %d\n", Ret);
     return Ret;
 }
@@ -1058,7 +1066,7 @@ static int RdmaGetPriority(CP_Services Svcs, void *CP_Stream,
  */
 static void RdmaUnGetPriority(CP_Services Svcs, void *CP_Stream)
 {
-    Svcs->verbose(CP_Stream, "RDMA Dataplane unloading\n");
+    Svcs->verbose(CP_Stream, DPPerStepVerbose, "RDMA Dataplane unloading\n");
 }
 
 extern NO_SANITIZE_THREAD CP_DP_Interface LoadRdmaDP()

--- a/source/adios2/toolkit/sst/dp_interface.h
+++ b/source/adios2/toolkit/sst/dp_interface.h
@@ -383,8 +383,13 @@ struct _CP_DP_Interface
         getPriority; // both sides, part of DP selection process.
     CP_DP_UnGetPriorityFunc unGetPriority;
 };
+#define DPTraceVerbose 5
+#define DPPerRankVerbose 4
+#define DPPerStepVerbose 3
+#define DPSummaryVerbose 2
+#define DPCriticalVerbose 1
 
-typedef void (*CP_VerboseFunc)(void *CP_Stream, char *Format, ...);
+typedef void (*CP_VerboseFunc)(void *CP_Stream, int Level, char *Format, ...);
 typedef CManager (*CP_GetCManagerFunc)(void *CP_stream);
 typedef SMPI_Comm (*CP_GetMPICommFunc)(void *CP_Stream);
 typedef int (*CP_SendToPeerFunc)(void *CP_Stream, CP_PeerCohort PeerCohort,

--- a/source/adios2/toolkit/sst/sst_data.h
+++ b/source/adios2/toolkit/sst/sst_data.h
@@ -27,6 +27,7 @@ struct _SstBlock
 
 #define SST_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                \
     MACRO(MarshalMethod, MarshalMethod, size_t, SstMarshalBP)                  \
+    MACRO(verbose, Int, int, 0)                                                \
     MACRO(RegistrationMethod, RegMethod, size_t, 0)                            \
     MACRO(DataTransport, String, char *, NULL)                                 \
     MACRO(WANDataTransport, String, char *, NULL)                              \


### PR DESCRIPTION
And be specifiable via the same engine parameter as insitu ("verbose").  The old environment variable, SstVerbose, also still works.  If both are specified with take the greatest as the verbosity level.   @philip-davis Note changes in dp_interface and rdma_dp.