### PR TITLE
added work around to read out 1D hdf5 string var (with 1 element) as …

### DIFF
--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -192,6 +192,9 @@ public:
     void AddVar(core::IO &io, std::string const &name, hid_t datasetId,
                 unsigned int ts);
 
+    void AddVarString(core::IO &io, std::string const &name, hid_t datasetId,
+                      unsigned int ts);
+
     template <class T>
     void AddNonStringAttribute(core::IO &io, std::string const &attrName,
                                hid_t attrId, hid_t h5Type, hsize_t arraySize);


### PR DESCRIPTION
…scalar string var in ADIOS

Does not support 1D string var with more than 1 element or N-D string var (N >=2).
Because ADIOS does not support string array.