### PR TITLE
Zero out first and last KB of data buffer in BP4, instead of the enti…

### DIFF
--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -111,7 +111,7 @@ void BP4Writer::Flush(const int transportIndex)
 {
     TAU_SCOPED_TIMER("BP4Writer::Flush");
     DoFlush(false, transportIndex);
-    m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_Data);
+    m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_Data, false, false);
 
     if (m_BP4Serializer.m_Parameters.CollectiveMetadata)
     {
@@ -683,10 +683,10 @@ void BP4Writer::WriteCollectiveMetadataFile(const bool isFinal)
         }
     }
     /*Clear the local indices buffer at the end of each step*/
-    m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_Metadata, true);
+    m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_Metadata, true, true);
 
     /* clear the metadata index buffer*/
-    m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_MetadataIndex, true);
+    m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_MetadataIndex, true, true);
 
     /* reset the metadata index table*/
     m_BP4Serializer.ResetMetadataIndexTable();

--- a/source/adios2/engine/bp4/BP4Writer.tcc
+++ b/source/adios2/engine/bp4/BP4Writer.tcc
@@ -89,7 +89,7 @@ void BP4Writer::PutSyncCommon(Variable<T> &variable,
     if (resizeResult == format::BP4Base::ResizeResult::Flush)
     {
         DoFlush(false);
-        m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_Data);
+        m_BP4Serializer.ResetBuffer(m_BP4Serializer.m_Data, false, false);
 
         // new group index for incoming variable
         m_BP4Serializer.PutProcessGroupIndex(

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.cpp
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.cpp
@@ -10,6 +10,8 @@
 
 #include "BufferSTL.h"
 #include "BufferSTL.tcc"
+#include <cstdlib>
+#include <cstring>
 
 namespace adios2
 {
@@ -51,7 +53,24 @@ void BufferSTL::Reset(const bool resetAbsolutePosition,
     }
     if (zeroInitialize)
     {
-        m_Buffer.assign(m_Buffer.size(), '\0');
+        std::fill(m_Buffer.begin(), m_Buffer.end(), 0);
+    }
+    else
+    {
+        // just zero out the first and last 1kb
+        const size_t bufsize = m_Buffer.size();
+        size_t s = (bufsize < 1024 ? bufsize : 1024);
+        std::fill_n(m_Buffer.begin(), s, 0);
+        if (bufsize > 1024)
+        {
+            size_t pos = bufsize - 1024;
+            if (pos < 1024)
+            {
+                pos = 1024;
+            }
+            s = bufsize - pos;
+            std::fill_n(next(m_Buffer.begin(), pos), s, 0);
+        }
     }
 }
 


### PR DESCRIPTION
…re buffer which is costly at scale.