### PR TITLE
Removed the Info map from VariableBase::Operation

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Variable.cpp
+++ b/bindings/CXX11/adios2/cxx11/Variable.cpp
@@ -182,8 +182,7 @@ namespace adios2
                                                                                \
         for (const auto &op : m_Variable->m_Operations)                        \
         {                                                                      \
-            operations.push_back(                                              \
-                Operation{Operator(op.Op), op.Parameters, op.Info});           \
+            operations.push_back(Operation{Operator(op.Op), op.Parameters});   \
         }                                                                      \
         return operations;                                                     \
     }                                                                          \

--- a/bindings/Python/py11Variable.cpp
+++ b/bindings/Python/py11Variable.cpp
@@ -91,8 +91,7 @@ std::vector<Variable::Operation> Variable::Operations() const
 
     for (const auto &op : m_VariableBase->m_Operations)
     {
-        operations.push_back(
-            Operation{Operator(op.Op), op.Parameters, op.Info});
+        operations.push_back(Operation{Operator(op.Op), op.Parameters});
     }
     return operations;
 }

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -246,7 +246,7 @@ size_t VariableBase::AddOperation(Operator &op,
     if (op.IsDataTypeValid(m_Type))
     {
         m_Operations.push_back(
-            Operation{&op, helper::LowerCaseParams(parameters), Params()});
+            Operation{&op, helper::LowerCaseParams(parameters)});
     }
     else
     {

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -81,8 +81,6 @@ public:
         core::Operator *Op;
         /** Variable specific parameters */
         Params Parameters;
-        /** resulting information from executing Operation (e.g. buffer size) */
-        Params Info;
     };
 
     /** Registered transforms */

--- a/source/adios2/toolkit/format/bp/BPSerializer.h
+++ b/source/adios2/toolkit/format/bp/BPSerializer.h
@@ -155,6 +155,9 @@ protected:
     void PutOperationPayloadInBuffer(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::BPInfo &blockInfo);
+
+private:
+    size_t m_OutputSizeMetadataPosition;
 };
 
 } // end namespace format

--- a/source/adios2/toolkit/format/bp/BPSerializer.tcc
+++ b/source/adios2/toolkit/format/bp/BPSerializer.tcc
@@ -366,9 +366,7 @@ void BPSerializer::PutCharacteristicOperation(
     const typename core::Variable<T>::BPInfo &blockInfo,
     std::vector<char> &buffer) noexcept
 {
-    auto &operation = blockInfo.Operations[0];
-
-    const std::string type = operation.Op->m_TypeString;
+    const std::string type = blockInfo.Operations[0].Op->m_TypeString;
     const uint8_t typeLength = static_cast<uint8_t>(type.size());
     helper::InsertToBuffer(buffer, &typeLength);
     helper::InsertToBuffer(buffer, type.c_str(), type.size());
@@ -388,7 +386,7 @@ void BPSerializer::PutCharacteristicOperation(
     const uint64_t inputSize = static_cast<uint64_t>(
         helper::GetTotalSize(blockInfo.Count) * sizeof(T));
     // being naughty here
-    Params &info = const_cast<Params &>(operation.Info);
+    Params &info = const_cast<Params &>(blockInfo.Operations[0].Info);
     info["InputSize"] = std::to_string(inputSize);
 
     // fixed size only stores inputSize 8-bytes and outputSize 8-bytes
@@ -405,15 +403,14 @@ void BPSerializer::PutOperationPayloadInBuffer(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::BPInfo &blockInfo)
 {
-    core::Operator &op = *blockInfo.Operations[0].Op;
     const Params &parameters = blockInfo.Operations[0].Parameters;
     // being naughty here
     Params &info = const_cast<Params &>(blockInfo.Operations[0].Info);
 
-    const size_t outputSize =
-        op.Operate(reinterpret_cast<char *>(blockInfo.Data), blockInfo.Start,
-                   blockInfo.Count, variable.m_Type,
-                   m_Data.m_Buffer.data() + m_Data.m_Position, parameters);
+    const size_t outputSize = blockInfo.Operations[0].Op->Operate(
+        reinterpret_cast<char *>(blockInfo.Data), blockInfo.Start,
+        blockInfo.Count, variable.m_Type,
+        m_Data.m_Buffer.data() + m_Data.m_Position, parameters);
 
     info["OutputSize"] = std::to_string(outputSize);
 


### PR DESCRIPTION
This PR is to further refine the Operator framework. The original design of using a map<string, string> Info to hold operation metadata and intermediate results was very inefficient and confusing, as it needs to expose those intermediate results and compressor metadata everywhere, and every time it is used, it has to be cast from string to numbers back and forth, which does not make any sense.

With the self-contained compression buffer, now BP5, as well as any future engines and serializers, can handle this logic within a few lines of code, whereas in the original BPOperation, it needs a whole class, making it extremely hard for future engine / serializer developers to understand how it works. So it is now removed. 