### PR TITLE
Remove operations functionality in C Fortran

### DIFF
--- a/bindings/C/adios2/c/adios2_c_variable.cpp
+++ b/bindings/C/adios2/c/adios2_c_variable.cpp
@@ -540,6 +540,25 @@ adios2_error adios2_set_operation_parameter(adios2_variable *variable,
     }
 }
 
+adios2_error adios2_remove_operations(adios2_variable *variable)
+{
+    try
+    {
+        adios2::helper::CheckForNullptr(variable,
+                                        "for adios2_variable, in call to "
+                                        "adios2_remove_operations");
+        adios2::core::VariableBase *variableBase =
+            reinterpret_cast<adios2::core::VariableBase *>(variable);
+        variableBase->RemoveOperations();
+        return adios2_error_none;
+    }
+    catch (...)
+    {
+        return static_cast<adios2_error>(
+            adios2::helper::ExceptionToError("adios2_remove_operations"));
+    }
+}
+
 adios2_error adios2_variable_min(void *min, const adios2_variable *variable)
 {
     try

--- a/bindings/C/adios2/c/adios2_c_variable.h
+++ b/bindings/C/adios2/c/adios2_c_variable.h
@@ -229,6 +229,14 @@ adios2_error adios2_set_operation_parameter(adios2_variable *variable,
                                             const char *key, const char *value);
 
 /**
+ * Removes all current Operations associated with AddOperation.
+ * Provides the posibility to apply or not operators on a block basis.
+ * @param variable handler on which operation is applied to
+ * @return adios2_error 0: success, see enum adios2_error for errors
+ */
+adios2_error adios2_remove_operations(adios2_variable *variable);
+
+/**
  * Read mode only: return the absolute minimum for current variable
  * @param min output: variable minimum, must be of the same type as the variable
  * handler

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -300,7 +300,7 @@ public:
 
     /**
      * Removes all current Operations associated with AddOperation.
-     * Provides the posibility to apply or not operators on a step basis.
+     * Provides the posibility to apply or not operators on a block basis.
      */
     void RemoveOperations();
 

--- a/bindings/Fortran/f2c/adios2_f2c_variable.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_variable.cpp
@@ -322,6 +322,13 @@ void FC_GLOBAL(adios2_set_operation_parameter_f2c,
     }
 }
 
+void FC_GLOBAL(adios2_remove_operations_f2c,
+               ADIOS2_REMOVE_OPERATIONS_F2C)(adios2_variable **variable,
+                                             int *ierr)
+{
+    *ierr = static_cast<int>(adios2_remove_operations(*variable));
+}
+
 void FC_GLOBAL(adios2_variable_min_f2c,
                ADIOS2_VARIABLE_MIN_F2C)(void *min,
                                         const adios2_variable **variable,

--- a/bindings/Fortran/modules/adios2_variable_mod.f90
+++ b/bindings/Fortran/modules/adios2_variable_mod.f90
@@ -12,6 +12,7 @@ module adios2_variable_mod
     use adios2_functions_mod
     implicit none
     external adios2_add_operation_f2c
+    external adios2_remove_operations_f2c
     external adios2_set_block_selection_f2c
     external adios2_set_memory_selection_f2c
     external adios2_set_operation_parameter_f2c
@@ -186,6 +187,13 @@ contains
                                                 TRIM(ADJUSTL(key))//char(0), &
                                                 TRIM(ADJUSTL(value))//char(0), &
                                                 ierr)
+    end subroutine
+
+    subroutine adios2_remove_operations(variable, ierr)
+        type(adios2_variable), intent(in):: variable
+        integer, intent(out):: ierr
+
+        call adios2_remove_operations_f2c(variable%f2c, ierr)
     end subroutine
 
 end module

--- a/testing/adios2/bindings/fortran/operation/CMakeLists.txt
+++ b/testing/adios2/bindings/fortran/operation/CMakeLists.txt
@@ -5,4 +5,5 @@ endif()
 
 if(ADIOS2_HAVE_ZFP)
   fortran_add_test_helper(BPWriteReadZfp2D MPI_ONLY)
+  fortran_add_test_helper(BPWriteReadZfp2DRemove MPI_ONLY)
 endif()

