### PR TITLE
Fix bug: BP4 with time aggregation (FlushStepCount > 1) broke if ther…

### DIFF
--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
@@ -958,12 +958,10 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
 
                 const uint64_t variablesIndexStart = position;
                 ptrs.push_back(variablesIndexStart);
-                if (!varIndicesInfo.empty())
+                const auto itvars = varIndicesInfo.find(t);
+                if (itvars != varIndicesInfo.end())
                 {
-
-                    std::unordered_map<std::string,
-                                       std::vector<std::tuple<size_t, size_t>>>
-                        perStepVarIndicesInfo = varIndicesInfo.at(t);
+                    const auto perStepVarIndicesInfo = itvars->second;
                     size_t perStepVarCountPosition = position;
                     const uint32_t perStepVarCountU32 =
                         static_cast<uint32_t>(perStepVarIndicesInfo.size());
@@ -1026,11 +1024,10 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
                 const uint64_t attributesIndexStart = position;
                 ptrs.push_back(attributesIndexStart);
 
-                if (!attrIndicesInfo.empty())
+                const auto itattrs = attrIndicesInfo.find(t);
+                if (itattrs != attrIndicesInfo.end())
                 {
-                    std::unordered_map<std::string,
-                                       std::vector<std::tuple<size_t, size_t>>>
-                        perStepAttrIndicesInfo = attrIndicesInfo.at(t);
+                    const auto perStepAttrIndicesInfo = itattrs->second;
                     size_t perStepAttrCountPosition = position;
                     const uint32_t perStepAttrCountU32 =
                         static_cast<uint32_t>(perStepAttrIndicesInfo.size());

--- a/testing/adios2/engine/bp/TestBPTimeAggregation.cpp
+++ b/testing/adios2/engine/bp/TestBPTimeAggregation.cpp
@@ -42,6 +42,8 @@ void TimeAggregation1D8(const std::string flushstepscount)
 #else
     adios2::ADIOS adios;
 #endif
+    const std::string TestName =
+        "TimeAggregation1D8 flush every " + flushstepscount + " steps";
     {
         adios2::IO io = adios.DeclareIO("TestIO");
 
@@ -73,6 +75,8 @@ void TimeAggregation1D8(const std::string flushstepscount)
             auto var_r32 = io.DefineVariable<float>("r32", shape, start, count);
             auto var_r64 =
                 io.DefineVariable<double>("r64", shape, start, count);
+
+            io.DefineAttribute<std::string>("TestName", TestName);
         }
 
         if (!engineName.empty())
@@ -230,6 +234,12 @@ void TimeAggregation1D8(const std::string flushstepscount)
         ASSERT_EQ(var_r64.Steps(), NSteps);
         ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
 
+        auto attr = io.InquireAttribute<std::string>("TestName");
+        EXPECT_TRUE(attr);
+        ASSERT_EQ(attr.Data().size() == 1, true);
+        ASSERT_EQ(attr.Type(), adios2::GetType<std::string>());
+        ASSERT_EQ(attr.Data().front(), TestName);
+
         // TODO: other types
 
         SmallTestData testData;
@@ -355,6 +365,9 @@ void TimeAggregation2D4x2(const std::string flushstepscount)
 #else
     adios2::ADIOS adios;
 #endif
+    const std::string TestName =
+        "TimeAggregation2D4x2 flush every " + flushstepscount + " steps";
+
     {
         adios2::IO io = adios.DeclareIO("TestIO");
 
@@ -387,6 +400,8 @@ void TimeAggregation2D4x2(const std::string flushstepscount)
             auto var_r32 = io.DefineVariable<float>("r32", shape, start, count);
             auto var_r64 =
                 io.DefineVariable<double>("r64", shape, start, count);
+
+            io.DefineAttribute<std::string>("TestName", TestName);
         }
 
         if (!engineName.empty())
@@ -551,6 +566,12 @@ void TimeAggregation2D4x2(const std::string flushstepscount)
         ASSERT_EQ(var_r64.Steps(), NSteps);
         ASSERT_EQ(var_r64.Shape()[0], Ny);
         ASSERT_EQ(var_r64.Shape()[1], static_cast<size_t>(mpiSize * Nx));
+
+        auto attr = io.InquireAttribute<std::string>("TestName");
+        EXPECT_TRUE(attr);
+        ASSERT_EQ(attr.Data().size() == 1, true);
+        ASSERT_EQ(attr.Type(), adios2::GetType<std::string>());
+        ASSERT_EQ(attr.Data().front(), TestName);
 
         std::string IString;
         std::array<int8_t, Nx * Ny> I8;


### PR DESCRIPTION
…e were attributes.

Calling map.at() without checking if the particular step exists resulted in exception which was not caught.