### PR TITLE
Restructure to allow direct specification of array order

### DIFF
--- a/bindings/C/adios2/c/adios2_c_adios.cpp
+++ b/bindings/C/adios2/c/adios2_c_adios.cpp
@@ -17,6 +17,30 @@
 extern "C" {
 #endif
 
+adios2::ArrayOrdering adios2_ToArrayOrdering(const adios2_arrayordering Corder)
+{
+    adios2::ArrayOrdering order = adios2::ArrayOrdering::Auto;
+    switch (Corder)
+    {
+
+    case adios2_arrayordering_rowmajor:
+        order = adios2::ArrayOrdering::RowMajor;
+        break;
+
+    case adios2_arrayordering_columnmajor:
+        order = adios2::ArrayOrdering::ColumnMajor;
+        break;
+
+    case adios2_arrayordering_auto:
+        order = adios2::ArrayOrdering::Auto;
+        break;
+
+    default:
+        break;
+    }
+    return order;
+}
+
 adios2_adios *adios2_init_config_glue_serial(const char *config_file,
                                              const adios2_debug_mode debug_mode,
                                              const char *host_language)
@@ -60,6 +84,25 @@ adios2_io *adios2_declare_io(adios2_adios *adios, const char *name)
             adios, "for adios2_adios, in call to adios2_declare_io");
         io = reinterpret_cast<adios2_io *>(
             &reinterpret_cast<adios2::core::ADIOS *>(adios)->DeclareIO(name));
