### PR TITLE
rename OperatorType enum

### DIFF
--- a/source/adios2/core/Operator.h
+++ b/source/adios2/core/Operator.h
@@ -80,14 +80,14 @@ public:
 
     enum OperatorType : char
     {
-        BLOSC = 0,
-        BZIP2 = 1,
-        LIBPRESSIO = 2,
-        MGARD = 3,
-        PNG = 4,
-        SIRIUS = 5,
-        Sz = 6,
-        ZFP = 7
+        COMPRESS_BLOSC = 0,
+        COMPRESS_BZIP2 = 1,
+        COMPRESS_LIBPRESSIO = 2,
+        COMPRESS_MGARD = 3,
+        COMPRESS_PNG = 4,
+        COMPRESS_SIRIUS = 5,
+        COMPRESS_SZ = 6,
+        COMPRESS_ZFP = 7
     };
 
 protected:

--- a/source/adios2/operator/compress/CompressBZIP2.cpp
+++ b/source/adios2/operator/compress/CompressBZIP2.cpp
@@ -41,7 +41,7 @@ size_t CompressBZIP2::Operate(const char *dataIn, const Dims &blockStart,
     unsigned int destOffset = 0;
 
     // Universal operator metadata
-    PutParameter(bufferOut, destOffset, OperatorType::BZIP2);
+    PutParameter(bufferOut, destOffset, OperatorType::COMPRESS_BZIP2);
     PutParameter(bufferOut, destOffset, bufferVersion);
     PutParameter(bufferOut, destOffset, static_cast<uint16_t>(0));
     // Universal operator metadata end

--- a/source/adios2/operator/compress/CompressBlosc.cpp
+++ b/source/adios2/operator/compress/CompressBlosc.cpp
@@ -50,7 +50,7 @@ size_t CompressBlosc::Operate(const char *dataIn, const Dims &blockStart,
     const uint8_t bufferVersion = 1;
 
     // Universal operator metadata
-    PutParameter(bufferOut, bufferOutOffset, OperatorType::BLOSC);
+    PutParameter(bufferOut, bufferOutOffset, OperatorType::COMPRESS_BLOSC);
     PutParameter(bufferOut, bufferOutOffset, bufferVersion);
     PutParameter(bufferOut, bufferOutOffset, static_cast<uint16_t>(0));
     // Universal operator metadata end

--- a/source/adios2/operator/compress/CompressLibPressio.cpp
+++ b/source/adios2/operator/compress/CompressLibPressio.cpp
@@ -292,7 +292,7 @@ size_t CompressLibPressio::Operate(const char *dataIn, const Dims &blockStart,
     size_t bufferOutOffset = 0;
 
     // Universal operator metadata
-    PutParameter(bufferOut, bufferOutOffset, OperatorType::LIBPRESSIO);
+    PutParameter(bufferOut, bufferOutOffset, OperatorType::COMPRESS_LIBPRESSIO);
     PutParameter(bufferOut, bufferOutOffset, bufferVersion);
     PutParameter(bufferOut, bufferOutOffset, static_cast<uint16_t>(0));
     // Universal operator metadata end

--- a/source/adios2/operator/compress/CompressMGARD.cpp
+++ b/source/adios2/operator/compress/CompressMGARD.cpp
@@ -34,7 +34,7 @@ size_t CompressMGARD::Operate(const char *dataIn, const Dims &blockStart,
     size_t bufferOutOffset = 0;
 
     // Universal operator metadata
-    PutParameter(bufferOut, bufferOutOffset, OperatorType::MGARD);
+    PutParameter(bufferOut, bufferOutOffset, OperatorType::COMPRESS_MGARD);
     PutParameter(bufferOut, bufferOutOffset, bufferVersion);
     PutParameter(bufferOut, bufferOutOffset, static_cast<uint16_t>(0));
     // Universal operator metadata end

--- a/source/adios2/operator/compress/CompressPNG.cpp
+++ b/source/adios2/operator/compress/CompressPNG.cpp
@@ -55,7 +55,7 @@ size_t CompressPNG::Operate(const char *dataIn, const Dims &blockStart,
     const uint8_t bufferVersion = 1;
 
     // Universal operator metadata
-    PutParameter(bufferOut, bufferOutOffset, OperatorType::PNG);
+    PutParameter(bufferOut, bufferOutOffset, OperatorType::COMPRESS_PNG);
     PutParameter(bufferOut, bufferOutOffset, bufferVersion);
     PutParameter(bufferOut, bufferOutOffset, static_cast<uint16_t>(0));
     // Universal operator metadata end

--- a/source/adios2/operator/compress/CompressSZ.cpp
+++ b/source/adios2/operator/compress/CompressSZ.cpp
@@ -37,7 +37,7 @@ size_t CompressSZ::Operate(const char *dataIn, const Dims &blockStart,
     size_t bufferOutOffset = 0;
 
     // Universal operator metadata
-    PutParameter(bufferOut, bufferOutOffset, OperatorType::Sz);
+    PutParameter(bufferOut, bufferOutOffset, OperatorType::COMPRESS_SZ);
     PutParameter(bufferOut, bufferOutOffset, bufferVersion);
     PutParameter(bufferOut, bufferOutOffset, static_cast<uint16_t>(0));
     // Universal operator metadata end

--- a/source/adios2/operator/compress/CompressSirius.cpp
+++ b/source/adios2/operator/compress/CompressSirius.cpp
@@ -42,7 +42,7 @@ size_t CompressSirius::Operate(const char *dataIn, const Dims &blockStart,
     size_t bufferOutOffset = 0;
 
     // Universal operator metadata
-    PutParameter(bufferOut, bufferOutOffset, OperatorType::SIRIUS);
+    PutParameter(bufferOut, bufferOutOffset, OperatorType::COMPRESS_SIRIUS);
     PutParameter(bufferOut, bufferOutOffset, bufferVersion);
     PutParameter(bufferOut, bufferOutOffset, static_cast<uint16_t>(0));
     // Universal operator metadata end

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -65,7 +65,7 @@ size_t CompressZFP::Operate(const char *dataIn, const Dims &blockStart,
     size_t bufferOutOffset = 0;
 
     // Universal operator metadata
-    PutParameter(bufferOut, bufferOutOffset, OperatorType::ZFP);
+    PutParameter(bufferOut, bufferOutOffset, OperatorType::COMPRESS_ZFP);
     PutParameter(bufferOut, bufferOutOffset, bufferVersion);
     PutParameter(bufferOut, bufferOutOffset, static_cast<uint16_t>(0));
     // Universal operator metadata end

--- a/source/adios2/operator/compress/CompressorFactory.cpp
+++ b/source/adios2/operator/compress/CompressorFactory.cpp
@@ -174,7 +174,7 @@ size_t CompressorFactory::Decompress(const char *bufferIn, const size_t sizeIn,
     Operator::OperatorType compressorType;
     std::memcpy(&compressorType, bufferIn, 1);
 
-    if (compressorType == Operator::OperatorType::BLOSC)
+    if (compressorType == Operator::OperatorType::COMPRESS_BLOSC)
     {
 #ifdef ADIOS2_HAVE_BLOSC
         compress::CompressBlosc op({});
@@ -184,7 +184,7 @@ size_t CompressorFactory::Decompress(const char *bufferIn, const size_t sizeIn,
                                  "with BLOSC, can't use compressor\n");
 #endif
     }
-    else if (compressorType == Operator::OperatorType::BZIP2)
+    else if (compressorType == Operator::OperatorType::COMPRESS_BZIP2)
     {
 #ifdef ADIOS2_HAVE_BZIP2
         compress::CompressBZIP2 op({});
@@ -194,7 +194,7 @@ size_t CompressorFactory::Decompress(const char *bufferIn, const size_t sizeIn,
                                  "with BZIP2, can't use compressor\n");
 #endif
     }
-    else if (compressorType == Operator::OperatorType::LIBPRESSIO)
+    else if (compressorType == Operator::OperatorType::COMPRESS_LIBPRESSIO)
     {
 #ifdef ADIOS2_HAVE_LIBPRESSIO
         compress::CompressLibPressio op({});
@@ -204,7 +204,7 @@ size_t CompressorFactory::Decompress(const char *bufferIn, const size_t sizeIn,
                                  "with LibPressio, can't use compressor\n");
 #endif
     }
-    else if (compressorType == Operator::OperatorType::MGARD)
+    else if (compressorType == Operator::OperatorType::COMPRESS_MGARD)
     {
 #ifdef ADIOS2_HAVE_MGARD
         compress::CompressMGARD op({});
@@ -214,7 +214,7 @@ size_t CompressorFactory::Decompress(const char *bufferIn, const size_t sizeIn,
                                  "with MGARD, can't use compressor\n");
 #endif
     }
-    else if (compressorType == Operator::OperatorType::PNG)
+    else if (compressorType == Operator::OperatorType::COMPRESS_PNG)
     {
 #ifdef ADIOS2_HAVE_PNG
         compress::CompressPNG op({});
@@ -224,7 +224,7 @@ size_t CompressorFactory::Decompress(const char *bufferIn, const size_t sizeIn,
                                  "with PNG, can't use compressor\n");
 #endif
     }
-    else if (compressorType == Operator::OperatorType::SIRIUS)
+    else if (compressorType == Operator::OperatorType::COMPRESS_SIRIUS)
     {
 #ifdef ADIOS2_HAVE_MHS
         compress::CompressSirius op({});
@@ -234,7 +234,7 @@ size_t CompressorFactory::Decompress(const char *bufferIn, const size_t sizeIn,
                                  "with MHS, can't use Sirius compressor\n");
 #endif
     }
-    else if (compressorType == Operator::OperatorType::Sz)
+    else if (compressorType == Operator::OperatorType::COMPRESS_SZ)
     {
 #ifdef ADIOS2_HAVE_SZ
         compress::CompressSZ op({});
@@ -244,7 +244,7 @@ size_t CompressorFactory::Decompress(const char *bufferIn, const size_t sizeIn,
                                  "with SZ, can't use compressor\n");
 #endif
     }
-    else if (compressorType == Operator::OperatorType::ZFP)
+    else if (compressorType == Operator::OperatorType::COMPRESS_ZFP)
     {
 #ifdef ADIOS2_HAVE_ZFP
         compress::CompressZFP op({});


### PR DESCRIPTION
This is to avoid naming conflicts with the macros defined in compression libraries. For example, SZ library defines a universal macro SZ, which, in some compiling environments, has a conflict with OperatorType::SZ. 