### PR TITLE
WIP: Correct return value of adios2_variable_ndims

### DIFF
--- a/bindings/C/adios2/c/adios2_c_variable.cpp
+++ b/bindings/C/adios2/c/adios2_c_variable.cpp
@@ -295,7 +295,7 @@ adios2_error adios2_variable_ndims(size_t *ndims,
                                         "adios2_variable_ndims");
         const adios2::core::VariableBase *variableBase =
             reinterpret_cast<const adios2::core::VariableBase *>(variable);
-        *ndims = variableBase->m_Shape.size();
+        *ndims = variableBase->m_Count.size();
         return adios2_error_none;
     }
     catch (...)


### PR DESCRIPTION
For local arrays, `m_Shape` is empty, while `m_Count` is not, so we read off ndims there.

Closes https://github.com/ornladios/ADIOS2/issues/2711