+    }
+    catch (...)
+    {
+        adios2::helper::ExceptionToError("adios2_declare_io");
+    }
+    return io;
+}
+
+adios2_io *adios2_declare_io_order(adios2_adios *adios, const char *name,
+                                   adios2_arrayordering order)
+{
+    adios2_io *io = nullptr;
+    try
+    {
+        adios2::helper::CheckForNullptr(
+            adios, "for adios2_adios, in call to adios2_declare_io");
+        io = reinterpret_cast<adios2_io *>(
+            &reinterpret_cast<adios2::core::ADIOS *>(adios)->DeclareIO(
+                name, adios2_ToArrayOrdering(order)));
     }
     catch (...)
     {

--- a/bindings/C/adios2/c/adios2_c_adios.h
+++ b/bindings/C/adios2/c/adios2_c_adios.h
@@ -73,6 +73,16 @@ adios2_adios *adios2_init_config_serial(const char *config_file);
 adios2_io *adios2_declare_io(adios2_adios *adios, const char *name);
 
 /**
+ * Declares a new io handler with specific array ordering
+ * @param adios owner the io handler
+ * @param name unique io identifier within current adios handler
+ * @param order array ordering
+ * @return success: handler, failure: NULL
+ */
+adios2_io *adios2_declare_io_order(adios2_adios *adios, const char *name,
+                                   adios2_arrayordering order);
+
+/**
  * Retrieves a previously declared io handler by name
  * @param adios owner the io handler
  * @param name unique name for the previously declared io handler

--- a/bindings/C/adios2/c/adios2_c_types.h
+++ b/bindings/C/adios2/c/adios2_c_types.h
@@ -138,6 +138,13 @@ typedef enum
     adios2_shapeid_local_array = 4
 } adios2_shapeid;
 
+typedef enum
+{
+    adios2_arrayordering_rowmajor,
+    adios2_arrayordering_columnmajor,
+    adios2_arrayordering_auto
+} adios2_arrayordering;
+
 static const size_t adios2_string_array_element_max_size = 4096;
 
 static const size_t adios2_local_value_dim = SIZE_MAX - 2;

--- a/bindings/CXX11/adios2/cxx11/ADIOS.cpp
+++ b/bindings/CXX11/adios2/cxx11/ADIOS.cpp
@@ -31,10 +31,10 @@ ADIOS::ADIOS(const std::string &configFile, const std::string &hostLanguage,
 
 ADIOS::operator bool() const noexcept { return m_ADIOS ? true : false; }
 
-IO ADIOS::DeclareIO(const std::string name)
+IO ADIOS::DeclareIO(const std::string name, const ArrayOrdering ArrayOrder)
 {
     CheckPointer("for io name " + name + ", in call to ADIOS::DeclareIO");
-    return IO(&m_ADIOS->DeclareIO(name));
+    return IO(&m_ADIOS->DeclareIO(name, ArrayOrder));
 }
 
 IO ADIOS::AtIO(const std::string name)

--- a/bindings/CXX11/adios2/cxx11/ADIOS.h
+++ b/bindings/CXX11/adios2/cxx11/ADIOS.h
@@ -164,7 +164,8 @@ public:
      * @exception std::invalid_argument if IO with unique name is already
      * declared
      */
-    IO DeclareIO(const std::string name);
+    IO DeclareIO(const std::string name,
+                 const ArrayOrdering ArrayOrder = ArrayOrdering::Auto);
 
     /**
      * Retrieve an existing IO object previously created with DeclareIO.

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -141,6 +141,14 @@ enum class DataType
     Compound
 };
 
+/** Type of ArrayOrdering */
+enum class ArrayOrdering
+{
+    RowMajor,    /// Contiguous elements of a row lie together in memory
+    ColumnMajor, /// Contiguous elements of a column lie together in memory
+    Auto         /// Default based on language type
+};
+
 // Types
 using std::size_t;
 

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -121,7 +121,7 @@ ADIOS::ADIOS(const std::string hostLanguage)
 
 ADIOS::~ADIOS() = default;
 
-IO &ADIOS::DeclareIO(const std::string name)
+IO &ADIOS::DeclareIO(const std::string name, const ArrayOrdering ArrayOrder)
 {
     auto itIO = m_IOs.find(name);
 
@@ -132,6 +132,7 @@ IO &ADIOS::DeclareIO(const std::string name)
         if (!io.IsDeclared()) // exists from config xml
         {
             io.SetDeclared();
+            io.SetArrayOrder(ArrayOrder);
             return io;
         }
         else
@@ -149,6 +150,7 @@ IO &ADIOS::DeclareIO(const std::string name)
         std::forward_as_tuple(*this, name, false, m_HostLanguage));
     IO &io = ioPair.first->second;
     io.SetDeclared();
+    io.SetArrayOrder(ArrayOrder);
     return io;
 }
 

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -86,7 +86,8 @@ public:
      * @exception std::invalid_argument if IO with unique name is already
      * declared
      */
-    IO &DeclareIO(const std::string name);
+    IO &DeclareIO(const std::string name,
+                  const ArrayOrdering ArrayOrder = ArrayOrdering::Auto);
 
     /**
      * Retrieve a reference to an existing IO object created with DeclareIO.

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -322,6 +322,19 @@ bool IO::InConfigFile() const noexcept { return m_InConfigFile; }
 
 void IO::SetDeclared() noexcept { m_IsDeclared = true; }
 
+void IO::SetArrayOrder(const ArrayOrdering ArrayOrder) noexcept
+{
+    if (ArrayOrder == ArrayOrdering::Auto)
+    {
+        if (helper::IsRowMajor(m_HostLanguage))
+            m_ArrayOrder = ArrayOrdering::RowMajor;
+        else
+            m_ArrayOrder = ArrayOrdering::ColumnMajor;
+    }
+    else
+        m_ArrayOrder = ArrayOrder;
+}
+
 bool IO::IsDeclared() const noexcept { return m_IsDeclared; }
 
 bool IO::RemoveVariable(const std::string &name) noexcept

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -59,6 +59,8 @@ public:
     /** from ADIOS class passed to Engine created with Open */
     const std::string m_HostLanguage = "C++";
 
+    ArrayOrdering m_ArrayOrder;
+
     /** From SetParameter, parameters for a particular engine from m_Type */
     Params m_Parameters;
 
@@ -350,6 +352,8 @@ public:
      * Sets declared to true if IO exists in code created with ADIOS DeclareIO
      */
     void SetDeclared() noexcept;
+
+    void SetArrayOrder(const ArrayOrdering ArrayOrder) noexcept;
 
     /**
      * Check if declared in code

--- a/source/adios2/engine/bp3/BP3Reader.tcc
+++ b/source/adios2/engine/bp3/BP3Reader.tcc
@@ -105,7 +105,7 @@ void BP3Reader::ReadVariableBlocks(Variable<T> &variable)
 
                 m_BP3Deserializer.PostDataRead(
                     variable, blockInfo, subStreamBoxInfo,
-                    helper::IsRowMajor(m_IO.m_HostLanguage), 0);
+                    m_IO.m_ArrayOrder == ArrayOrdering::RowMajor, 0);
             } // substreams loop
             // advance pointer to next step
             blockInfo.Data += helper::GetTotalSize(blockInfo.Count);

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -222,7 +222,8 @@ void BP3Writer::InitBPBuffer()
     else
     {
         m_BP3Serializer.PutProcessGroupIndex(
-            m_IO.m_Name, m_IO.m_HostLanguage,
+            m_IO.m_Name,
+            (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor) ? "C++" : "Fortran",
             m_FileDataManager.GetTransportsTypes());
     }
 }

--- a/source/adios2/engine/bp3/BP3Writer.tcc
+++ b/source/adios2/engine/bp3/BP3Writer.tcc
@@ -40,7 +40,8 @@ void BP3Writer::PutCommon(Variable<T> &variable,
     if (!m_BP3Serializer.m_MetadataSet.DataPGIsOpen)
     {
         m_BP3Serializer.PutProcessGroupIndex(
-            m_IO.m_Name, m_IO.m_HostLanguage,
+            m_IO.m_Name,
+            (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor) ? "C++" : "Fortran",
             m_FileDataManager.GetTransportsTypes());
     }
 
@@ -53,7 +54,7 @@ void BP3Writer::PutCommon(Variable<T> &variable,
     }
 
     // WRITE INDEX to data buffer and metadata structure (in memory)//
-    const bool sourceRowMajor = helper::IsRowMajor(m_IO.m_HostLanguage);
+    const bool sourceRowMajor = (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor);
     m_BP3Serializer.PutVariableMetadata(variable, blockInfo, sourceRowMajor,
                                         &span);
     span.m_Value = value;
@@ -83,7 +84,8 @@ void BP3Writer::PutSyncCommon(Variable<T> &variable,
     if (!m_BP3Serializer.m_MetadataSet.DataPGIsOpen)
     {
         m_BP3Serializer.PutProcessGroupIndex(
-            m_IO.m_Name, m_IO.m_HostLanguage,
+            m_IO.m_Name,
+            (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor) ? "C++" : "Fortran",
             m_FileDataManager.GetTransportsTypes());
     }
 
@@ -94,12 +96,13 @@ void BP3Writer::PutSyncCommon(Variable<T> &variable,
 
         // new group index for incoming variable
         m_BP3Serializer.PutProcessGroupIndex(
-            m_IO.m_Name, m_IO.m_HostLanguage,
+            m_IO.m_Name,
+            (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor) ? "C++" : "Fortran",
             m_FileDataManager.GetTransportsTypes());
     }
 
     // WRITE INDEX to data buffer and metadata structure (in memory)//
-    const bool sourceRowMajor = helper::IsRowMajor(m_IO.m_HostLanguage);
+    const bool sourceRowMajor = (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor);
     m_BP3Serializer.PutVariableMetadata(variable, blockInfo, sourceRowMajor);
     m_BP3Serializer.PutVariablePayload(variable, blockInfo, sourceRowMajor);
 }

--- a/source/adios2/engine/bp4/BP4Reader.tcc
+++ b/source/adios2/engine/bp4/BP4Reader.tcc
@@ -105,7 +105,7 @@ void BP4Reader::ReadVariableBlocks(Variable<T> &variable)
 
                 m_BP4Deserializer.PostDataRead(
                     variable, blockInfo, subStreamBoxInfo,
-                    helper::IsRowMajor(m_IO.m_HostLanguage), 0);
+                    m_IO.m_ArrayOrder == ArrayOrdering::RowMajor, 0);
             } // substreams loop
             // advance pointer to next step
             blockInfo.Data += helper::GetTotalSize(blockInfo.Count);

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -393,7 +393,8 @@ void BP4Writer::InitBPBuffer()
     }
 
     m_BP4Serializer.PutProcessGroupIndex(
-        m_IO.m_Name, m_IO.m_HostLanguage,
+        m_IO.m_Name,
+        (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor) ? "C++" : "Fortran",
         m_FileDataManager.GetTransportsTypes());
 }
 

--- a/source/adios2/engine/bp4/BP4Writer.tcc
+++ b/source/adios2/engine/bp4/BP4Writer.tcc
@@ -40,7 +40,8 @@ void BP4Writer::PutCommon(Variable<T> &variable,
     if (!m_BP4Serializer.m_MetadataSet.DataPGIsOpen)
     {
         m_BP4Serializer.PutProcessGroupIndex(
-            m_IO.m_Name, m_IO.m_HostLanguage,
+            m_IO.m_Name,
+            (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor) ? "C++" : "Fortran",
             m_FileDataManager.GetTransportsTypes());
     }
 
@@ -53,7 +54,7 @@ void BP4Writer::PutCommon(Variable<T> &variable,
     }
 
     // WRITE INDEX to data buffer and metadata structure (in memory)//
-    const bool sourceRowMajor = helper::IsRowMajor(m_IO.m_HostLanguage);
+    const bool sourceRowMajor = m_IO.m_ArrayOrder == ArrayOrdering::RowMajor;
     m_BP4Serializer.PutVariableMetadata(variable, blockInfo, sourceRowMajor,
                                         &span);
     span.m_Value = value;
@@ -82,7 +83,8 @@ void BP4Writer::PutSyncCommon(Variable<T> &variable,
     if (!m_BP4Serializer.m_MetadataSet.DataPGIsOpen)
     {
         m_BP4Serializer.PutProcessGroupIndex(
-            m_IO.m_Name, m_IO.m_HostLanguage,
+            m_IO.m_Name,
+            (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor) ? "C++" : "Fortran",
             m_FileDataManager.GetTransportsTypes());
     }
 
@@ -93,12 +95,13 @@ void BP4Writer::PutSyncCommon(Variable<T> &variable,
 
         // new group index for incoming variable
         m_BP4Serializer.PutProcessGroupIndex(
-            m_IO.m_Name, m_IO.m_HostLanguage,
+            m_IO.m_Name,
+            (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor) ? "C++" : "Fortran",
             m_FileDataManager.GetTransportsTypes());
     }
 
     // WRITE INDEX to data buffer and metadata structure (in memory)//
-    const bool sourceRowMajor = helper::IsRowMajor(m_IO.m_HostLanguage);
+    const bool sourceRowMajor = m_IO.m_ArrayOrder == ArrayOrdering::RowMajor;
     m_BP4Serializer.PutVariableMetadata(variable, blockInfo, sourceRowMajor);
     m_BP4Serializer.PutVariablePayload(variable, blockInfo, sourceRowMajor);
 }

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -211,7 +211,7 @@ void BP5Reader::Init()
     m_IO.m_ReadStreaming = false;
 
     ParseParams(m_IO, m_Parameters);
-    m_ReaderIsRowMajor = helper::IsRowMajor(m_IO.m_HostLanguage);
+    m_ReaderIsRowMajor = (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor);
     InitTransports();
 
     /* Do a collective wait for the file(s) to appear within timeout.

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -794,7 +794,7 @@ void BP5Writer::MakeHeader(format::BufferSTL &b, const std::string fileType,
     // byte 48 columnMajor
     // write if data is column major in metadata and data
     const uint8_t columnMajor =
-        (helper::IsRowMajor(m_IO.m_HostLanguage) == false) ? 'y' : 'n';
+        (m_IO.m_ArrayOrder == ArrayOrdering::ColumnMajor) ? 'y' : 'n';
     helper::CopyToBuffer(buffer, position, &columnMajor);
 
     // byte 49-63: unused

--- a/source/adios2/engine/dataman/DataManReader.cpp
+++ b/source/adios2/engine/dataman/DataManReader.cpp
@@ -22,7 +22,7 @@ DataManReader::DataManReader(IO &io, const std::string &name,
                              const Mode openMode, helper::Comm comm)
 : Engine("DataManReader", io, name, openMode, std::move(comm)),
   m_FinalStep(std::numeric_limits<signed long int>::max()),
-  m_Serializer(m_Comm, helper::IsRowMajor(io.m_HostLanguage)),
+  m_Serializer(m_Comm, (io.m_ArrayOrder == ArrayOrdering::RowMajor)),
   m_RequesterThreadActive(true), m_SubscriberThreadActive(true)
 {
     m_MpiRank = m_Comm.Rank();

--- a/source/adios2/engine/dataman/DataManReader.tcc
+++ b/source/adios2/engine/dataman/DataManReader.tcc
@@ -31,7 +31,7 @@ void DataManReader::GetSyncCommon(Variable<T> &variable, T *data)
 template <class T>
 void DataManReader::GetDeferredCommon(Variable<T> &variable, T *data)
 {
-    if (helper::IsRowMajor(m_IO.m_HostLanguage))
+    if (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor)
     {
         while (true)
         {

--- a/source/adios2/engine/dataman/DataManWriter.cpp
+++ b/source/adios2/engine/dataman/DataManWriter.cpp
@@ -20,7 +20,7 @@ namespace engine
 DataManWriter::DataManWriter(IO &io, const std::string &name,
                              const Mode openMode, helper::Comm comm)
 : Engine("DataManWriter", io, name, openMode, std::move(comm)), m_SentSteps(0),
-  m_Serializer(m_Comm, helper::IsRowMajor(io.m_HostLanguage)),
+  m_Serializer(m_Comm, (io.m_ArrayOrder == ArrayOrdering::RowMajor)),
   m_ReplyThreadActive(true), m_PublishThreadActive(true)
 {
 

--- a/source/adios2/engine/dataman/DataManWriter.tcc
+++ b/source/adios2/engine/dataman/DataManWriter.tcc
@@ -32,7 +32,7 @@ template <class T>
 void DataManWriter::PutDeferredCommon(Variable<T> &variable, const T *values)
 {
     variable.SetData(values);
-    if (helper::IsRowMajor(m_IO.m_HostLanguage))
+    if (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor)
     {
         m_Serializer.PutData(variable, m_Name, CurrentStep(), m_MpiRank, "");
     }

--- a/source/adios2/engine/dataspaces/DataSpacesReader.cpp
+++ b/source/adios2/engine/dataspaces/DataSpacesReader.cpp
@@ -179,7 +179,7 @@ StepStatus DataSpacesReader::BeginStep(StepMode mode, const float timeout_sec)
         shape.resize(var_dim_size);
         if (var_dim_size > 0)
         {
-            bool isOrderC = helper::IsRowMajor(m_IO.m_HostLanguage);
+            bool isOrderC = io.m_ArrayOrder == RowMajor;
             for (int i = 0; i < var_dim_size; i++)
             {
                 if (isOrderC)

--- a/source/adios2/engine/dataspaces/DataSpacesReader.tcc
+++ b/source/adios2/engine/dataspaces/DataSpacesReader.tcc
@@ -60,7 +60,7 @@ void DataSpacesReader::ReadDsData(Variable<T> &variable, T *data, int version)
 {
     uint64_t lb_in[MAX_DS_NDIM], ub_in[MAX_DS_NDIM], gdims_in[MAX_DS_NDIM];
     int ndims = std::max(variable.m_Shape.size(), variable.m_Count.size());
-    bool isOrderC = helper::IsRowMajor(m_IO.m_HostLanguage);
+    bool isOrderC = io.m_ArrayOrder == RowMajor;
     /* Order of dimensions: in DataSpaces: fast --> slow --> slowest
            For example:
            Fortran: i,j,k --> i, j, k  = lb[0], lb[1], lb[2]

--- a/source/adios2/engine/dataspaces/DataSpacesWriter.tcc
+++ b/source/adios2/engine/dataspaces/DataSpacesWriter.tcc
@@ -42,7 +42,7 @@ void DataSpacesWriter::DoPutSyncCommon(Variable<T> &variable, const T *values)
     unsigned int version;
     version = m_CurrentStep;
     int ndims = std::max(variable.m_Shape.size(), variable.m_Count.size());
-    bool isOrderC = helper::IsRowMajor(m_IO.m_HostLanguage);
+    bool isOrderC = io.m_ArrayOrder == RowMajor;
     /* Order of dimensions: in DataSpaces: fast --> slow --> slowest
            For example:
            Fortran: i,j,k --> i, j, k  = lb[0], lb[1], lb[2]

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -159,7 +159,7 @@ size_t HDF5ReaderP::ReadDataset(hid_t dataSetId, hid_t h5Type,
     else
     {
         std::vector<hsize_t> start(ndims), count(ndims), stride(ndims);
-        bool isOrderC = helper::IsRowMajor(m_IO.m_HostLanguage);
+        bool isOrderC = (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor);
 
         for (size_t i = 0u; i < ndims; i++)
         {

--- a/source/adios2/engine/insitumpi/InSituMPIReader.cpp
+++ b/source/adios2/engine/insitumpi/InSituMPIReader.cpp
@@ -343,8 +343,7 @@ void InSituMPIReader::PerformGets()
     // bool writer_IsRowMajor = m_BP3Deserializer.m_IsRowMajor;
     // recalculate seek offsets to payload offset 0 (beginning of blocks)
     int nRequests = insitumpi::FixSeeksToZeroOffset(
-        m_ReadScheduleMap, helper::IsRowMajor(m_IO.m_HostLanguage));
-
+        m_ReadScheduleMap, (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor));
     if (m_CurrentStep == 0 || !m_ReaderSelectionsLocked)
     {
         // Send schedule to writers

--- a/source/adios2/engine/ssc/SscHelper.cpp
+++ b/source/adios2/engine/ssc/SscHelper.cpp
@@ -375,7 +375,7 @@ void Deserialize(const Buffer &input, BlockVecVec &output, IO &io,
         {                                                                      \
             Dims vStart = b.start;                                             \
             Dims vShape = b.shape;                                             \
-            if (!helper::IsRowMajor(io.m_HostLanguage))                        \
+            if (io.m_ArrayOrder != ArrayOrdering::RowMajor)                    \
             {                                                                  \
                 std::reverse(vStart.begin(), vStart.end());                    \
                 std::reverse(vShape.begin(), vShape.end());                    \

--- a/source/adios2/engine/ssc/SscReader.tcc
+++ b/source/adios2/engine/ssc/SscReader.tcc
@@ -33,7 +33,7 @@ void SscReader::GetDeferredDeltaCommon(Variable<T> &variable, T *data)
     Dims vCount = variable.m_Count;
     Dims vShape = variable.m_Shape;
 
-    if (!helper::IsRowMajor(m_IO.m_HostLanguage))
+    if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
     {
         std::reverse(vStart.begin(), vStart.end());
         std::reverse(vCount.begin(), vCount.end());
@@ -101,7 +101,7 @@ void SscReader::GetDeferredCommon(Variable<T> &variable, T *data)
     Dims vCount = variable.m_Count;
     Dims vShape = variable.m_Shape;
 
-    if (!helper::IsRowMajor(m_IO.m_HostLanguage))
+    if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
     {
         std::reverse(vStart.begin(), vStart.end());
         std::reverse(vCount.begin(), vCount.end());
@@ -183,7 +183,7 @@ SscReader::BlocksInfoCommon(const Variable<T> &variable,
                 b.Step = m_CurrentStep;
                 b.StepsStart = m_CurrentStep;
                 b.StepsCount = 1;
-                if (!helper::IsRowMajor(m_IO.m_HostLanguage))
+                if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
                 {
                     std::reverse(b.Start.begin(), b.Start.end());
                     std::reverse(b.Count.begin(), b.Count.end());

--- a/source/adios2/engine/ssc/SscWriter.tcc
+++ b/source/adios2/engine/ssc/SscWriter.tcc
@@ -94,7 +94,7 @@ void SscWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
     Dims vCount = variable.m_Count;
     Dims vShape = variable.m_Shape;
 
-    if (!helper::IsRowMajor(m_IO.m_HostLanguage))
+    if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
     {
         std::reverse(vStart.begin(), vStart.end());
         std::reverse(vCount.begin(), vCount.end());

--- a/source/adios2/engine/sst/SstParamParser.cpp
+++ b/source/adios2/engine/sst/SstParamParser.cpp
@@ -117,7 +117,7 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
     // not really a parameter, but a convenient way to pass this around
     auto lf_SetIsRowMajorParameter = [&](const std::string key,
                                          int &parameter) {
-        parameter = adios2::helper::IsRowMajor(io.m_HostLanguage);
+        parameter = (io.m_ArrayOrder == adios2::ArrayOrdering::RowMajor);
         return true;
     };
 

--- a/source/adios2/engine/sst/SstReader.tcc
+++ b/source/adios2/engine/sst/SstReader.tcc
@@ -172,7 +172,8 @@ void SstReader::ReadVariableBlocksFill(Variable<T> &variable,
 
                     m_BP3Deserializer->PostDataRead(
                         variable, blockInfo, subStreamInfo,
-                        helper::IsRowMajor(m_IO.m_HostLanguage), threadID);
+                        (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor),
+                        threadID);
                     ++iter;
                 }
                 // if remote data buffer is not compressed

--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -77,8 +77,11 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
 
         if (!m_BP3Serializer->m_MetadataSet.DataPGIsOpen)
         {
-            m_BP3Serializer->PutProcessGroupIndex(m_IO.m_Name,
-                                                  m_IO.m_HostLanguage, {"SST"});
+            m_BP3Serializer->PutProcessGroupIndex(
+                m_IO.m_Name,
+                (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor) ? "C++"
+                                                               : "Fortran",
+                {"SST"});
         }
         const size_t dataSize =
             helper::PayloadSize(blockInfo.Data, blockInfo.Count) +
@@ -93,7 +96,8 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
             throw std::runtime_error("Failed to resize BP3 serializer buffer");
         }
 
-        const bool sourceRowMajor = helper::IsRowMajor(m_IO.m_HostLanguage);
+        const bool sourceRowMajor =
+            (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor);
         m_BP3Serializer->PutVariableMetadata(variable, blockInfo,
                                              sourceRowMajor);
         m_BP3Serializer->PutVariablePayload(variable, blockInfo,

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
@@ -38,7 +38,10 @@ void BP3Deserializer::ParseMetadata(const BufferSTL &bufferSTL,
 
 {
     ParseMinifooter(bufferSTL);
-    ParsePGIndex(bufferSTL, engine.m_IO.m_HostLanguage);
+    ParsePGIndex(bufferSTL,
+                 (engine.m_IO.m_ArrayOrder == ArrayOrdering::RowMajor)
+                     ? "C++"
+                     : "Fortran");
     ParseVariablesIndex(bufferSTL, engine);
     ParseAttributesIndex(bufferSTL, engine);
 }

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
@@ -67,8 +67,12 @@ size_t BP4Deserializer::ParseMetadata(const BufferSTL &bufferSTL,
             std::find(selectedSteps.begin(), selectedSteps.end(), i) !=
                 selectedSteps.end())
         {
-            ParsePGIndexPerStep(bufferSTL, engine.m_IO.m_HostLanguage, 0,
-                                i + 1);
+            ParsePGIndexPerStep(
+                bufferSTL,
+                (engine.m_IO.m_ArrayOrder == ArrayOrdering::RowMajor)
+                    ? "C++"
+                    : "Fortran",
+                0, i + 1);
             ParseVariablesIndexPerStep(bufferSTL, engine, 0, i + 1);
             ParseAttributesIndexPerStep(bufferSTL, engine, 0, i + 1);
             lastposition = m_MetadataIndexTable[0][i + 1][3];

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -149,7 +149,7 @@ void HDF5Common::ParseParameters(core::IO &io)
         }
     }
 
-    m_OrderByC = helper::IsRowMajor(io.m_HostLanguage);
+    m_OrderByC = (io.m_ArrayOrder == ArrayOrdering::RowMajor);
 }
 
 void HDF5Common::Append(const std::string &name, helper::Comm const &comm)
@@ -619,7 +619,7 @@ void HDF5Common::AddVar(core::IO &io, std::string const &name, hid_t datasetId,
         shape.resize(ndims);
         if (ndims > 0)
         {
-            bool isOrderC = helper::IsRowMajor(io.m_HostLanguage);
+            bool isOrderC = (io.m_ArrayOrder == ArrayOrdering::RowMajor);
             for (int i = 0; i < ndims; i++)
             {
                 if (isOrderC)


### PR DESCRIPTION
@germasch Please look to see if this would reference the concerns you raise about array ordering in  #2759.
@pnorbert, @JasonRuonanWang, et al.  I think we have a notorious shortage of cross-language tests, so perhaps this needs extra attention before merge.  The basic approach is minimalistic.  There's a new parameter to DeclareIO that has an optional value specifying the array element ordering.  The default is Auto, meaning that it's determined by the language specified when the ADIOS object is created, but it can also be RowMajor or ColumnMajor.  This does *not* change the format of BP3/4 files on disk, where the language specified serves as a stand-in for the array ordering.  Instead we store C++ for RowMajor and Fortran for ColumnMajor.  