### PR TITLE
Adding documentation for using Cuda buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,7 @@ message("    ${CMAKE_CXX_COMPILER}")
 message("")
 if(ADIOS2_HAVE_CUDA)
 	message("  Cuda Compiler : ${CMAKE_CUDA_COMPILER} ")
+	message("    Cuda Architecture : ${CMAKE_CUDA_ARCHITECTURES} ")
 endif()
 if(ADIOS2_HAVE_Fortran)
   message("  Fortran Compiler : ${CMAKE_Fortran_COMPILER_ID} "

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -148,7 +148,9 @@ public:
     explicit operator bool() const noexcept;
 
     /**
-     * Sets the memory step for all following Puts
+     * Sets the memory space for all following Puts
+     * to either host (default) or device (currently only CUDA supported)
+     * @param mem memory space where Put buffers are allocated
      */
     void SetMemorySpace(const MemorySpace mem);
 

--- a/docs/user_guide/source/components/engine.rst
+++ b/docs/user_guide/source/components/engine.rst
@@ -290,6 +290,19 @@ Only use it if absolutely necessary (*e.g.* memory bound application or out of s
          // var4 = { 2, 2, 2};
 
 
+The ``data`` fed to the ``Put`` function is assumed to be allocated on the Host (default mode). In order to use data allocated on the device, the memory space of the variable needs to be set to Cuda.
+
+     .. code-block:: c++
+
+         variable.SetMemorySpace(adios2::MemorySpace::CUDA);
+         engine.Put(variable, gpuData, mode);
+
+.. note::
+
+   Only CUDA allocated buffers are supported for device data.
+   Only the BP4 engine is capable of receiving device allocated buffers.
+
+
 PerformsPuts
 ------------
 


### PR DESCRIPTION
1. Cmake output for the cuda architecture will (hopefully) prevent users from trying to run on a different architecture than the default one (set to V100 for Summit runs) without setting the correct `CMAKE_CUDA_ARCHITECTURES`

2. Minimal text on the limitations and how to device buffers for readthedocs 