### PR TITLE
Add const char* entry to ADIOS constructors to avoid ugliness

### DIFF
--- a/bindings/CXX11/adios2/cxx11/ADIOS.cpp
+++ b/bindings/CXX11/adios2/cxx11/ADIOS.cpp
@@ -19,6 +19,8 @@ ADIOS::ADIOS(const std::string &configFile, const bool debugMode)
 {
 }
 
+ADIOS::ADIOS(const char *configFile) : ADIOS(std::string(configFile), "C++") {}
+
 ADIOS::ADIOS(const bool debugMode) : ADIOS("", "C++") {}
 
 ADIOS::ADIOS(const std::string &configFile, const std::string &hostLanguage,

--- a/bindings/CXX11/adios2/cxx11/ADIOS.h
+++ b/bindings/CXX11/adios2/cxx11/ADIOS.h
@@ -100,6 +100,14 @@ public:
     ADIOS(const std::string &configFile, const bool debugMode = true);
 
     /**
+     * Starting point for non-MPI serial apps. Creates an ADIOS object allowing
+     * a runtime config file.
+     * @param configFile runtime config file
+     * @exception std::invalid_argument if user input is incorrect
+     */
+    ADIOS(const char *configFile);
+
+    /**
      * Starting point for non-MPI apps. Creates an ADIOS object
      * @param debugMode is deprecated and has no effect on library behavior
      * @exception std::invalid_argument if user input is incorrect

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -23,6 +23,16 @@ TEST(ADIOSInterface, MPICommRemoved)
 
 #endif
 
+TEST(ADIOSInterface, BADConfigFile)
+{
+    EXPECT_THROW(adios2::ADIOS adios("notthere.xml");
+                 adios2::IO io = adios.DeclareIO("TestIO");
+
+                 adios2::Engine engine =
+                     io.Open("test.bp", adios2::Mode::Write);
+                 , std::logic_error);
+}
+
 /** ADIOS2_CXX11_API
  */
 class ADIOS2_CXX11_API : public ::testing::Test


### PR DESCRIPTION
As reported by @khuck , the ADIOS2 C++ API has some unexpected behaviour.  In particular, constructors like this:
	     adios2::ADIOS adios("config.xml");
Do *not* match with this constructor:
    ADIOS(const std::string &configFile, const bool debugMode = true);
Instead, they match with this constructor:
    ADIOS(const bool debugMode = true);

Because C++ (at least some compilers) would preferentially convert the "const char*" to "bool", resulting in a config file specification that is silently ignored. For more info see:
    https://www.bfilipek.com/2019/07/surprising-conversions-char-bool.html

This PR adds a new entry to the C++ API:
    ADIOS(const char *configFile);

And adds a test to make sure that the simple ADIOS("configfile.xml") specification results in an attempt to parse that file, not the specification being ignored.  We might want to further examine the ADIOS API for similar instances.
