### PR TITLE
CUDA: encapsulate cuda interface dependency

### DIFF
--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -23,6 +23,11 @@
 #include "adios2/helper/adiosFunctions.h" //helper::GetTotalSize
 #include "adios2/helper/adiosString.h"
 
+#ifdef ADIOS2_HAVE_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
 namespace adios2
 {
 namespace core

--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -15,6 +15,11 @@
 
 #include "adios2/helper/adiosType.h"
 
+#ifdef ADIOS2_HAVE_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
 namespace adios2
 {
 namespace helper
@@ -306,6 +311,13 @@ uint64_t PaddingToAlignOffset(uint64_t offset, uint64_t alignment_size)
     }
     return padSize;
 }
+
+#ifdef ADIOS2_HAVE_CUDA
+void MemcpyGPUToBuffer(void *dst, const char *src, size_t byteCount)
+{
+    cudaMemcpy(dst, src, byteCount, cudaMemcpyDeviceToHost);
+}
+#endif
 
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -39,13 +39,18 @@ template <class T>
 void InsertToBuffer(std::vector<char> &buffer, const T *source,
                     const size_t elements = 1) noexcept;
 
+#ifdef ADIOS2_HAVE_CUDA
 /*
  * Copies data from a GPU buffer to a specific location in the adios buffer
  */
-#ifdef ADIOS2_HAVE_CUDA
 template <class T>
 void CopyFromGPUToBuffer(std::vector<char> &buffer, size_t &position,
                          const T *source, const size_t elements = 1) noexcept;
+
+/**
+ * Wrapper around cudaMemcpy needed for isolating CUDA interface dependency
+ */
+void MemcpyGPUToBuffer(void *dst, const char *src, size_t byteCount);
 #endif
 
 /**

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -20,10 +20,6 @@
 #include <iostream>
 #include <thread>
 /// \endcond
-#ifdef ADIOS2_HAVE_CUDA
-#include <cuda.h>
-#include <cuda_runtime.h>
-#endif
 
 #include "adios2/helper/adiosMath.h"
 #include "adios2/helper/adiosSystem.h"
@@ -84,8 +80,7 @@ void CopyFromGPUToBuffer(std::vector<char> &buffer, size_t &position,
                          const T *source, const size_t elements) noexcept
 {
     const char *src = reinterpret_cast<const char *>(source);
-    cudaMemcpy(buffer.data() + position, src, elements * sizeof(T),
-               cudaMemcpyDeviceToHost);
+    MemcpyGPUToBuffer(buffer.data() + position, src, elements * sizeof(T));
     position += elements * sizeof(T);
 }
 #endif


### PR DESCRIPTION
Fixes #2911

~~It includes the cuda toolkit headers directories as include path for CXX files. This is intended since CXX sources should be able to include `cuda.h`~~

CUDA: encapsulate cuda interface dependency