### PR TITLE
Tune linearizeindex

### DIFF
--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -188,6 +188,12 @@ constexpr float DefaultBufferGrowthFactor = 1.05f;
  *  2Gb - 100Kb (tolerance)*/
 constexpr size_t DefaultMaxFileBatchSize = 2147381248;
 
+/** maximum number of dimensions supported */
+constexpr size_t MaxDimensions = 24;
+
+static const size_t DimZeros[MaxDimensions] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
 constexpr char PathSeparator =
 #ifdef _WIN32
     '\\';

--- a/source/adios2/helper/adiosMath.h
+++ b/source/adios2/helper/adiosMath.h
@@ -129,6 +129,7 @@ Box<Dims> StartEndBox(const Dims &start, const Dims &count,
                       const bool reverse = false) noexcept;
 
 Box<Dims> StartCountBox(const Dims &start, const Dims &end) noexcept;
+void EndToCount(const Dims &start, const Dims &end, Box<Dims> &box) noexcept;
 
 /**
  * Returns the intersection box { start, end } where end is inclusive from box1

--- a/source/adios2/helper/adiosMath.h
+++ b/source/adios2/helper/adiosMath.h
@@ -129,7 +129,9 @@ Box<Dims> StartEndBox(const Dims &start, const Dims &count,
                       const bool reverse = false) noexcept;
 
 Box<Dims> StartCountBox(const Dims &start, const Dims &end) noexcept;
-void EndToCount(const Dims &start, const Dims &end, Box<Dims> &box) noexcept;
+
+// Fastest version but caller must ensure count[] is allocated
+void EndToCount(const Dims &start, const Dims &end, size_t *count) noexcept;
 
 /**
  * Returns the intersection box { start, end } where end is inclusive from box1
@@ -172,15 +174,17 @@ bool IsIntersectionContiguousSubarray(const Box<Dims> &blockBox,
 
 /**
  * Get a linear index for a point inside a localBox depending on data layout
- * Linear index start count version
+ * Linear index start count version, faster versions but dimension has to be
+ * passed
+ * @param ndim
  * @param start
  * @param count
  * @param point
  * @param isRowMajor
  * @return
  */
-size_t LinearIndex(const Dims &start, const Dims &count, const Dims &point,
-                   const bool isRowMajor) noexcept;
+size_t LinearIndex(const size_t ndim, const size_t *start, const size_t *count,
+                   const size_t *point, const bool isRowMajor) noexcept;
 
 /**
  * Get a linear index for a point inside a localBox depending on data layout
@@ -190,6 +194,10 @@ size_t LinearIndex(const Dims &start, const Dims &count, const Dims &point,
  * @param isZeroIndex
  * @return linear index for contiguous memory
  */
+// size_t LinearIndex(const Box<Dims> &startEndBox, const Dims &point,
+//                   const bool isRowMajor) noexcept;
+
+/** Faster versions but caller must make sure count is preallocated */
 size_t LinearIndex(const Box<Dims> &startEndBox, const Dims &point,
                    const bool isRowMajor) noexcept;
 

--- a/source/adios2/helper/adiosMath.inl
+++ b/source/adios2/helper/adiosMath.inl
@@ -16,7 +16,9 @@
 
 #include <algorithm> // std::minmax_element, std::min_element, std::max_element
                      // std::transform
-#include <limits>    //std::numeri_limits
+#include <cstdint>
+#include <cstring>
+#include <limits> //std::numeri_limits
 #include <thread>
 
 #include "adios2/common/ADIOSMacros.h"
