### PR TITLE
Remove F2008 string allocation from Fortran binding. sadios2_availabl…

### DIFF
--- a/bindings/Fortran/modules/adios2_io_mod.f90
+++ b/bindings/Fortran/modules/adios2_io_mod.f90
@@ -158,25 +158,52 @@ contains
     end subroutine
 
 
-    subroutine adios2_available_variables(io, nvars, varnamelist, ierr)
+    subroutine adios2_available_variables(io, namestruct, ierr)
         type(adios2_io), intent(in) :: io
-        integer, intent(out) :: nvars
-        character(len=:), dimension(:), allocatable, intent(out) :: varnamelist
+        type(adios2_namestruct), intent(out) :: namestruct
         integer, intent(out) :: ierr
 
-        integer(kind=8):: namestruct
-        integer :: count, max_name_len
-
-        call adios2_available_variables_f2c(io%f2c, namestruct, count, &
-                        max_name_len, ierr)
+        call adios2_available_variables_f2c(io%f2c, namestruct%f2c, &
+                   namestruct%count,  namestruct%max_name_len, ierr)
         if (ierr == 0) then
-            allocate(character(len=max_name_len) :: varnamelist(count))
+            namestruct%valid = .true.
         endif
-
-        call adios2_retrieve_variable_names_f2c(namestruct, count, &
-                        max_name_len, varnamelist, ierr)
-        nvars = count
     end subroutine
+
+    subroutine adios2_retrieve_names(namestruct, namelist, ierr)
+        type(adios2_namestruct), intent(inout) :: namestruct
+        character(*), dimension(*), intent(inout) :: namelist
+        integer, intent(out) :: ierr
+
+        if (namestruct%valid .and. namestruct%f2c > 0_8) then
+            call adios2_retrieve_namelist_f2c(namestruct%f2c, namelist, ierr)
+        else
+            write(*,*) "ADIOS2 Fortran ERROR: invalid namestruct when calling adios2_retrieve_names()"
+        endif
+        namestruct%valid = .false.
+    end subroutine
+
+    !
+    ! F2008 implementation that allows for allocating a character array inside
+    !
+    ! subroutine adios2_available_variables(io, nvars, varnamelist, ierr)
+    !     type(adios2_io), intent(in) :: io
+    !     integer, intent(out) :: nvars
+    !     character(len=:), dimension(:), allocatable, intent(out) :: varnamelist
+    !     integer, intent(out) :: ierr
+
+    !     integer(kind=8):: namestruct
+    !     integer :: count, max_name_len
+
+    !     call adios2_available_variables_f2c(io%f2c, namestruct, count, &
+    !                     max_name_len, ierr)
+    !     if (ierr == 0) then
+    !         allocate(character(len=max_name_len) :: varnamelist(count))
+    !     endif
+
+    !     call adios2_retrieve_variable_names_f2c(namestruct, varnamelist, ierr)
+    !     nvars = count
+    ! end subroutine
 
 
     subroutine adios2_inquire_variable(variable, io, name, ierr)
@@ -233,25 +260,37 @@ contains
 
     end subroutine
 
-    subroutine adios2_available_attributes(io, nattrs, attrnamelist, ierr)
+    subroutine adios2_available_attributes(io, namestruct, ierr)
         type(adios2_io), intent(in) :: io
-        integer, intent(out) :: nattrs
-        character(len=:), dimension(:), allocatable, intent(out) :: attrnamelist
+        type(adios2_namestruct), intent(out) :: namestruct
         integer, intent(out) :: ierr
 
-        integer(kind=8):: namestruct
-        integer :: count, max_name_len
-
-        call adios2_available_attributes_f2c(io%f2c, namestruct, count, &
-                        max_name_len, ierr)
+        call adios2_available_attributes_f2c(io%f2c, namestruct%f2c, &
+                   namestruct%count,  namestruct%max_name_len, ierr)
         if (ierr == 0) then
-            allocate(character(len=max_name_len) :: attrnamelist(count))
+            namestruct%valid = .true.
         endif
-
-        call adios2_retrieve_attribute_names_f2c(namestruct, count, &
-                        max_name_len, attrnamelist, ierr)
-        nattrs = count
     end subroutine
