### PR TITLE
Python Module: __version__

### DIFF
--- a/bindings/Python/__init__.py.in
+++ b/bindings/Python/__init__.py.in
@@ -1,1 +1,3 @@
 from .adios2@ADIOS2_LIBRARY_SUFFIX@ import *
+
+__version__ = "@ADIOS2_VERSION@"


### PR DESCRIPTION
The `adios2` Python module should expose an `adios2.__version__` attribute ([PEP-8](https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names)).