### PR TITLE
Add 'char' to supported types. Only added to C++ and tested with BP e…

### DIFF
--- a/source/adios2/common/ADIOSMacros.h
+++ b/source/adios2/common/ADIOSMacros.h
@@ -33,6 +33,7 @@
  </pre>
 */
 #define ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(MACRO)                 \
+    MACRO(char)                                                                \
     MACRO(int8_t)                                                              \
     MACRO(int16_t)                                                             \
     MACRO(int32_t)                                                             \
@@ -196,6 +197,7 @@
 #define ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)                          \
     MACRO(std::string, string)                                                 \
     MACRO(int8_t, int8)                                                        \
+    MACRO(char, char)                                                          \
     MACRO(uint8_t, uint8)                                                      \
     MACRO(int16_t, int16)                                                      \
     MACRO(uint16_t, uint16)                                                    \
@@ -211,6 +213,7 @@
 
 #define ADIOS2_FOREACH_PRIMITVE_STDTYPE_2ARGS(MACRO)                           \
     MACRO(int8_t, int8)                                                        \
+    MACRO(char, char)                                                          \
     MACRO(uint8_t, uint8)                                                      \
     MACRO(int16_t, int16)                                                      \
     MACRO(uint16_t, uint16)                                                    \

--- a/source/adios2/common/ADIOSTypes.cpp
+++ b/source/adios2/common/ADIOSTypes.cpp
@@ -187,6 +187,9 @@ std::string ToString(DataType type)
     {
     case DataType::None:
         break;
+    case DataType::Char:
+        return "char";
+        break;
     case DataType::Int8:
         return "int8_t";
     case DataType::Int16:

--- a/source/adios2/common/ADIOSTypes.cpp
+++ b/source/adios2/common/ADIOSTypes.cpp
@@ -189,7 +189,6 @@ std::string ToString(DataType type)
         break;
     case DataType::Char:
         return "char";
-        break;
     case DataType::Int8:
         return "int8_t";
     case DataType::Int16:

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -137,6 +137,7 @@ enum class DataType
     FloatComplex,
     DoubleComplex,
     String,
+    Char,
     Compound
 };
 

--- a/source/adios2/common/ADIOSTypes.inl
+++ b/source/adios2/common/ADIOSTypes.inl
@@ -79,6 +79,16 @@ struct TypeInfo
     using ValueType = T;
 };
 
