### PR TITLE
Add adiosLog in helper for better looking output

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(adios2_core
   helper/adiosXMLUtil.cpp
   helper/adiosYAML.cpp
   helper/adiosCUDA.cu
+  helper/adiosLog.cpp
 
 #engine derived classes
   engine/bp3/BP3Reader.cpp engine/bp3/BP3Reader.tcc

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -516,9 +516,6 @@ protected:
      *  if no communicator is passed */
     helper::Comm m_Comm;
 
-    /** added to exceptions to improve debugging */
-    std::string m_EndMessage;
-
     /** keeps track of current advance status */
     StepStatus m_AdvanceStatus = StepStatus::OK;
 

--- a/source/adios2/engine/bp3/BP3Reader.cpp
+++ b/source/adios2/engine/bp3/BP3Reader.cpp
@@ -135,8 +135,7 @@ void BP3Reader::Init()
     if (m_OpenMode != Mode::Read)
     {
         throw std::invalid_argument(
-            "ERROR: BPFileReader only supports OpenMode::Read from" + m_Name +
-            " " + m_EndMessage);
+            "ERROR: BPFileReader only supports OpenMode::Read from" + m_Name);
     }
 
     // if IO was involved in reading before this flag may be true now

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -32,7 +32,6 @@ BP3Writer::BP3Writer(IO &io, const std::string &name, const Mode mode,
 {
     PERFSTUBS_SCOPED_TIMER("BP3Writer::Open");
     m_IO.m_ReadStreaming = false;
-    m_EndMessage = " in call to IO Open BPFileWriter " + m_Name + "\n";
     Init();
 }
 

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -30,7 +30,8 @@ BP4Reader::BP4Reader(IO &io, const std::string &name, const Mode mode,
   m_MDIndexFileManager(m_Comm), m_ActiveFlagFileManager(m_Comm)
 {
     PERFSTUBS_SCOPED_TIMER("BP4Reader::Open");
-    helper::Log("Engine", "BP4Reader", "BP4Reader", m_Name, 0, m_Comm.Rank(), 5,
+    helper::GetParameter(m_IO.m_Parameters, "Verbose", m_Verbosity);
+    helper::Log("Engine", "BP4Reader", "Open", m_Name, 0, m_Comm.Rank(), 5,
                 m_Verbosity, helper::LogMode::OUTPUT);
     Init();
 }
@@ -165,7 +166,6 @@ void BP4Reader::PerformGets()
 // PRIVATE
 void BP4Reader::Init()
 {
-    helper::GetParameter(m_IO.m_Parameters, "Verbose", m_Verbosity);
     if (m_OpenMode != Mode::Read)
     {
         throw std::invalid_argument("ERROR: BPFileReader only "
@@ -792,6 +792,8 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 void BP4Reader::DoClose(const int transportIndex)
 {
     PERFSTUBS_SCOPED_TIMER("BP4Reader::Close");
+    helper::Log("Engine", "BP4Reader", "Close", m_Name, 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
     PerformGets();
     m_DataFileManager.CloseFiles();
     m_MDFileManager.CloseFiles();

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -32,7 +32,7 @@ BP4Reader::BP4Reader(IO &io, const std::string &name, const Mode mode,
     PERFSTUBS_SCOPED_TIMER("BP4Reader::Open");
     helper::GetParameter(m_IO.m_Parameters, "Verbose", m_Verbosity);
     helper::Log("Engine", "BP4Reader", "Open", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
     Init();
 }
 
@@ -41,7 +41,7 @@ StepStatus BP4Reader::BeginStep(StepMode mode, const float timeoutSeconds)
     PERFSTUBS_SCOPED_TIMER("BP4Reader::BeginStep");
     helper::Log("Engine", "BP4Reader", "BeginStep",
                 std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
-                helper::LogMode::OUTPUT);
+                helper::LogMode::INFO);
 
     if (mode != StepMode::Read)
     {
@@ -116,7 +116,7 @@ size_t BP4Reader::CurrentStep() const { return m_CurrentStep; }
 void BP4Reader::EndStep()
 {
     helper::Log("Engine", "BP4Reader", "EndStep", std::to_string(CurrentStep()),
-                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);
+                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);
     if (!m_BetweenStepPairs)
     {
         throw std::logic_error(
@@ -131,7 +131,7 @@ void BP4Reader::PerformGets()
 {
     PERFSTUBS_SCOPED_TIMER("BP4Reader::PerformGets");
     helper::Log("Engine", "BP4Reader", "PerformGets", "", 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
     if (m_BP4Deserializer.m_DeferredVariables.empty())
     {
         return;
@@ -776,14 +776,14 @@ StepStatus BP4Reader::CheckForNewSteps(Seconds timeoutSeconds)
     {                                                                          \
         PERFSTUBS_SCOPED_TIMER("BP4Reader::Get");                              \
         helper::Log("Engine", "BP4Reader", "GetSync", variable.m_Name, 0,      \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         GetSyncCommon(variable, data);                                         \
     }                                                                          \
     void BP4Reader::DoGetDeferred(Variable<T> &variable, T *data)              \
     {                                                                          \
         PERFSTUBS_SCOPED_TIMER("BP4Reader::Get");                              \
         helper::Log("Engine", "BP4Reader", "GetDeferred", variable.m_Name, 0,  \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         GetDeferredCommon(variable, data);                                     \
     }
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
@@ -793,7 +793,7 @@ void BP4Reader::DoClose(const int transportIndex)
 {
     PERFSTUBS_SCOPED_TIMER("BP4Reader::Close");
     helper::Log("Engine", "BP4Reader", "Close", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
     PerformGets();
     m_DataFileManager.CloseFiles();
     m_MDFileManager.CloseFiles();

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -30,12 +30,18 @@ BP4Reader::BP4Reader(IO &io, const std::string &name, const Mode mode,
   m_MDIndexFileManager(m_Comm), m_ActiveFlagFileManager(m_Comm)
 {
     PERFSTUBS_SCOPED_TIMER("BP4Reader::Open");
+    helper::Log("Engine", "BP4Reader", "BP4Reader", m_Name, 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
     Init();
 }
 
 StepStatus BP4Reader::BeginStep(StepMode mode, const float timeoutSeconds)
 {
     PERFSTUBS_SCOPED_TIMER("BP4Reader::BeginStep");
+    helper::Log("Engine", "BP4Reader", "BeginStep",
+                std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
+                helper::LogMode::OUTPUT);
+
     if (mode != StepMode::Read)
     {
         throw std::invalid_argument("ERROR: mode is not supported yet, "
@@ -108,6 +114,8 @@ size_t BP4Reader::CurrentStep() const { return m_CurrentStep; }
 
 void BP4Reader::EndStep()
 {
+    helper::Log("Engine", "BP4Reader", "EndStep", std::to_string(CurrentStep()),
+                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);
     if (!m_BetweenStepPairs)
     {
         throw std::logic_error(
@@ -121,6 +129,8 @@ void BP4Reader::EndStep()
 void BP4Reader::PerformGets()
 {
     PERFSTUBS_SCOPED_TIMER("BP4Reader::PerformGets");
+    helper::Log("Engine", "BP4Reader", "PerformGets", "", 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
     if (m_BP4Deserializer.m_DeferredVariables.empty())
     {
         return;
@@ -155,11 +165,12 @@ void BP4Reader::PerformGets()
 // PRIVATE
 void BP4Reader::Init()
 {
+    helper::GetParameter(m_IO.m_Parameters, "Verbose", m_Verbosity);
     if (m_OpenMode != Mode::Read)
     {
         throw std::invalid_argument("ERROR: BPFileReader only "
                                     "supports OpenMode::Read from" +
-                                    m_Name + " " + m_EndMessage);
+                                    m_Name);
     }
     // if IO was involved in reading before this flag may be true now
     m_IO.m_ReadStreaming = false;
@@ -764,11 +775,15 @@ StepStatus BP4Reader::CheckForNewSteps(Seconds timeoutSeconds)
     void BP4Reader::DoGetSync(Variable<T> &variable, T *data)                  \
     {                                                                          \
         PERFSTUBS_SCOPED_TIMER("BP4Reader::Get");                              \
+        helper::Log("Engine", "BP4Reader", "GetSync", variable.m_Name, 0,      \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
         GetSyncCommon(variable, data);                                         \
     }                                                                          \
     void BP4Reader::DoGetDeferred(Variable<T> &variable, T *data)              \
     {                                                                          \
         PERFSTUBS_SCOPED_TIMER("BP4Reader::Get");                              \
+        helper::Log("Engine", "BP4Reader", "GetDeferred", variable.m_Name, 0,  \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
         GetDeferredCommon(variable, data);                                     \
     }
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -84,6 +84,8 @@ private:
     bool m_FirstStep = true;
     bool m_IdxHeaderParsed = false; // true after first index parsing
 
+    int m_Verbosity = 0;
+
     void Init();
     void InitTransports();
 

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -34,8 +34,11 @@ BP4Writer::BP4Writer(IO &io, const std::string &name, const Mode mode,
   m_FileMetadataIndexManager(m_Comm), m_FileDrainer()
 {
     PERFSTUBS_SCOPED_TIMER("BP4Writer::Open");
+    helper::GetParameter(m_IO.m_Parameters, "Verbose", m_Verbosity);
+    helper::Log("Engine", "BP4Writer", "Open", m_Name, 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
+
     m_IO.m_ReadStreaming = false;
-    m_EndMessage = " in call to IO Open BP4Writer " + m_Name + "\n";
 
     Init();
 }
@@ -43,6 +46,10 @@ BP4Writer::BP4Writer(IO &io, const std::string &name, const Mode mode,
 StepStatus BP4Writer::BeginStep(StepMode mode, const float timeoutSeconds)
 {
     PERFSTUBS_SCOPED_TIMER("BP4Writer::BeginStep");
+    helper::Log("Engine", "BP4Writer", "BeginStep",
+                std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
+                helper::LogMode::OUTPUT);
+
     m_BP4Serializer.m_DeferredVariables.clear();
     m_BP4Serializer.m_DeferredVariablesDataSize = 0;
     m_IO.m_ReadStreaming = false;
@@ -57,6 +64,9 @@ size_t BP4Writer::CurrentStep() const
 void BP4Writer::PerformPuts()
 {
     PERFSTUBS_SCOPED_TIMER("BP4Writer::PerformPuts");
+    helper::Log("Engine", "BP4Writer", "PerformPuts", "", 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
+
     if (m_BP4Serializer.m_DeferredVariables.empty())
     {
         return;
@@ -90,6 +100,9 @@ void BP4Writer::PerformPuts()
 void BP4Writer::EndStep()
 {
     PERFSTUBS_SCOPED_TIMER("BP4Writer::EndStep");
+    helper::Log("Engine", "BP4Writer", "EndStep", std::to_string(CurrentStep()),
+                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);
+
     if (m_BP4Serializer.m_DeferredVariables.size() > 0)
     {
         PerformPuts();
@@ -140,6 +153,8 @@ void BP4Writer::Init()
                           const bool initialize, const T &value)               \
     {                                                                          \
         PERFSTUBS_SCOPED_TIMER("BP4Writer::Put");                              \
+        helper::Log("Engine", "BP4Writer", "Put", variable.m_Name, 0,          \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
         PutCommon(variable, span, 0, value);                                   \
     }
 
@@ -149,11 +164,17 @@ ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
 #define declare_type(T)                                                        \
     void BP4Writer::DoPutSync(Variable<T> &variable, const T *data)            \
     {                                                                          \
+        PERFSTUBS_SCOPED_TIMER("BP4Writer::Put");                              \
+        helper::Log("Engine", "BP4Writer", "PutSync", variable.m_Name, 0,      \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
         PutSyncCommon(variable, variable.SetBlockInfo(data, CurrentStep()));   \
         variable.m_BlocksInfo.pop_back();                                      \
     }                                                                          \
     void BP4Writer::DoPutDeferred(Variable<T> &variable, const T *data)        \
     {                                                                          \
+        PERFSTUBS_SCOPED_TIMER("BP4Writer::Put");                              \
+        helper::Log("Engine", "BP4Writer", "PutDeferred", variable.m_Name, 0,  \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
         PutDeferredCommon(variable, data);                                     \
     }
 
@@ -424,6 +445,9 @@ void BP4Writer::DoFlush(const bool isFinal, const int transportIndex)
 void BP4Writer::DoClose(const int transportIndex)
 {
     PERFSTUBS_SCOPED_TIMER("BP4Writer::Close");
+    helper::Log("Engine", "BP4Writer", "Close", m_Name, 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
+
     if (m_BP4Serializer.m_DeferredVariables.size() > 0)
     {
         PerformPuts();

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -36,7 +36,7 @@ BP4Writer::BP4Writer(IO &io, const std::string &name, const Mode mode,
     PERFSTUBS_SCOPED_TIMER("BP4Writer::Open");
     helper::GetParameter(m_IO.m_Parameters, "Verbose", m_Verbosity);
     helper::Log("Engine", "BP4Writer", "Open", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     m_IO.m_ReadStreaming = false;
 
@@ -48,7 +48,7 @@ StepStatus BP4Writer::BeginStep(StepMode mode, const float timeoutSeconds)
     PERFSTUBS_SCOPED_TIMER("BP4Writer::BeginStep");
     helper::Log("Engine", "BP4Writer", "BeginStep",
                 std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
-                helper::LogMode::OUTPUT);
+                helper::LogMode::INFO);
 
     m_BP4Serializer.m_DeferredVariables.clear();
     m_BP4Serializer.m_DeferredVariablesDataSize = 0;
@@ -65,7 +65,7 @@ void BP4Writer::PerformPuts()
 {
     PERFSTUBS_SCOPED_TIMER("BP4Writer::PerformPuts");
     helper::Log("Engine", "BP4Writer", "PerformPuts", "", 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     if (m_BP4Serializer.m_DeferredVariables.empty())
     {
@@ -101,7 +101,7 @@ void BP4Writer::EndStep()
 {
     PERFSTUBS_SCOPED_TIMER("BP4Writer::EndStep");
     helper::Log("Engine", "BP4Writer", "EndStep", std::to_string(CurrentStep()),
-                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);
+                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);
 
     if (m_BP4Serializer.m_DeferredVariables.size() > 0)
     {
@@ -154,7 +154,7 @@ void BP4Writer::Init()
     {                                                                          \
         PERFSTUBS_SCOPED_TIMER("BP4Writer::Put");                              \
         helper::Log("Engine", "BP4Writer", "Put", variable.m_Name, 0,          \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         PutCommon(variable, span, 0, value);                                   \
     }
 
@@ -166,7 +166,7 @@ ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
     {                                                                          \
         PERFSTUBS_SCOPED_TIMER("BP4Writer::Put");                              \
         helper::Log("Engine", "BP4Writer", "PutSync", variable.m_Name, 0,      \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         PutSyncCommon(variable, variable.SetBlockInfo(data, CurrentStep()));   \
         variable.m_BlocksInfo.pop_back();                                      \
     }                                                                          \
@@ -174,7 +174,7 @@ ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type)
     {                                                                          \
         PERFSTUBS_SCOPED_TIMER("BP4Writer::Put");                              \
         helper::Log("Engine", "BP4Writer", "PutDeferred", variable.m_Name, 0,  \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         PutDeferredCommon(variable, data);                                     \
     }
 
@@ -446,7 +446,7 @@ void BP4Writer::DoClose(const int transportIndex)
 {
     PERFSTUBS_SCOPED_TIMER("BP4Writer::Close");
     helper::Log("Engine", "BP4Writer", "Close", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     if (m_BP4Serializer.m_DeferredVariables.size() > 0)
     {

--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -88,6 +88,8 @@ private:
     std::vector<std::string> m_DrainMetadataIndexFileNames;
     std::vector<std::string> m_ActiveFlagFileNames;
 
+    int m_Verbosity = 0;
+
     void Init() final;
 
     /** Parses parameters from IO SetParameters */

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -238,7 +238,7 @@ void BP5Reader::Init()
         throw std::invalid_argument(
             "ERROR: BPFileReader only "
             "supports OpenMode::Read or OpenMode::ReadRandomAccess from" +
-            m_Name + " " + m_EndMessage);
+            m_Name);
     }
 
     // if IO was involved in reading before this flag may be true now

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -38,7 +38,6 @@ BP5Writer::BP5Writer(IO &io, const std::string &name, const Mode mode,
 {
     PERFSTUBS_SCOPED_TIMER("BP5Writer::Open");
     m_IO.m_ReadStreaming = false;
-    m_EndMessage = " in call to IO Open BP5Writer " + m_Name + "\n";
 
     Init();
 }

--- a/source/adios2/engine/dataman/DataManReader.cpp
+++ b/source/adios2/engine/dataman/DataManReader.cpp
@@ -37,7 +37,7 @@ DataManReader::DataManReader(IO &io, const std::string &name,
                          m_ReceiverBufferSize);
 
     helper::Log("Engine", "DataManReader", "Open", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     if (m_IPAddress.empty())
     {
@@ -129,7 +129,7 @@ StepStatus DataManReader::BeginStep(StepMode stepMode,
 {
     helper::Log("Engine", "DataManReader", "BeginStep",
                 std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
-                helper::LogMode::OUTPUT);
+                helper::LogMode::INFO);
 
     float timeout = timeoutSeconds;
 
@@ -142,7 +142,7 @@ StepStatus DataManReader::BeginStep(StepMode stepMode,
     {
         helper::Log("Engine", "DataManReader", "BeginStep",
                     "EndOfStream, final step is " + std::to_string(m_FinalStep),
-                    0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);
+                    0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);
 
         return StepStatus::EndOfStream;
     }
@@ -154,7 +154,7 @@ StepStatus DataManReader::BeginStep(StepMode stepMode,
     {
         helper::Log("Engine", "DataManReader", "BeginStep",
                     "EndOfStream due to timeout", 0, m_Comm.Rank(), 5,
-                    m_Verbosity, helper::LogMode::OUTPUT);
+                    m_Verbosity, helper::LogMode::INFO);
         return StepStatus::EndOfStream;
     }
 
@@ -320,14 +320,13 @@ void DataManReader::SubscribeThread()
     void DataManReader::DoGetSync(Variable<T> &variable, T *data)              \
     {                                                                          \
         helper::Log("Engine", "DataManReader", "GetSync", variable.m_Name, 0,  \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         GetSyncCommon(variable, data);                                         \
     }                                                                          \
     void DataManReader::DoGetDeferred(Variable<T> &variable, T *data)          \
     {                                                                          \
         helper::Log("Engine", "DataManReader", "GetDeferred", variable.m_Name, \
-                    0, m_Comm.Rank(), 5, m_Verbosity,                          \
-                    helper::LogMode::OUTPUT);                                  \
+                    0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);  \
         GetDeferredCommon(variable, data);                                     \
     }                                                                          \
     std::map<size_t, std::vector<typename Variable<T>::BPInfo>>                \

--- a/source/adios2/engine/dataman/DataManWriter.cpp
+++ b/source/adios2/engine/dataman/DataManWriter.cpp
@@ -45,13 +45,18 @@ DataManWriter::DataManWriter(IO &io, const std::string &name,
     helper::GetParameter(m_IO.m_Parameters, "CombiningSteps", m_CombiningSteps);
     helper::GetParameter(m_IO.m_Parameters, "FloatAccuracy", m_FloatAccuracy);
 
+    helper::Log("Engine", "DataManWriter", "Open", m_Name, 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
+
     m_HandshakeJson["Threading"] = m_Threading;
     m_HandshakeJson["Transport"] = m_TransportMode;
     m_HandshakeJson["FloatAccuracy"] = m_FloatAccuracy;
 
     if (m_IPAddress.empty())
     {
-        throw(std::invalid_argument("IP address not specified"));
+        helper::Log("Engine", "DataManWriter", "Open",
+                    "IP address not specified", 0, m_Comm.Rank(), 0,
+                    m_Verbosity, helper::LogMode::EXCEPTION);
     }
 
     if (m_MonitorActive)
@@ -127,10 +132,9 @@ StepStatus DataManWriter::BeginStep(StepMode mode, const float timeout_sec)
         m_Monitor.BeginStep(m_CurrentStep);
     }
 
-    if (m_Verbosity >= 10)
-    {
-        std::cout << "DataManWriter::BeginStep " << m_CurrentStep << std::endl;
-    }
+    helper::Log("Engine", "DataManWriter", "BeginStep",
+                std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
+                helper::LogMode::OUTPUT);
 
     m_Serializer.AttachTimeStamp(
         std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -146,6 +150,10 @@ void DataManWriter::PerformPuts() {}
 
 void DataManWriter::EndStep()
 {
+    helper::Log("Engine", "DataManWriter", "EndStep",
+                std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
+                helper::LogMode::OUTPUT);
+
     if (m_CurrentStep == 0)
     {
         m_Serializer.PutAttributes(m_IO);
@@ -177,11 +185,6 @@ void DataManWriter::EndStep()
     {
         m_Monitor.EndStep(m_CurrentStep);
     }
-
-    if (m_Verbosity >= 10)
-    {
-        std::cout << "DataManWriter::EndStep " << m_CurrentStep << std::endl;
-    }
 }
 
 void DataManWriter::Flush(const int transportIndex) {}
@@ -191,10 +194,15 @@ void DataManWriter::Flush(const int transportIndex) {}
 #define declare_type(T)                                                        \
     void DataManWriter::DoPutSync(Variable<T> &variable, const T *values)      \
     {                                                                          \
+        helper::Log("Engine", "DataManWriter", "PutSync", variable.m_Name, 0,  \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
         PutSyncCommon(variable, values);                                       \
     }                                                                          \
     void DataManWriter::DoPutDeferred(Variable<T> &variable, const T *values)  \
     {                                                                          \
+        helper::Log("Engine", "DataManWriter", "PutDeferred", variable.m_Name, \
+                    0, m_Comm.Rank(), 5, m_Verbosity,                          \
+                    helper::LogMode::OUTPUT);                                  \
         PutDeferredCommon(variable, values);                                   \
     }
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
@@ -202,6 +210,9 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 
 void DataManWriter::DoClose(const int transportIndex)
 {
+    helper::Log("Engine", "DataManWriter", "Close", m_Name, 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
+
     if (m_CombinedSteps < m_CombiningSteps && m_CombinedSteps > 0)
     {
         m_Serializer.AttachAttributesToLocalPack();
@@ -280,11 +291,6 @@ void DataManWriter::DoClose(const int transportIndex)
     }
 
     m_IsClosed = true;
-
-    if (m_Verbosity >= 10)
-    {
-        std::cout << "DataManWriter::DoClose " << m_CurrentStep << std::endl;
-    }
 }
 
 bool DataManWriter::IsBufferQueueEmpty()

--- a/source/adios2/engine/dataman/DataManWriter.cpp
+++ b/source/adios2/engine/dataman/DataManWriter.cpp
@@ -46,7 +46,7 @@ DataManWriter::DataManWriter(IO &io, const std::string &name,
     helper::GetParameter(m_IO.m_Parameters, "FloatAccuracy", m_FloatAccuracy);
 
     helper::Log("Engine", "DataManWriter", "Open", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     m_HandshakeJson["Threading"] = m_Threading;
     m_HandshakeJson["Transport"] = m_TransportMode;
@@ -134,7 +134,7 @@ StepStatus DataManWriter::BeginStep(StepMode mode, const float timeout_sec)
 
     helper::Log("Engine", "DataManWriter", "BeginStep",
                 std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
-                helper::LogMode::OUTPUT);
+                helper::LogMode::INFO);
 
     m_Serializer.AttachTimeStamp(
         std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -152,7 +152,7 @@ void DataManWriter::EndStep()
 {
     helper::Log("Engine", "DataManWriter", "EndStep",
                 std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
-                helper::LogMode::OUTPUT);
+                helper::LogMode::INFO);
 
     if (m_CurrentStep == 0)
     {
@@ -195,14 +195,13 @@ void DataManWriter::Flush(const int transportIndex) {}
     void DataManWriter::DoPutSync(Variable<T> &variable, const T *values)      \
     {                                                                          \
         helper::Log("Engine", "DataManWriter", "PutSync", variable.m_Name, 0,  \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         PutSyncCommon(variable, values);                                       \
     }                                                                          \
     void DataManWriter::DoPutDeferred(Variable<T> &variable, const T *values)  \
     {                                                                          \
         helper::Log("Engine", "DataManWriter", "PutDeferred", variable.m_Name, \
-                    0, m_Comm.Rank(), 5, m_Verbosity,                          \
-                    helper::LogMode::OUTPUT);                                  \
+                    0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);  \
         PutDeferredCommon(variable, values);                                   \
     }
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
@@ -211,7 +210,7 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 void DataManWriter::DoClose(const int transportIndex)
 {
     helper::Log("Engine", "DataManWriter", "Close", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     if (m_CombinedSteps < m_CombiningSteps && m_CombinedSteps > 0)
     {

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -32,10 +32,10 @@ HDF5ReaderP::HDF5ReaderP(IO &io, const std::string &name, const Mode openMode,
                          helper::Comm comm)
 : Engine("HDF5Reader", io, name, openMode, std::move(comm))
 {
-    m_EndMessage = ", in call to IO HDF5Reader Open " + m_Name + "\n";
     if (!helper::IsHDF5File(name, m_Comm, {}))
-        throw std::invalid_argument("!ADIOS2 Error: Invalid HDF5 file found" +
-                                    m_EndMessage);
+    {
+        throw std::invalid_argument("!ADIOS2 Error: Invalid HDF5 file found");
+    }
 
     Init();
 }

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -24,7 +24,6 @@ HDF5WriterP::HDF5WriterP(IO &io, const std::string &name, const Mode mode,
 : Engine("HDF5Writer", io, name, mode, std::move(comm))
 {
     m_IO.m_ReadStreaming = false;
-    m_EndMessage = ", in call to IO HDF5Writer Open " + m_Name + "\n";
     Init();
 }
 

--- a/source/adios2/engine/inline/InlineReader.cpp
+++ b/source/adios2/engine/inline/InlineReader.cpp
@@ -28,7 +28,6 @@ InlineReader::InlineReader(IO &io, const std::string &name, const Mode mode,
 : Engine("InlineReader", io, name, mode, std::move(comm))
 {
     PERFSTUBS_SCOPED_TIMER("InlineReader::Open");
-    m_EndMessage = " in call to IO Open InlineReader " + m_Name + "\n";
     m_ReaderRank = m_Comm.Rank();
     Init();
     if (m_Verbosity == 5)

--- a/source/adios2/engine/inline/InlineWriter.cpp
+++ b/source/adios2/engine/inline/InlineWriter.cpp
@@ -29,7 +29,6 @@ InlineWriter::InlineWriter(IO &io, const std::string &name, const Mode mode,
 : Engine("InlineWriter", io, name, mode, std::move(comm))
 {
     PERFSTUBS_SCOPED_TIMER("InlineWriter::Open");
-    m_EndMessage = " in call to InlineWriter " + m_Name + " Open\n";
     m_WriterRank = m_Comm.Rank();
     Init();
     if (m_Verbosity == 5)

--- a/source/adios2/engine/skeleton/SkeletonReader.cpp
+++ b/source/adios2/engine/skeleton/SkeletonReader.cpp
@@ -26,7 +26,6 @@ SkeletonReader::SkeletonReader(IO &io, const std::string &name, const Mode mode,
                                helper::Comm comm)
 : Engine("SkeletonReader", io, name, mode, std::move(comm))
 {
-    m_EndMessage = " in call to IO Open SkeletonReader " + m_Name + "\n";
     m_ReaderRank = m_Comm.Rank();
     Init();
     if (m_Verbosity == 5)

--- a/source/adios2/engine/skeleton/SkeletonWriter.cpp
+++ b/source/adios2/engine/skeleton/SkeletonWriter.cpp
@@ -27,7 +27,6 @@ SkeletonWriter::SkeletonWriter(IO &io, const std::string &name, const Mode mode,
                                helper::Comm comm)
 : Engine("SkeletonWriter", io, name, mode, std::move(comm))
 {
-    m_EndMessage = " in call to SkeletonWriter " + m_Name + " Open\n";
     m_WriterRank = m_Comm.Rank();
     Init();
     if (m_Verbosity == 5)

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -32,7 +32,7 @@ SscReader::SscReader(IO &io, const std::string &name, const Mode mode,
                          m_OpenTimeoutSecs);
 
     helper::Log("Engine", "SSCReader", "Open", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     SyncMpiPattern();
 }
@@ -73,7 +73,7 @@ StepStatus SscReader::BeginStep(const StepMode stepMode,
 
     helper::Log("Engine", "SSCReader", "BeginStep",
                 std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
-                helper::LogMode::OUTPUT);
+                helper::LogMode::INFO);
 
     m_StepBegun = true;
 
@@ -168,7 +168,7 @@ void SscReader::PerformGets()
 {
 
     helper::Log("Engine", "SSCReader", "PerformGets", "", 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
         m_ReaderSelectionsLocked == false)
@@ -297,7 +297,7 @@ void SscReader::EndStep()
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
     helper::Log("Engine", "SSCReader", "EndStep", std::to_string(CurrentStep()),
-                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);
+                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);
 
     PerformGets();
 
@@ -475,14 +475,14 @@ void SscReader::CalculatePosition(ssc::BlockVecVec &bvv,
     void SscReader::DoGetSync(Variable<T> &variable, T *data)                  \
     {                                                                          \
         helper::Log("Engine", "SSCReader", "GetSync", variable.m_Name, 0,      \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         GetDeferredCommon(variable, data);                                     \
         PerformGets();                                                         \
     }                                                                          \
     void SscReader::DoGetDeferred(Variable<T> &variable, T *data)              \
     {                                                                          \
         helper::Log("Engine", "SSCReader", "GetDeferred", variable.m_Name, 0,  \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         GetDeferredCommon(variable, data);                                     \
     }                                                                          \
     std::vector<typename Variable<T>::BPInfo> SscReader::DoBlocksInfo(         \
@@ -498,7 +498,7 @@ void SscReader::DoClose(const int transportIndex)
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
     helper::Log("Engine", "SSCReader", "Close", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     if (!m_StepBegun)
     {

--- a/source/adios2/engine/ssc/SscReader.tcc
+++ b/source/adios2/engine/ssc/SscReader.tcc
@@ -12,8 +12,7 @@
 #define ADIOS2_ENGINE_SSCREADER_TCC_
 
 #include "SscReader.h"
-#include "adios2/helper/adiosMemory.h"
-#include "adios2/helper/adiosSystem.h"
+#include "adios2/helper/adiosFunctions.h"
 #include <adios2-perfstubs-interface.h>
 #include <iostream>
 
@@ -57,8 +56,10 @@ void SscReader::GetDeferredDeltaCommon(Variable<T> &variable, T *data)
     {
         if (d == 0)
         {
-            throw(std::runtime_error(
-                "SetSelection count dimensions cannot be 0"));
+            helper::Log("Engine", "SSCReader", "GetDeferredDeltaCommon",
+                        "SetSelection count dimensions cannot be 0", 0,
+                        m_Comm.Rank(), 0, m_Verbosity,
+                        helper::LogMode::EXCEPTION);
         }
     }
 }
@@ -152,7 +153,9 @@ void SscReader::GetDeferredCommon(Variable<T> &variable, T *data)
                     }
                     else
                     {
-                        throw(std::runtime_error("ShapeID not supported"));
+                        helper::Log("Engine", "SSCReader", "GetDeferredCommon",
+                                    "unknown ShapeID", 0, m_Comm.Rank(), 0,
+                                    m_Verbosity, helper::LogMode::ERROR);
                     }
                 }
             }

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -30,7 +30,7 @@ SscWriter::SscWriter(IO &io, const std::string &name, const Mode mode,
                          m_OpenTimeoutSecs);
 
     helper::Log("Engine", "SSCWriter", "Open", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     int providedMpiMode;
     MPI_Query_thread(&providedMpiMode);
@@ -59,7 +59,7 @@ StepStatus SscWriter::BeginStep(StepMode mode, const float timeoutSeconds)
 
     helper::Log("Engine", "SSCWriter", "BeginStep",
                 std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
-                helper::LogMode::OUTPUT);
+                helper::LogMode::INFO);
 
     if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
         m_ReaderSelectionsLocked == false)
@@ -95,7 +95,7 @@ void SscWriter::PerformPuts()
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
     helper::Log("Engine", "SSCWriter", "PerformPuts", "", 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 }
 
 void SscWriter::EndStepFirst()
@@ -133,7 +133,7 @@ void SscWriter::EndStep()
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
     helper::Log("Engine", "SSCWriter", "EndStep", std::to_string(CurrentStep()),
-                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);
+                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);
 
     if (m_CurrentStep == 0)
     {
@@ -177,7 +177,7 @@ void SscWriter::SyncMpiPattern()
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
     helper::Log("Engine", "SSCWriter", "SyncMpiPattern", "", 0, m_Comm.Rank(),
-                5, m_Verbosity, helper::LogMode::OUTPUT);
+                5, m_Verbosity, helper::LogMode::INFO);
 
     MPI_Group streamGroup;
     MPI_Group writerGroup;
@@ -210,7 +210,7 @@ void SscWriter::SyncWritePattern(bool finalStep)
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
     helper::Log("Engine", "SSCWriter", "SyncWritePattern", "", 0, m_Comm.Rank(),
-                5, m_Verbosity, helper::LogMode::OUTPUT);
+                5, m_Verbosity, helper::LogMode::INFO);
 
     ssc::Buffer localBuffer(8);
     localBuffer.value<uint64_t>() = 8;
@@ -244,7 +244,7 @@ void SscWriter::SyncReadPattern()
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
     helper::Log("Engine", "SSCWriter", "SyncReadPattern", "", 0, m_Comm.Rank(),
-                5, m_Verbosity, helper::LogMode::OUTPUT);
+                5, m_Verbosity, helper::LogMode::INFO);
 
     ssc::Buffer globalBuffer;
 
@@ -317,14 +317,14 @@ void SscWriter::CalculatePosition(ssc::BlockVecVec &writerVecVec,
     void SscWriter::DoPutSync(Variable<T> &variable, const T *data)            \
     {                                                                          \
         helper::Log("Engine", "SSCWriter", "PutSync", variable.m_Name, 0,      \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         PutDeferredCommon(variable, data);                                     \
         PerformPuts();                                                         \
     }                                                                          \
     void SscWriter::DoPutDeferred(Variable<T> &variable, const T *data)        \
     {                                                                          \
         helper::Log("Engine", "SSCWriter", "PutDeferred", variable.m_Name, 0,  \
-                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::INFO);     \
         PutDeferredCommon(variable, data);                                     \
     }
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
@@ -335,7 +335,7 @@ void SscWriter::DoClose(const int transportIndex)
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
     helper::Log("Engine", "SSCWriter", "Close", m_Name, 0, m_Comm.Rank(), 5,
-                m_Verbosity, helper::LogMode::OUTPUT);
+                m_Verbosity, helper::LogMode::INFO);
 
     if (m_Threading && m_EndStepThread.joinable())
     {

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -29,7 +29,7 @@ SscWriter::SscWriter(IO &io, const std::string &name, const Mode mode,
     helper::GetParameter(m_IO.m_Parameters, "OpenTimeoutSecs",
                          m_OpenTimeoutSecs);
 
-    helper::Log("Engine", "SSCWriter", "Open", m_Name, 0, m_Comm.Rank(), 0,
+    helper::Log("Engine", "SSCWriter", "Open", m_Name, 0, m_Comm.Rank(), 5,
                 m_Verbosity, helper::LogMode::OUTPUT);
 
     int providedMpiMode;

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -9,9 +9,7 @@
  */
 
 #include "SscWriter.tcc"
-#include "adios2/helper/adiosComm.h"
 #include "adios2/helper/adiosCommMPI.h"
-#include "adios2/helper/adiosString.h"
 
 namespace adios2
 {
@@ -31,17 +29,18 @@ SscWriter::SscWriter(IO &io, const std::string &name, const Mode mode,
     helper::GetParameter(m_IO.m_Parameters, "OpenTimeoutSecs",
                          m_OpenTimeoutSecs);
 
+    helper::Log("Engine", "SSCWriter", "Open", m_Name, 0, m_Comm.Rank(), 0,
+                m_Verbosity, helper::LogMode::OUTPUT);
+
     int providedMpiMode;
     MPI_Query_thread(&providedMpiMode);
     if (m_Threading && providedMpiMode != MPI_THREAD_MULTIPLE)
     {
         m_Threading = false;
-        if (m_WriterRank == 0 && m_Verbosity > 0)
-        {
-            std::cout << "SSC Threading disabled as MPI is not initialized "
-                         "with multi-threads"
-                      << std::endl;
-        }
+        helper::Log("Engine", "SSCWriter", "Open",
+                    "SSC Threading disabled as MPI is not initialized with "
+                    "multi-threads",
+                    0, m_Comm.Rank(), 1, m_Verbosity, helper::LogMode::WARNING);
     }
 
     SyncMpiPattern();
@@ -58,12 +57,9 @@ StepStatus SscWriter::BeginStep(StepMode mode, const float timeoutSeconds)
 
     ++m_CurrentStep;
 
-    if (m_Verbosity >= 5)
-    {
-        std::cout << "SscWriter::BeginStep, World Rank " << m_StreamRank
-                  << ", Writer Rank " << m_WriterRank << ", Step "
-                  << m_CurrentStep << std::endl;
-    }
+    helper::Log("Engine", "SSCWriter", "BeginStep",
+                std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
+                helper::LogMode::OUTPUT);
 
     if (m_CurrentStep == 0 || m_WriterDefinitionsLocked == false ||
         m_ReaderSelectionsLocked == false)
@@ -95,7 +91,12 @@ StepStatus SscWriter::BeginStep(StepMode mode, const float timeoutSeconds)
 
 size_t SscWriter::CurrentStep() const { return m_CurrentStep; }
 
-void SscWriter::PerformPuts() { PERFSTUBS_SCOPED_TIMER_FUNC(); }
+void SscWriter::PerformPuts()
+{
+    PERFSTUBS_SCOPED_TIMER_FUNC();
+    helper::Log("Engine", "SSCWriter", "PerformPuts", "", 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
+}
 
 void SscWriter::EndStepFirst()
 {
@@ -131,12 +132,8 @@ void SscWriter::EndStep()
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
-    if (m_Verbosity >= 5)
-    {
-        std::cout << "SscWriter::EndStep, World Rank " << m_StreamRank
-                  << ", Writer Rank " << m_WriterRank << ", Step "
-                  << m_CurrentStep << std::endl;
-    }
+    helper::Log("Engine", "SSCWriter", "EndStep", std::to_string(CurrentStep()),
+                0, m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);
 
     if (m_CurrentStep == 0)
     {
@@ -179,6 +176,9 @@ void SscWriter::SyncMpiPattern()
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
+    helper::Log("Engine", "SSCWriter", "SyncMpiPattern", "", 0, m_Comm.Rank(),
+                5, m_Verbosity, helper::LogMode::OUTPUT);
+
     MPI_Group streamGroup;
     MPI_Group writerGroup;
     MPI_Comm readerComm;
@@ -208,12 +208,9 @@ void SscWriter::SyncMpiPattern()
 void SscWriter::SyncWritePattern(bool finalStep)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
-    if (m_Verbosity >= 5)
-    {
-        std::cout << "SscWriter::SyncWritePattern, World Rank " << m_StreamRank
-                  << ", Writer Rank " << m_WriterRank << ", Step "
-                  << m_CurrentStep << std::endl;
-    }
+
+    helper::Log("Engine", "SSCWriter", "SyncWritePattern", "", 0, m_Comm.Rank(),
+                5, m_Verbosity, helper::LogMode::OUTPUT);
 
     ssc::Buffer localBuffer(8);
     localBuffer.value<uint64_t>() = 8;
@@ -245,12 +242,9 @@ void SscWriter::SyncWritePattern(bool finalStep)
 void SscWriter::SyncReadPattern()
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
-    if (m_Verbosity >= 5)
-    {
-        std::cout << "SscWriter::SyncReadPattern, World Rank " << m_StreamRank
-                  << ", Writer Rank " << m_WriterRank << ", Step "
-                  << m_CurrentStep << std::endl;
-    }
+
+    helper::Log("Engine", "SSCWriter", "SyncReadPattern", "", 0, m_Comm.Rank(),
+                5, m_Verbosity, helper::LogMode::OUTPUT);
 
     ssc::Buffer globalBuffer;
 
@@ -322,11 +316,15 @@ void SscWriter::CalculatePosition(ssc::BlockVecVec &writerVecVec,
 #define declare_type(T)                                                        \
     void SscWriter::DoPutSync(Variable<T> &variable, const T *data)            \
     {                                                                          \
+        helper::Log("Engine", "SSCWriter", "PutSync", variable.m_Name, 0,      \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
         PutDeferredCommon(variable, data);                                     \
         PerformPuts();                                                         \
     }                                                                          \
     void SscWriter::DoPutDeferred(Variable<T> &variable, const T *data)        \
     {                                                                          \
+        helper::Log("Engine", "SSCWriter", "PutDeferred", variable.m_Name, 0,  \
+                    m_Comm.Rank(), 5, m_Verbosity, helper::LogMode::OUTPUT);   \
         PutDeferredCommon(variable, data);                                     \
     }
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
@@ -336,11 +334,8 @@ void SscWriter::DoClose(const int transportIndex)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
-    if (m_Verbosity >= 5)
-    {
-        std::cout << "SscWriter::DoClose, World Rank " << m_StreamRank
-                  << ", Writer Rank " << m_WriterRank << std::endl;
-    }
+    helper::Log("Engine", "SSCWriter", "Close", m_Name, 0, m_Comm.Rank(), 5,
+                m_Verbosity, helper::LogMode::OUTPUT);
 
     if (m_Threading && m_EndStepThread.joinable())
     {

--- a/source/adios2/engine/ssc/SscWriter.h
+++ b/source/adios2/engine/ssc/SscWriter.h
@@ -15,7 +15,6 @@
 #include "adios2/core/Engine.h"
 #include "adios2/helper/adiosMpiHandshake.h"
 #include <mpi.h>
-#include <queue>
 
 namespace adios2
 {

--- a/source/adios2/engine/ssc/SscWriter.tcc
+++ b/source/adios2/engine/ssc/SscWriter.tcc
@@ -12,10 +12,9 @@
 #define ADIOS2_ENGINE_SSCWRITER_TCC_
 
 #include "SscWriter.h"
-#include "adios2/helper/adiosSystem.h"
+#include "adios2/helper/adiosFunctions.h"
 #include <adios2-perfstubs-interface.h>
 #include <cstring>
-#include <iostream>
 
 namespace adios2
 {
@@ -38,8 +37,10 @@ void SscWriter::PutDeferredCommon(Variable<std::string> &variable,
         {
             if (b.bufferCount < data->size())
             {
-                throw(std::runtime_error(
-                    "SSC only accepts fixed length string variables"));
+                helper::Log("Engine", "SSCWriter", "PutDeferredCommon",
+                            "SSC only accepts fixed length string variables",
+                            -1, m_Comm.Rank(), 0, m_Verbosity,
+                            helper::LogMode::EXCEPTION);
             }
             std::memcpy(m_Buffer.data() + b.bufferStart, data->data(),
                         data->size());
@@ -70,7 +71,9 @@ void SscWriter::PutDeferredCommon(Variable<std::string> &variable,
         }
         else
         {
-            throw std::runtime_error("IO pattern changed after locking");
+            helper::Log("Engine", "SSCWriter", "PutDeferredCommon",
+                        "IO pattern changed after locking", -1, m_Comm.Rank(),
+                        0, m_Verbosity, helper::LogMode::EXCEPTION);
         }
     }
 }
@@ -139,7 +142,9 @@ void SscWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
         }
         else
         {
-            throw std::runtime_error("IO pattern changed after locking");
+            helper::Log("Engine", "SSCWriter", "PutDeferredCommon",
+                        "IO pattern changed after locking", -1, m_Comm.Rank(),
+                        0, m_Verbosity, helper::LogMode::EXCEPTION);
         }
     }
 }

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -43,7 +43,7 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
             "ERROR: SstReader did not find active "
             "Writer contact info in file \"" +
             m_Name + SST_POSTFIX +
-            "\".  Timeout or non-current SST contact file?" + m_EndMessage);
+            "\".  Timeout or non-current SST contact file?");
     }
 
     // Maybe need other writer-side params in the future, but for now only
@@ -293,8 +293,7 @@ StepStatus SstReader::BeginStep(StepMode Mode, const float timeout_sec)
     case adios2::StepMode::Append:
     case adios2::StepMode::Update:
         throw std::invalid_argument(
-            "ERROR: SstReader::BeginStep inappropriate StepMode specified" +
-            m_EndMessage);
+            "ERROR: SstReader::BeginStep inappropriate StepMode specified");
     case adios2::StepMode::Read:
         break;
     }

--- a/source/adios2/helper/adiosFunctions.h
+++ b/source/adios2/helper/adiosFunctions.h
@@ -13,6 +13,7 @@
 #define ADIOS2_HELPER_ADIOSFUNCTIONS_H_
 
 #include "adios2/helper/adiosCUDA.h"    //CUDA functions
+#include "adios2/helper/adiosLog.h"     //logging functions
 #include "adios2/helper/adiosMath.h"    //math functions (cmath, algorithm)
 #include "adios2/helper/adiosMemory.h"  //memcpy, std::copy, insert, resize
 #include "adios2/helper/adiosNetwork.h" //network and staging functions

--- a/source/adios2/helper/adiosLog.cpp
+++ b/source/adios2/helper/adiosLog.cpp
@@ -19,9 +19,6 @@ namespace adios2
 namespace helper
 {
 
-std::string lastEngineActivity;
-int lastRank = -1;
-
 std::string timeColor = "\033[1;36m";
 std::string outputColor = "\033[1;32m";
 std::string warningColor = "\033[1;33m";
@@ -31,14 +28,17 @@ std::string defaultColor = "\033[0m";
 
 void Log(const std::string &component, const std::string &source,
          const std::string &activity, const std::string &message,
+         const int priority, const int verbosity, const LogMode mode)
+{
+    Log(component, source, activity, message, -1, -1, priority, verbosity,
+        mode);
+}
+
+void Log(const std::string &component, const std::string &source,
+         const std::string &activity, const std::string &message,
          const int logRank, const int commRank, const int priority,
          const int verbosity, const LogMode mode)
 {
-
-    if (component == "Engine")
-    {
-        lastRank = commRank;
-    }
 
     if (mode != LogMode::EXCEPTION)
     {
@@ -63,51 +63,42 @@ void Log(const std::string &component, const std::string &source,
     }
     m << timeColor << " [" << timeStr << "]" << defaultColor;
 
-    if (mode == OUTPUT)
+    if (mode == INFO)
     {
-        m << outputColor << " [ADIOS2 Output]" << defaultColor;
+        m << outputColor << " [ADIOS2 INFO]" << defaultColor;
     }
     else if (mode == WARNING)
     {
-        m << warningColor << " [ADIOS2 Warning]" << defaultColor;
+        m << warningColor << " [ADIOS2 WARNING]" << defaultColor;
     }
     else if (mode == ERROR)
     {
-        m << errorColor << " [ADIOS2 Error]" << defaultColor;
+        m << errorColor << " [ADIOS2 ERROR]" << defaultColor;
     }
     else if (mode == EXCEPTION)
     {
-        m << exceptionColor << " [ADIOS2 Exception]" << defaultColor;
+        m << exceptionColor << " [ADIOS2 EXCEPTION]" << defaultColor;
     }
 
     if (commRank >= 0)
     {
         m << " [Rank " << commRank << "]";
     }
-    else if (lastRank >= 0)
-    {
-        m << " [Rank " << lastRank << "]";
-    }
 
     m << " <" << component << "> <" << source << "> <" << activity
-      << "> : " << message;
+      << "> : " << message << std::endl;
 
-    if (component == "Engine")
+    if (mode == INFO || mode == WARNING)
     {
-        lastEngineActivity = m.str();
-    }
-
-    if (mode == OUTPUT || mode == WARNING)
-    {
-        std::cout << m.str() << std::endl;
+        std::cout << m.str();
     }
     else if (mode == ERROR)
     {
-        std::cerr << m.str() << std::endl;
+        std::cerr << m.str();
     }
     else if (mode == EXCEPTION)
     {
-        std::cerr << m.str() << std::endl;
+        std::cerr << m.str();
         throw(m.str());
     }
 }

--- a/source/adios2/helper/adiosLog.cpp
+++ b/source/adios2/helper/adiosLog.cpp
@@ -17,10 +17,9 @@ namespace adios2
 {
 namespace helper
 {
-std::string lastEngine;
-std::string lastActivity;
-std::string lastMessage;
-int lastRank;
+
+std::string lastEngineActivity;
+int lastRank = -1;
 
 std::string timeColor = "\033[1;36m";
 std::string outputColor = "\033[1;32m";
@@ -37,20 +36,19 @@ void Log(const std::string &component, const std::string &source,
 
     if (component == "Engine")
     {
-        lastEngine = source;
-        lastActivity = activity;
-        lastMessage = message;
         lastRank = commRank;
     }
 
-    if (logRank >= 0 && commRank >= 0 && logRank != commRank)
+    if (mode != LogMode::EXCEPTION)
     {
-        return;
-    }
-
-    if (priority > verbosity)
-    {
-        return;
+        if (logRank >= 0 && commRank >= 0 && logRank != commRank)
+        {
+            return;
+        }
+        if (priority > verbosity)
+        {
+            return;
+        }
     }
 
     std::stringstream m;
@@ -85,9 +83,18 @@ void Log(const std::string &component, const std::string &source,
     {
         m << " [Rank " << commRank << "]";
     }
+    else if (lastRank >= 0)
+    {
+        m << " [Rank " << lastRank << "]";
+    }
 
-    m << " " << component << " " << source << " " << activity << ": "
-      << message;
+    m << " <" << component << "> <" << source << "> <" << activity
+      << "> : " << message;
+
+    if (component == "Engine")
+    {
+        lastEngineActivity = m.str();
+    }
 
     if (mode == OUTPUT || mode == WARNING)
     {

--- a/source/adios2/helper/adiosLog.cpp
+++ b/source/adios2/helper/adiosLog.cpp
@@ -1,0 +1,108 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosLog.cpp
+ *
+ *  Created on: Nov 15, 2021
+ *      Author: Jason Wang jason.ruonan.wang@gmail.com
+ */
+
+#include "adiosLog.h"
+#include <chrono>
+#include <iostream>
+#include <sstream>
+
+namespace adios2
+{
+namespace helper
+{
+std::string lastEngine;
+std::string lastActivity;
+std::string lastMessage;
+int lastRank;
+
+std::string timeColor = "\033[1;36m";
+std::string outputColor = "\033[1;32m";
+std::string warningColor = "\033[1;33m";
+std::string errorColor = "\033[1;31m";
+std::string exceptionColor = "\033[1;34m";
+std::string defaultColor = "\033[0m";
+
+void Log(const std::string &component, const std::string &source,
+         const std::string &activity, const std::string &message,
+         const int logRank, const int commRank, const int priority,
+         const int verbosity, const LogMode mode)
+{
+
+    if (component == "Engine")
+    {
+        lastEngine = source;
+        lastActivity = activity;
+        lastMessage = message;
+        lastRank = commRank;
+    }
+
+    if (logRank >= 0 && commRank >= 0 && logRank != commRank)
+    {
+        return;
+    }
+
+    if (priority > verbosity)
+    {
+        return;
+    }
+
+    std::stringstream m;
+
+    auto timeNow =
+        std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::string timeStr(std::ctime(&timeNow));
+    if (timeStr[timeStr.size() - 1] == '\n')
+    {
+        timeStr[timeStr.size() - 1] = '\0';
+    }
+    m << timeColor << " [" << timeStr << "]" << defaultColor;
+
+    if (mode == OUTPUT)
+    {
+        m << outputColor << " [ADIOS2 Output]" << defaultColor;
+    }
+    else if (mode == WARNING)
+    {
+        m << warningColor << " [ADIOS2 Warning]" << defaultColor;
+    }
+    else if (mode == ERROR)
+    {
+        m << errorColor << " [ADIOS2 Error]" << defaultColor;
+    }
+    else if (mode == EXCEPTION)
+    {
+        m << exceptionColor << " [ADIOS2 Exception]" << defaultColor;
+    }
+
+    if (commRank >= 0)
+    {
+        m << " [Rank " << commRank << "]";
+    }
+
+    m << " " << component << " " << source << " " << activity << ": "
+      << message;
+
+    if (mode == OUTPUT || mode == WARNING)
+    {
+        std::cout << m.str() << std::endl;
+    }
+    else if (mode == ERROR)
+    {
+        std::cerr << m.str() << std::endl;
+    }
+    else if (mode == EXCEPTION)
+    {
+        std::cerr << m.str() << std::endl;
+        throw(m.str());
+    }
+}
+
+} // end namespace helper
+} // end namespace adios2

--- a/source/adios2/helper/adiosLog.cpp
+++ b/source/adios2/helper/adiosLog.cpp
@@ -10,6 +10,7 @@
 
 #include "adiosLog.h"
 #include <chrono>
+#include <ctime>
 #include <iostream>
 #include <sstream>
 

--- a/source/adios2/helper/adiosLog.h
+++ b/source/adios2/helper/adiosLog.h
@@ -20,8 +20,22 @@ enum LogMode : char
     EXCEPTION = 'x',
     ERROR = 'e',
     WARNING = 'w',
-    OUTPUT = 'o'
+    INFO = 'i'
 };
+
+/**
+ * Print outputs, warnings, errors, and exceptions
+ * @param component: Engine, Transport, Operator, etc.
+ * @param source: class name of component
+ * @param activity: function name where this is called
+ * @param message: text message
+ * @param priority: only print if(priority<=verbosity)
+ * @param verbosity: engine parameter for engine wide verbosity level
+ * @param mode: OUTPUT, WARNING, ERROR, or EXCEPTION
+ */
+void Log(const std::string &component, const std::string &source,
+         const std::string &activity, const std::string &message,
+         const int priority, const int verbosity, const LogMode mode);
 
 /**
  * Print outputs, warnings, errors, and exceptions

--- a/source/adios2/helper/adiosLog.h
+++ b/source/adios2/helper/adiosLog.h
@@ -1,0 +1,32 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosLog.h
+ *
+ *  Created on: Nov 15, 2021
+ *      Author: Jason Wang jason.ruonan.wang@gmail.com
+ */
+
+#include <string>
+
+namespace adios2
+{
+namespace helper
+{
+
+enum LogMode : char
+{
+    EXCEPTION = 'x',
+    ERROR = 'e',
+    WARNING = 'w',
+    OUTPUT = 'o'
+};
+
+void Log(const std::string &component, const std::string &source,
+         const std::string &operation, const std::string &message,
+         const int logRank, const int commRank, const int priority,
+         const int verbosity, const LogMode mode);
+
+} // end namespace helper
+} // end namespace adios2

--- a/source/adios2/helper/adiosLog.h
+++ b/source/adios2/helper/adiosLog.h
@@ -23,8 +23,20 @@ enum LogMode : char
     OUTPUT = 'o'
 };
 
+/**
+ * Print outputs, warnings, errors, and exceptions
+ * @param component: Engine, Transport, Operator, etc.
+ * @param source: class name of component
+ * @param activity: function name where this is called
+ * @param message: text message
+ * @param logRank: only print if(logRank==commRank)
+ * @param commRank: current MPI rank
+ * @param priority: only print if(priority<=verbosity)
+ * @param verbosity: engine parameter for engine wide verbosity level
+ * @param mode: OUTPUT, WARNING, ERROR, or EXCEPTION
+ */
 void Log(const std::string &component, const std::string &source,
-         const std::string &operation, const std::string &message,
+         const std::string &activity, const std::string &message,
          const int logRank, const int commRank, const int priority,
          const int verbosity, const LogMode mode);
 


### PR DESCRIPTION
For long time we have only had arbitrarily styled runtime output. Some of them are very ambiguous and uninformative. This PR is the start of an attempt to have a more unified and finer-grained output style, which at least let users know the outputs are from ADIOS2 rather than some thirdparty libraries, and have some ideas which layer of ADIOS2 they are from. 

Some basic example outputs that have been implemented are:

```
 [Wed Nov 17 02:27:02 2021] [ADIOS2 Output] [Rank 0] <Engine> <BP4Writer> <Open> : myVector_cpp.bp
 [Wed Nov 17 02:27:02 2021] [ADIOS2 Output] [Rank 0] <Engine> <BP4Writer> <PutDeferred> : bpFloats
 [Wed Nov 17 02:27:02 2021] [ADIOS2 Output] [Rank 0] <Engine> <BP4Writer> <PutDeferred> : bpInts
 [Wed Nov 17 02:27:02 2021] [ADIOS2 Output] [Rank 0] <Engine> <BP4Writer> <Close> : myVector_cpp.bp
 [Wed Nov 17 02:27:02 2021] [ADIOS2 Output] [Rank 0] <Engine> <BP4Writer> <PerformPuts> : 
```