### PR TITLE
Fix a performance issue for first step data in ssc

### DIFF
--- a/source/adios2/engine/ssc/SscHelper.h
+++ b/source/adios2/engine/ssc/SscHelper.h
@@ -37,6 +37,8 @@ struct BlockInfo
     size_t bufferStart;
     size_t bufferCount;
     std::vector<char> value;
+    void *data;
+    bool performed;
 };
 using BlockVec = std::vector<BlockInfo>;
 using BlockVecVec = std::vector<BlockVec>;

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -407,12 +407,28 @@ void SscReader::SyncReadPattern()
                   << m_CurrentStep << std::endl;
     }
 
-    if (m_ReaderRank == 0)
+    nlohmann::json localReadPatternJson;
+
+    for (const auto &i : m_LocalReadPattern)
     {
-        m_LocalReadPatternJson["Pattern"] = m_ReaderSelectionsLocked;
+        localReadPatternJson["Variables"].emplace_back();
+        auto &jref = localReadPatternJson["Variables"].back();
+        jref["Name"] = i.name;
+        jref["Type"] = i.type;
+        jref["ShapeID"] = i.shapeId;
+        jref["Start"] = i.start;
+        jref["Count"] = i.count;
+        jref["Shape"] = i.shape;
+        jref["BufferStart"] = i.bufferStart;
+        jref["BufferCount"] = i.bufferCount;
     }
 
-    std::string localStr = m_LocalReadPatternJson.dump();
+    if (m_ReaderRank == 0)
+    {
+        localReadPatternJson["Pattern"] = m_ReaderSelectionsLocked;
+    }
+
+    std::string localStr = localReadPatternJson.dump();
 
     // aggregate global read pattern
     size_t localSize = localStr.size();

--- a/source/adios2/engine/ssc/SscReader.h
+++ b/source/adios2/engine/ssc/SscReader.h
@@ -46,7 +46,6 @@ private:
     ssc::BlockVecVec m_GlobalWritePattern;
     ssc::BlockVec m_LocalReadPattern;
     nlohmann::json m_GlobalWritePatternJson;
-    nlohmann::json m_LocalReadPatternJson;
 
     ssc::RankPosMap m_AllReceivingWriterRanks;
     std::vector<char> m_Buffer;

--- a/source/adios2/engine/ssc/SscReader.h
+++ b/source/adios2/engine/ssc/SscReader.h
@@ -54,7 +54,6 @@ private:
     MPI_Comm m_StreamComm;
     std::string m_MpiMode = "twosided";
     std::vector<MPI_Request> m_MpiRequests;
-    std::unordered_set<int> m_ReceivedRanks;
 
     int m_StreamRank;
     int m_StreamSize;
@@ -83,7 +82,7 @@ private:
     void GetDeferredCommon(Variable<T> &variable, T *data);
 
     template <class T>
-    void GetDeferredDeltaCommon(Variable<T> &variable);
+    void GetDeferredDeltaCommon(Variable<T> &variable, T *data);
 
     void CalculatePosition(ssc::BlockVecVec &mapVec,
                            ssc::RankPosMap &allOverlapRanks);

