### PR TITLE
implemented IO::AddOperation

### DIFF
--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -152,10 +152,11 @@ std::string IO::AttributeType(const std::string &name) const
     return ToString(m_IO->InquireAttributeType(name));
 }
 
-size_t IO::AddOperation(const Operator op, const Params &parameters)
+void IO::AddOperation(const std::string &variable,
+                      const std::string &operatorType, const Params &parameters)
 {
     helper::CheckForNullptr(m_IO, "in call to IO::AddOperation");
-    return m_IO->AddOperation(*op.m_Operator, parameters);
+    return m_IO->AddOperation(variable, operatorType, parameters);
 }
 
 std::string IO::EngineType() const

--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -342,27 +342,15 @@ public:
     std::string AttributeType(const std::string &name) const;
 
     /**
-     * EXPERIMENTAL: carries information about an Operation added with
-     * AddOperation
-     */
-    struct Operation
-    {
-        /** Operator associated with this operation */
-        const Operator Op;
-        /** Parameters settings for this operation */
-        const adios2::Params Parameters;
-        /** Information associated with this operation */
-        const adios2::Params Info;
-    };
-
-    /**
-     * EXPERIMENTAL: Adds operation and parameters to current IO object
-     * @param op operator to be added
+     * Adds operation and parameters to current IO object
+     * @param variable variable to add operator to
+     * @param operatorType operator type to define
      * @param parameters key/value settings particular to the IO, not to
      * be confused by op own parameters
-     * @return operation index handler in Operations()
      */
-    size_t AddOperation(const Operator op, const Params &parameters = Params());
+    void AddOperation(const std::string &variable,
+                      const std::string &operatorType,
+                      const Params &parameters = Params());
 
     /**
      * Inspect current engine type from SetEngine

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -500,12 +500,15 @@ DataType IO::InquireAttributeType(const std::string &name,
     return itAttribute->second->m_Type;
 }
 
-size_t IO::AddOperation(Operator &op, const Params &parameters) noexcept
+void IO::AddOperation(const std::string &variable,
+                      const std::string &operatorType,
+                      const Params &parameters) noexcept
 {
     PERFSTUBS_SCOPED_TIMER("IO::other");
-    m_Operations.push_back(
-        Operation{&op, helper::LowerCaseParams(parameters), Params()});
-    return m_Operations.size() - 1;
+    auto params = helper::LowerCaseParams(parameters);
+    Operator *op = &m_ADIOS.DefineOperator(
+        m_Name + "_" + variable + "_" + operatorType, operatorType, params);
+    m_VarOpsPlaceholder[variable].emplace_back(Operation{op, params, Params()});
 }
 
 Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -75,9 +75,6 @@ public:
         Params Info;
     };
 
-    /** From AddOperation, contains operators added to this IO */
-    std::vector<Operation> m_Operations;
-
     /** BP3 engine default if unknown */
     std::string m_EngineType = "File";
 
@@ -370,12 +367,13 @@ public:
     /**
      * Adds an operator defined by the ADIOS class. Could be a variable set
      * transform, callback function, etc.
-     * @param op operator created by the ADIOS class
-     * @param parameters specific parameters for current IO
-     * @return operation handler
+     * @param variable
+     * @param operatorType
+     * @param parameters
      */
