### PR TITLE
BP4 engine capable of using device buffers with Put

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ adios_option(MGARD     "Enable support for MGARD transforms" AUTO)
 adios_option(PNG       "Enable support for PNG transforms" AUTO)
 adios_option(MPI       "Enable support for MPI" AUTO)
 adios_option(DAOS      "Enable support for DAOS" AUTO)
+adios_option(CUDA       "Enable support for Cuda" AUTO)
 adios_option(DataMan   "Enable support for DataMan" AUTO)
 adios_option(DataSpaces "Enable support for DATASPACES" AUTO)
 adios_option(SSC       "Enable support for SSC" AUTO)
@@ -174,7 +175,7 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 set(ADIOS2_CONFIG_OPTS
-    Blosc BZip2 ZFP SZ MGARD PNG MPI DataMan DAOS Table SSC SST BP5 DataSpaces ZeroMQ HDF5 HDF5_VOL IME Python Fortran SysVShMem Profiling Endian_Reverse LIBPRESSIO
+    Blosc BZip2 ZFP SZ MGARD PNG MPI DataMan CUDA DAOS Table SSC SST BP5 DataSpaces ZeroMQ HDF5 HDF5_VOL IME Python Fortran SysVShMem Profiling Endian_Reverse LIBPRESSIO
 )
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})
 configure_file(
@@ -296,6 +297,9 @@ message("  C++ Compiler : ${CMAKE_CXX_COMPILER_ID} "
                          "${CMAKE_CXX_COMPILER_WRAPPER}")
 message("    ${CMAKE_CXX_COMPILER}")
 message("")
+if(ADIOS2_HAVE_CUDA)
+  message("  Cuda Compiler : ${CMAKE_CUDA_COMPILER} ")
+endif()
 if(ADIOS2_HAVE_Fortran)
   message("  Fortran Compiler : ${CMAKE_Fortran_COMPILER_ID} "
                                "${CMAKE_Fortran_COMPILER_VERSION} "

--- a/bindings/CXX11/adios2/cxx11/Variable.cpp
+++ b/bindings/CXX11/adios2/cxx11/Variable.cpp
@@ -32,6 +32,14 @@ namespace adios2
     }                                                                          \
                                                                                \
     template <>                                                                \
+    void Variable<T>::SetMemorySpace(const MemorySpace mem)                    \
+    {                                                                          \
+        helper::CheckForNullptr(m_Variable,                                    \
+                                "in call to Variable<T>::SetShape");           \
+        m_Variable->SetMemorySpace(mem);                                       \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
     void Variable<T>::SetShape(const Dims &shape)                              \
     {                                                                          \
         helper::CheckForNullptr(m_Variable,                                    \

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -197,6 +197,11 @@ public:
     void SetStepSelection(const adios2::Box<size_t> &stepSelection);
 
     /**
+     * Sets the memory step for all following Puts
+     */
+    void SetMemorySpace(const MemorySpace mem);
+
+    /**
      * Returns the number of elements required for pre-allocation based on
      * current count and stepsCount
      * @return elements of type T required for pre-allocation

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -141,6 +141,16 @@ endif()
 
 set(mpi_find_components C)
 
+# Cuda
+if(ADIOS2_USE_CUDA STREQUAL AUTO)
+  find_package(CUDA)
+elseif(ADIOS2_USE_CUDA)
+  find_package(CUDA REQUIRED)
+endif()
+if(CUDA_FOUND)
+  set(ADIOS2_HAVE_CUDA TRUE)
+endif()
+
 # Fortran
 if(ADIOS2_USE_Fortran STREQUAL AUTO)
   include(CheckLanguage)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(hello)
 add_subdirectory(query)
 add_subdirectory(useCases)
 add_subdirectory(inlineMWE)
+add_subdirectory(cuda)
 
 if(ADIOS2_HAVE_MPI)
   add_subdirectory(heatTransfer)

--- a/examples/cuda/CMakeLists.txt
+++ b/examples/cuda/CMakeLists.txt
@@ -1,0 +1,12 @@
+#------------------------------------------------------------------------------#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#------------------------------------------------------------------------------#
+
+if(ADIOS2_HAVE_CUDA)
+  enable_language(CUDA)
+  add_executable(GPUWriteRead_cuda cudaWriteRead.cu)
+  target_include_directories(GPUWriteRead_cuda PUBLIC ${CUDA_INCLUDE_DIRS})
+  target_link_libraries(GPUWriteRead_cuda PUBLIC adios2::cxx11 ${CUDA_LIBRARIES})
+  set_target_properties(GPUWriteRead_cuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+endif()

--- a/examples/cuda/cudaWriteRead.cu
+++ b/examples/cuda/cudaWriteRead.cu
@@ -1,0 +1,103 @@
+/*
+ * Simple example of writing and reading data
+ * through ADIOS2 BP engine with multiple simulations steps
+ * for every IO step.
+ */
+
+#include <ios>
+#include <vector>
+#include <iostream>
+
+#include <adios2.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+__global__ void update_array(float *vect, int val) {
+    vect[blockIdx.x] += val;
+}
+
+int BPWrite(const std::string fname, const size_t N, int nSteps){
+  // Initialize the simulation data
+  float *gpuSimData;
+  cudaMalloc(&gpuSimData, N * sizeof(float));
+  cudaMemset(gpuSimData, 0, N);
+ 
+  // Set up the ADIOS structures
+  adios2::ADIOS adios;
+  adios2::IO io = adios.DeclareIO("WriteIO");
+
+  // Declare an array for the ADIOS data of size (NumOfProcesses * N)
+  const adios2::Dims shape{static_cast<size_t>(N)};
+  const adios2::Dims start{static_cast<size_t>(0)};
+  const adios2::Dims count{N};
+  auto data = io.DefineVariable<float>("data", shape, start, count);
+
+  adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+  
+  // Simulation steps
+  for (size_t step = 0; step < nSteps; ++step)
+  {
+      // Make a 1D selection to describe the local dimensions of the
+      // variable we write and its offsets in the global spaces
+      adios2::Box<adios2::Dims> sel({0}, {N});
+      data.SetSelection(sel);
+
+      // Start IO step every write step
+      bpWriter.BeginStep();
+      data.SetMemorySpace(adios2::MemorySpace::CUDA);
+      bpWriter.Put(data, gpuSimData);
+      bpWriter.EndStep();
+
+      // Update values in the simulation data
+      update_array<<<N,1>>>(gpuSimData, 10);
+  }
+
+  bpWriter.Close();
+  return 0;
+}
+
+int BPRead(const std::string fname, const size_t N, int nSteps){
+  // Create ADIOS structures
+  adios2::ADIOS adios;
+  adios2::IO io = adios.DeclareIO("ReadIO");
+
+  adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+  auto data = io.InquireVariable<float>("data");
+  std::cout << "Steps expected by the reader: " << bpReader.Steps() << std::endl;
+  std::cout << "Expecting data per step: " << data.Shape()[0];
+  std::cout  << " elements" << std::endl;
+
+  int write_step = bpReader.Steps();
+  // Create the local buffer and initialize the access point in the ADIOS file
+  std::vector<float> simData(N); //set size to N
+  const adios2::Dims start{0};
+  const adios2::Dims count{N};
+  const adios2::Box<adios2::Dims> sel(start, count);
+  data.SetSelection(sel);
+  
+  // Read the data in each of the ADIOS steps
+  for (size_t step = 0; step < write_step; step++)
+  {
+      data.SetStepSelection({step, 1});
+      bpReader.Get(data, simData.data());
+      bpReader.PerformGets();
+      std::cout << "Simualation step " << step << " : ";
+      std::cout << simData.size() << " elements: " << simData[1] << std::endl;
+  }
+  bpReader.Close();
+  return 0;
+}
+
+int main(int argc, char **argv){
+  const std::string fname("GPUWriteRead.bp");
+  const int device_id = 1;
+  cudaSetDevice(device_id);
+  const size_t N = 6000;
+  int nSteps = 10, ret = 0;
+
+  ret += BPWrite(fname, N, nSteps);
+  ret += BPRead(fname, N, nSteps);
+  return ret;
+}

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -104,6 +104,13 @@ add_library(adios2_core
 set_property(TARGET adios2_core PROPERTY EXPORT_NAME core)
 set_property(TARGET adios2_core PROPERTY OUTPUT_NAME adios2${ADIOS2_LIBRARY_SUFFIX}_core)
 
+if(ADIOS2_HAVE_CUDA)
+  enable_language(CUDA)
+  target_include_directories(adios2_core PUBLIC ${CUDA_INCLUDE_DIRS})
+  target_link_libraries(adios2_core PUBLIC ${CUDA_LIBRARIES})
+  set_target_properties(adios2_core PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+endif()
+
 target_include_directories(adios2_core
   PUBLIC
     $<BUILD_INTERFACE:${ADIOS2_SOURCE_DIR}/source>

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(adios2_core
   helper/adiosXML.cpp
   helper/adiosXMLUtil.cpp
   helper/adiosYAML.cpp
+  helper/adiosCUDA.cu
 
 #engine derived classes  
   engine/bp3/BP3Reader.cpp engine/bp3/BP3Reader.tcc

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -32,6 +32,13 @@
 namespace adios2
 {
 
+/** Memory space for the buffers received with Put */
+enum class MemorySpace
+{
+    Host, ///< default memory space
+    CUDA  ///< GPU memory spaces
+};
+
 /** Variable shape type identifier, assigned automatically from the signature of
  *  DefineVariable */
 enum class ShapeID

--- a/source/adios2/core/Variable.cpp
+++ b/source/adios2/core/Variable.cpp
@@ -49,6 +49,7 @@ namespace core
         info.StepsCount = stepsCount;                                          \
         info.Data = const_cast<T *>(data);                                     \
         info.Operations = m_Operations;                                        \
+        info.IsGPU = m_IsGPU;                                                  \
         m_BlocksInfo.push_back(info);                                          \
         return m_BlocksInfo.back();                                            \
     }                                                                          \
@@ -58,6 +59,20 @@ namespace core
     {                                                                          \
         m_Data = const_cast<T *>(data);                                        \
     }                                                                          \
+                                                                               \
+    template <>                                                                \
+    void Variable<T>::SetMemorySpace(const MemorySpace mem)                    \
+    {                                                                          \
+        switch(mem)                                                            \
+        {                                                                      \
+            case MemorySpace::CUDA:                                            \
+                m_IsGPU = true;                                                \
+                break;                                                         \
+            default:                                                           \
+                m_IsGPU = false;                                               \
+        }                                                                      \
+    }                                                                          \
+                                                                               \
                                                                                \
     template <>                                                                \
     T *Variable<T>::GetData() const noexcept                                   \

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -71,6 +71,7 @@ public:
     T m_Max = T();
     /** current value */
     T m_Value = T();
+    bool m_IsGPU = false;
 
     struct BPInfo
     {
@@ -106,6 +107,7 @@ public:
         SelectionType Selection = SelectionType::BoundingBox;
         bool IsValue = false;
         bool IsReverseDims = false;
+        bool IsGPU = false;
     };
 
     /** use for multiblock info */
@@ -126,6 +128,7 @@ public:
                          const size_t stepsCount = 1) noexcept;
 
     void SetData(const T *data) noexcept;
+    void SetMemorySpace(const MemorySpace mem);
 
     T *GetData() const noexcept;
 

--- a/source/adios2/helper/adiosCUDA.cu
+++ b/source/adios2/helper/adiosCUDA.cu
@@ -1,0 +1,47 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosCUDA.cpp
+ *
+ *  Created on: May 9, 2021
+ *      Author: Ana Gainaru gainarua@ornl.gov
+ */
+
+#ifndef ADIOS2_HELPER_ADIOSCUDA_CU_
+#define ADIOS2_HELPER_ADIOSCUDA_CU_
+
+#include <thrust/extrema.h>
+#include <thrust/device_ptr.h>
+#include "adios2/common/ADIOSMacros.h"
+
+#include "adiosCUDA.h"
+
+namespace {
+template <class T>
+void CUDAMinMaxImpl(const T *values, const size_t size, T &min, T &max)
+{
+    cudaDeviceSynchronize();
+    thrust::device_ptr<const T> dev_ptr(values);
+    auto res = thrust::minmax_element(dev_ptr, dev_ptr + size);
+    cudaMemcpy(&min, thrust::raw_pointer_cast(res.first), sizeof(T), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&max, thrust::raw_pointer_cast(res.second), sizeof(T), cudaMemcpyDeviceToHost);
+}
+// types non supported on the device
+void CUDAMinMaxImpl(const long double *values, const size_t size, long double &min, long double &max) {}
+void CUDAMinMaxImpl(const std::complex<float> *values, const size_t size, std::complex<float> &min, std::complex<float> &max) {}
+void CUDAMinMaxImpl(const std::complex<double> *values, const size_t size, std::complex<double> &min, std::complex<double> &max) {}
+}
+
+template <class T>
+void adios2::helper::CUDAMinMax(const T *values, const size_t size, T &min, T &max)
+{
+  CUDAMinMaxImpl(values, size, min, max);
+}
+
+#define declare_type(T) \
+template void adios2::helper::CUDAMinMax(const T *values, const size_t size, T &min, T &max);
+ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+#endif /* ADIOS2_HELPER_ADIOSCUDA_CU_ */

--- a/source/adios2/helper/adiosCUDA.h
+++ b/source/adios2/helper/adiosCUDA.h
@@ -1,0 +1,29 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosCUDA.h CUDA functions used in the ADIOS framework
+ *
+ *  Created on: May 9, 2021
+ *      Author: Ana Gainaru gainarua@ornl.gov
+ */
+
+#ifndef ADIOS2_HELPER_ADIOSCUDA_H_
+#define ADIOS2_HELPER_ADIOSCUDA_H_
+
+namespace adios2
+{
+namespace helper
+{
+
+/*
+ * CUDA kernel for computing the min and max from a 
+ * GPU buffer
+ */
+template <class T>
+void CUDAMinMax(const T *values, const size_t size, T &min, T &max);
+
+} // helper
+} // adios2
+
+#endif /* ADIOS2_HELPER_ADIOSCUDA_H_ */

--- a/source/adios2/helper/adiosFunctions.h
+++ b/source/adios2/helper/adiosFunctions.h
@@ -20,5 +20,6 @@
 #include "adios2/helper/adiosType.h"    //Type casting, conversion, checks, etc.
 #include "adios2/helper/adiosXML.h"     //XML parsing
 #include "adios2/helper/adiosYAML.h"    //YAML parsing
+#include "adios2/helper/adiosCUDA.h"    //CUDA functions
 
 #endif /* ADIOS2_HELPER_ADIOSFUNCTIONS_H_ */

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -39,6 +39,15 @@ template <class T>
 void InsertToBuffer(std::vector<char> &buffer, const T *source,
                     const size_t elements = 1) noexcept;
 
+/*
+* Copies data from a GPU buffer to a specific location in the adios buffer
+*/
+#ifdef ADIOS2_HAVE_CUDA
+template <class T>
+void CopyFromGPUToBuffer(std::vector<char> &buffer, size_t &position, const T *source,
+                  const size_t elements = 1) noexcept;
+#endif
+
 /**
  * Copies data to a specific location in the buffer updating position
  * Does not update vec.size().

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -20,6 +20,10 @@
 #include <iostream>
 #include <thread>
 /// \endcond
+#ifdef ADIOS2_HAVE_CUDA
+  #include <cuda.h>
+  #include <cuda_runtime.h>
+#endif
 
 #include "adios2/helper/adiosMath.h"
 #include "adios2/helper/adiosSystem.h"
@@ -73,6 +77,18 @@ void InsertToBuffer(std::vector<char> &buffer, const T *source,
     const char *src = reinterpret_cast<const char *>(source);
     buffer.insert(buffer.end(), src, src + elements * sizeof(T));
 }
+
+#ifdef ADIOS2_HAVE_CUDA
+template <class T>
+void CopyFromGPUToBuffer(std::vector<char> &buffer, size_t &position,
+                         const T *source, const size_t elements) noexcept
+{
+    const char *src = reinterpret_cast<const char *>(source);
+    cudaMemcpy(buffer.data() + position, src, elements * sizeof(T),
+               cudaMemcpyDeviceToHost);
+    position += elements * sizeof(T);
+}
+#endif
 
 template <class T>
 void CopyToBuffer(std::vector<char> &buffer, size_t &position, const T *source,

--- a/source/adios2/toolkit/format/bp/BPSerializer.tcc
+++ b/source/adios2/toolkit/format/bp/BPSerializer.tcc
@@ -72,6 +72,13 @@ inline void BPSerializer::PutPayloadInBuffer(
 {
     const size_t blockSize = helper::GetTotalSize(blockInfo.Count);
     m_Profiler.Start("memcpy");
+    if(blockInfo.IsGPU){
+        helper::CopyFromGPUToBuffer(m_Data.m_Buffer, m_Data.m_Position,
+                     blockInfo.Data, blockSize);
+        m_Profiler.Stop("memcpy");
+        m_Data.m_AbsolutePosition += blockSize * sizeof(T);
+        return;
+    }
     if (!blockInfo.MemoryStart.empty())
     {
         helper::CopyMemoryBlock(

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
@@ -334,6 +334,14 @@ BP4Serializer::GetBPStats(const bool singleValue,
     stats.Step = m_MetadataSet.TimeStep;
     stats.FileIndex = GetFileIndex();
 
+   #ifdef ADIOS2_HAVE_CUDA
+   if (blockInfo.IsGPU){
+       const size_t size = helper::GetTotalSize(blockInfo.Count);
+       helper::CUDAMinMax(blockInfo.Data, size, stats.Min, stats.Max);
+       return stats;
+   }
+   #endif
+
     // support span
     if (blockInfo.Data == nullptr && m_Parameters.StatsLevel > 0)
     {


### PR DESCRIPTION
Write side only

Users need to specify the memory space for an ADIOS variable (by default Host) and call Put in the same way as before.
All consecutive Puts will use the same memory space unless updated.

```c++
      bpWriter.BeginStep();
      data.SetMemorySpace(adios2::MemorySpace::CUDA);
      bpWriter.Put(data, gpuSimData);
      bpWriter.EndStep();
```

For now only CUDA is supported, when/if we allow Kokkos, Sycl, etc buffers to be submitted, the m_IsGPU parameter inside variables need to be more than boolean.