### PR TITLE
prevent cmake failure when no Fortran compiler is present

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -372,7 +372,7 @@ include(CheckTypeRepresentation)
 #check_float_type_representation(double DOUBLE_TYPE_C)
 #check_float_type_representation("long double" LONG_DOUBLE_TYPE_C)
 
-if(ADIOS2_USE_Fortran)
+if(ADIOS2_HAVE_Fortran)
   #check_float_type_representation(real REAL_TYPE_Fortran LANGUAGE Fortran)
   #check_float_type_representation("real(kind=4)" REAL4_TYPE_Fortran LANGUAGE Fortran)
   #check_float_type_representation("real(kind=8)" REAL8_TYPE_Fortran LANGUAGE Fortran)


### PR DESCRIPTION
`ADIOS2_USE_Fortran` is `AUTO` by default, so even if no Fortran compiler was found, it'd still try to check a Fortran compiler flag, which failed without a Fortran compiler being enabled:

```
CMake Error at /opt/local/share/cmake-3.19/Modules/Internal/CheckCompilerFlag.cmake:52 (message):
  check_compiler_flag: Fortran: needs to be enabled before use.
```

The right thing to use is `ADIOS2_HAVE_Fortran`.