@@ -39,7 +41,9 @@ void GetMinMaxSelection(const T *values, const Dims &shape, const Dims &start,
         const size_t stride = count.back();
         const size_t startCoord = dimensions - 2;
 
-        Dims currentPoint(start); // current point for contiguous memory
+        // current point for contiguous memory
+        size_t currentPoint[MaxDimensions];
+        std::memcpy(currentPoint, start.data(), dimensions * sizeof(size_t));
         bool run = true;
         bool firstStep = true;
 
@@ -47,7 +51,7 @@ void GetMinMaxSelection(const T *values, const Dims &shape, const Dims &start,
         {
             // here copy current linear memory between currentPoint and end
             const size_t startOffset = helper::LinearIndex(
-                Dims(shape.size(), 0), shape, currentPoint, true);
+                dimensions, DimZeros, shape.data(), currentPoint, true);
 
             T minStride, maxStride;
             GetMinMax(values + startOffset, stride, minStride, maxStride);
@@ -104,7 +108,9 @@ void GetMinMaxSelection(const T *values, const Dims &shape, const Dims &start,
         const size_t stride = count.front();
         const size_t startCoord = 1;
 
-        Dims currentPoint(start); // current point for contiguous memory
+        // current point for contiguous memory
+        size_t currentPoint[MaxDimensions];
+        std::memcpy(currentPoint, start.data(), dimensions * sizeof(size_t));
         bool run = true;
         bool firstStep = true;
 
@@ -112,7 +118,7 @@ void GetMinMaxSelection(const T *values, const Dims &shape, const Dims &start,
         {
             // here copy current linear memory between currentPoint and end
             const size_t startOffset = helper::LinearIndex(
-                Dims(shape.size(), 0), shape, currentPoint, false);
+                dimensions, DimZeros, shape.data(), currentPoint, false);
 
             T minStride, maxStride;
             GetMinMax(values + startOffset, stride, minStride, maxStride);
@@ -165,8 +171,8 @@ void GetMinMaxSelection(const T *values, const Dims &shape, const Dims &start,
 
     if (shape.size() == 1)
     {
-        const size_t startOffset =
-            helper::LinearIndex(Dims(1, 0), shape, start, isRowMajor);
+        const size_t startOffset = helper::LinearIndex(
+            1, DimZeros, shape.data(), start.data(), isRowMajor);
         const size_t totalSize = helper::GetTotalSize(count);
         GetMinMax(values + startOffset, totalSize, min, max);
         return;

--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -106,28 +106,30 @@ void ClipRowMajor(char *dest, const Dims &destStart, const Dims &destCount,
 
     /// start iteration
     Dims currentPoint(interStart); // current point for memory copy
-    const size_t interOffset =
-        LinearIndex(srcStart, srcCount, interStart, true);
+    const size_t interOffset = LinearIndex(
+        dimensions, srcStart.data(), srcCount.data(), interStart.data(), true);
 
     bool run = true;
 
     while (run)
     {
-
         // here copy current linear memory between currentPoint and end
         const size_t srcBeginOffset =
             srcMemStart.empty()
-                ? LinearIndex(srcStart, srcCount, currentPoint, true) -
+                ? LinearIndex(dimensions, srcStart.data(), srcCount.data(),
+                              currentPoint.data(), true) -
                       interOffset
-                : LinearIndex(Dims(srcMemCount.size(), 0), srcMemCount,
+                : LinearIndex(dimensions, DimZeros, srcMemCount.data(),
                               VectorsOp(std::plus<size_t>(),
                                         VectorsOp(std::minus<size_t>(),
                                                   currentPoint, interStart),
-                                        srcMemStart),
+                                        srcMemStart)
+                                  .data(),
                               true);
 
         const size_t destBeginOffset = helper::LinearIndex(
-            destStartFinal, destCountFinal, currentPoint, true);
+            dimensions, destStartFinal.data(), destCountFinal.data(),
+            currentPoint.data(), true);
 
         CopyPayloadStride(src + srcBeginOffset, stride, dest + destBeginOffset,
                           endianReverse, destType);
@@ -193,8 +195,8 @@ void ClipColumnMajor(char *dest, const Dims &destStart, const Dims &destCount,
 
     /// start iteration
     Dims currentPoint(interStart); // current point for memory copy
-    const size_t interOffset =
-        LinearIndex(srcStart, srcCount, interStart, false);
+    const size_t interOffset = LinearIndex(
+        dimensions, srcStart.data(), srcCount.data(), interStart.data(), false);
 
     bool run = true;
 
@@ -203,17 +205,20 @@ void ClipColumnMajor(char *dest, const Dims &destStart, const Dims &destCount,
         // here copy current linear memory between currentPoint and end
         const size_t srcBeginOffset =
             srcMemStart.empty()
-                ? LinearIndex(srcStart, srcCount, currentPoint, false) -
+                ? LinearIndex(dimensions, srcStart.data(), srcCount.data(),
+                              currentPoint.data(), false) -
                       interOffset
-                : LinearIndex(Dims(srcMemCount.size(), 0), srcMemCount,
+                : LinearIndex(dimensions, DimZeros, srcMemCount.data(),
                               VectorsOp(std::plus<size_t>(),
                                         VectorsOp(std::minus<size_t>(),
                                                   currentPoint, interStart),
-                                        srcMemStart),
+                                        srcMemStart)
+                                  .data(),
                               false);
 
         const size_t destBeginOffset = helper::LinearIndex(
-            destStartFinal, destCountFinal, currentPoint, false);
+            dimensions, destStartFinal.data(), destCountFinal.data(),
+            currentPoint.data(), false);
 
         CopyPayloadStride(src + srcBeginOffset, stride, dest + destBeginOffset,
                           endianReverse, destType);


### PR DESCRIPTION
The discussed read test went from 22.8s to 4.5s on my PC. 
The consequences are: 
- 24 as max dimension limit set in ADIOSTypes.h, and the first const array in ADIOSTypes.h named DimZeros.
- LinearIndex and EndToCount works on size_t * pointers and number of dimensions must be passed by the caller
