### PR TITLE
Fix: FindBlosc Env Hint

### DIFF
--- a/cmake/FindBlosc.cmake
+++ b/cmake/FindBlosc.cmake
@@ -27,7 +27,7 @@
 #                           as an environment variable.
 
 if(NOT BLOSC_FOUND)
-  if((NOT BLOSC_ROOT) AND (NOT (ENV{BLOSC_ROOT} STREQUAL "")))
+  if((NOT BLOSC_ROOT) AND (DEFINED ENV{BLOSC_ROOT}))
     set(BLOSC_ROOT "$ENV{BLOSC_ROOT}")
   endif()
   if(BLOSC_ROOT)

--- a/cmake/FindBlosc.cmake
+++ b/cmake/FindBlosc.cmake
@@ -37,9 +37,14 @@ if(NOT BLOSC_FOUND)
       NO_DEFAULT_PATHS
     )
   endif()
+  if(WIN32) # uses a Unix-like library prefix on Windows
+    set(BLOSC_LIBRARY_OPTS
+      libblosc ${BLOSC_LIBRARY_OPTS}
+    )
+  endif()
 
   find_path(BLOSC_INCLUDE_DIR blosc.h ${BLOSC_INCLUDE_OPTS})
-  find_library(BLOSC_LIBRARY blosc ${BLOSC_LIBRARY_OPTS})
+  find_library(BLOSC_LIBRARY NAMES blosc ${BLOSC_LIBRARY_OPTS})
   if(BLOSC_INCLUDE_DIR)
     file(STRINGS ${BLOSC_INCLUDE_DIR}/blosc.h _ver_string
       REGEX [=[BLOSC_VERSION_STRING +"[^"]*"]=]


### PR DESCRIPTION
The current check always returned true for the BLOSC_ROOT env var, even if it is unset.

cc @chuckatkins 

Orthogonal to this, I cannot find a `libblosc.lib` install on Windows with this `FindBlosc.cmake` logic - help appreciated.
I already tried setting `CMAKE_PREFIX_PATH='C:/Program Files (x86)/blosc'` and `BLOSC_ROOT='C:/Program Files (x86)/blosc'` but  this still results in:
```
  CMake Error at C:/hostedtoolcache/windows/Python/3.7.9/x64/Lib/site-packages/cmake/data/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
    Could NOT find Blosc (missing: BLOSC_LIBRARY) (found suitable version
    "1.15.0", minimum required is "1.7")
  -- Configuring incomplete, errors occurred!
```

The blosc install (static) on Windows looks like this:
```
$  cmake -S dep-blosc/c-blosc-1.15.0 -B build-blosc ^
    -DCMAKE_BUILD_TYPE=Release  ^
    -DBUILD_BENCHMARKS=OFF      ^
    -DBUILD_SHARED=OFF          ^
    -DBUILD_STATIC=ON           ^
    -DBUILD_TESTS=OFF
# ...
    -- Install configuration: "Release"
    -- Installing: C:/Program Files (x86)/blosc/lib/pkgconfig/blosc.pc
    -- Installing: C:/Program Files (x86)/blosc/bin/msvcp140.dll
    -- Installing: C:/Program Files (x86)/blosc/bin/msvcp140_1.dll
    -- Installing: C:/Program Files (x86)/blosc/bin/msvcp140_2.dll
    -- Installing: C:/Program Files (x86)/blosc/bin/msvcp140_codecvt_ids.dll
    -- Installing: C:/Program Files (x86)/blosc/bin/vcruntime140_1.dll
    -- Installing: C:/Program Files (x86)/blosc/bin/vcruntime140.dll
    -- Installing: C:/Program Files (x86)/blosc/bin/concrt140.dll
    -- Up-to-date: C:/Program Files (x86)/blosc/bin
    -- Installing: C:/Program Files (x86)/blosc/include/blosc.h
    -- Installing: C:/Program Files (x86)/blosc/include/blosc-export.h
    -- Installing: C:/Program Files (x86)/blosc/lib/libblosc.lib
```

Manually setting `-DBLOSC_LIBRARY="C:/Program Files (x86)/blosc/lib/libblosc.lib"` for the ADIOS 2.6.0 build is a work-around that builds for me.

Update:
I think the reason for that is that `CMAKE_FIND_LIBRARY_PREFIXES` on Windows is empty but blosc uses a unix-like `lib`-prefix convention: https://stackoverflow.com/a/28253243/2719194 The 2nd commit addresses this.