### PR TITLE
CMAKE: add check for ZFP_CUDA

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -95,6 +95,30 @@ elseif(ADIOS2_USE_ZFP)
 endif()
 if(ZFP_FOUND)
   set(ADIOS2_HAVE_ZFP TRUE)
+  set(ADIOS2_HAVE_ZFP_CUDA ${ZFP_CUDA})
+
+  # Older versions of ZFP
+  if(NOT ADIOS2_HAVE_ZFP_CUDA)
+    get_target_property(ZFP_INCLUDE_DIRECTORIES zfp::zfp INTERFACE_INCLUDE_DIRECTORIES)
+    set(CMAKE_REQUIRED_INCLUDES ${ZFP_INCLUDE_DIRECTORIES})
+    set(CMAKE_REQUIRED_LIBRARIES zfp::zfp)
+    include(CheckCSourceRuns)
+    check_c_source_runs("
+    #include <zfp.h>
+
+    int main()
+    {
+      zfp_stream* stream = zfp_stream_open(NULL);
+      return !zfp_stream_set_execution(stream, zfp_exec_cuda);
+    }"
+    ADIOS2_HAVE_ZFP_CUDA)
+    unset(CMAKE_REQUIRED_INCLUDES)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+  endif()
+
+  if(ADIOS2_HAVE_ZFP_CUDA)
+    add_compile_definitions(ADIOS2_HAVE_ZFP_CUDA)
+  endif()
 endif()
 
 # SZ

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -312,7 +312,9 @@ constexpr char precision[] = "precision";
 
 namespace value
 {
+#ifdef ADIOS2_HAVE_ZFP_CUDA
 constexpr char backend_cuda[] = "cuda";
+#endif
 constexpr char backend_omp[] = "omp";
 constexpr char backend_serial[] = "serial";
 }

--- a/source/adios2/operator/compress/CompressZFP.h
+++ b/source/adios2/operator/compress/CompressZFP.h
@@ -12,10 +12,6 @@
 #ifndef ADIOS2_TRANSFORM_COMPRESS_COMPRESSZFP_H_
 #define ADIOS2_TRANSFORM_COMPRESS_COMPRESSZFP_H_
 
-extern "C" {
-#include <zfp.h>
-}
-
 #include "adios2/core/Operator.h"
 
 namespace adios2
@@ -61,28 +57,6 @@ public:
     bool IsDataTypeValid(const DataType type) const final;
 
 private:
-    /**
-     * Returns Zfp supported zfp_type based on adios string type
-     * @param type adios type as string, see GetDataType<T> in
-     * helper/adiosType.inl
-     * @return zfp_type
-     */
-    zfp_type GetZfpType(DataType type) const;
-
-    /**
-     * Constructor Zfp zfp_field based on input information around the data
-     * pointer
-     * @param data
-     * @param shape
-     * @param type
-     * @return zfp_field*
-     */
-    zfp_field *GetZFPField(const char *data, const Dims &shape,
-                           DataType type) const;
-
-    zfp_stream *GetZFPStream(const Dims &dimensions, DataType type,
-                             const Params &parameters) const;
-
     /**
      * Decompress function for V1 buffer. Do NOT remove even if the buffer
      * version is updated. Data might be still in lagacy formats. This function

--- a/testing/adios2/engine/bp/operations/CMakeLists.txt
+++ b/testing/adios2/engine/bp/operations/CMakeLists.txt
@@ -30,7 +30,7 @@ if(ADIOS2_HAVE_ZFP)
       )
   endforeach()
 
-  if(ADIOS2_HAVE_CUDA)
+  if(ADIOS2_HAVE_CUDA AND ADIOS2_HAVE_ZFP_CUDA)
     enable_language(CUDA)
 
     gtest_add_tests_helper(WriteReadZfpCuda MPI_ALLOW BP Engine.BP. .BP4


### PR DESCRIPTION
In the previous PR #2920 which added among other things tests for ZFP with CUDA it does not check if the current ZFP installation supports ZFP. 

For this purpose I added a PR at the ZFP which adds a parameter to see this (https://github.com/LLNL/zfp/pull/147).

While this has been merged to keep compatibility to previous commits of ZFP I added some logic at our cmake code to figure out if we have ZFP_CUDA.

__EDITED__

I made some refactor at the compressZFP so that it moves out the include from the header to the implementation file, also I changed some of the defines provide from ZFP to more stable ones. 

I also made the code compatible for ZFP 0.5.1 (the one that we publicly support) to 0.5.5 (latest).