--- a/source/adios2/engine/ssc/SscReader.tcc
+++ b/source/adios2/engine/ssc/SscReader.tcc
@@ -24,7 +24,7 @@ namespace engine
 {
 
 template <class T>
-void SscReader::GetDeferredDeltaCommon(Variable<T> &variable)
+void SscReader::GetDeferredDeltaCommon(Variable<T> &variable, T *data)
 {
     TAU_SCOPED_TIMER_FUNC();
 
@@ -49,6 +49,8 @@ void SscReader::GetDeferredDeltaCommon(Variable<T> &variable)
     b.shape = vShape;
     b.bufferStart = 0;
     b.bufferCount = 0;
+    b.data = data;
+    b.performed = false;
 
     for (const auto &d : b.count)
     {
@@ -56,31 +58,6 @@ void SscReader::GetDeferredDeltaCommon(Variable<T> &variable)
         {
             throw(std::runtime_error(
                 "SetSelection count dimensions cannot be 0"));
-        }
-    }
-
-    ssc::JsonToBlockVecVec(m_GlobalWritePatternJson, m_GlobalWritePattern);
-    size_t oldSize = m_AllReceivingWriterRanks.size();
-    m_AllReceivingWriterRanks =
-        ssc::CalculateOverlap(m_GlobalWritePattern, m_LocalReadPattern);
-    CalculatePosition(m_GlobalWritePattern, m_AllReceivingWriterRanks);
-    size_t newSize = m_AllReceivingWriterRanks.size();
-    if (oldSize != newSize)
-    {
-        size_t totalDataSize = 0;
-        for (auto i : m_AllReceivingWriterRanks)
-        {
-            totalDataSize += i.second.second;
-        }
-        m_Buffer.resize(totalDataSize);
-        for (const auto &i : m_AllReceivingWriterRanks)
-        {
-            MPI_Win_lock(MPI_LOCK_SHARED, i.first, 0, m_MpiWin);
-            MPI_Get(m_Buffer.data() + i.second.first,
-                    static_cast<int>(i.second.second), MPI_CHAR, i.first, 0,
-                    static_cast<int>(i.second.second), MPI_CHAR, m_MpiWin);
-            MPI_Win_unlock(i.first, m_MpiWin);
-            m_ReceivedRanks.insert(i.first);
         }
     }
 }
@@ -95,16 +72,19 @@ void SscReader::GetDeferredCommon(Variable<std::string> &variable,
     if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
         m_ReaderSelectionsLocked == false)
     {
-        GetDeferredDeltaCommon(variable);
+        GetDeferredDeltaCommon(variable, data);
     }
-    for (const auto &i : m_AllReceivingWriterRanks)
+    else
     {
-        const auto &v = m_GlobalWritePattern[i.first];
-        for (const auto &b : v)
+        for (const auto &i : m_AllReceivingWriterRanks)
         {
-            if (b.name == variable.m_Name)
+            const auto &v = m_GlobalWritePattern[i.first];
+            for (const auto &b : v)
             {
-                *data = std::string(b.value.begin(), b.value.end());
+                if (b.name == variable.m_Name)
+                {
+                    *data = std::string(b.value.begin(), b.value.end());
+                }
             }
         }
     }
@@ -130,46 +110,49 @@ void SscReader::GetDeferredCommon(Variable<T> &variable, T *data)
     if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
         m_ReaderSelectionsLocked == false)
     {
-        GetDeferredDeltaCommon(variable);
+        GetDeferredDeltaCommon(variable, data);
     }
