### PR TITLE
adios_iotest/settings: avoid an off-by-one

### DIFF
--- a/source/utils/adios_iotest/settings.cpp
+++ b/source/utils/adios_iotest/settings.cpp
@@ -88,12 +88,16 @@ size_t Settings::stringToNumber(const std::string &varName,
     return retval;
 }
 
+#ifdef _WIN32
+#define strdup _strdup
+#endif
+
 int Settings::parseCSDecomp(const char *arg)
 {
-    char *argCopy = (char *)malloc(strlen(arg) * sizeof(*argCopy));
+    char *argCopy;
     char *ratio;
 
-    strcpy(argCopy, arg);
+    argCopy = strdup(arg);
     ratio = strtok(argCopy, ",");
     while (ratio)
     {


### PR DESCRIPTION
`argCopy`'s allocation did not save space for the `NUL` terminating
byte. Instead of manually calculating memory sizes, use `strdup`.