### PR TITLE
added a missing header file and fixed incorrect format introduced in #2608

### DIFF
--- a/source/adios2/core/Group.cpp
+++ b/source/adios2/core/Group.cpp
@@ -183,8 +183,7 @@ std::vector<std::string> Group::AvailableAttributes()
             std::string variablePath = currentPath + groupDelimiter + v;
             variablePath = variablePath.substr(
                 ADIOS_root.size() + 1, variablePath.size() - ADIOS_root.size());
-            if (attributes.find(variablePath) !=
-                attributes.end())
+            if (attributes.find(variablePath) != attributes.end())
             {
                 available_attributes.push_back(v);
             }
@@ -201,11 +200,11 @@ std::vector<std::string> Group::AvailableGroups()
     std::set<std::string> val = mapPtr->treeMap[currentPath];
     {
         for (auto v : val)
-            {
-                if (mapPtr->treeMap.find(currentPath + groupDelimiter + v) !=
-                    mapPtr->treeMap.end())
-                    available_groups.push_back(v);
-            }
+        {
+            if (mapPtr->treeMap.find(currentPath + groupDelimiter + v) !=
+                mapPtr->treeMap.end())
+                available_groups.push_back(v);
+        }
     }
     return available_groups;
 }

--- a/testing/adios2/hierarchy/TestHierarchicalReading.cpp
+++ b/testing/adios2/hierarchy/TestHierarchicalReading.cpp
@@ -2,6 +2,7 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */
+#include <array>
 #include <cstdint>
 #include <cstring>
 


### PR DESCRIPTION
#2608 introduced a missing header file which fails to compile in some environments. This PR added the header file and fixed a few seemingly incorrect format introduced in #2608 too.