+
+    ! subroutine adios2_available_attributes(io, nattrs, attrnamelist, ierr)
+    !     type(adios2_io), intent(in) :: io
+    !     integer, intent(out) :: nattrs
+    !     character(len=:), dimension(:), allocatable, intent(out) :: attrnamelist
+    !     integer, intent(out) :: ierr
+
+    !     integer(kind=8):: namestruct
+    !     integer :: count, max_name_len
+
+    !     call adios2_available_attributes_f2c(io%f2c, namestruct, count, &
+    !                     max_name_len, ierr)
+    !     if (ierr == 0) then
+    !         allocate(character(len=max_name_len) :: attrnamelist(count))
+    !     endif
+
+    !     call adios2_retrieve_attribute_names_f2c(namestruct, count, &
+    !                     max_name_len, attrnamelist, ierr)
+    !     nattrs = count
+    ! end subroutine
 
     subroutine adios2_inquire_attribute(attribute, io, name, ierr)
         type(adios2_attribute), intent(out) :: attribute

--- a/bindings/Fortran/modules/adios2_io_mod.f90
+++ b/bindings/Fortran/modules/adios2_io_mod.f90
@@ -24,6 +24,9 @@ module adios2_io_mod
     external adios2_get_parameter_f2c
     external adios2_get_parameter_length_f2c
     external adios2_in_config_file_f2c
+    external adios2_available_variables_f2c
+    external adios2_available_attributes_f2c
+    external adios2_retrieve_namelist_f2c
     external adios2_inquire_attribute_f2c
     external adios2_inquire_variable_f2c
     external adios2_io_engine_type_f2c

--- a/bindings/Fortran/modules/adios2_parameters_mod.f90
+++ b/bindings/Fortran/modules/adios2_parameters_mod.f90
@@ -127,4 +127,11 @@ module adios2_parameters_mod
         character(len=64):: type = ''
     end type
 
+    type adios2_namestruct
+        integer(kind=8):: f2c = 0_8
+        logical :: valid = .false.
+        integer :: count
+        integer :: max_name_len
+    end type
+
 end module

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - adios2-openmpi
   - sphinx
   - breathe=4.18.1
+  - funcparserlib>=0.3.6
   - pip
   - pip:
     - blockdiag>=1.5.4

--- a/testing/adios2/bindings/fortran/TestBPWriteTypes.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypes.F90
@@ -28,7 +28,6 @@ program TestBPWriteTypes
 
      character(len=4096), dimension(:), allocatable :: varnamelist
      type(adios2_namestruct) :: namestruct
-     integer :: nvars
 
 #if ADIOS2_USE_MPI
      ! Launch MPI

--- a/testing/adios2/bindings/fortran/TestBPWriteTypes.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypes.F90
@@ -26,7 +26,8 @@ program TestBPWriteTypes
      integer(kind=4) :: ndims
      integer(kind=8), dimension(:), allocatable :: shape_in
 
-     character(len=:), dimension(:), allocatable :: varnamelist
+     character(len=4096), dimension(:), allocatable :: varnamelist
+     type(adios2_namestruct) :: namestruct
      integer :: nvars
 
 #if ADIOS2_USE_MPI
@@ -235,14 +236,24 @@ program TestBPWriteTypes
      call adios2_steps(nsteps, bpReader, ierr)
      if(nsteps /= 3) stop 'ftypes.bp must have 3 steps'
 
-     call adios2_available_variables(ioRead, nvars, varnamelist, ierr)
+     call adios2_available_variables(ioRead, namestruct, ierr)
      if (ierr /= 0) stop 'adios2_available_variables returned with error'
-     write(*,*) 'Number of variables = ', nvars
-     if (nvars /= 14) stop 'adios2_available_variables returned not the expected 14'
-     do i=1,nvars
+     if (.not.namestruct%valid) stop 'adios2_available_variables returned invalid struct'
+     write(*,*) 'Number of variables = ', namestruct%count
+     write(*,*) 'Max name length = ', namestruct%max_name_len
+     if (namestruct%count /= 14) stop 'adios2_available_variables returned not the expected 14'
+
+     allocate(varnamelist(namestruct%count))
+
+     call adios2_retrieve_names(namestruct, varnamelist, ierr)
+     if (ierr /= 0) stop 'adios2_retrieve_names returned with error'
+     do i=1,namestruct%count
           write(*,'("Var[",i2,"] = ",a12)') i, varnamelist(i)
      end do
      deallocate(varnamelist)
+
+     if (namestruct%f2c /= 0_8) stop 'namestruct f2c pointer is not null after adios2_retrieve_names()'
+     if (namestruct%valid) stop 'namestruct is not invalidated after adios2_retrieve_names()'
 
 
      call adios2_inquire_variable(variables(1), ioRead, "var_I8", ierr)


### PR DESCRIPTION
…e_variables() and adios2_available_attributes return a struct, user has to allocate character array and call adios2_retrieve_names() to fill the array with the names.

Fixes #2847 