### PR TITLE
FindBlosc.cmake: Threads

### DIFF
--- a/cmake/FindBlosc.cmake
+++ b/cmake/FindBlosc.cmake
@@ -54,6 +54,24 @@ if(NOT BLOSC_FOUND)
     endif()
   endif()
 
+  # Blosc depends on pthreads
+  # https://github.com/Blosc/c-blosc/blob/master/blosc/CMakeLists.txt
+  # https://github.com/Blosc/c-blosc/pull/318
+  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+  if(WIN32)
+    # try to use the system library
+    find_package(Threads)
+    if(NOT Threads_FOUND)
+      message(STATUS "Blosc: used the internal pthread library for win32 systems.")
+      set(BLOSC_LIBRARIES)
+    else()
+      set(BLOSC_LIBRARIES Threads::Threads)
+    endif()
+  else()
+    find_package(Threads REQUIRED)
+    set(BLOSC_LIBRARIES Threads::Threads)
+  endif()
+
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(Blosc
     FOUND_VAR BLOSC_FOUND
@@ -68,6 +86,7 @@ if(NOT BLOSC_FOUND)
       set_target_properties(Blosc::Blosc PROPERTIES
         IMPORTED_LOCATION             "${BLOSC_LIBRARY}"
         INTERFACE_INCLUDE_DIRECTORIES "${BLOSC_INCLUDE_DIR}"
+        INTERFACE_LINK_LIBRARIES      "${BLOSC_LIBRARIES}"
       )
     endif()
   endif()


### PR DESCRIPTION
This fixes static lib build issues for `ppc64le` (manylinux images for Summit/OLCF): https://github.com/openPMD/openPMD-api/pull/1013
```
/opt/rh/devtoolset-9/root/usr/bin/c++ -fPIC -O3 -DNDEBUG CMakeFiles/sst_conn_tool.dir/sst_conn_tool.c.o [...] ../../../../../lib64/libadios2_enet.a ../../../../../lib64/libadios2_taustubs.a -ldl -lpthread /usr/local/lib/libblosc.a /usr/local/lib64/libzfp.a -lm /usr/local/lib/libhdf5.a /usr/lib64/libdl.so /usr/lib64/libm.so 
/opt/rh/devtoolset-9/root/usr/libexec/gcc/aarch64-redhat-linux/9/ld: /usr/local/lib/libblosc.a(blosc.c.o): in function `blosc_init.part.0':
blosc.c:(.text+0x3c4): undefined reference to `pthread_atfork'
collect2: error: ld returned 1 exit status
```

Blosc depends unconditionally on threads.
If we are not using the blosc cmake config package, we need to re-add the pthreads flags or we will get linker errors.

We are sometimes lucky at the moment that in some build configs pthread flags land in the right order on the commands line, but generally we should declare this dependency.

Refs.:
- https://github.com/Blosc/c-blosc/blob/master/blosc/CMakeLists.txt
- https://github.com/Blosc/c-blosc/pull/318

