### PR TITLE
core::iovec, TransportMan.Write(iovec), Transport:Writev

### DIFF
--- a/source/adios2/core/CoreTypes.h
+++ b/source/adios2/core/CoreTypes.h
@@ -1,0 +1,38 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * CoreTypes.h : types used only in the core framework, in contrast to
+ *               ADIOSTypes.h, which is a public user-facing header
+ *
+ *  Created on: Aug 11, 2021
+ *      Author:  Norbert Podhorszki pnorbert@ornl.gov
+ */
+
+#ifndef ADIOS2_CORETYPES_H_
+#define ADIOS2_CORETYPES_H_
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <cstddef>
+#include <cstdint>
+/// \endcond
+
+#include "adios2/common/ADIOSConfig.h"
+
+namespace adios2
+{
+namespace core
+{
+
+struct iovec
+{
+    //  Base address of a memory region for input or output.
+    const void *iov_base;
+    //  The size of the memory pointed to by iov_base.
+    size_t iov_len;
+};
+
+} // end namespace core
+} // end namespace adios2
+
+#endif /* ADIOS2_CORETYPES_H_ */

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -10,6 +10,7 @@
 #define ADIOS2_ENGINE_BP5_BP5WRITER_H_
 
 #include "adios2/common/ADIOSConfig.h"
+#include "adios2/core/CoreTypes.h"
 #include "adios2/core/Engine.h"
 #include "adios2/engine/bp5/BP5Engine.h"
 #include "adios2/helper/adiosComm.h"
@@ -145,9 +146,8 @@ private:
 
     void WriteMetadataFileIndex(uint64_t MetaDataPos, uint64_t MetaDataSize);
 
-    uint64_t
-    WriteMetadata(const std::vector<format::BufferV::iovec> MetaDataBlocks,
-                  const std::vector<format::BufferV::iovec> AttributeBlocks);
+    uint64_t WriteMetadata(const std::vector<core::iovec> &MetaDataBlocks,
+                           const std::vector<core::iovec> &AttributeBlocks);
 
     /** Write Data to disk, in an aggregator chain */
     void WriteData(format::BufferV *Data);
@@ -168,9 +168,8 @@ private:
     void MarshalAttributes();
 
     /* Two-level-shm aggregator functions */
-    void WriteMyOwnData(format::BufferV::BufferV_iovec DataVec);
-    void SendDataToAggregator(format::BufferV::BufferV_iovec DataVec,
-                              const size_t TotalSize);
+    void WriteMyOwnData(format::BufferV *Data);
+    void SendDataToAggregator(format::BufferV *Data);
     void WriteOthersData(const size_t TotalSize);
 
     template <class T>

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -293,11 +293,18 @@ void SstWriter::EndStep()
         newblock->MetaMetaBlocks = MetaMetaBlocks;
         newblock->metadata.DataSize = TSInfo->MetaEncodeBuffer->m_FixedSize;
         newblock->metadata.block = TSInfo->MetaEncodeBuffer->Data();
-        format::BufferV::BufferV_iovec iovec = TSInfo->DataBuffer->DataVec();
-        newblock->data.DataSize = iovec[0].iov_len;
-        newblock->data.block = (char *)iovec[0].iov_base;
+        std::vector<core::iovec> iovec = TSInfo->DataBuffer->DataVec();
+        if (!iovec.empty())
+        {
+            newblock->data.DataSize = iovec[0].iov_len;
+            newblock->data.block = (char *)iovec[0].iov_base;
+        }
+        else
+        {
+            newblock->data.DataSize = 0;
+            newblock->data.block = nullptr;
+        }
         newblock->TSInfo = TSInfo;
