### PR TITLE
Do not shrink serialization buffer upon EndStep – Fix Performance Bug

### DIFF
--- a/testing/adios2/engine/bp/TestBPBufferSize.cpp
+++ b/testing/adios2/engine/bp/TestBPBufferSize.cpp
@@ -231,7 +231,8 @@ TEST_F(BPBufferSizeTest, SyncDeferredIdenticalUsage)
          * size
          * */
         const size_t TotalDataSize = Nx * sizeof(double) * 3;
-        const size_t MaxExtra = 16777216; /* 16MB extra allowed in buffer */
+        const size_t MaxExtra =
+            18 * 1024 * 1024; /* 18MB extra allowed in buffer */
         for (size_t step = 0; step < NSteps; ++step)
         {
             EXPECT_LT(bufsize_sync_beginstep[step], TotalDataSize + MaxExtra);


### PR DESCRIPTION

The BP4 serialization engine maintains the same serialization buffer `format::BP4Serializer` across steps. This allows to avoid heavyweight allocation operations after a certain "warmup" phase. Methods such as [`format::BPBase::ResizeBuffer`](https://github.com/ornladios/ADIOS2/blob/addcb471f0341c93ba7a5f99a1a58a571a374f8a/source/adios2/toolkit/format/bp/BPBase.cpp#L305) support this idea by taking care not to shrink the buffer.

The method [`format::BP4Serializer::SerializeDataBuffer`](https://github.com/ornladios/ADIOS2/blob/addcb471f0341c93ba7a5f99a1a58a571a374f8a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp#L375) (called upon `Engine::EndStep`) does, however, pay no such attention.

This has noticeable consequences in writing to ADIOS2 via openPMD in PIConGPU. (Possibly related to the fact that the openPMD plugin in PIConGPU will repeatedly call `Engine::PerformPuts`, leading to a low buffer "fill status" upon `Engine::EndStep`, resulting in an actual shrinking of the buffer). While the buffer is never actually reallocated (which would happen only upon `std::vector::shrink_to_fit`), resizing it back up to the needed size in the following step involves zero-initialization. This means that ADIOS spends a lot of time per step just filling gigabytes of main memory with zeros. Quick measurements suggest a speedup down from ~1 minute for a data dump to ~30 seconds after fixing this.

This PR quickly fixes the issue by adding conditionals to avoid shrinking the buffer.