-    size_t AddOperation(Operator &op,
-                        const Params &parameters = Params()) noexcept;
+    void AddOperation(const std::string &variable,
+                      const std::string &operatorType,
+                      const Params &parameters = Params()) noexcept;
 
     /**
      * @brief Creates a polymorphic object that derives the Engine class,

--- a/testing/adios2/engine/dataman/TestDataMan2DBzip2.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan2DBzip2.cpp
@@ -106,6 +106,7 @@ void DataManWriterP2PMemSelect(const Dims &shape, const Dims &start,
     adios2::IO dataManIO = adios.DeclareIO("WAN");
     dataManIO.SetEngine("DataMan");
     dataManIO.SetParameters(engineParams);
+    dataManIO.AddOperation("bpFloats", "bzip2");
     std::vector<char> myChars(datasize);
     std::vector<unsigned char> myUChars(datasize);
     std::vector<short> myShorts(datasize);
@@ -129,9 +130,6 @@ void DataManWriterP2PMemSelect(const Dims &shape, const Dims &start,
         dataManIO.DefineVariable<unsigned int>("bpUInts", shape, start, count);
     auto bpFloats =
         dataManIO.DefineVariable<float>("bpFloats", shape, start, count);
-    adios2::Operator bzip2Op =
-        adios.DefineOperator("Compressor", adios2::ops::LosslessBZIP2);
-    bpFloats.AddOperation(bzip2Op, {});
     auto bpDoubles =
         dataManIO.DefineVariable<double>("bpDoubles", shape, start, count);
     auto bpComplexes = dataManIO.DefineVariable<std::complex<float>>(

--- a/testing/adios2/engine/dataman/TestDataMan2DSz.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan2DSz.cpp
@@ -107,6 +107,7 @@ void DataManWriterP2PMemSelect(const Dims &shape, const Dims &start,
     adios2::IO dataManIO = adios.DeclareIO("WAN");
     dataManIO.SetEngine("DataMan");
     dataManIO.SetParameters(engineParams);
+    dataManIO.AddOperation("bpFloats", "sz", {{"accuracy", "0.01"}});
     std::vector<char> myChars(datasize);
     std::vector<unsigned char> myUChars(datasize);
     std::vector<short> myShorts(datasize);
@@ -130,9 +131,6 @@ void DataManWriterP2PMemSelect(const Dims &shape, const Dims &start,
         dataManIO.DefineVariable<unsigned int>("bpUInts", shape, start, count);
     auto bpFloats =
         dataManIO.DefineVariable<float>("bpFloats", shape, start, count);
-    adios2::Operator szOp =
-        adios.DefineOperator("szCompressor", adios2::ops::LossySZ);
-    bpFloats.AddOperation(szOp, {{adios2::ops::sz::key::accuracy, "0.01"}});
     auto bpDoubles =
         dataManIO.DefineVariable<double>("bpDoubles", shape, start, count);
     auto bpComplexes = dataManIO.DefineVariable<std::complex<float>>(

--- a/testing/adios2/engine/dataman/TestDataMan2DZfp.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan2DZfp.cpp
@@ -107,6 +107,10 @@ void DataManWriterP2PMemSelect(const Dims &shape, const Dims &start,
     adios2::IO dataManIO = adios.DeclareIO("WAN");
     dataManIO.SetEngine("DataMan");
     dataManIO.SetParameters(engineParams);
+    dataManIO.AddOperation("bpFloats", "zfp", {{"accuracy", "0.01"}});
+    dataManIO.AddOperation("bpDoubles", "zfp", {{"accuracy", "0.1"}});
+    dataManIO.AddOperation("bpComplexes", "zfp", {{"accuracy", "0.1"}});
+    dataManIO.AddOperation("bpDComplexes", "zfp", {{"accuracy", "0.1"}});
     std::vector<char> myChars(datasize);
     std::vector<unsigned char> myUChars(datasize);
     std::vector<short> myShorts(datasize);
@@ -130,19 +134,12 @@ void DataManWriterP2PMemSelect(const Dims &shape, const Dims &start,
         dataManIO.DefineVariable<unsigned int>("bpUInts", shape, start, count);
     auto bpFloats =
         dataManIO.DefineVariable<float>("bpFloats", shape, start, count);
-    adios2::Operator zfpOp =
-        adios.DefineOperator("zfpCompressor", adios2::ops::LossyZFP);
-    bpFloats.AddOperation(zfpOp, {{adios2::ops::zfp::key::accuracy, "0.1"}});
     auto bpDoubles =
         dataManIO.DefineVariable<double>("bpDoubles", shape, start, count);
-    bpDoubles.AddOperation(zfpOp, {{adios2::ops::zfp::key::accuracy, "0.1"}});
     auto bpComplexes = dataManIO.DefineVariable<std::complex<float>>(
         "bpComplexes", shape, start, count);
-    bpComplexes.AddOperation(zfpOp, {{adios2::ops::zfp::key::accuracy, "0.1"}});
     auto bpDComplexes = dataManIO.DefineVariable<std::complex<double>>(
         "bpDComplexes", shape, start, count);
-    bpDComplexes.AddOperation(zfpOp,
-                              {{adios2::ops::zfp::key::accuracy, "0.1"}});
     dataManIO.DefineAttribute<int>("AttInt", 110);
     adios2::Engine dataManWriter =
         dataManIO.Open("stream", adios2::Mode::Write);


### PR DESCRIPTION
The original IO::AddOperation function was not implemented to a workable level. While the XML API provides a purely parameter configurable operator addition mechanism, the non-XML API should also provide an equivalent way of adding operators by only passing std::string based parameters. 

This is important to applications which are very expensive to modify. With the previous Variable::AddOperation being the only way, user applications have to be modified every time there is a change in the operators or a new operator is implemented. Being able to add arbitrary operators to arbitrary variables by only passing pure std::string based parameters can save huge amount of effort maintaining such application codes. 