-
-    for (const auto &i : m_AllReceivingWriterRanks)
+    else
     {
-        const auto &v = m_GlobalWritePattern[i.first];
-        for (const auto &b : v)
-        {
-            if (b.name == variable.m_Name)
-            {
-                bool empty = false;
-                for (const auto c : b.count)
-                {
-                    if (c == 0)
-                    {
-                        empty = true;
-                    }
-                }
-                if (empty)
-                {
-                    continue;
-                }
 
-                if (b.shapeId == ShapeID::GlobalArray ||
-                    b.shapeId == ShapeID::LocalArray)
+        for (const auto &i : m_AllReceivingWriterRanks)
+        {
+            const auto &v = m_GlobalWritePattern[i.first];
+            for (const auto &b : v)
+            {
+                if (b.name == variable.m_Name)
                 {
-                    helper::NdCopy<T>(m_Buffer.data() + b.bufferStart, b.start,
-                                      b.count, true, true,
-                                      reinterpret_cast<char *>(data), vStart,
-                                      vCount, true, true);
-                }
-                else if (b.shapeId == ShapeID::GlobalValue ||
-                         b.shapeId == ShapeID::LocalValue)
-                {
-                    std::memcpy(data, m_Buffer.data() + b.bufferStart,
-                                b.bufferCount);
-                }
-                else
-                {
-                    throw(std::runtime_error("ShapeID not supported"));
+                    bool empty = false;
+                    for (const auto c : b.count)
+                    {
+                        if (c == 0)
+                        {
+                            empty = true;
+                        }
+                    }
+                    if (empty)
+                    {
+                        continue;
+                    }
+
+                    if (b.shapeId == ShapeID::GlobalArray ||
+                        b.shapeId == ShapeID::LocalArray)
+                    {
+                        helper::NdCopy<T>(m_Buffer.data() + b.bufferStart,
+                                          b.start, b.count, true, true,
+                                          reinterpret_cast<char *>(data),
+                                          vStart, vCount, true, true);
+                    }
+                    else if (b.shapeId == ShapeID::GlobalValue ||
+                             b.shapeId == ShapeID::LocalValue)
+                    {
+                        std::memcpy(data, m_Buffer.data() + b.bufferStart,
+                                    b.bufferCount);
+                    }
+                    else
+                    {
+                        throw(std::runtime_error("ShapeID not supported"));
+                    }
                 }
             }
         }

--- a/source/adios2/engine/ssc/SscReader.tcc
+++ b/source/adios2/engine/ssc/SscReader.tcc
@@ -42,10 +42,13 @@ void SscReader::GetDeferredDeltaCommon(Variable<T> &variable)
     m_LocalReadPattern.emplace_back();
     auto &b = m_LocalReadPattern.back();
     b.name = variable.m_Name;
-    b.count = vCount;
-    b.start = vStart;
-    b.shape = vShape;
     b.type = helper::GetDataType<T>();
+    b.shapeId = variable.m_ShapeID;
+    b.start = vStart;
+    b.count = vCount;
+    b.shape = vShape;
+    b.bufferStart = 0;
+    b.bufferCount = 0;
 
     for (const auto &d : b.count)
     {
@@ -55,17 +58,6 @@ void SscReader::GetDeferredDeltaCommon(Variable<T> &variable)
                 "SetSelection count dimensions cannot be 0"));
         }
     }
-
-    m_LocalReadPatternJson["Variables"].emplace_back();
-    auto &jref = m_LocalReadPatternJson["Variables"].back();
-    jref["Name"] = variable.m_Name;
-    jref["Type"] = helper::GetDataType<T>();
-    jref["ShapeID"] = variable.m_ShapeID;
-    jref["Start"] = vStart;
-    jref["Count"] = vCount;
-    jref["Shape"] = vShape;
-    jref["BufferStart"] = 0;
-    jref["BufferCount"] = 0;
 
     ssc::JsonToBlockVecVec(m_GlobalWritePatternJson, m_GlobalWritePattern);
     size_t oldSize = m_AllReceivingWriterRanks.size();

--- a/testing/adios2/engine/ssc/TestSscBase.cpp
+++ b/testing/adios2/engine/ssc/TestSscBase.cpp
@@ -183,21 +183,6 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
             engine.Get(bpInts, myInts.data(), adios2::Mode::Sync);
             engine.Get(bpUInts, myUInts.data(), adios2::Mode::Sync);
-            engine.Get(bpFloats, myFloats.data(), adios2::Mode::Sync);
-            engine.Get(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
-            engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
-            engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
-            std::string s;
-            engine.Get(stringVar, s);
-            ASSERT_EQ(s, "sample string sample string sample string");
-            ASSERT_EQ(stringVar.Min(),
-                      "sample string sample string sample string");
-            ASSERT_EQ(stringVar.Max(),
-                      "sample string sample string sample string");
-
-            int i;
-            engine.Get(scalarInt, &i);
-            ASSERT_EQ(i, currentStep);
 
             VerifyData(myChars.data(), currentStep, start, count, shape,
                        mpiRank);
@@ -211,6 +196,14 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
                        mpiRank);
             VerifyData(myUInts.data(), currentStep, start, count, shape,
                        mpiRank);
