### PR TITLE
enabled complex types and larger dimensions for ZFP

### DIFF
--- a/source/adios2/common/ADIOSMacros.h
+++ b/source/adios2/common/ADIOSMacros.h
@@ -125,7 +125,9 @@
     MACRO(int32_t)                                                             \
     MACRO(int64_t)                                                             \
     MACRO(float)                                                               \
-    MACRO(double)
+    MACRO(double)                                                              \
+    MACRO(std::complex<float>)                                                 \
+    MACRO(std::complex<double>)
 
 #define ADIOS2_FOREACH_SZ_TYPE_1ARG(MACRO)                                     \
     MACRO(float)                                                               \

--- a/source/adios2/core/Operator.cpp
+++ b/source/adios2/core/Operator.cpp
@@ -113,6 +113,41 @@ size_t Operator::DoBufferMaxSize(const void *dataIn, const Dims &dimensions,
                                 m_Type + ", in call to BufferMaxSize\n");
 }
 
+Dims Operator::ConvertDims(const Dims &dimensions, const DataType type,
+                           const size_t targetDims) const
+{
+    Dims ret = dimensions;
+
+    while (true)
+    {
+        auto it = std::find(ret.begin(), ret.end(), 1);
+        if (it == ret.end())
+        {
+            break;
+        }
+        else
+        {
+            ret.erase(it);
+        }
+    }
+
+    if (targetDims > 0 && targetDims < dimensions.size())
+    {
+        while (ret.size() > targetDims)
+        {
+            ret[1] *= ret[0];
+            ret.erase(ret.begin());
+        }
+    }
+
+    if (type == helper::GetDataType<std::complex<float>>() ||
+        type == helper::GetDataType<std::complex<double>>())
+    {
+        ret.back() *= 2;
+    }
+    return ret;
+}
+
 // PRIVATE
 void Operator::CheckCallbackType(const std::string type) const
 {

--- a/source/adios2/core/Operator.h
+++ b/source/adios2/core/Operator.h
@@ -125,6 +125,18 @@ protected:
                                    DataType type,
                                    const Params &parameters) const;
 
+    /**
+     * Used by lossy compressors with a limitation on complex data types or
+     * dimentions Returns a adios2::Dims object that meets the requirement of a
+     * compressor
+     * @param dimensions
+     * @param type
+     * @param targetDims
+     * @return refined dimensions
+     */
+    Dims ConvertDims(const Dims &dimensions, const DataType type,
+                     const size_t targetDims = 0) const;
+
 private:
     void CheckCallbackType(const std::string type) const;
 };

--- a/testing/adios2/engine/bp/operations/CMakeLists.txt
+++ b/testing/adios2/engine/bp/operations/CMakeLists.txt
@@ -18,6 +18,8 @@ if(ADIOS2_HAVE_ZFP)
   bp3_bp4_gtest_add_tests_helper(WriteReadZfpHighLevelAPI MPI_ALLOW)
   bp3_bp4_gtest_add_tests_helper(WriteReadZfpConfig MPI_ALLOW)
 
+  gtest_add_tests_helper(ZfpComplex MPI_NONE BPWriteRead Engine. "")
+
   foreach(tgt
       ${Test.Engine.BP.WriteReadZfpConfig-TARGETS}
       )

--- a/testing/adios2/engine/bp/operations/CMakeLists.txt
+++ b/testing/adios2/engine/bp/operations/CMakeLists.txt
@@ -18,7 +18,7 @@ if(ADIOS2_HAVE_ZFP)
   bp3_bp4_gtest_add_tests_helper(WriteReadZfpHighLevelAPI MPI_ALLOW)
   bp3_bp4_gtest_add_tests_helper(WriteReadZfpConfig MPI_ALLOW)
 
