### PR TITLE
Bpversion and fileopen

### DIFF
--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -590,8 +590,8 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         }
         else
         {
-            // File default for writing: BP5
-            engineTypeLC = "bp5";
+            // File default for writing: BP4
+            engineTypeLC = "bp4";
         }
     }
 

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -557,6 +557,12 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
             if (adios2sys::SystemTools::FileIsDirectory(name))
             {
                 char v = helper::BPVersion(name, comm, m_TransportsParameters);
+                if (v == 'X')
+                {
+                    // BP4 did not create this file pre 2.8.0 so if not found,
+                    // lets assume bp4
+                    v = '4';
+                }
                 engineTypeLC = "bp";
                 engineTypeLC.push_back(v);
             }
@@ -584,22 +590,27 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         }
         else
         {
-            engineTypeLC = "bp4";
+            // File default for writing: BP5
+            engineTypeLC = "bp5";
         }
     }
 
     // filestream is either BP5 or BP4 depending on .bpversion
-    /* TODO: Timeout is not handled properly for BP5 streaming
-        since this selection picks BP4 Read engine if the BP5 stream is
-        not yet created
-    */
+    /* Note: Mismatch between BP4/BP5 writer and FileStream reader is not
+       handled if writer has not created the directory yet, when FileStream
+       falls back to default */
     if (engineTypeLC == "filestream")
     {
         char v = helper::BPVersion(name, comm, m_TransportsParameters);
+        if (v == 'X')
+        {
+            // FileStream default: BP4
+            v = '4';
+        }
         engineTypeLC = "bp";
         engineTypeLC.push_back(v);
-        std::cout << "Engine " << engineTypeLC << " selected for FileStream"
-                  << std::endl;
+        // std::cout << "Engine " << engineTypeLC << " selected for FileStream"
+        //          << std::endl;
     }
 
     // For the inline engine, there must be exactly 1 reader, and exactly 1

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -184,13 +184,13 @@ void BP4Writer::InitTransports()
                    PathSeparator + m_Name;
     }
 
+    // Names passed to IO AddTransport option with key "Name"
+    const std::vector<std::string> transportsNames =
+        m_FileDataManager.GetFilesBaseNames(m_BBName,
+                                            m_IO.m_TransportsParameters);
+
     if (m_BP4Serializer.m_Aggregator.m_IsAggregator)
     {
-        // Names passed to IO AddTransport option with key "Name"
-        const std::vector<std::string> transportsNames =
-            m_FileDataManager.GetFilesBaseNames(m_BBName,
-                                                m_IO.m_TransportsParameters);
-
         // /path/name.bp.dir/name.bp.rank
         m_SubStreamNames = m_BP4Serializer.GetBPSubStreamNames(transportsNames);
         if (m_DrainBB)
@@ -285,6 +285,19 @@ void BP4Writer::InitTransports()
                 m_FileDrainer.AddOperationOpen(name, m_OpenMode);
             }
         }
+    }
+
+    // last process create .bpversion file with content "4"
+    if (m_Comm.Rank() == m_Comm.Size() - 1)
+    {
+        std::vector<std::string> versionNames =
+            m_BP4Serializer.GetBPVersionFileNames(transportsNames);
+        auto emptyComm = helper::Comm();
+        transportman::TransportMan tm(emptyComm);
+        tm.OpenFiles(versionNames, Mode::Write, m_IO.m_TransportsParameters,
+                     false);
+        char b[1] = {'4'};
+        tm.WriteFiles(b, 1);
     }
 }
 

--- a/source/adios2/engine/bp5/BP5Engine.cpp
+++ b/source/adios2/engine/bp5/BP5Engine.cpp
@@ -92,6 +92,28 @@ std::string BP5Engine::GetBPMetadataIndexFileName(const std::string &name) const
     return bpMetaDataIndexRankName;
 }
 