+
+            engine.Get(bpFloats, myFloats.data(), adios2::Mode::Deferred);
+            engine.Get(bpDoubles, myDoubles.data(), adios2::Mode::Deferred);
+            engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Deferred);
+            engine.Get(bpDComplexes, myDComplexes.data(),
+                       adios2::Mode::Deferred);
+            engine.PerformGets();
+
             VerifyData(myFloats.data(), currentStep, start, count, shape,
                        mpiRank);
             VerifyData(myDoubles.data(), currentStep, start, count, shape,
@@ -219,6 +212,19 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
                        mpiRank);
             VerifyData(myDComplexes.data(), currentStep, start, count, shape,
                        mpiRank);
+
+            std::string s;
+            engine.Get(stringVar, s);
+            ASSERT_EQ(s, "sample string sample string sample string");
+            ASSERT_EQ(stringVar.Min(),
+                      "sample string sample string sample string");
+            ASSERT_EQ(stringVar.Max(),
+                      "sample string sample string sample string");
+
+            int i;
+            engine.Get(scalarInt, &i);
+            engine.PerformGets();
+            ASSERT_EQ(i, currentStep);
             engine.EndStep();
         }
         else if (status == adios2::StepStatus::EndOfStream)

--- a/testing/adios2/engine/ssc/TestSscBase.cpp
+++ b/testing/adios2/engine/ssc/TestSscBase.cpp
@@ -215,6 +215,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
             std::string s;
             engine.Get(stringVar, s);
+            engine.PerformGets();
             ASSERT_EQ(s, "sample string sample string sample string");
             ASSERT_EQ(stringVar.Min(),
                       "sample string sample string sample string");

--- a/testing/adios2/engine/ssc/TestSscBaseUnlocked.cpp
+++ b/testing/adios2/engine/ssc/TestSscBaseUnlocked.cpp
@@ -185,7 +185,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             std::string s;
-            engine.Get(stringVar, s);
+            engine.Get(stringVar, s, adios2::Mode::Sync);
             ASSERT_EQ(s, "sample string sample string sample string");
             ASSERT_EQ(stringVar.Min(),
                       "sample string sample string sample string");

