### PR TITLE
Use `if` instead of `switch` to check MPI constants

### DIFF
--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -78,15 +78,11 @@ void CheckMPIReturn(const int value, const std::string &hint)
     }
 
     std::string error;
-    switch (value)
-    {
-    case MPI_ERR_COMM:
+    if (value == MPI_ERR_COMM) {
         error = "MPI_ERR_COMM";
-        break;
-    case MPI_ERR_INTERN:
+    } else if (value == MPI_ERR_INTERN) {
         error = "MPI_ERR_INTERN";
-        break;
-    default:
+    } else {
         error = "MPI_ERR number: " + std::to_string(value);
     }
 

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -78,11 +78,16 @@ void CheckMPIReturn(const int value, const std::string &hint)
     }
 
     std::string error;
-    if (value == MPI_ERR_COMM) {
+    if (value == MPI_ERR_COMM)
+    {
         error = "MPI_ERR_COMM";
-    } else if (value == MPI_ERR_INTERN) {
+    }
+    else if (value == MPI_ERR_INTERN)
+    {
         error = "MPI_ERR_INTERN";
-    } else {
+    }
+    else
+    {
         error = "MPI_ERR number: " + std::to_string(value);
     }
 


### PR DESCRIPTION
I am using and MPI library where the MPI error codes (`MPI_ERR_COMM` etc.) are not compile-time constants. If I read the MPI standard (version 3.1, section 2.5.4) correctly, it states that only very few MPI constants are compile-time constants.

ADIOS2 fails to build with this MPI library. This patch changes a `switch` to an `if` statement to remedy this.