+std::vector<std::string>
+BP5Engine::GetBPVersionFileNames(const std::vector<std::string> &names) const
+    noexcept
+{
+    std::vector<std::string> versionFileNames;
+    versionFileNames.reserve(names.size());
+    for (const auto &name : names)
+    {
+        versionFileNames.push_back(GetBPVersionFileName(name));
+    }
+    return versionFileNames;
+}
+
+std::string BP5Engine::GetBPVersionFileName(const std::string &name) const
+    noexcept
+{
+    const std::string bpName = helper::RemoveTrailingSlash(name);
+    /* the name of the version file is ".bpversion" */
+    const std::string bpVersionFileName(bpName + PathSeparator + ".bpversion");
+    return bpVersionFileName;
+}
+
 std::string BP5Engine::GetBPSubStreamName(const std::string &name,
                                           const size_t id,
                                           const bool hasSubFiles,

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -79,6 +79,11 @@ public:
                                    const bool hasSubFiles = true,
                                    const bool isReader = false) const noexcept;
 
+    std::vector<std::string>
+    GetBPVersionFileNames(const std::vector<std::string> &names) const noexcept;
+
+    std::string GetBPVersionFileName(const std::string &name) const noexcept;
+
 #define BP5_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                \
     MACRO(OpenTimeoutSecs, Int, int, 3600)                                     \
     MACRO(BeginStepPollingFrequencySecs, Int, int, 0)                          \

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -93,7 +93,7 @@ public:
     MACRO(NodeLocal, Bool, bool, false)                                        \
     MACRO(verbose, Int, int, 0)                                                \
     MACRO(CollectiveMetadata, Bool, bool, true)                                \
-    MACRO(NumAggregators, UInt, unsigned int, 0)                               \
+    MACRO(NumAggregators, UInt, unsigned int, 999999)                          \
     MACRO(AsyncTasks, Bool, bool, true)                                        \
     MACRO(GrowthFactor, Float, float, DefaultBufferGrowthFactor)               \
     MACRO(InitialBufferSize, SizeBytes, size_t, DefaultInitialBufferSize)      \

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -93,7 +93,7 @@ public:
     MACRO(NodeLocal, Bool, bool, false)                                        \
     MACRO(verbose, Int, int, 0)                                                \
     MACRO(CollectiveMetadata, Bool, bool, true)                                \
-    MACRO(NumAggregators, UInt, unsigned int, 999999999)                       \
+    MACRO(NumAggregators, UInt, unsigned int, 0)                               \
     MACRO(AsyncTasks, Bool, bool, true)                                        \
     MACRO(GrowthFactor, Float, float, DefaultBufferGrowthFactor)               \
     MACRO(InitialBufferSize, SizeBytes, size_t, DefaultInitialBufferSize)      \

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -198,11 +198,9 @@ void BP5Reader::Init()
         std::chrono::steady_clock::now() + timeoutSeconds;
 
     OpenFiles(timeoutInstant, pollSeconds, timeoutSeconds);