-  gtest_add_tests_helper(ZfpComplex MPI_NONE BPWriteRead Engine. "")
+  gtest_add_tests_helper(ZfpComplex MPI_ALLOW BPWriteRead Engine. "")
 
   foreach(tgt
       ${Test.Engine.BP.WriteReadZfpConfig-TARGETS}

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpComplex.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpComplex.cpp
@@ -1,0 +1,282 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * TestBPWriteReadZfpComplex.cpp
+ *
+ *  Created on: Jun 18, 2021
+ *      Author: Jason Wang
+ */
+
+#include <adios2.h>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <numeric>
+#include <thread>
+
+using namespace adios2;
+
+std::string ioName="TestIO";
+std::string fileName="TestBPWriteReadZfpComplex";
+
+class BPEngineTest : public ::testing::Test
+{
+public:
+    BPEngineTest() = default;
+};
+
+template <class T>
+void PrintData(const T *data, const size_t step, const Dims &start,
+               const Dims &count)
+{
+    size_t size = std::accumulate(count.begin(), count.end(), 1, std::multiplies<size_t>());
+    std::cout << "Step: " << step << " Size:" << size << "\n";
+    size_t printsize = 128;
+
+    if (size < printsize)
+    {
+        printsize = size;
+    }
+    int s = 0;
+    for (size_t i = 0; i < printsize; ++i)
+    {
+        ++s;
+        std::cout << data[i] << " ";
+        if (s == count[1])
+        {
+            std::cout << std::endl;
+            s = 0;
+        }
+    }
+
+    std::cout << "]" << std::endl;
+}
+
+template <class T>
+void GenData(std::vector<T> &data, const size_t step, const Dims &start,
+             const Dims &count, const Dims &shape)
+{
+    if (start.size() == 2)
+    {
+        for (size_t i = 0; i < count[0]; ++i)
+        {
+            for (size_t j = 0; j < count[1]; ++j)
+            {
+                data[i * count[1] + j] =
+                    (i + start[1]) * shape[1] + j + start[0] + 0.01*step;
+            }
+        }
+    }
+}
+
+template <class T>
+void VerifyData(const std::complex<T> *data, size_t step, const Dims &start,
+                const Dims &count, const Dims &shape)
+{
+    size_t size = std::accumulate(count.begin(), count.end(), 1,
+                                  std::multiplies<size_t>());
+    std::vector<std::complex<T>> tmpdata(size);
+    GenData(tmpdata, step, start, count, shape);
+    for (size_t i = 0; i < size; ++i)
+    {
+        ASSERT_EQ(abs(data[i].real() - tmpdata[i].real()) < 0.01, true);
+        ASSERT_EQ(abs(data[i].imag() - tmpdata[i].imag()) < 0.01, true);
+    }
+}
+
+template <class T>
+void VerifyData(const T *data, size_t step, const Dims &start,
+                const Dims &count, const Dims &shape)
+{
+    size_t size = std::accumulate(count.begin(), count.end(), 1,
+                                  std::multiplies<size_t>());
+    std::vector<T> tmpdata(size);
+    GenData(tmpdata, step, start, count, shape);
+    for (size_t i = 0; i < size; ++i)
+    {
+        ASSERT_EQ(abs((double)(data[i] - tmpdata[i])) < 0.01, true);
+    }
+}
+
+void Writer(const Dims &shape, const Dims &start, const Dims &count, const size_t steps)
+{
+    size_t datasize = std::accumulate(count.begin(), count.end(), 1, std::multiplies<size_t>());
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO(ioName);
+    std::vector<char> myChars(datasize);
+    std::vector<unsigned char> myUChars(datasize);
+    std::vector<short> myShorts(datasize);
+    std::vector<unsigned short> myUShorts(datasize);
+    std::vector<int> myInts(datasize);
+    std::vector<unsigned int> myUInts(datasize);
+    std::vector<float> myFloats(datasize);
+    std::vector<double> myDoubles(datasize);
+    std::vector<std::complex<float>> myComplexes(datasize);
+    std::vector<std::complex<double>> myDComplexes(datasize);
+    auto bpChars = io.DefineVariable<char>("bpChars", shape, start, count);
+    auto bpUChars = io.DefineVariable<unsigned char>("bpUChars", shape, start, count);
+    auto bpShorts = io.DefineVariable<short>("bpShorts", shape, start, count);
+    auto bpUShorts = io.DefineVariable<unsigned short>( "bpUShorts", shape, start, count);
+    auto bpInts = io.DefineVariable<int>("bpInts", shape, start, count);
+    auto bpUInts = io.DefineVariable<unsigned int>("bpUInts", shape, start, count);
+    auto bpFloats = io.DefineVariable<float>("bpFloats", shape, start, count);
+    adios2::Operator zfpOp = adios.DefineOperator("zfpCompressor", adios2::ops::LossyZFP);
+    bpFloats.AddOperation(zfpOp, {{"accuracy", "0.1"}});
+    auto bpDoubles = io.DefineVariable<double>("bpDoubles", shape, start, count);
+    bpDoubles.AddOperation(zfpOp, {{"accuracy", "0.1"}});
+    auto bpComplexes = io.DefineVariable<std::complex<float>>( "bpComplexes", shape, start, count);
+    bpComplexes.AddOperation(zfpOp, {{"accuracy", "0.1"}});
+    auto bpDComplexes = io.DefineVariable<std::complex<double>>( "bpDComplexes", shape, start, count);
+    bpDComplexes.AddOperation(zfpOp, {{"accuracy", "0.1"}});
+    io.DefineAttribute<int>("AttInt", 110);
+    adios2::Engine writerEngine = io.Open(fileName, adios2::Mode::Write);
+    for (int i = 0; i < steps; ++i)
+    {
+        writerEngine.BeginStep();
+        GenData(myChars, i, start, count, shape);
+        GenData(myUChars, i, start, count, shape);
+        GenData(myShorts, i, start, count, shape);
+        GenData(myUShorts, i, start, count, shape);
+        GenData(myInts, i, start, count, shape);
+        GenData(myUInts, i, start, count, shape);
+        GenData(myFloats, i, start, count, shape);
+        GenData(myDoubles, i, start, count, shape);
+        GenData(myComplexes, i, start, count, shape);
+        GenData(myDComplexes, i, start, count, shape);
+        writerEngine.Put(bpChars, myChars.data(), adios2::Mode::Sync);
+        writerEngine.Put(bpUChars, myUChars.data(), adios2::Mode::Sync);
+        writerEngine.Put(bpShorts, myShorts.data(), adios2::Mode::Sync);
+        writerEngine.Put(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
+        writerEngine.Put(bpInts, myInts.data(), adios2::Mode::Sync);
+        writerEngine.Put(bpUInts, myUInts.data(), adios2::Mode::Sync);
+        writerEngine.Put(bpFloats, myFloats.data(), adios2::Mode::Sync);
+        writerEngine.Put(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
+        writerEngine.Put(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
+        writerEngine.Put(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
+        writerEngine.EndStep();
+    }
+    writerEngine.Close();
+}
+
+void Reader(const Dims &shape, const Dims &start, const Dims &count, const size_t steps)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO(ioName);
+    adios2::Engine readerEngine = io.Open(fileName, adios2::Mode::Read);
+
+    size_t datasize = std::accumulate(count.begin(), count.end(), 1, std::multiplies<size_t>());
+    std::vector<char> myChars(datasize);
+    std::vector<unsigned char> myUChars(datasize);
+    std::vector<short> myShorts(datasize);
+    std::vector<unsigned short> myUShorts(datasize);
+    std::vector<int> myInts(datasize);
+    std::vector<unsigned int> myUInts(datasize);
+    std::vector<float> myFloats(datasize);
+    std::vector<double> myDoubles(datasize);
+    std::vector<std::complex<float>> myComplexes(datasize);
+    std::vector<std::complex<double>> myDComplexes(datasize);
+    size_t currentStep;
+    while (true)
+    {
+        adios2::StepStatus status = readerEngine.BeginStep();
+        if (status == adios2::StepStatus::OK)
+        {
+            const auto &vars = io.AvailableVariables();
+            ASSERT_EQ(vars.size(), 10);
+            currentStep = readerEngine.CurrentStep();
+            GenData(myChars, currentStep, start,count,  shape);
+            GenData(myUChars, currentStep,  start,count,  shape);
+            GenData(myShorts, currentStep,   start,count, shape);
+            GenData(myUShorts, currentStep,   start,count, shape);
+            GenData(myInts, currentStep,  start,count,  shape);
+            GenData(myUInts, currentStep,  start,count,  shape);
+            GenData(myFloats, currentStep,  start,count,  shape);
+            GenData(myDoubles, currentStep,  start,count,  shape);
+            GenData(myComplexes, currentStep,  start,count,  shape);
+            GenData(myDComplexes, currentStep,  start,count,  shape);
+            adios2::Variable<char> bpChars = io.InquireVariable<char>("bpChars");
+            adios2::Variable<unsigned char> bpUChars = io.InquireVariable<unsigned char>("bpUChars");
+            adios2::Variable<short> bpShorts = io.InquireVariable<short>("bpShorts");
+            adios2::Variable<unsigned short> bpUShorts = io.InquireVariable<unsigned short>("bpUShorts");
+            adios2::Variable<int> bpInts = io.InquireVariable<int>("bpInts");
+            adios2::Variable<unsigned int> bpUInts = io.InquireVariable<unsigned int>("bpUInts");
+            adios2::Variable<float> bpFloats = io.InquireVariable<float>("bpFloats");
+            adios2::Variable<double> bpDoubles = io.InquireVariable<double>("bpDoubles");
+            adios2::Variable<std::complex<float>> bpComplexes = io.InquireVariable<std::complex<float>>("bpComplexes");
+            adios2::Variable<std::complex<double>> bpDComplexes = io.InquireVariable<std::complex<double>>("bpDComplexes");
+            auto charsBlocksInfo = readerEngine.AllStepsBlocksInfo(bpChars);
+
+            bpChars.SetSelection({start, count});
+            bpUChars.SetSelection({start, count});
+            bpShorts.SetSelection({start, count});
+            bpUShorts.SetSelection({start, count});
+            bpInts.SetSelection({start, count});
+            bpUInts.SetSelection({start, count});
+            bpFloats.SetSelection({start, count});
+            bpDoubles.SetSelection({start, count});
+            bpComplexes.SetSelection({start, count});
+            bpDComplexes.SetSelection({start, count});
+
+            readerEngine.Get(bpChars, myChars.data(), adios2::Mode::Sync);
+            readerEngine.Get(bpUChars, myUChars.data(), adios2::Mode::Sync);
+            readerEngine.Get(bpShorts, myShorts.data(), adios2::Mode::Sync);
+            readerEngine.Get(bpUShorts, myUShorts.data(), adios2::Mode::Sync);
+            readerEngine.Get(bpInts, myInts.data(), adios2::Mode::Sync);
+            readerEngine.Get(bpUInts, myUInts.data(), adios2::Mode::Sync);
+            readerEngine.Get(bpFloats, myFloats.data(), adios2::Mode::Sync);
+            readerEngine.Get(bpDoubles, myDoubles.data(), adios2::Mode::Sync);
+            readerEngine.Get(bpComplexes, myComplexes.data(), adios2::Mode::Sync);
+            readerEngine.Get(bpDComplexes, myDComplexes.data(), adios2::Mode::Sync);
+
+            VerifyData(myChars.data(), currentStep, start, count, shape);
+            VerifyData(myUChars.data(), currentStep, start, count, shape);
+            VerifyData(myShorts.data(), currentStep, start, count, shape);
+            VerifyData(myUShorts.data(), currentStep, start, count, shape);
+            VerifyData(myInts.data(), currentStep, start, count, shape);
+            VerifyData(myUInts.data(), currentStep, start, count, shape);
+            VerifyData(myFloats.data(), currentStep, start, count, shape);
+            VerifyData(myDoubles.data(), currentStep, start, count, shape);
+            VerifyData(myComplexes.data(), currentStep, start, count, shape);
+            VerifyData(myDComplexes.data(), currentStep, start, count, shape);
+            readerEngine.EndStep();
+        }
+        else if (status == adios2::StepStatus::EndOfStream)
+        {
+            break;
+        }
+        else if (status == adios2::StepStatus::NotReady)
+        {
+            continue;
+        }
+    }
+
+    auto attInt = io.InquireAttribute<int>("AttInt");
+    ASSERT_EQ(110, attInt.Data()[0]);
+    readerEngine.Close();
+}
+
+TEST_F(BPEngineTest, ZfpComplex)
+{
+    Dims shape = {10, 10};
+    Dims start = {2, 2};
+    Dims count = {5, 5};
+    size_t steps = 500;
+
+    Writer(shape, start, count, steps);
+    Reader(shape, start, count, steps);
+}
+
+
+int main(int argc, char **argv)
+{
+#if ADIOS2_USE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+    result = RUN_ALL_TESTS();
+#if ADIOS2_USE_MPI
+    MPI_Finalize();
+#endif
+    return result;
+}

--- a/testing/adios2/engine/dataman/TestDataMan2DZfp.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan2DZfp.cpp
@@ -135,10 +135,14 @@ void DataManWriterP2PMemSelect(const Dims &shape, const Dims &start,
     bpFloats.AddOperation(zfpOp, {{adios2::ops::zfp::key::accuracy, "0.1"}});
     auto bpDoubles =
         dataManIO.DefineVariable<double>("bpDoubles", shape, start, count);
+    bpDoubles.AddOperation(zfpOp, {{adios2::ops::zfp::key::accuracy, "0.1"}});
     auto bpComplexes = dataManIO.DefineVariable<std::complex<float>>(
         "bpComplexes", shape, start, count);
+    bpComplexes.AddOperation(zfpOp, {{adios2::ops::zfp::key::accuracy, "0.1"}});
     auto bpDComplexes = dataManIO.DefineVariable<std::complex<double>>(
         "bpDComplexes", shape, start, count);
+    bpDComplexes.AddOperation(zfpOp,
+                              {{adios2::ops::zfp::key::accuracy, "0.1"}});
     dataManIO.DefineAttribute<int>("AttInt", 110);
     adios2::Engine dataManWriter =
         dataManIO.Open("stream", adios2::Mode::Write);


### PR DESCRIPTION
This PR provides a temporary solution for applications which need lossy compression for complex data types, by treating complex arrays as real arrays. It also supports data arrays larger than 3D by merging some of the slower changing dimensions. 

Again this is only a temporary solution, as a workaround for some of our users. The ultimate solution will depend on the underlying compression algorithms providing native supports.