### PR TITLE
EVPath: force implicit libm link

### DIFF
--- a/thirdparty/EVPath/EVPath/CMakeLists.txt
+++ b/thirdparty/EVPath/EVPath/CMakeLists.txt
@@ -131,6 +131,9 @@ set(_pkg_config_libs)
 set(_pkg_config_private_libs)
 
 include(CheckCSourceCompiles)
+
+# Avoid recent compilers to optimizing out libm function calls
+set(CMAKE_REQUIRED_FLAGS "-O0")
 set(LIBM_TEST_SOURCE "#include<math.h>\nfloat f; int main(){sqrt(f);return 0;}")
 check_c_source_compiles("${LIBM_TEST_SOURCE}" HAVE_MATH)
 if(NOT HAVE_MATH)


### PR DESCRIPTION
Since some compilers will implicitely link libm, the EVPath project
CMakeList.txt first tests if it needs to be explicitly linked and if
that is the case it will implicitly link libm.

Unfortunately this test seems to give false positives in some machines,
thus skipping the implicit linkage of libm results in linking errors.

Backport from a patch for ADIOS2 OpenSUSE pkg.

https://build.opensuse.org/package/view_file/home:vicentebolea/ADIOS2/evpath-link-m.patch?expand=1

@eisenhauer I believe that EVPath is your realm, this is an extract of the patch, however, probably we can find a more elegant way to resolve this