-    if (!m_Parameters.StreamReader)
-    {
-        /* non-stream reader gets as much steps as available now */
-        InitBuffer(timeoutInstant, pollSeconds / 10, timeoutSeconds);
-    }
+
+    /* non-stream reader gets as much steps as available now */
+    InitBuffer(timeoutInstant, pollSeconds / 10, timeoutSeconds);
 }
 
 bool BP5Reader::SleepOrQuit(const TimePoint &timeoutInstant,

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -192,7 +192,7 @@ void BP5Writer::WriteMetadataFileIndex(uint64_t MetaDataPos,
     m_FileMetadataIndexManager.WriteFiles((char *)m_WriterDataPos.data(),
                                           m_WriterDataPos.size() *
                                               sizeof(uint64_t));
-    std::cout << "Write Index positions = {";
+    /*std::cout << "Write Index positions = {";
     for (size_t i = 0; i < m_WriterDataPos.size(); ++i)
     {
         std::cout << m_WriterDataPos[i];
@@ -201,7 +201,7 @@ void BP5Writer::WriteMetadataFileIndex(uint64_t MetaDataPos,
             std::cout << ", ";
         }
     }
-    std::cout << "}" << std::endl;
+    std::cout << "}" << std::endl;*/
 }
 
 void BP5Writer::MarshalAttributes()

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -615,7 +615,6 @@ void BP5Writer::InitBPBuffer()
         MakeHeader(bi, "Index Table", true);
         m_FileMetadataIndexManager.WriteFiles(bi.m_Buffer.data(),
                                               bi.m_Position);
-
         // where each rank's data will end up
         m_FileMetadataIndexManager.WriteFiles((char *)Assignment.data(),
                                               sizeof(Assignment[0]) *

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -153,6 +153,9 @@ void BP5Writer::WriteData(format::BufferV *Data)
     int i = 0;
     while (DataVec[i].iov_base != NULL)
     {
+        std::cout << "Rank " << m_Comm.Rank() << " write block " << i
+                  << " len = " << DataVec[i].iov_len << " file offset "
+                  << m_DataPos << std::endl;
         if (i == 0)
         {
             m_FileDataManager.WriteFileAt((char *)DataVec[i].iov_base,

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -153,9 +153,6 @@ void BP5Writer::WriteData(format::BufferV *Data)
     int i = 0;
     while (DataVec[i].iov_base != NULL)
     {
-        std::cout << "Rank " << m_Comm.Rank() << " write block " << i
-                  << " len = " << DataVec[i].iov_len << " file offset "
-                  << m_DataPos << std::endl;
         if (i == 0)
         {
             m_FileDataManager.WriteFileAt((char *)DataVec[i].iov_base,

--- a/source/adios2/helper/adiosSystem.cpp
+++ b/source/adios2/helper/adiosSystem.cpp
@@ -164,8 +164,7 @@ bool IsHDF5File(const std::string &name, helper::Comm &comm,
 char BPVersion(const std::string &name, helper::Comm &comm,
                const std::vector<Params> &transportsParameters) noexcept
 {
-    char version[] = {'4'};
-    // BP4 did not create this file pre 2.8.0 so if not found, lets assume bp4
+    char version[] = {'X'};
     std::string versionFileName = name + PathSeparator + ".bpversion";
     if (!comm.Rank())
     {

--- a/source/adios2/helper/adiosSystem.h
+++ b/source/adios2/helper/adiosSystem.h
@@ -77,7 +77,8 @@ int ExceptionToError(const std::string &function);
 
 bool IsHDF5File(const std::string &name, helper::Comm &comm,
                 const std::vector<Params> &transportsParameters) noexcept;
-
+char BPVersion(const std::string &name, helper::Comm &comm,
+               const std::vector<Params> &transportsParameters) noexcept;
 } // end namespace helper
 } // end namespace adios2
 

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
@@ -84,6 +84,28 @@ std::string BP4Base::GetBPMetadataIndexFileName(const std::string &name) const
 }
 
 std::vector<std::string>
+BP4Base::GetBPVersionFileNames(const std::vector<std::string> &names) const
+    noexcept
+{
+    std::vector<std::string> versionFileNames;
+    versionFileNames.reserve(names.size());
+    for (const auto &name : names)
+    {
+        versionFileNames.push_back(GetBPVersionFileName(name));
+    }
+    return versionFileNames;
+}
+
+std::string BP4Base::GetBPVersionFileName(const std::string &name) const
+    noexcept
+{
+    const std::string bpName = helper::RemoveTrailingSlash(name);
+    /* the name of the version file is ".bpversion" */
+    const std::string bpVersionFileName(bpName + PathSeparator + ".bpversion");
+    return bpVersionFileName;
+}
+
+std::vector<std::string>
 BP4Base::GetBPActiveFlagFileNames(const std::vector<std::string> &names) const
     noexcept
 {

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.h
@@ -105,6 +105,11 @@ public:
         noexcept;
 
     std::vector<std::string>
+    GetBPVersionFileNames(const std::vector<std::string> &names) const noexcept;
+
+    std::string GetBPVersionFileName(const std::string &name) const noexcept;
+
+    std::vector<std::string>
     GetBPActiveFlagFileNames(const std::vector<std::string> &names) const
         noexcept;
 

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1550,8 +1550,6 @@ int doList(const char *path)
         if (verbose)
         {
             printf("File info:\n");
-            printf("  adios2 engine: %s\n", fp->m_EngineType.c_str());
-            printf("  stream mode:   %s\n", (filestream ? "yes" : "no"));
             printf("  of variables:  %zu\n", io.GetVariables().size());
             printf("  of attributes: %zu\n", io.GetAttributes().size());
             // printf("  of meshes:     %d\n", fp->nmeshes);

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -83,20 +83,21 @@ std::string format;       // format string for one data element (e.g. %6.2f)
 // Flags from arguments or defaults
 bool dump; // dump data not just list info(flag == 1)
 bool output_xml;
-bool use_regexp;       // use varmasks as regular expressions
-bool sortnames;        // sort names before listing
-bool listattrs;        // do list attributes too
-bool listmeshes;       // do list meshes too
-bool attrsonly;        // do list attributes only
-bool longopt;          // -l is turned on
-bool timestep;         // read step by step
-bool noindex;          // do no print array indices with data
-bool printByteAsChar;  // print 8 bit integer arrays as string
-bool plot;             // dump histogram related information
-bool hidden_attrs;     // show hidden attrs in BP file
-int hidden_attrs_flag; // to be passed on in option struct
-bool show_decomp;      // show decomposition of arrays
-bool show_version;     // print binary version info of file before work
+bool use_regexp;         // use varmasks as regular expressions
+bool sortnames;          // sort names before listing
+bool listattrs;          // do list attributes too
+bool listmeshes;         // do list meshes too
+bool attrsonly;          // do list attributes only
+bool longopt;            // -l is turned on
+bool timestep;           // read step by step
+bool filestream = false; // are we using an engine through FileStream?
+bool noindex;            // do no print array indices with data
+bool printByteAsChar;    // print 8 bit integer arrays as string
+bool plot;               // dump histogram related information
+bool hidden_attrs;       // show hidden attrs in BP file
+int hidden_attrs_flag;   // to be passed on in option struct
+bool show_decomp;        // show decomposition of arrays
+bool show_version;       // print binary version info of file before work
 
 // other global variables
 char *prgname; /* argv[0] */
@@ -915,7 +916,7 @@ int doList_vars(core::Engine *fp, core::IO *io)
         {
             Entry e(vpair.second->m_Type, vpair.second.get());
             bool valid = true;
-            if (timestep)
+            if (timestep && !filestream)
             {
                 valid = e.var->IsValidStep(fp->CurrentStep() + 1);
                 // fprintf(stdout, "Entry: ptr = %p valid = %d\n", e.var,
@@ -1445,15 +1446,39 @@ std::vector<std::string> getEnginesList(const std::string path)
     if (slen >= 3 && path.compare(slen - 3, 3, ".h5") == 0)
     {
         list.push_back("HDF5");
-        list.push_back("BPFile");
+        if (timestep)
+        {
+            list.push_back("FileStream");
+            list.push_back("BP3");
+        }
+        else
+        {
+            list.push_back("BPFile");
+        }
+    }
+    else
+    {
+        if (timestep)
+        {
+            list.push_back("FileStream");
+            list.push_back("BP3");
+        }
+        else
+        {
+            list.push_back("BPFile");
+        }
+        list.push_back("HDF5");
+    }
+#else
+    if (timestep)
+    {
+        list.push_back("FileStream");
+        list.push_back("BP3");
     }
     else
     {
         list.push_back("BPFile");
-        list.push_back("HDF5");
     }
-#else
-    list.push_back("BPFile");
 #endif
     return list;
 }
@@ -1498,6 +1523,10 @@ int doList(const char *path)
         try
         {
             fp = &io.Open(path, Mode::Read);
+            if (engineName == "FileStream")
+            {
+                filestream = true;
+            }
         }
         catch (std::exception &e)
         {
@@ -1521,6 +1550,8 @@ int doList(const char *path)
         if (verbose)
         {
             printf("File info:\n");
+            printf("  adios2 engine: %s\n", fp->m_EngineType.c_str());
+            printf("  stream mode:   %s\n", (filestream ? "yes" : "no"));
             printf("  of variables:  %zu\n", io.GetVariables().size());
             printf("  of attributes: %zu\n", io.GetAttributes().size());
             // printf("  of meshes:     %d\n", fp->nmeshes);


### PR DESCRIPTION
BP4/BP5 write engines now create a .bpversion file immediately at open, which is used to determine what reader engine to use when File, BPFile, FileStream virtual engines are selected. 

-- also turning back aggregation by default to trigger ctest failures