-        delete[] iovec;
         if (TSInfo->AttributeEncodeBuffer)
         {
             newblock->attribute_data.DataSize =

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -871,15 +871,14 @@ std::vector<char> BP5Serializer::CopyMetadataToContiguous(
     return Ret;
 }
 
-std::vector<BufferV::iovec> BP5Serializer::BreakoutContiguousMetadata(
+std::vector<core::iovec> BP5Serializer::BreakoutContiguousMetadata(
     std::vector<char> *Aggregate, const std::vector<size_t> Counts,
     std::vector<MetaMetaInfoBlock> &UniqueMetaMetaBlocks,
-    std::vector<BufferV::iovec> &AttributeBlocks,
-    std::vector<uint64_t> &DataSizes,
+    std::vector<core::iovec> &AttributeBlocks, std::vector<uint64_t> &DataSizes,
     std::vector<uint64_t> &WriterDataPositions) const
 {
     size_t Position = 0;
-    std::vector<BufferV::iovec> MetadataBlocks;
+    std::vector<core::iovec> MetadataBlocks;
     MetadataBlocks.reserve(Counts.size());
     DataSizes.resize(Counts.size());
     for (size_t Rank = 0; Rank < Counts.size(); Rank++)

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.h
@@ -10,6 +10,7 @@
 
 #include "BP5Base.h"
 #include "adios2/core/Attribute.h"
+#include "adios2/core/CoreTypes.h"
 #include "adios2/core/IO.h"
 #include "adios2/toolkit/format/buffer/BufferV.h"
 #include "adios2/toolkit/format/buffer/heap/BufferSTL.h"
@@ -93,10 +94,10 @@ public:
         const format::Buffer *AttributeEncodeBuffer, uint64_t DataSize,
         uint64_t WriterDataPos) const;
 
-    std::vector<BufferV::iovec> BreakoutContiguousMetadata(
+    std::vector<core::iovec> BreakoutContiguousMetadata(
         std::vector<char> *Aggregate, const std::vector<size_t> Counts,
         std::vector<MetaMetaInfoBlock> &UniqueMetaMetaBlocks,
-        std::vector<BufferV::iovec> &AttributeBlocks,
+        std::vector<core::iovec> &AttributeBlocks,
         std::vector<uint64_t> &DataSizes,
         std::vector<uint64_t> &WriterDataPositions) const;
 

--- a/source/adios2/toolkit/format/buffer/BufferV.h
+++ b/source/adios2/toolkit/format/buffer/BufferV.h
@@ -9,6 +9,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/CoreTypes.h"
 #include <iostream>
 
 namespace adios2
@@ -21,19 +22,12 @@ class BufferV
 public:
     const std::string m_Type;
 
-    typedef struct iovec
-    {
-        const void
-            *iov_base;  //  Base address of a memory region for input or output.
-        size_t iov_len; //  The size of the memory pointed to by iov_base.
-    } * BufferV_iovec;
-
     uint64_t Size() noexcept;
 
     BufferV(const std::string type, const bool AlwaysCopy = false);
     virtual ~BufferV();
 
-    virtual BufferV_iovec DataVec() noexcept = 0;
+    virtual std::vector<core::iovec> DataVec() noexcept = 0;
 
     /*
      *  This is used in PerformPuts() to copy externally referenced data so that

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
@@ -218,17 +218,16 @@ void *ChunkV::GetPtr(int bufferIdx, size_t posInBuffer)
     }
 }
 
-ChunkV::BufferV_iovec ChunkV::DataVec() noexcept
+std::vector<core::iovec> ChunkV::DataVec() noexcept
 {
-    BufferV_iovec ret = new iovec[DataV.size() + 1];
+    std::vector<core::iovec> iov(DataV.size());
     for (std::size_t i = 0; i < DataV.size(); ++i)
     {
         // For ChunkV, all entries in DataV are actual iov entries.
-        ret[i].iov_base = DataV[i].Base;
-        ret[i].iov_len = DataV[i].Size;
+        iov[i].iov_base = DataV[i].Base;
+        iov[i].iov_len = DataV[i].Size;
     }
-    ret[DataV.size()] = {NULL, 0};
-    return ret;
+    return iov;
 }
 
 } // end namespace format

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
@@ -9,6 +9,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/CoreTypes.h"
 
 #include "adios2/toolkit/format/buffer/BufferV.h"
 
@@ -28,7 +29,7 @@ public:
            const size_t ChunkSize = DefaultBufferChunkSize);
     virtual ~ChunkV();
 
-    virtual BufferV_iovec DataVec() noexcept;
+    virtual std::vector<core::iovec> DataVec() noexcept;
 
     virtual size_t AddToVec(const size_t size, const void *buf, size_t align,
                             bool CopyReqd);

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
@@ -195,23 +195,22 @@ void *MallocV::GetPtr(int bufferIdx, size_t posInBuffer)
     }
 }
 
-MallocV::BufferV_iovec MallocV::DataVec() noexcept
+std::vector<core::iovec> MallocV::DataVec() noexcept
 {
-    BufferV_iovec ret = new iovec[DataV.size() + 1];
+    std::vector<core::iovec> iov(DataV.size());
     for (std::size_t i = 0; i < DataV.size(); ++i)
     {
         if (DataV[i].External)
         {
-            ret[i].iov_base = DataV[i].Base;
+            iov[i].iov_base = DataV[i].Base;
         }
         else
         {
-            ret[i].iov_base = m_InternalBlock + DataV[i].Offset;
+            iov[i].iov_base = m_InternalBlock + DataV[i].Offset;
         }
-        ret[i].iov_len = DataV[i].Size;
+        iov[i].iov_len = DataV[i].Size;
     }
-    ret[DataV.size()] = {NULL, 0};
-    return ret;
+    return iov;
 }
 
 } // end namespace format

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.h
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.h
@@ -9,6 +9,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/CoreTypes.h"
 
 #include "adios2/toolkit/format/buffer/BufferV.h"
 
@@ -27,7 +28,7 @@ public:
             double GrowthFactor = DefaultBufferGrowthFactor);
     virtual ~MallocV();
 
-    virtual BufferV_iovec DataVec() noexcept;
+    virtual std::vector<core::iovec> DataVec() noexcept;
 
     /**
      * Reset the buffer to initial state (without freeing internal buffers)

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -27,6 +27,19 @@ void Transport::IWrite(const char *buffer, size_t size, Status &status,
     throw std::invalid_argument("ERROR: this class doesn't implement IWrite\n");
 }
 
+void Transport::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
+{
+    if (iovcnt > 0)
+    {
+        Write(static_cast<const char *>(iov[0].iov_base), iov[0].iov_len,
+              start);
+        for (int c = 1; c < iovcnt; ++c)
+        {
+            Write(static_cast<const char *>(iov[c].iov_base), iov[c].iov_len);
+        }
+    }
+}
+
 void Transport::IRead(char *buffer, size_t size, Status &status, size_t start)
 {
     throw std::invalid_argument("ERROR: this class doesn't implement IRead\n");

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -18,6 +18,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/CoreTypes.h"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/toolkit/profiling/iochrono/IOChrono.h"
 
@@ -104,6 +105,17 @@ public:
                        size_t start = MaxSizeT) = 0;
 
     virtual void IWrite(const char *buffer, size_t size, Status &status,
+                        size_t start = MaxSizeT);
+
+    /**
+     * Writes to transport, writev version. Note that size is non-const due to
+     * the nature of underlying transport libraries
+     * @param iovec array pointer
+     * @param iovcnt number of entries
+     * @param start starting position for writing (to allow rewind), if not
+     * passed then start at current stream position
+     */
+    virtual void WriteV(const core::iovec *iov, const int iovcnt,
                         size_t start = MaxSizeT);
 
     /**

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -287,6 +287,7 @@ void FilePOSIX::Write(const char *buffer, size_t size, size_t start)
     }
 }
 
+#ifdef REALLY_WANT_WRITEV
 void FilePOSIX::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
 {
     auto lf_Write = [&](const core::iovec *iov, const int iovcnt) {
@@ -378,6 +379,7 @@ void FilePOSIX::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
         cntTotal += cnt;
     }
 }
+#endif
 
 void FilePOSIX::Read(char *buffer, size_t size, size_t start)
 {

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -42,6 +42,8 @@ public:
                    const bool async = false) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
+    void WriteV(const core::iovec *iov, const int iovcnt,
+                size_t start = MaxSizeT) final;
 
     void Read(char *buffer, size_t size, size_t start = MaxSizeT) final;
 

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -42,8 +42,12 @@ public:
                    const bool async = false) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
+
+#ifdef REALLY_WANT_WRITEV
+    /* Actual writev() function, inactive for now */
     void WriteV(const core::iovec *iov, const int iovcnt,
                 size_t start = MaxSizeT) final;
+#endif
 
     void Read(char *buffer, size_t size, size_t start = MaxSizeT) final;
 

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -243,6 +243,53 @@ void TransportMan::WriteFileAt(const char *buffer, const size_t size,
     }
 }
 
+void TransportMan::WriteFiles(const core::iovec *iov, const size_t iovcnt,
+                              const int transportIndex)
+{
+    if (transportIndex == -1)
+    {
+        for (auto &transportPair : m_Transports)
+        {
+            auto &transport = transportPair.second;
+            if (transport->m_Type == "File")
+            {
+                // make this truly asynch?
+                transport->WriteV(iov, static_cast<int>(iovcnt));
+            }
+        }
+    }
+    else
+    {
+        auto itTransport = m_Transports.find(transportIndex);
+        CheckFile(itTransport, ", in call to WriteFiles with index " +
+                                   std::to_string(transportIndex));
+        itTransport->second->WriteV(iov, static_cast<int>(iovcnt));
+    }
+}
+
+void TransportMan::WriteFileAt(const core::iovec *iov, const size_t iovcnt,
+                               const size_t start, const int transportIndex)
+{
+    if (transportIndex == -1)
+    {
+        for (auto &transportPair : m_Transports)
+        {
+            auto &transport = transportPair.second;
+            if (transport->m_Type == "File")
+            {
+                transport->WriteV(iov, static_cast<int>(iovcnt), start);
+            }
+        }
+    }
+    else
+    {
+        auto itTransport = m_Transports.find(transportIndex);
+        CheckFile(itTransport, ", in call to WriteFileAt with index " +
+                                   std::to_string(transportIndex));
+        itTransport->second->WriteV(iov, static_cast<int>(iovcnt), start);
+    }
+}
+
 void TransportMan::SeekToFileEnd(const int transportIndex)
 {
     if (transportIndex == -1)

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "adios2/core/CoreTypes.h"
 #include "adios2/toolkit/transport/Transport.h"
 
 namespace adios2
@@ -137,9 +138,29 @@ public:
      * @param transportIndex
      * @param buffer
      * @param size
+     * @param start offset in file
      */
     void WriteFileAt(const char *buffer, const size_t size, const size_t start,
                      const int transportIndex = -1);
+
+    /**
+     * Write to file transports, writev version
+     * @param transportIndex
+     * @param iovec array pointer
+     * @param iovcnt number of entries
+     */
+    void WriteFiles(const core::iovec *iov, const size_t iovcnt,
+                    const int transportIndex = -1);
+
+    /**
+     * Write data to a specific location in files, writev version
+     * @param transportIndex
+     * @param iovec array pointer
+     * @param iovcnt number of entries
+     * @param start offset in file
+     */
+    void WriteFileAt(const core::iovec *iov, const size_t iovcnt,
+                     const size_t start, const int transportIndex = -1);
 
     size_t GetFileSize(const size_t transportIndex = 0) const;
 

--- a/testing/h5vol/TestH5VolWriteReadBPFile.cpp
+++ b/testing/h5vol/TestH5VolWriteReadBPFile.cpp
@@ -209,12 +209,14 @@ void HDF5NativeWriter::CreateAndStoreScalar(std::string const &variableName,
                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
         ret = H5Dwrite(dsetID, type, H5S_ALL, H5S_ALL, plistID, values);
+        EXPECT_GE(ret, 0);
 
 #ifdef DOUBLECHECK
         size_t typesize = H5Tget_size(type);
         char *val = (char *)(calloc(typesize, sizeof(char)));
 
         hid_t ret2 = H5Dread(dsetID, type, H5S_ALL, H5S_ALL, H5P_DEFAULT, val);
+        EXPECT_GE(ret2, 0);
         std::cerr << "        ....  typesize=" << typesize << "  val=" << val
                   << std::endl;
         free val;


### PR DESCRIPTION
- Clean up BufferV::iovec by using std::vector, and add it to core/CoreTypes. 
- Add vector IO operations to TransportMan::Write(), and a generic loop implementation of Transport::WriteV
- Implement FilePOSIX::WriteV() with using posix writev() with max 8 entries at a time, but keep this turned off since it is not performing better at scale on Summit or Cori after limited testing. The rest of this PR still simplifies using vectorized IO.
