### PR TITLE
bindings: Help C++11 clients avoid calling serial constructor with MPI_Comm

### DIFF
--- a/bindings/CXX11/adios2/cxx11/ADIOS.h
+++ b/bindings/CXX11/adios2/cxx11/ADIOS.h
@@ -62,6 +62,20 @@ public:
      */
     ADIOS(const std::string &configFile, MPI_Comm comm,
           const bool debugMode = true);
+#else
+    // Client code that does not enable ADIOS2_USE_MPI may accidentally
+    // try to pass a MPI_Comm instance to our constructor.  If the type
+    // the MPI library uses to implement MPI_Comm happens to be convertible
+    // to one of the types offered by our serial constructors (e.g. 'bool'),
+    // the invocation will appear to succeed but will ignore the
+    // communicator passed.  Add explicitly deleted constructors that have
+    // better conversions for common MPI_Comm types.
+
+    // openmpi uses 'ompi_communicator_t*' for MPI_Comm
+    ADIOS(void *define_ADIOS2_USE_MPI_to_use_MPI_constructor) = delete;
+
+    // mpich uses 'int' for MPI_Comm
+    ADIOS(int define_ADIOS2_USE_MPI_to_use_MPI_constructor) = delete;
 #endif
 
     /**

--- a/examples/hello/sstWriter/helloSstWriter.cpp
+++ b/examples/hello/sstWriter/helloSstWriter.cpp
@@ -30,7 +30,6 @@ int main(int argc, char *argv[])
 #else
     rank = 0;
     size = 1;
-#define MPI_COMM_WORLD 0
 #endif
 
     std::vector<float> myFloats = {
@@ -42,7 +41,11 @@ int main(int argc, char *argv[])
 
     try
     {
+#if ADIOS2_USE_MPI
         adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+        adios2::ADIOS adios;
+#endif
         adios2::IO sstIO = adios.DeclareIO("myIO");
         sstIO.SetEngine("Sst");
 


### PR DESCRIPTION
Client code that does not enable `ADIOS2_USE_MPI` may accidentally try to pass a `MPI_Comm` instance to our constructor.  If the type the MPI library uses to implement MPI_Comm happens to be convertible to one of the types offered by our serial constructors (e.g. `bool`), the invocation will appear to succeed but will ignore the communicator passed.  Add explicitly deleted constructors that have better conversions for common `MPI_Comm` types.

With this, an attempt in client code to call the `adios2::ADIOS` constructor with a `MPI_Comm` object will fail to compile with an error such as:

    error: use of deleted function 'adios2::ADIOS::ADIOS(void*)'
        adios2::ADIOS adios(comm);
    ...note: declared here
        ADIOS(void *define_ADIOS2_USE_MPI_to_use_MPI_constructor) = delete;
        ^~~~~
