### PR TITLE
h5vol: remove forced SHARED build to respect BUILD_SHARED_LIBS option

### DIFF
--- a/source/h5vol/CMakeLists.txt
+++ b/source/h5vol/CMakeLists.txt
@@ -3,7 +3,7 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-add_library(adios2_h5vol SHARED
+add_library(adios2_h5vol
   H5VolReadWrite.c
   H5Vol.c
   H5VolUtil.c


### PR DESCRIPTION
This fixes #2917.