### PR TITLE
modify daos cmake file to make it find daos library more easily

### DIFF
--- a/cmake/FindDAOS.cmake
+++ b/cmake/FindDAOS.cmake
@@ -25,17 +25,15 @@
 #                           variable, it will override any setting specified
 #                           as an environment variable.
 
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  if((NOT DAOS_ROOT) AND (NOT (ENV{DAOS_ROOT} STREQUAL "")))
-    set(DAOS_ROOT "$ENV{DAOS_ROOT}")
-  endif()
-  if(DAOS_ROOT)
-    set(DAOS_INCLUDE_OPTS HINTS ${DAOS_ROOT}/include NO_DEFAULT_PATHS)
-    set(DAOS_LIBRARY_OPTS
-      HINTS ${DAOS_ROOT}/lib ${DAOS_ROOT}/lib64
-      NO_DEFAULT_PATHS
+if((NOT DAOS_ROOT) AND (NOT (ENV{DAOS_ROOT} STREQUAL "")))
+  set(DAOS_ROOT "$ENV{DAOS_ROOT}")
+endif()
+if(DAOS_ROOT)
+  set(DAOS_INCLUDE_OPTS HINTS ${DAOS_ROOT}/include NO_DEFAULT_PATHS)
+  set(DAOS_LIBRARY_OPTS
+    HINTS ${DAOS_ROOT}/lib ${DAOS_ROOT}/lib64
+    NO_DEFAULT_PATHS
     )
-  endif()
 endif()
 
 

--- a/cmake/FindDAOS.cmake
+++ b/cmake/FindDAOS.cmake
@@ -37,7 +37,7 @@ if(DAOS_ROOT)
 endif()
 
 
-message(STATUS "DAOS_ROOT is is \"$ENV{DAOS_ROOT}\"")
+message(STATUS "DAOS_ROOT is : ${DAOS_ROOT}")
 find_path(DAOS_INCLUDE_DIR daos_api.h ${DAOS_INCLUDE_OPTS})
 find_library(DAOS_LIBRARY libdaos.so ${DAOS_LIBRARY_OPTS})
 find_library(DFS_LIBRARY libdfs.so ${DAOS_LIBRARY_OPTS})


### PR DESCRIPTION
In the original FindDAOS.cmake file there is a condition 

if(CMAKE_VERSION VERSION_LESS 3.12)

which assumes that if cmake version is newer than 3.12 then it should be able to automatically find DAOS library. However, cmake 3.21 does not seem to find the DAOS library at all even for a DAOS installation in /usr/local. By removing this condition, any cmake version is now able to find DAOS automatically. 