### PR TITLE
reorder cmake build option messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 set(ADIOS2_CONFIG_OPTS
-    Blosc BZip2 ZFP SZ MGARD PNG CUDA MPI DataMan DAOS MHS SSC SST BP5 DataSpaces ZeroMQ HDF5 HDF5_VOL IME Python Fortran SysVShMem Profiling Endian_Reverse LIBPRESSIO
+    BP5 DataMan DataSpaces HDF5 HDF5_VOL MHS SSC SST CUDA Fortran MPI Python Blosc BZip2 LIBPRESSIO MGARD PNG SZ ZFP DAOS IME SysVShMem ZeroMQ Profiling Endian_Reverse
 )
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})
 configure_file(


### PR DESCRIPTION
As we have more and more build options, the cmake output is getting a little confusing. This PR is to reorder the build option output in the order of ADIOS2 engines, languages/programming envs, operators, transports, and others. Items in each category are in alphabetic order. 