### PR TITLE
Delay adding large Deferred Puts to output vector until last minute

### DIFF
--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -140,8 +140,6 @@ uint64_t BP5Writer::WriteMetadata(
 
 void BP5Writer::WriteData(format::BufferV *Data)
 {
-    format::BufferV::BufferV_iovec DataVec = Data->DataVec();
-    (void)DataVec;
     switch (m_Parameters.AggregationType)
     {
     case (int)AggregationType::EveryoneWrites:

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.h
@@ -131,9 +131,17 @@ private:
         FMFormat AttributeFormat = NULL;
         void *AttributeData = NULL;
         int AttributeSize = 0;
-        int CompressZFP = 0;
-        attr_list ZFPParams = NULL;
     };
+
+    struct DeferredExtern
+    {
+        size_t MetaOffset;
+        size_t BlockID;
+        const void *Data;
+        size_t DataSize;
+        size_t AlignReq;
+    };
+    std::vector<DeferredExtern> DeferredExterns;
 
     FFSWriterMarshalBase Info;
     void *MetadataBuf = NULL;
@@ -175,6 +183,8 @@ private:
     size_t *CopyDims(const size_t Count, const size_t *Vals);
     size_t *AppendDims(size_t *OldDims, const size_t OldCount,
                        const size_t Count, const size_t *Vals);
+
+    void DumpDeferredBlocks();
 
     typedef struct _ArrayRec
     {


### PR DESCRIPTION
This has the effect of grouping the data blocks that we've had to copy so that we can fit more of them into chunks, rather than the prior approach which would close off a chunk as soon as we saw a large deferred put that we were going to leave in application memory until we were putting the data to disk.