### PR TITLE
MaxShmSize parameter for BP5 to control the segment size by the user.…

### DIFF
--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -196,6 +196,10 @@ constexpr size_t DefaultMinDeferredSize = 4 * 1024 * 1024;
  *  2Gb - 100Kb (tolerance)*/
 constexpr size_t DefaultMaxFileBatchSize = 2147381248;
 
+/** default maximum shared memory segment size
+ *  128Mb */
+constexpr uint64_t DefaultMaxShmSize = 128 * 1024 * 1024;
+
 constexpr char PathSeparator =
 #ifdef _WIN32
     '\\';

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -120,6 +120,7 @@ public:
     MACRO(InitialBufferSize, SizeBytes, size_t, DefaultInitialBufferSize)      \
     MACRO(MinDeferredSize, SizeBytes, size_t, DefaultMinDeferredSize)          \
     MACRO(BufferChunkSize, SizeBytes, size_t, DefaultBufferChunkSize)          \
+    MACRO(MaxShmSize, SizeBytes, size_t, DefaultMaxShmSize)                    \
     MACRO(BufferVType, BufferVType, int, (int)BufferVType::ChunkVType)         \
     MACRO(ReaderShortCircuitReads, Bool, bool, false)
 

--- a/source/adios2/toolkit/aggregator/mpi/MPIShmChain.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIShmChain.h
@@ -45,7 +45,7 @@ private:
     std::atomic_flag flag_; //{ATOMIC_FLAG_INIT};
 };
 
-constexpr size_t SHM_BUF_SIZE = 4194304; // 4MB
+// constexpr size_t SHM_BUF_SIZE = 4194304; // 4MB
 // we allocate 2x this size + a bit for shared memory segment
 
 /** A one- or two-layer aggregator chain for using Shared memory within a
@@ -129,6 +129,10 @@ public:
     void UnlockConsumerBuffer();
     void ResetBuffers() noexcept;
 
+    // 2*blocksize+some is allocated but only up to maxsegmentsize
+    void CreateShm(size_t blocksize, const size_t maxsegmentsize);
+    void DestroyShm();
+
 private:
     struct HandshakeStruct
     {
@@ -142,8 +146,6 @@ private:
     void HandshakeLinks_Complete(HandshakeStruct &hs);
 
     helper::Comm::Win m_Win;
-    void CreateShm();
-    void DestroyShm();
 
     enum class LastBufferUsed
     {
@@ -165,10 +167,12 @@ private:
         aggregator::Spinlock lockA;
         aggregator::Spinlock lockB;
         // the actual data buffers
-        char bufA[SHM_BUF_SIZE];
-        char bufB[SHM_BUF_SIZE];
+        // char bufA[SHM_BUF_SIZE];
+        // char bufB[SHM_BUF_SIZE];
     };
     ShmSegment *m_Shm;
+    char *m_ShmBufA;
+    char *m_ShmBufB;
 };
 
 } // end namespace aggregator


### PR DESCRIPTION
… Default is 128MB, raised from 8MB to increase performance. Only as much is allocated as necessary but up to the maximum.