--- a/testing/adios2/engine/ssc/TestSscLockBeforeEndStep.cpp
+++ b/testing/adios2/engine/ssc/TestSscLockBeforeEndStep.cpp
@@ -194,7 +194,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
                       "sample string sample string sample string");
 
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
             ASSERT_EQ(i, currentStep);
 
             VerifyData(myChars.data(), currentStep, start, count, shape,

--- a/testing/adios2/engine/ssc/TestSscLockBeforeEndStep.cpp
+++ b/testing/adios2/engine/ssc/TestSscLockBeforeEndStep.cpp
@@ -186,7 +186,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             std::string s;
-            engine.Get(stringVar, s);
+            engine.Get(stringVar, s, adios2::Mode::Sync);
             ASSERT_EQ(s, "sample string sample string sample string");
             ASSERT_EQ(stringVar.Min(),
                       "sample string sample string sample string");

--- a/testing/adios2/engine/ssc/TestSscOneSidedFencePull.cpp
+++ b/testing/adios2/engine/ssc/TestSscOneSidedFencePull.cpp
@@ -171,7 +171,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
 
             ASSERT_EQ(i, currentStep);
 

--- a/testing/adios2/engine/ssc/TestSscOneSidedFencePush.cpp
+++ b/testing/adios2/engine/ssc/TestSscOneSidedFencePush.cpp
@@ -171,7 +171,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
 
             ASSERT_EQ(i, currentStep);
 

--- a/testing/adios2/engine/ssc/TestSscOneSidedPostPull.cpp
+++ b/testing/adios2/engine/ssc/TestSscOneSidedPostPull.cpp
@@ -171,7 +171,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
 
             ASSERT_EQ(i, currentStep);
 

--- a/testing/adios2/engine/ssc/TestSscOneSidedPostPush.cpp
+++ b/testing/adios2/engine/ssc/TestSscOneSidedPostPush.cpp
@@ -171,7 +171,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
 
             ASSERT_EQ(i, currentStep);
 

--- a/testing/adios2/engine/ssc/TestSscOnlyOneStep.cpp
+++ b/testing/adios2/engine/ssc/TestSscOnlyOneStep.cpp
@@ -187,7 +187,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             std::string s;
-            engine.Get(stringVar, s);
+            engine.Get(stringVar, s, adios2::Mode::Sync);
             ASSERT_EQ(s, "sample string sample string sample string");
             ASSERT_EQ(stringVar.Min(),
                       "sample string sample string sample string");
@@ -195,7 +195,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
                       "sample string sample string sample string");
 
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
             ASSERT_EQ(i, currentStep);
 
             VerifyData(myChars.data(), currentStep, start, count, shape,

--- a/testing/adios2/engine/ssc/TestSscOnlyTwoSteps.cpp
+++ b/testing/adios2/engine/ssc/TestSscOnlyTwoSteps.cpp
@@ -187,7 +187,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             std::string s;
-            engine.Get(stringVar, s);
+            engine.Get(stringVar, s, adios2::Mode::Sync);
             ASSERT_EQ(s, "sample string sample string sample string");
             ASSERT_EQ(stringVar.Min(),
                       "sample string sample string sample string");
@@ -195,7 +195,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
                       "sample string sample string sample string");
 
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
             ASSERT_EQ(i, currentStep);
 
             VerifyData(myChars.data(), currentStep, start, count, shape,

--- a/testing/adios2/engine/ssc/TestSscReaderMultiblock.cpp
+++ b/testing/adios2/engine/ssc/TestSscReaderMultiblock.cpp
@@ -202,7 +202,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             auto scalarInt = dataManIO.InquireVariable<int>("scalarInt");
 
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
             ASSERT_EQ(i, currentStep);
 
             adios2::Dims startTmp = start;

--- a/testing/adios2/engine/ssc/TestSscString.cpp
+++ b/testing/adios2/engine/ssc/TestSscString.cpp
@@ -149,6 +149,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
             int i;
             engine.Get(scalarInt, &i);
+            engine.PerformGets();
             ASSERT_EQ(i, currentStep);
 
             VerifyData(myChars.data(), currentStep, start, count, shape,

--- a/testing/adios2/engine/ssc/TestSscString.cpp
+++ b/testing/adios2/engine/ssc/TestSscString.cpp
@@ -137,7 +137,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
                 dataManIO.InquireVariable<std::string>("stringVar");
 
             std::string s;
-            engine.Get(stringVar, s);
+            engine.Get(stringVar, s, adios2::Mode::Sync);
             ASSERT_EQ(s, "sample string sample string sample string");
             ASSERT_EQ(stringVar.Min(),
                       "sample string sample string sample string");

--- a/testing/adios2/engine/ssc/TestSscUnbalanced.cpp
+++ b/testing/adios2/engine/ssc/TestSscUnbalanced.cpp
@@ -171,7 +171,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
 
             ASSERT_EQ(i, currentStep);
 

--- a/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
+++ b/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
@@ -237,7 +237,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             std::string s;
-            engine.Get(stringVar, s);
+            engine.Get(stringVar, s, adios2::Mode::Sync);
             ASSERT_EQ(s, "sample string sample string sample string");
             ASSERT_EQ(stringVar.Min(),
                       "sample string sample string sample string");

--- a/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
+++ b/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
@@ -245,7 +245,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
                       "sample string sample string sample string");
 
             int i;
-            engine.Get(scalarInt, &i);
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
             ASSERT_EQ(i, currentStep);
 
             VerifyData(myChars.data(), currentStep, {0, 0}, vshape, vshape,

--- a/testing/adios2/engine/ssc/TestSscWriterMultiblock.cpp
+++ b/testing/adios2/engine/ssc/TestSscWriterMultiblock.cpp
@@ -212,8 +212,7 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
             engine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
             engine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
             int i;
-            engine.Get(scalarInt, &i);
-
+            engine.Get(scalarInt, &i, adios2::Mode::Sync);
             ASSERT_EQ(i, currentStep);
 
             VerifyData(myChars.data(), currentStep, start, shape, shape,


### PR DESCRIPTION
This might be related to the performance bottleneck seen in WarpX reported by @lwan86 