### PR TITLE
fix: IO object has a flag m_ReadStreaming set to false initially but …

### DIFF
--- a/source/adios2/engine/bp3/BP3Reader.cpp
+++ b/source/adios2/engine/bp3/BP3Reader.cpp
@@ -126,6 +126,9 @@ void BP3Reader::Init()
             " " + m_EndMessage);
     }
 
+    // if IO was involved in reading before this flag may be true now
+    m_IO.m_ReadStreaming = false;
+
     InitTransports();
     InitBuffer();
 }

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -148,6 +148,8 @@ void BP4Reader::Init()
                                     "supports OpenMode::Read from" +
                                     m_Name + " " + m_EndMessage);
     }
+    // if IO was involved in reading before this flag may be true now
+    m_IO.m_ReadStreaming = false;
 
     m_BP4Deserializer.Init(m_IO.m_Parameters, "in call to BP4::Open to write");
     InitTransports();

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -180,6 +180,9 @@ void BP5Reader::Init()
                                     m_Name + " " + m_EndMessage);
     }
 
+    // if IO was involved in reading before this flag may be true now
+    m_IO.m_ReadStreaming = false;
+
     ParseParams(m_IO, m_Parameters);
     m_ReaderIsRowMajor = helper::IsRowMajor(m_IO.m_HostLanguage);
     InitTransports();


### PR DESCRIPTION
…set to true by a reader engine in the first BeginStep. If later a second reader is created using the existing IO object, the mode stayed true, which breaks the Open() routine processing all variables and steps. Now each reader initializes this flag to false to ensure running properly.