+// Hack "char" type into this convoluted struct definition which is the key
+// to translate between bindings API types to supported stdtypes
+template <>
+struct TypeInfo<char,
+                typename std::enable_if<std::is_integral<char>::value>::type>
+{
+    using IOType = char;
+    using ValueType = char;
+};
+
 template <typename T>
 struct TypeInfo<T, typename std::enable_if<std::is_integral<T>::value>::type>
 {

--- a/source/adios2/common/ADIOSTypes.inl
+++ b/source/adios2/common/ADIOSTypes.inl
@@ -83,7 +83,7 @@ struct TypeInfo
 // to translate between bindings API types to supported stdtypes
 template <>
 struct TypeInfo<char,
-                typename std::enable_if<std::is_integral<char>::value>::type>
+                typename std::enable_if<std::is_same<char, char>::value>::type>
 {
     using IOType = char;
     using ValueType = char;

--- a/source/adios2/helper/adiosType.cpp
+++ b/source/adios2/helper/adiosType.cpp
@@ -23,6 +23,10 @@ namespace helper
 DataType GetDataTypeFromString(std::string const &type) noexcept
 {
     // Keep in sync with adios2::ToString(DataType).
+    if (type == "char")
+    {
+        return DataType::Char;
+    }
     if (type == "int8_t")
     {
         return DataType::Int8;

--- a/source/adios2/helper/adiosType.inl
+++ b/source/adios2/helper/adiosType.inl
@@ -31,6 +31,12 @@ inline DataType GetDataType<std::string>() noexcept
 }
 
 template <>
+inline DataType GetDataType<char>() noexcept
+{
+    return DataType::Char;
+}
+
+template <>
 inline DataType GetDataType<int8_t>() noexcept
 {
     return DataType::Int8;

--- a/source/adios2/toolkit/format/bp/BPBase.h
+++ b/source/adios2/toolkit/format/bp/BPBase.h
@@ -396,6 +396,8 @@ protected:
         type_complex = 10,        //!< type_complex
         type_double_complex = 11, //!< type_double_complex
         type_string_array = 12,   //!< type_string_array
+
+        type_char = 55 //!< type_char
     };
 
     /** Maps C++ type to DataTypes enum */

--- a/source/adios2/toolkit/format/bp/BPBase.inl
+++ b/source/adios2/toolkit/format/bp/BPBase.inl
@@ -47,6 +47,7 @@ make_TypeTraits(type_double, double)
 make_TypeTraits(type_long_double, long double)
 make_TypeTraits(type_complex, cfloat)
 make_TypeTraits(type_double_complex, cdouble)
+make_TypeTraits(type_char, char)
 /* clang-format on */
 #undef make_TypeTraits
 

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -331,7 +331,7 @@ void HDF5Common::ReadAllVariables(core::IO &io)
     }
 
     GetNumAdiosSteps();
-    int i = 0;
+    unsigned int i = 0;
 
     for (i = 0; i < m_NumAdiosSteps; i++)
     {
@@ -353,7 +353,7 @@ void HDF5Common::FindVarsFromH5(core::IO &io, hid_t top_id, const char *gname,
     herr_t ret = H5Gget_num_objs(gid, &numObj);
     if (ret >= 0)
     {
-        int k = 0;
+        hsize_t k = 0;
         char name[100];
         for (k = 0; k < numObj; k++)
         {
@@ -451,7 +451,7 @@ void HDF5Common::ReadVariables(unsigned int ts, core::IO &io)
     herr_t ret = H5Gget_num_objs(gid, &numObj);
     if (ret >= 0)
     {
-        int k = 0;
+        hsize_t k = 0;
         char name[50];
         for (k = 0; k < numObj; k++)
         {
@@ -682,11 +682,12 @@ void HDF5Common::SetAdiosStep(int step)
 
     GetNumAdiosSteps();
 
-    if (step >= m_NumAdiosSteps)
+    unsigned int ustep = static_cast<unsigned int>(step);
+    if (ustep >= m_NumAdiosSteps)
         throw std::ios_base::failure(
             "ERROR: given time step is more than actual known steps.");
 
-    if (m_CurrentAdiosStep == step)
+    if (m_CurrentAdiosStep == ustep)
     {
         return;
     }
@@ -703,7 +704,7 @@ void HDF5Common::SetAdiosStep(int step)
                                      stepName + ", in call to Open\n");
     }
 
-    m_CurrentAdiosStep = step;
+    m_CurrentAdiosStep = ustep;
 }
 
 //
@@ -861,7 +862,7 @@ void HDF5Common::CreateDataset(const std::string &varName, hid_t h5Type,
     hid_t topId = m_GroupId;
     if (list.size() > 1)
     {
-        for (int i = 0; i < list.size() - 1; i++)
+        for (size_t i = 0; i < list.size() - 1; i++)
         {
             if (H5Lexists(topId, list[i].c_str(), H5P_DEFAULT) == 0)
             { // does not exist, so create
@@ -990,7 +991,7 @@ bool HDF5Common::OpenDataset(const std::string &varName,
 
     hid_t topId = m_GroupId;
 
-    for (int i = 0; i < list.size() - 1; i++)
+    for (size_t i = 0; i < list.size() - 1; i++)
     {
         if (H5Lexists(topId, list[i].c_str(), H5P_DEFAULT) == 0)
         { // does not exist, err
@@ -1060,7 +1061,7 @@ void HDF5Common::RemoveEmptyDataset(const std::string &varName)
     hid_t topId = m_GroupId;
     std::vector<hid_t> datasetChain;
 
-    for (int i = 0; i < list.size() - 1; i++)
+    for (size_t i = 0; i < list.size() - 1; i++)
     {
         if (H5Lexists(topId, list[i].c_str(), H5P_DEFAULT) == 0)
             break;
@@ -1130,7 +1131,7 @@ void HDF5Common::ReadInStringAttr(core::IO &io, const std::string &attrName,
         H5Aread(attrId, h5Type, val.get());
 
         std::vector<std::string> stringArray;
-        for (int i = 0; i < dims[0]; i++)
+        for (hsize_t i = 0; i < dims[0]; i++)
         {
             auto input = std::string(&val[i * typeSize], typeSize);
             // remove the padded empty space;
@@ -1253,11 +1254,11 @@ void HDF5Common::WriteStringAttr(core::IO &io,
     else if (adiosAttr->m_Elements >= 1)
     {
         // is array
-        int max = 0;
-        int idxWithMax = 0;
-        for (int i = 0; i < adiosAttr->m_Elements; i++)
+        size_t max = 0;
+        size_t idxWithMax = 0;
+        for (size_t i = 0; i < adiosAttr->m_Elements; i++)
         {
-            int curr = adiosAttr->m_DataArray[i].size();
+            size_t curr = adiosAttr->m_DataArray[i].size();
             if (max < curr)
             {
                 max = curr;
@@ -1268,7 +1269,7 @@ void HDF5Common::WriteStringAttr(core::IO &io,
         hid_t h5Type = GetTypeStringScalar(adiosAttr->m_DataArray[idxWithMax]);
         // std::vector<char> temp;
         std::string all;
-        for (int i = 0; i < adiosAttr->m_Elements; i++)
+        for (size_t i = 0; i < adiosAttr->m_Elements; i++)
         {
             std::string curr = adiosAttr->m_DataArray[i];
             curr.resize(max, ' ');
@@ -1349,10 +1350,10 @@ void HDF5Common::LocateAttrParent(const std::string &attrName,
     if (list.size() >= 1)
     {
         std::string ts;
-        for (int i = 0; i < m_CurrentAdiosStep; i++)
+        for (unsigned int i = 0; i < m_CurrentAdiosStep; i++)
         {
             StaticGetAdiosStepString(ts, i);
-            for (int j = 0; j < list.size() - 1; j++)
+            for (size_t j = 0; j < list.size() - 1; j++)
             {
                 ts += delimiter;
                 ts += list[j].c_str();
@@ -1499,7 +1500,7 @@ void HDF5Common::ReadAttrToIO(core::IO &io)
     if (ret >= 0)
     {
         numAttrs = oinfo.num_attrs;
-        int k = 0;
+        hsize_t k = 0;
         const int MAX_ATTR_NAME_SIZE = 100;
         for (k = 0; k < numAttrs; k++)
         {
@@ -1561,7 +1562,7 @@ void HDF5Common::ReadNativeAttrToIO(core::IO &io, hid_t datasetId,
             return; // warning: reading attrs at every var can be very time
                     // consuimg
         }
-        int k = 0;
+        hsize_t k = 0;
         const int MAX_ATTR_NAME_SIZE = 100;
         for (k = 0; k < numAttrs; k++)
         {

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -49,7 +49,7 @@ public:
             return;
         }
 
-        for (int i = 0; i < m_Chain.size() - 1; i++)
+        for (size_t i = 0; i < m_Chain.size() - 1; i++)
         {
             H5Gclose(m_Chain[i]);
         }

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
@@ -65,8 +65,8 @@ void HDF5Common::GetHDF5SpaceSpec(const core::Variable<T> &variable,
                                   std::vector<hsize_t> &count,
                                   std::vector<hsize_t> &offset)
 {
-    int dimSize = std::max(variable.m_Shape.size(), variable.m_Count.size());
-    for (int i = 0; i < dimSize; ++i)
+    size_t dimSize = std::max(variable.m_Shape.size(), variable.m_Count.size());
+    for (size_t i = 0; i < dimSize; ++i)
     {
         if (variable.m_Shape.size() == dimSize)
         {
@@ -101,7 +101,7 @@ void HDF5Common::GetHDF5SpaceSpec(const core::Variable<T> &variable,
     if (m_OrderByC)
         return;
 
-    for (int i = 0; i < dimSize / 2; ++i)
+    for (size_t i = 0; i < dimSize / 2; ++i)
     {
         std::swap(dimsf[i], dimsf[dimSize - 1 - i]);
         std::swap(count[i], count[dimSize - 1 - i]);
@@ -320,6 +320,12 @@ template <>
 hid_t HDF5Common::GetHDF5Type<std::string>()
 {
     return H5T_C_S1;
+}
+
+template <>
+hid_t HDF5Common::GetHDF5Type<char>()
+{
+    return H5T_NATIVE_UCHAR;
 }
 
 template <>

--- a/source/utils/bp4dbg/adios2/bp4dbg/data.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/data.py
@@ -43,6 +43,8 @@ def ReadEncodedStringArray(f, ID, limit, nStrings):
 def readDataToNumpyArray(f, typeName, nElements):
     if typeName == 'byte':
         return np.fromfile(f, dtype=np.int8, count=nElements)
+    elif typeName == 'char':
+        return np.fromfile(f, dtype=np.uint8, count=nElements)
     elif typeName == 'short':
         return np.fromfile(f, dtype=np.int16, count=nElements)
     elif typeName == 'integer':

--- a/source/utils/bp4dbg/adios2/bp4dbg/metadata.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/metadata.py
@@ -2,6 +2,7 @@ import numpy as np
 from os import fstat
 from .utils import *
 
+
 def ReadEncodedStringFromBuffer(buf, pos, ID, limit, lenbytes=2):
     # 'lenbytes' bytes length + string without \0
     if lenbytes == 1:
@@ -57,6 +58,9 @@ def ReadDimensionCharacteristics(buf, pos):
 def bDataToNumpyArray(cData, typeName, nElements, startPos=0):
     if typeName == 'byte':
         return np.frombuffer(cData, dtype=np.int8, count=nElements,
+                             offset=startPos)
+    elif typeName == 'char':
+        return np.frombuffer(cData, dtype=np.uint8, count=nElements,
                              offset=startPos)
     elif typeName == 'short':
         return np.frombuffer(cData, dtype=np.int16, count=nElements,

--- a/source/utils/bp4dbg/adios2/bp4dbg/utils.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/utils.py
@@ -19,7 +19,9 @@ dataTypes = {
     9: 'string',
     10: 'complex',
     11: 'double_complex',
-    12: 'string_array'
+    12: 'string_array',
+
+    55: 'char'
 }
 
 dataTypeSize = {
@@ -41,7 +43,9 @@ dataTypeSize = {
     9: 0,
     10: 8,
     11: 16,
-    12: 0
+    12: 0,
+
+    55: 1
 }
 
 

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -2771,6 +2771,9 @@ int print_data(const void *data, int item, DataType adiosvartype,
     // print next data item
     switch (adiosvartype)
     {
+    case DataType::Char:
+        fprintf(outf, (f ? fmt : "%c"), ((char *)data)[item]);
+        break;
     case DataType::UInt8:
         fprintf(outf, (f ? fmt : "%hhu"), ((unsigned char *)data)[item]);
         break;

--- a/testing/adios2/engine/SmallTestData.h
+++ b/testing/adios2/engine/SmallTestData.h
@@ -70,6 +70,11 @@ struct SmallTestData
          std::complex<double>(14.2, 15.2), std::complex<double>(15.2, 16.2),
          std::complex<double>(16.2, 17.2), std::complex<double>(17.2, 18.2),
          std::complex<double>(18.2, 19.2), std::complex<double>(19.2, 20.2)}};
+
+    std::array<char, 10> CHAR = {
+        {'a', 'b', 'c', 'y', 'z', 'A', 'B', 'C', 'Y', 'Z'}};
+    std::array<bool, 10> TF = {
+        {true, false, true, true, false, false, true, false, false, true}};
 };
 
 SmallTestData generateNewSmallTestData(SmallTestData in, int step, int rank,
@@ -98,6 +103,20 @@ SmallTestData generateNewSmallTestData(SmallTestData in, int step, int rank,
         v.imag(v.imag() + static_cast<double>(j));
     });
 
+    std::for_each(in.CHAR.begin(), in.CHAR.end(), [&](char &v) {
+        char jc = static_cast<char>(j);
+        char inc = jc % ('z' - 'a');
+        v += inc;
+        if (v > 'z')
+        {
+            v = 'a' + (v - 'z') - 1;
+        }
+        else if (v > 'Z' && v < 'a')
+        {
+            v = 'A' + (v - 'Z') - 1;
+        }
+    });
+
     return in;
 }
 
@@ -124,6 +143,20 @@ void UpdateSmallTestData(SmallTestData &in, int step, int rank, int size)
     std::for_each(in.CR64.begin(), in.CR64.end(), [&](std::complex<double> &v) {
         v.real(v.real() + static_cast<double>(j));
         v.imag(v.imag() + static_cast<double>(j));
+    });
+
+    std::for_each(in.CHAR.begin(), in.CHAR.end(), [&](char &v) {
+        char jc = static_cast<char>(j);
+        char inc = jc % ('z' - 'a');
+        v += inc;
+        if (v > 'z')
+        {
+            v = 'a' + (v - 'z') - 1;
+        }
+        else if (v > 'Z' && v < 'a')
+        {
+            v = 'A' + (v - 'Z') - 1;
+        }
     });
 }
 


### PR DESCRIPTION
…ngines. Python can read it back but converts it to numpy single-byte integer type.

Implements request in #2620.

```
$ bin/Test.Engine.BP.WriteReadADIOS2.Serial "--gtest_filter=BPWriteReadTestADIOS2.ADIOS2BPWriteRead1D8" "BP4"
Note: Google Test filter = BPWriteReadTestADIOS2.ADIOS2BPWriteRead1D8
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from BPWriteReadTestADIOS2
[ RUN      ] BPWriteReadTestADIOS2.ADIOS2BPWriteRead1D8
[       OK ] BPWriteReadTestADIOS2.ADIOS2BPWriteRead1D8 (6 ms)
[----------] 1 test from BPWriteReadTestADIOS2 (6 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (7 ms total)
[  PASSED  ] 1 test.
$ ./bin/bpls ADIOS2BPWriteRead1D8.bp/ -ld ch -n 8
  char      ch       3*{8} = B / z
    (0,0)    b c d z a B C D
    (1,0)    c d e a b C D E
    (2,0)    d e f b c D E F
```