--- a/testing/adios2/bindings/fortran/operation/TestBPWriteReadZfp2DRemove.F90
+++ b/testing/adios2/bindings/fortran/operation/TestBPWriteReadZfp2DRemove.F90
@@ -1,0 +1,144 @@
+program TestBPWriteReadHeatMapZfp2DRemove
+  use mpi
+  use adios2
+
+  implicit none
+
+  type(adios2_adios) :: adios
+  type(adios2_io) :: ioPut, ioGet
+  type(adios2_engine) :: bpWriter, bpReader
+  type(adios2_variable), dimension(2) :: var_temperatures, var_temperaturesIn
+  type(adios2_operator) :: zfp_operator
+  integer:: operation_id
+  integer(kind=4) :: step_status, i, x,y
+
+  real(kind=4), dimension(:, :), allocatable :: temperatures_r4, &
+                                                sel_temperatures_r4
+
+  real(kind=8), dimension(:, :), allocatable :: temperatures_r8, &
+                                                sel_temperatures_r8
+
+  integer(kind=8), dimension(2) :: ishape, istart, icount
+  integer(kind=8), dimension(2) :: sel_start, sel_count
+  integer :: ierr, irank, isize
+  integer :: in1, in2
+  integer :: i1, i2
+
+  call MPI_INIT(ierr)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, irank, ierr)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, isize, ierr)
+
+  in1 = 10
+  in2 = 10
+
+  icount = (/in1, in2/)
+  istart = (/0, in2*irank/)
+  ishape = (/in1, in2*isize/)
+
+  allocate (temperatures_r4(in1, in2))
+  allocate (temperatures_r8(in1, in2))
+
+  temperatures_r4 = 1.0
+  temperatures_r8 = 1.0_8
+
+  ! Start adios2 Writer
+  call adios2_init(adios, MPI_COMM_WORLD, adios2_debug_mode_on, ierr)
+  
+  call adios2_define_operator(zfp_operator, adios, 'CompressorZfp', 'zfp', ierr)
+  call adios2_declare_io(ioPut, adios, 'HeatMapWrite', ierr)
+  
+  call adios2_define_variable(var_temperatures(1), ioPut, &
+                              'temperatures_r4', adios2_type_real, &
+                              2, ishape, istart, icount, &
+                              adios2_constant_dims, ierr)
+
+  call adios2_define_variable(var_temperatures(2), ioPut, &
+                              'temperatures_r8', adios2_type_dp, &
+                              2, ishape, istart, icount, &
+                              adios2_constant_dims, ierr)
+
+  call adios2_open(bpWriter, ioPut, 'HeatMapZfp2DRemove_f.bp', adios2_mode_write, &
+                   ierr)
+
+  do i=0,4
+
+    call adios2_begin_step(bpWriter, adios2_step_mode_append, -1.0, &
+                           step_status, ierr)
+    
+    if( mod(i,2) == 0 ) then
+      call adios2_add_operation(operation_id, var_temperatures(1), &
+                            zfp_operator, 'rate', '8', ierr)
+      if( operation_id /= 0 ) stop 'operation_id not added for real type'
+      
+      call adios2_add_operation(operation_id, var_temperatures(2), &
+                            zfp_operator, 'rate', '8', ierr)
+      if( operation_id /= 0 ) stop 'operation_id not added for dp type'
+                    
+    else
+      call adios2_remove_operations(var_temperatures(1), ierr)
+      call adios2_remove_operations(var_temperatures(2), ierr)
+    end if
+    
+    call adios2_put(bpWriter, var_temperatures(1), temperatures_r4, ierr)
+    call adios2_put(bpWriter, var_temperatures(2), temperatures_r8, ierr)
+
+    call adios2_end_step(bpWriter, ierr)
+  end do
+
+  call adios2_close(bpWriter, ierr)
+
+  if (allocated(temperatures_r4)) deallocate (temperatures_r4)
+  if (allocated(temperatures_r8)) deallocate (temperatures_r8)
+
+  ! Start adios2 Reader in rank 0
+  if (irank == 0) then
+
+    call adios2_declare_io(ioGet, adios, 'HeatMapRead', ierr)
+
+    call adios2_open(bpReader, ioGet, 'HeatMapZfp2DRemove_f.bp', &
+                     adios2_mode_read, MPI_COMM_SELF, ierr)
+
+    sel_start = (/0, 0/)
+    sel_count = (/ishape(1), ishape(2)/)
+
+    allocate (sel_temperatures_r4(sel_count(1), sel_count(2)))
+    allocate (sel_temperatures_r8(sel_count(1), sel_count(2)))
+
+    sel_temperatures_r4 = 0.0_4
+    sel_temperatures_r8 = 0.0_8
+    
+    do i=0,4
+      
+      call adios2_begin_step(bpReader, adios2_step_mode_read, -1.0, &
+                             step_status, ierr)  
+
+      call adios2_inquire_variable(var_temperaturesIn(1), ioGet, &
+                                 'temperatures_r4', ierr)
+      call adios2_inquire_variable(var_temperaturesIn(2), ioGet, &
+                                 'temperatures_r8', ierr)
+
+      call adios2_set_selection(var_temperaturesIn(1), 2, sel_start, sel_count, &
+                              ierr)
+      call adios2_set_selection(var_temperaturesIn(2), 2, sel_start, sel_count, &
+                              ierr)
+  
+      call adios2_get(bpReader, var_temperaturesIn(1), sel_temperatures_r4, ierr)
+      call adios2_get(bpReader, var_temperaturesIn(2), sel_temperatures_r8, ierr)
+      call adios2_end_step(bpReader, ierr)
+
+      if (sum(sel_temperatures_r4) /= 100*isize) stop 'Test failed real*4'
+      if (sum(sel_temperatures_r8) /= 100*isize) stop 'Test failed real*8'
+    
+    end do  
+
+    call adios2_close(bpReader, ierr)
+
+    if (allocated(sel_temperatures_r4)) deallocate (sel_temperatures_r4)
+    if (allocated(sel_temperatures_r8)) deallocate (sel_temperatures_r8)
+
+  end if
+
+  call adios2_finalize(adios, ierr)
+  call MPI_Finalize(ierr)
+
+end program TestBPWriteReadHeatMapZfp2DRemove


### PR DESCRIPTION
Extend current functionality in C++ API for `Variable<T>::RemoveOperations` to C and Fortran API `adios2_remove_operations`
Related to #2867
