### PR TITLE
Unified operator parameters, and centralized all operator logics into the Operator framework

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Operator.cpp
+++ b/bindings/CXX11/adios2/cxx11/Operator.cpp
@@ -46,9 +46,4 @@ Params Operator::Parameters() const
 // PRIVATE
 Operator::Operator(core::Operator *op) : m_Operator(op) {}
 
-std::string ToString(const Operator &op)
-{
-    return std::string("Operator(Type: \"" + op.Type() + "\")");
-}
-
 } // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/Operator.h
+++ b/bindings/CXX11/adios2/cxx11/Operator.h
@@ -78,8 +78,6 @@ private:
     core::Operator *m_Operator = nullptr;
 };
 
-std::string ToString(const IO &io);
-
 } // end namespace adios2
 
 #endif /* ADIOS2_BINDINGS_CXX11_CXX11_OPERATOR_H_ */

--- a/bindings/CXX11/adios2/cxx11/Variable.cpp
+++ b/bindings/CXX11/adios2/cxx11/Variable.cpp
@@ -172,6 +172,13 @@ namespace adios2
     }                                                                          \
                                                                                \
     template <>                                                                \
+    size_t Variable<T>::AddOperation(const std::string &type,                  \
+                                     const Params &parameters)                 \
+    {                                                                          \
+        return m_Variable->AddOperation(type, parameters);                     \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
     std::vector<Operator> Variable<T>::Operations() const                      \
     {                                                                          \
         helper::CheckForNullptr(m_Variable,                                    \

--- a/bindings/CXX11/adios2/cxx11/Variable.cpp
+++ b/bindings/CXX11/adios2/cxx11/Variable.cpp
@@ -172,17 +172,16 @@ namespace adios2
     }                                                                          \
                                                                                \
     template <>                                                                \
-    std::vector<typename Variable<T>::Operation> Variable<T>::Operations()     \
-        const                                                                  \
+    std::vector<Operator> Variable<T>::Operations() const                      \
     {                                                                          \
         helper::CheckForNullptr(m_Variable,                                    \
                                 "in call to Variable<T>::Operations");         \
-        std::vector<Operation> operations;                                     \
+        std::vector<Operator> operations;                                      \
         operations.reserve(m_Variable->m_Operations.size());                   \
                                                                                \
         for (const auto &op : m_Variable->m_Operations)                        \
         {                                                                      \
-            operations.push_back(Operation{Operator(op.Op), op.Parameters});   \
+            operations.push_back(Operator(op));                                \
         }                                                                      \
         return operations;                                                     \
     }                                                                          \

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -285,6 +285,9 @@ public:
     size_t AddOperation(const Operator op,
                         const adios2::Params &parameters = adios2::Params());
 
+    size_t AddOperation(const std::string &type,
+                        const adios2::Params &parameters = adios2::Params());
+
     /**
      * Inspects current operators added with AddOperator
      * @return vector of Variable<T>::OperatorInfo

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -276,20 +276,6 @@ public:
     size_t BlockID() const;
 
     /**
-     * EXPERIMENTAL: carries information about an Operation added with
-     * AddOperation
-     */
-    struct Operation
-    {
-        /** Operator associated with this operation */
-        const adios2::Operator Op;
-        /** Parameters settings for this operation */
-        const adios2::Params Parameters;
-        /** Information associated with this operation */
-        adios2::Params Info;
-    };
-
-    /**
      *Adds operation and parameters to current Variable object
      * @param op operator to be added
      * @param parameters key/value settings particular to the Variable, not to
@@ -303,7 +289,7 @@ public:
      * Inspects current operators added with AddOperator
      * @return vector of Variable<T>::OperatorInfo
      */
-    std::vector<Operation> Operations() const;
+    std::vector<Operator> Operations() const;
 
     /**
      * Removes all current Operations associated with AddOperation.

--- a/bindings/Python/py11Variable.cpp
+++ b/bindings/Python/py11Variable.cpp
@@ -83,15 +83,15 @@ size_t Variable::AddOperation(const Operator op, const Params &parameters)
     return m_VariableBase->AddOperation(*op.m_Operator, parameters);
 }
 
-std::vector<Variable::Operation> Variable::Operations() const
+std::vector<Operator> Variable::Operations() const
 {
     helper::CheckForNullptr(m_VariableBase, "in call to Variable::Operations");
-    std::vector<Variable::Operation> operations;
+    std::vector<Operator> operations;
     operations.reserve(m_VariableBase->m_Operations.size());
 
     for (const auto &op : m_VariableBase->m_Operations)
     {
-        operations.push_back(Operation{Operator(op.Op), op.Parameters});
+        operations.push_back(Operator(op));
     }
     return operations;
 }

--- a/bindings/Python/py11Variable.h
+++ b/bindings/Python/py11Variable.h
@@ -96,17 +96,6 @@ public:
     size_t BlockID() const;
 
     /**
-     * EXPERIMENTAL: carries information about an Operation added with
-     * AddOperation
-     */
-    struct Operation
-    {
-        const Operator Op;
-        const Params Parameters;
-        const Params Info;
-    };
-
-    /**
      * EXPERIMENTAL: Adds operation and parameters to current Variable object
      * @param op operator to be added
      * @param parameters key/value settings particular to the Variable, not to
@@ -119,7 +108,7 @@ public:
      * EXPERIMENTAL: inspects current operators added with AddOperator
      * @return vector of Variable<T>::OperatorInfo
      */
-    std::vector<Operation> Operations() const;
+    std::vector<Operator> Operations() const;
 
     /** Contains sub-block information for a particular Variable<T> */
     struct Info

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -18,9 +18,11 @@ add_library(adios2_core
   core/VariableCompound.cpp core/VariableCompound.tcc
   core/Group.cpp core/Group.tcc
 
-#operator callback
+#operator
   operator/callback/Signature1.cpp
   operator/callback/Signature2.cpp
+  operator/OperatorFactory.cpp
+  operator/compress/CompressNull.cpp
 
 #helper
   helper/adiosComm.h  helper/adiosComm.cpp
@@ -93,9 +95,6 @@ add_library(adios2_core
 
   toolkit/burstbuffer/FileDrainer.cpp
   toolkit/burstbuffer/FileDrainerSingleThread.cpp
-
-  operator/compress/CompressorFactory.cpp
-  operator/compress/CompressNull.cpp
 )
 set_property(TARGET adios2_core PROPERTY EXPORT_NAME core)
 set_property(TARGET adios2_core PROPERTY OUTPUT_NAME adios2${ADIOS2_LIBRARY_SUFFIX}_core)

--- a/source/adios2/common/ADIOSMacros.h
+++ b/source/adios2/common/ADIOSMacros.h
@@ -121,36 +121,6 @@
     MACRO(std::complex<float>)                                                 \
     MACRO(std::complex<double>)
 
-#define ADIOS2_FOREACH_ZFP_TYPE_1ARG(MACRO)                                    \
-    MACRO(int32_t)                                                             \
-    MACRO(int64_t)                                                             \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(std::complex<float>)                                                 \
-    MACRO(std::complex<double>)
-
-#define ADIOS2_FOREACH_SZ_TYPE_1ARG(MACRO)                                     \
-    MACRO(float)                                                               \
-    MACRO(double)                                                              \
-    MACRO(std::complex<float>)                                                 \
-    MACRO(std::complex<double>)
-
-#define ADIOS2_FOREACH_SIRIUS_TYPE_1ARG(MACRO) MACRO(float)
-
-#define ADIOS2_FOREACH_LIBPRESSIO_TYPE_1ARG(MACRO)                             \
-    MACRO(uint8_t)                                                             \
-    MACRO(uint16_t)                                                            \
-    MACRO(uint32_t)                                                            \
-    MACRO(uint64_t)                                                            \
-    MACRO(int8_t)                                                              \
-    MACRO(int16_t)                                                             \
-    MACRO(int32_t)                                                             \
-    MACRO(int64_t)                                                             \
-    MACRO(float)                                                               \
-    MACRO(double)
-
-#define ADIOS2_FOREACH_MGARD_TYPE_1ARG(MACRO) MACRO(double)
-
 #define ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(MACRO)                              \
     MACRO(std::string)                                                         \
     MACRO(char)                                                                \

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -18,7 +18,7 @@
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosCommDummy.h"
 #include "adios2/helper/adiosFunctions.h" //InquireKey, BroadcastFile
-#include "adios2/operator/compress/CompressorFactory.h"
+#include "adios2/operator/OperatorFactory.h"
 #include <adios2sys/SystemTools.hxx>
 
 #include <adios2-perfstubs-interface.h>
@@ -155,8 +155,7 @@ Operator &ADIOS::DefineOperator(const std::string &name, const std::string type,
                                 const Params &parameters)
 {
     CheckOperator(name);
-    auto itPair =
-        m_Operators.emplace(name, compress::MakeOperator(type, parameters));
+    auto itPair = m_Operators.emplace(name, MakeOperator(type, parameters));
     return *itPair.first->second.get();
 }
 

--- a/source/adios2/core/Operator.h
+++ b/source/adios2/core/Operator.h
@@ -76,7 +76,7 @@ public:
      */
     virtual size_t Operate(const char *dataIn, const Dims &blockStart,
                            const Dims &blockCount, const DataType type,
-                           char *bufferOut, const Params &parameters) = 0;
+                           char *bufferOut) = 0;
 
     /**
      * @param bufferIn

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -95,7 +95,7 @@ public:
         Dims Count;
         Dims MemoryStart;
         Dims MemoryCount;
-        std::vector<Operation> Operations;
+        std::vector<Operator *> Operations;
         size_t Step = 0;
         size_t StepsStart = 0;
         size_t StepsCount = 0;

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -245,8 +245,11 @@ size_t VariableBase::AddOperation(Operator &op,
 {
     if (op.IsDataTypeValid(m_Type))
     {
-        m_Operations.push_back(
-            Operation{&op, helper::LowerCaseParams(parameters)});
+        for (const auto &p : parameters)
+        {
+            op.SetParameter(helper::LowerCase(p.first), p.second);
+        }
+        m_Operations.push_back(&op);
     }
     else
     {
@@ -271,7 +274,7 @@ void VariableBase::SetOperationParameter(const size_t operationID,
             "SetOperationParameter\n");
     }
 
-    m_Operations[operationID].Parameters[key] = value;
+    m_Operations[operationID]->SetParameter(key, value);
 }
 
 void VariableBase::CheckDimensions(const std::string hint) const

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -240,6 +240,12 @@ void VariableBase::SetStepSelection(const Box<size_t> &boxSteps)
     }
 }
 
+size_t VariableBase::AddOperation(const std::string &op,
+                                  const Params &parameters) noexcept
+{
+    return m_Operations.size() - 1;
+}
+
 size_t VariableBase::AddOperation(Operator &op,
                                   const Params &parameters) noexcept
 {
@@ -260,7 +266,11 @@ size_t VariableBase::AddOperation(Operator &op,
     return m_Operations.size() - 1;
 }
 
-void VariableBase::RemoveOperations() noexcept { m_Operations.clear(); }
+void VariableBase::RemoveOperations() noexcept
+{
+    m_PrivateOperations.clear();
+    m_Operations.clear();
+}
 
 void VariableBase::SetOperationParameter(const size_t operationID,
                                          const std::string key,

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -22,6 +22,7 @@
 #include "adios2/core/Variable.h"
 #include "adios2/helper/adiosFunctions.h" //helper::GetTotalSize
 #include "adios2/helper/adiosString.h"
+#include "adios2/operator/OperatorFactory.h"
 
 #ifdef ADIOS2_HAVE_CUDA
 #include <cuda.h>
@@ -240,9 +241,11 @@ void VariableBase::SetStepSelection(const Box<size_t> &boxSteps)
     }
 }
 
-size_t VariableBase::AddOperation(const std::string &op,
+size_t VariableBase::AddOperation(const std::string &type,
                                   const Params &parameters) noexcept
 {
+    m_PrivateOperations.emplace_back(MakeOperator(type, parameters));
+    m_Operations.push_back(m_PrivateOperations.back().get());
     return m_Operations.size() - 1;
 }
 

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -73,18 +73,8 @@ public:
      * already encountered in previous step */
     bool m_FirstStreamingStep = true;
 
-    /** Operators metadata info */
-    struct Operation
-    {
-        /** reference to object derived from Operator class,
-         *  needs a pointer to enable assignment operator (C++ class) */
-        core::Operator *Op;
-        /** Variable specific parameters */
-        Params Parameters;
-    };
-
     /** Registered transforms */
-    std::vector<Operation> m_Operations;
+    std::vector<Operator *> m_Operations;
 
     size_t m_AvailableStepsStart = 0;
     size_t m_AvailableStepsCount = 0;

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -169,6 +169,9 @@ public:
     size_t AddOperation(core::Operator &op,
                         const Params &parameters = Params()) noexcept;
 
+    size_t AddOperation(const std::string &op,
+                        const Params &parameters = Params()) noexcept;
+
     /**
      * Removes all current Operations associated with AddOperation.
      * Provides the posibility to apply or not operators on a step basis.
@@ -223,6 +226,8 @@ protected:
     bool m_ConstantDims = false; ///< true: fix m_Shape, m_Start, m_Count
 
     unsigned int m_DeferredCounter = 0;
+
+    std::vector<std::shared_ptr<Operator>> m_PrivateOperations;
 
     void InitShapeType();
 

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -13,6 +13,7 @@
 #define ADIOS2_CORE_VARIABLEBASE_H_
 
 /// \cond EXCLUDE_FROM_DOXYGEN
+#include <memory>
 #include <set>
 #include <sstream>
 #include <string>

--- a/source/adios2/helper/adiosLog.cpp
+++ b/source/adios2/helper/adiosLog.cpp
@@ -59,7 +59,7 @@ void Log(const std::string &component, const std::string &source,
     {
         if (mode == LogMode::EXCEPTION)
         {
-            throw(message);
+            throw message;
         }
         else
         {
@@ -118,7 +118,7 @@ void Log(const std::string &component, const std::string &source,
     else if (mode == EXCEPTION)
     {
         std::cerr << m.str();
-        throw(m.str());
+        throw m.str();
     }
 }
 

--- a/source/adios2/helper/adiosXML.cpp
+++ b/source/adios2/helper/adiosXML.cpp
@@ -19,6 +19,7 @@
 
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/IO.h"
+#include "adios2/helper/adiosLog.h"
 #include "adios2/helper/adiosString.h"
 #include "adios2/helper/adiosXMLUtil.h"
 
@@ -44,8 +45,8 @@ void ParseConfigXML(
 
         if (fileContents.empty())
         {
-            throw std::invalid_argument("ERROR: config xml file is empty, " +
-                                        hint + "\n");
+            helper::Log("Helper", "AdiosXML", "ParseConfigXML",
+                        "empty config xml file", helper::EXCEPTION);
         }
         return fileContents;
     };
@@ -82,23 +83,25 @@ void ParseConfigXML(
 
             if (*opName && *opType)
             {
-                throw std::invalid_argument(
-                    "ERROR: operator (" + std::string(opName->value()) +
-                    ") and type (" + std::string(opType->value()) +
-                    ") attributes can't coexist in <operation> element "
-                    "inside <variable name=\"" +
-                    variableName + "\"> element, " + hint + "\n");
+                helper::Log(
+                    "Helper", "AdiosXML", "ParseConfigXML",
+                    "operator (" + std::string(opName->value()) +
+                        ") and type (" + std::string(opType->value()) +
+                        ") attributes can't coexist in <operation> element "
+                        "inside <variable name=\"" +
+                        variableName + "\"> element",
+                    helper::EXCEPTION);
             }
 
             if (!*opName && !*opType)
             {
-                throw std::invalid_argument(
-                    "ERROR: <operation> element "
-                    "inside <variable name=\"" +
-                    variableName +
-                    "\"> element requires either operator "
-                    "(existing) or type (supported) attribute, " +
-                    hint + "\n");
+                helper::Log("Helper", "AdiosXML", "ParseConfigXML",
+                            "<operation> element "
+                            "inside <variable name=\"" +
+                                variableName +
+                                "\"> element requires either operator "
+                                "(existing) or type (supported) attribute",
+                            helper::EXCEPTION);
             }
 
             core::Operator *op = nullptr;
@@ -108,11 +111,12 @@ void ParseConfigXML(
                 auto itOperator = operators.find(std::string(opName->value()));
                 if (itOperator == operators.end())
                 {
-                    throw std::invalid_argument(
-                        "ERROR: operator " + std::string(opName->value()) +
-                        " not previously defined, from variable " +
-                        variableName + " inside io " + currentIO.m_Name + ", " +
-                        hint + "\n");
+                    helper::Log("Helper", "AdiosXML", "ParseConfigXML",
+                                "operator " + std::string(opName->value()) +
+                                    " not previously defined, from variable " +
+                                    variableName + " inside io " +
+                                    currentIO.m_Name,
+                                helper::EXCEPTION);
                 }
                 op = itOperator->second.get();
             }

--- a/source/adios2/operator/OperatorFactory.cpp
+++ b/source/adios2/operator/OperatorFactory.cpp
@@ -143,7 +143,7 @@ std::shared_ptr<Operator> MakeOperator(const std::string &type,
     {
         helper::Log("Operator", "OperatorFactory", "MakeOperator",
                     "ADIOS2 didn't compile with " + typeLowerCase +
-                        "library, operator not added",
+                        " library, operator not added",
                     helper::EXCEPTION);
     }
 

--- a/source/adios2/operator/OperatorFactory.cpp
+++ b/source/adios2/operator/OperatorFactory.cpp
@@ -8,7 +8,7 @@
  *      Author: Jason Wang jason.ruonan.wang@gmail.com
  */
 
-#include "CompressorFactory.h"
+#include "OperatorFactory.h"
 #include "adios2/helper/adiosFunctions.h"
 #include "adios2/operator/compress/CompressNull.h"
 #include <numeric>
@@ -48,8 +48,6 @@
 namespace adios2
 {
 namespace core
-{
-namespace compress
 {
 
 std::shared_ptr<Operator> MakeOperator(const std::string &type,
@@ -130,7 +128,7 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
         if (compressorType == "blosc")
         {
 #ifdef ADIOS2_HAVE_BLOSC
-            CompressBlosc c({});
+            compress::CompressBlosc c({});
             ret = c.Operate(dataIn, blockStart, blockCount, dataType, bufferOut,
                             parameters);
 #else
@@ -143,7 +141,7 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
         else if (compressorType == "bzip2")
         {
 #ifdef ADIOS2_HAVE_BZIP2
-            CompressBZIP2 c({});
+            compress::CompressBZIP2 c({});
             ret = c.Operate(dataIn, blockStart, blockCount, dataType, bufferOut,
                             parameters);
 #else
@@ -156,7 +154,7 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
         else if (compressorType == "libpressio")
         {
 #ifdef ADIOS2_HAVE_LIBPRESSIO
-            CompressLibPressio c({});
+            compress::CompressLibPressio c({});
             ret = c.Operate(dataIn, blockStart, blockCount, dataType, bufferOut,
                             parameters);
 #else
@@ -169,7 +167,7 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
         else if (compressorType == "mgard")
         {
 #ifdef ADIOS2_HAVE_MGARD
-            CompressMGARD c({});
+            compress::CompressMGARD c({});
             ret = c.Operate(dataIn, blockStart, blockCount, dataType, bufferOut,
                             parameters);
 #else
@@ -182,7 +180,7 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
         else if (compressorType == "png")
         {
 #ifdef ADIOS2_HAVE_PNG
-            CompressPNG c({});
+            compress::CompressPNG c({});
             ret = c.Operate(dataIn, blockStart, blockCount, dataType, bufferOut,
                             parameters);
 #else
@@ -194,7 +192,7 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
         else if (compressorType == "sirius")
         {
 #ifdef ADIOS2_HAVE_MHS
-            CompressSirius c({});
+            compress::CompressSirius c({});
             ret = c.Operate(dataIn, blockStart, blockCount, dataType, bufferOut,
                             parameters);
 #else
@@ -206,7 +204,7 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
         else if (compressorType == "sz")
         {
 #ifdef ADIOS2_HAVE_SZ
-            CompressSZ c({});
+            compress::CompressSZ c({});
             ret = c.Operate(dataIn, blockStart, blockCount, dataType, bufferOut,
                             parameters);
 #else
@@ -218,7 +216,7 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
         else if (compressorType == "zfp")
         {
 #ifdef ADIOS2_HAVE_ZFP
-            CompressZFP c({});
+            compress::CompressZFP c({});
             ret = c.Operate(dataIn, blockStart, blockCount, dataType, bufferOut,
                             parameters);
 #else
@@ -249,7 +247,7 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
     {
         helper::Log("Operator", "CompressorFactory", "Compress", e.what(),
                     helper::WARNING);
-        CompressNull c({});
+        compress::CompressNull c({});
         ret = c.Operate(dataIn, blockStart, blockCount, dataType, bufferOut,
                         parameters);
     }
@@ -350,6 +348,5 @@ size_t Decompress(const char *bufferIn, const size_t sizeIn, char *dataOut)
     return 0;
 }
 
-} // end namespace compress
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/operator/OperatorFactory.cpp
+++ b/source/adios2/operator/OperatorFactory.cpp
@@ -64,6 +64,8 @@ std::string OperatorTypeToString(const Operator::OperatorType type)
         return "mgard";
     case Operator::COMPRESS_PNG:
         return "png";
+    case Operator::COMPRESS_SIRIUS:
+        return "sirius";
     case Operator::COMPRESS_SZ:
         return "sz";
     case Operator::COMPRESS_ZFP:
@@ -109,6 +111,10 @@ std::shared_ptr<Operator> MakeOperator(const std::string &type,
 #ifdef ADIOS2_HAVE_PNG
         ret = std::make_shared<compress::CompressPNG>(parameters);
 #endif
+    }
+    else if (typeLowerCase == "sirius")
+    {
+        ret = std::make_shared<compress::CompressSirius>(parameters);
     }
     else if (typeLowerCase == "sz")
     {

--- a/source/adios2/operator/OperatorFactory.h
+++ b/source/adios2/operator/OperatorFactory.h
@@ -20,10 +20,6 @@ namespace core
 std::shared_ptr<Operator> MakeOperator(const std::string &type,
                                        const Params &parameters);
 
-size_t Compress(const char *dataIn, const Dims &blockStart,
-                const Dims &blockCount, const DataType type, char *bufferOut,
-                const Params &parameters, const std::string &compressorType);
-
 size_t Decompress(const char *bufferIn, const size_t sizeIn, char *dataOut);
 
 } // end namespace core

--- a/source/adios2/operator/OperatorFactory.h
+++ b/source/adios2/operator/OperatorFactory.h
@@ -10,6 +10,7 @@
 
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/Operator.h"
+#include <memory>
 
 namespace adios2
 {

--- a/source/adios2/operator/OperatorFactory.h
+++ b/source/adios2/operator/OperatorFactory.h
@@ -2,7 +2,7 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * CompressorFactory.h :
+ * OperatorFactory.h :
  *
  *  Created on: Sep 29, 2021
  *      Author: Jason Wang jason.ruonan.wang@gmail.com
@@ -15,8 +15,6 @@ namespace adios2
 {
 namespace core
 {
-namespace compress
-{
 
 std::shared_ptr<Operator> MakeOperator(const std::string &type,
                                        const Params &parameters);
@@ -27,6 +25,5 @@ size_t Compress(const char *dataIn, const Dims &blockStart,
 
 size_t Decompress(const char *bufferIn, const size_t sizeIn, char *dataOut);
 
-} // end namespace compress
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/operator/callback/Signature1.cpp
+++ b/source/adios2/operator/callback/Signature1.cpp
@@ -52,7 +52,7 @@ ADIOS2_FOREACH_STDTYPE_2ARGS(declare_type)
 
 size_t Signature1::Operate(const char *dataIn, const Dims &blockStart,
                            const Dims &blockCount, const DataType type,
-                           char *bufferOut, const Params &parameters)
+                           char *bufferOut)
 {
     return 0;
 }

--- a/source/adios2/operator/callback/Signature1.h
+++ b/source/adios2/operator/callback/Signature1.h
@@ -50,12 +50,11 @@ public:
      * @param type
      * @param bufferOut format will be: 'DataHeader ; (BloscCompressedChunk |
      * UncompressedData), [ BloscCompressedChunk, ...]'
-     * @param parameters
      * @return size of compressed buffer in bytes
      */
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &parameters) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     /**
      * @param bufferIn

--- a/source/adios2/operator/callback/Signature2.cpp
+++ b/source/adios2/operator/callback/Signature2.cpp
@@ -45,7 +45,7 @@ void Signature2::RunCallback2(void *arg1, const std::string &arg2,
 
 size_t Signature2::Operate(const char *dataIn, const Dims &blockStart,
                            const Dims &blockCount, const DataType type,
-                           char *bufferOut, const Params &parameters)
+                           char *bufferOut)
 {
     return 0;
 }

--- a/source/adios2/operator/callback/Signature2.h
+++ b/source/adios2/operator/callback/Signature2.h
@@ -43,12 +43,11 @@ public:
      * @param type
      * @param bufferOut format will be: 'DataHeader ; (BloscCompressedChunk |
      * UncompressedData), [ BloscCompressedChunk, ...]'
-     * @param parameters
      * @return size of compressed buffer in bytes
      */
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &parameters) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     /**
      * @param bufferIn

--- a/source/adios2/operator/compress/CompressBZIP2.cpp
+++ b/source/adios2/operator/compress/CompressBZIP2.cpp
@@ -34,7 +34,7 @@ CompressBZIP2::CompressBZIP2(const Params &parameters)
 
 size_t CompressBZIP2::Operate(const char *dataIn, const Dims &blockStart,
                               const Dims &blockCount, DataType type,
-                              char *bufferOut, const Params &parameters)
+                              char *bufferOut)
 {
 
     const uint8_t bufferVersion = 1;
@@ -54,14 +54,15 @@ size_t CompressBZIP2::Operate(const char *dataIn, const Dims &blockStart,
     int blockSize100k = 1;
     int verbosity = 0;
     int workFactor = 0;
-    if (!parameters.empty())
+    if (!m_Parameters.empty())
     {
         const std::string hint(" in call to CompressBZIP2 Compress " +
                                ToString(type) + "\n");
-        helper::SetParameterValueInt("blockSize100k", parameters, blockSize100k,
+        helper::SetParameterValueInt("blockSize100k", m_Parameters,
+                                     blockSize100k, hint);
+        helper::SetParameterValueInt("verbosity", m_Parameters, verbosity,
                                      hint);
-        helper::SetParameterValueInt("verbosity", parameters, verbosity, hint);
-        helper::SetParameterValueInt("workFactor", parameters, workFactor,
+        helper::SetParameterValueInt("workFactor", m_Parameters, workFactor,
                                      hint);
         if (blockSize100k < 1 || blockSize100k > 9)
         {

--- a/source/adios2/operator/compress/CompressBZIP2.h
+++ b/source/adios2/operator/compress/CompressBZIP2.h
@@ -37,12 +37,11 @@ public:
      * @param blockCount
      * @param type
      * @param bufferOut
-     * @param parameters
      * @return size of compressed buffer
      */
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &parameters) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     /**
      * @param bufferIn

--- a/source/adios2/operator/compress/CompressBlosc.cpp
+++ b/source/adios2/operator/compress/CompressBlosc.cpp
@@ -44,7 +44,7 @@ CompressBlosc::CompressBlosc(const Params &parameters)
 
 size_t CompressBlosc::Operate(const char *dataIn, const Dims &blockStart,
                               const Dims &blockCount, const DataType type,
-                              char *bufferOut, const Params &parameters)
+                              char *bufferOut)
 {
     size_t bufferOutOffset = 0;
     const uint8_t bufferVersion = 1;
@@ -77,7 +77,7 @@ size_t CompressBlosc::Operate(const char *dataIn, const Dims &blockStart,
     std::string compressor = "blosclz";
     size_t blockSize = 0;
 
-    for (const auto &itParameter : parameters)
+    for (const auto &itParameter : m_Parameters)
     {
         const std::string key = itParameter.first;
         const std::string value = itParameter.second;

--- a/source/adios2/operator/compress/CompressBlosc.h
+++ b/source/adios2/operator/compress/CompressBlosc.h
@@ -50,12 +50,11 @@ public:
      * @param type
      * @param bufferOut format will be: 'DataHeader ; (BloscCompressedChunk |
      * UncompressedData), [ BloscCompressedChunk, ...]'
-     * @param parameters
      * @return size of compressed buffer in bytes
      */
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &parameters) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     /**
      * @param bufferIn

--- a/source/adios2/operator/compress/CompressLibPressio.cpp
+++ b/source/adios2/operator/compress/CompressLibPressio.cpp
@@ -286,7 +286,7 @@ CompressLibPressio::CompressLibPressio(const Params &parameters)
 }
 size_t CompressLibPressio::Operate(const char *dataIn, const Dims &blockStart,
                                    const Dims &blockCount, const DataType type,
-                                   char *bufferOut, const Params &parameters)
+                                   char *bufferOut)
 {
     const uint8_t bufferVersion = 1;
     size_t bufferOutOffset = 0;
@@ -308,7 +308,7 @@ size_t CompressLibPressio::Operate(const char *dataIn, const Dims &blockStart,
                  static_cast<uint8_t>(pressio_minor_version()));
     PutParameter(bufferOut, bufferOutOffset,
                  static_cast<uint8_t>(pressio_patch_version()));
-    PutParameters(bufferOut, bufferOutOffset, parameters);
+    PutParameters(bufferOut, bufferOutOffset, m_Parameters);
     // zfp V1 metadata end
 
     auto inputs_dims = adios_to_libpressio_dims(blockCount);
@@ -320,7 +320,7 @@ size_t CompressLibPressio::Operate(const char *dataIn, const Dims &blockStart,
     pressio_compressor *compressor = nullptr;
     try
     {
-        compressor = adios_to_libpressio_compressor(parameters);
+        compressor = adios_to_libpressio_compressor(m_Parameters);
     }
     catch (std::exception &e)
     {

--- a/source/adios2/operator/compress/CompressLibPressio.cpp
+++ b/source/adios2/operator/compress/CompressLibPressio.cpp
@@ -376,13 +376,14 @@ size_t CompressLibPressio::InverseOperate(const char *bufferIn,
 
 bool CompressLibPressio::IsDataTypeValid(const DataType type) const
 {
-#define declare_type(T)                                                        \
-    if (helper::GetDataType<T>() == type)                                      \
-    {                                                                          \
-        return true;                                                           \
+    if (type == DataType::Int8 || type == DataType::UInt8 ||
+        type == DataType::Int16 || type == DataType::UInt16 ||
+        type == DataType::Int32 || type == DataType::UInt32 ||
+        type == DataType::Int64 || type == DataType::UInt64 ||
+        type == DataType::Float || type == DataType::Double)
+    {
+        return true;
     }
-    ADIOS2_FOREACH_LIBPRESSIO_TYPE_1ARG(declare_type)
-#undef declare_type
     return false;
 }
 

--- a/source/adios2/operator/compress/CompressLibPressio.h
+++ b/source/adios2/operator/compress/CompressLibPressio.h
@@ -37,12 +37,11 @@ public:
      * @param blockCount
      * @param type
      * @param bufferOut
-     * @param parameters
      * @return size of compressed buffer
      */
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &parameters) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     /**
      * @param bufferIn

--- a/source/adios2/operator/compress/CompressMGARD.cpp
+++ b/source/adios2/operator/compress/CompressMGARD.cpp
@@ -150,13 +150,10 @@ size_t CompressMGARD::InverseOperate(const char *bufferIn, const size_t sizeIn,
 
 bool CompressMGARD::IsDataTypeValid(const DataType type) const
 {
-#define declare_type(T)                                                        \
-    if (helper::GetDataType<T>() == type)                                      \
-    {                                                                          \
-        return true;                                                           \
+    if (type == DataType::Double)
+    {
+        return true;
     }
-    ADIOS2_FOREACH_MGARD_TYPE_1ARG(declare_type)
-#undef declare_type
     return false;
 }
 

--- a/source/adios2/operator/compress/CompressMGARD.cpp
+++ b/source/adios2/operator/compress/CompressMGARD.cpp
@@ -28,7 +28,7 @@ CompressMGARD::CompressMGARD(const Params &parameters)
 
 size_t CompressMGARD::Operate(const char *dataIn, const Dims &blockStart,
                               const Dims &blockCount, const DataType type,
-                              char *bufferOut, const Params &parameters)
+                              char *bufferOut)
 {
     const uint8_t bufferVersion = 1;
     size_t bufferOutOffset = 0;
@@ -84,14 +84,14 @@ size_t CompressMGARD::Operate(const char *dataIn, const Dims &blockStart,
     // Parameters
     bool hasTolerance = false;
     double tolerance, s = 0.0;
-    auto itAccuracy = parameters.find("accuracy");
-    if (itAccuracy != parameters.end())
+    auto itAccuracy = m_Parameters.find("accuracy");
+    if (itAccuracy != m_Parameters.end())
     {
         tolerance = std::stod(itAccuracy->second);
         hasTolerance = true;
     }
-    auto itTolerance = parameters.find("tolerance");
-    if (itTolerance != parameters.end())
+    auto itTolerance = m_Parameters.find("tolerance");
+    if (itTolerance != m_Parameters.end())
     {
         tolerance = std::stod(itTolerance->second);
         hasTolerance = true;
@@ -102,8 +102,8 @@ size_t CompressMGARD::Operate(const char *dataIn, const Dims &blockStart,
                                     "tolerance for MGARD compression "
                                     "operator\n");
     }
-    auto itSParameter = parameters.find("s");
-    if (itSParameter != parameters.end())
+    auto itSParameter = m_Parameters.find("s");
+    if (itSParameter != m_Parameters.end())
     {
         s = std::stod(itSParameter->second);
     }

--- a/source/adios2/operator/compress/CompressMGARD.h
+++ b/source/adios2/operator/compress/CompressMGARD.h
@@ -37,12 +37,11 @@ public:
      * @param blockCount
      * @param type
      * @param bufferOut
-     * @param parameters
      * @return size of compressed buffer
      */
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &parameters) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     /**
      * @param bufferIn

--- a/source/adios2/operator/compress/CompressNull.cpp
+++ b/source/adios2/operator/compress/CompressNull.cpp
@@ -25,7 +25,7 @@ CompressNull::CompressNull(const Params &parameters)
 
 size_t CompressNull::Operate(const char *dataIn, const Dims &blockStart,
                              const Dims &blockCount, const DataType varType,
-                             char *bufferOut, const Params &params)
+                             char *bufferOut)
 {
     const uint8_t bufferVersion = 1;
     size_t bufferOutOffset = 0;

--- a/source/adios2/operator/compress/CompressNull.h
+++ b/source/adios2/operator/compress/CompressNull.h
@@ -29,8 +29,8 @@ public:
     ~CompressNull() = default;
 
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &params) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     size_t InverseOperate(const char *bufferIn, const size_t sizeIn,
                           char *dataOut) final;

--- a/source/adios2/operator/compress/CompressPNG.cpp
+++ b/source/adios2/operator/compress/CompressPNG.cpp
@@ -50,7 +50,7 @@ CompressPNG::CompressPNG(const Params &parameters)
 
 size_t CompressPNG::Operate(const char *dataIn, const Dims &blockStart,
                             const Dims &blockCount, const DataType type,
-                            char *bufferOut, const Params &parameters)
+                            char *bufferOut)
 {
     size_t bufferOutOffset = 0;
     const uint8_t bufferVersion = 1;
@@ -84,7 +84,7 @@ size_t CompressPNG::Operate(const char *dataIn, const Dims &blockStart,
     int bitDepth = 8;
     std::string colorTypeStr = "PNG_COLOR_TYPE_RGBA";
 
-    for (const auto &itParameter : parameters)
+    for (const auto &itParameter : m_Parameters)
     {
         const std::string key = itParameter.first;
         const std::string value = itParameter.second;

--- a/source/adios2/operator/compress/CompressPNG.h
+++ b/source/adios2/operator/compress/CompressPNG.h
@@ -39,12 +39,11 @@ public:
      * @param blockCount
      * @param type
      * @param bufferOut
-     * @param parameters
      * @return size of compressed buffer
      */
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &parameters) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     /**
      * @param bufferIn

--- a/source/adios2/operator/compress/CompressSZ.cpp
+++ b/source/adios2/operator/compress/CompressSZ.cpp
@@ -321,13 +321,11 @@ size_t CompressSZ::InverseOperate(const char *bufferIn, const size_t sizeIn,
 
 bool CompressSZ::IsDataTypeValid(const DataType type) const
 {
-#define declare_type(T)                                                        \
-    if (helper::GetDataType<T>() == type)                                      \
-    {                                                                          \
-        return true;                                                           \
+    if (type == DataType::Float || type == DataType::Double ||
+        type == DataType::FloatComplex || type == DataType::DoubleComplex)
+    {
+        return true;
     }
-    ADIOS2_FOREACH_SZ_TYPE_1ARG(declare_type)
-#undef declare_type
     return false;
 }
 

--- a/source/adios2/operator/compress/CompressSZ.cpp
+++ b/source/adios2/operator/compress/CompressSZ.cpp
@@ -34,7 +34,7 @@ CompressSZ::CompressSZ(const Params &parameters)
 
 size_t CompressSZ::Operate(const char *dataIn, const Dims &blockStart,
                            const Dims &blockCount, const DataType varType,
-                           char *bufferOut, const Params &parameters)
+                           char *bufferOut)
 {
     const uint8_t bufferVersion = 2;
     size_t bufferOutOffset = 0;
@@ -85,7 +85,7 @@ size_t CompressSZ::Operate(const char *dataIn, const Dims &blockStart,
     std::string sz_configfile = "sz.config";
 
     Params::const_iterator it;
-    for (it = parameters.begin(); it != parameters.end(); it++)
+    for (it = m_Parameters.begin(); it != m_Parameters.end(); it++)
     {
         if (it->first == "init")
         {

--- a/source/adios2/operator/compress/CompressSZ.h
+++ b/source/adios2/operator/compress/CompressSZ.h
@@ -37,12 +37,11 @@ public:
      * @param blockCount
      * @param type
      * @param bufferOut
-     * @param parameters
      * @return size of compressed buffer
      */
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &parameters) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     /**
      * @param bufferIn

--- a/source/adios2/operator/compress/CompressSirius.cpp
+++ b/source/adios2/operator/compress/CompressSirius.cpp
@@ -36,7 +36,7 @@ CompressSirius::CompressSirius(const Params &parameters)
 
 size_t CompressSirius::Operate(const char *dataIn, const Dims &blockStart,
                                const Dims &blockCount, const DataType varType,
-                               char *bufferOut, const Params &params)
+                               char *bufferOut)
 {
     const uint8_t bufferVersion = 1;
     size_t bufferOutOffset = 0;

--- a/source/adios2/operator/compress/CompressSirius.cpp
+++ b/source/adios2/operator/compress/CompressSirius.cpp
@@ -115,13 +115,10 @@ size_t CompressSirius::InverseOperate(const char *bufferIn, const size_t sizeIn,
 
 bool CompressSirius::IsDataTypeValid(const DataType type) const
 {
-#define declare_type(T)                                                        \
-    if (helper::GetDataType<T>() == type)                                      \
-    {                                                                          \
-        return true;                                                           \
+    if (type == DataType::Float)
+    {
+        return true;
     }
-    ADIOS2_FOREACH_SIRIUS_TYPE_1ARG(declare_type)
-#undef declare_type
     return false;
 }
 

--- a/source/adios2/operator/compress/CompressSirius.h
+++ b/source/adios2/operator/compress/CompressSirius.h
@@ -30,8 +30,8 @@ public:
     ~CompressSirius() = default;
 
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &params) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     size_t InverseOperate(const char *bufferIn, const size_t sizeIn,
                           char *dataOut) final;

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -59,7 +59,7 @@ CompressZFP::CompressZFP(const Params &parameters)
 
 size_t CompressZFP::Operate(const char *dataIn, const Dims &blockStart,
                             const Dims &blockCount, const DataType type,
-                            char *bufferOut, const Params &parameters)
+                            char *bufferOut)
 {
 
     const uint8_t bufferVersion = 1;
@@ -82,13 +82,13 @@ size_t CompressZFP::Operate(const char *dataIn, const Dims &blockStart,
                  static_cast<uint8_t>(ZFP_VERSION_MINOR));
     PutParameter(bufferOut, bufferOutOffset,
                  static_cast<uint8_t>(ZFP_VERSION_RELEASE));
-    PutParameters(bufferOut, bufferOutOffset, parameters);
+    PutParameters(bufferOut, bufferOutOffset, m_Parameters);
     // zfp V1 metadata end
 
     Dims convertedDims = ConvertDims(blockCount, type, 3);
 
     zfp_field *field = GetZFPField(dataIn, convertedDims, type);
-    zfp_stream *stream = GetZFPStream(convertedDims, type, parameters);
+    zfp_stream *stream = GetZFPStream(convertedDims, type, m_Parameters);
 
     size_t maxSize = zfp_stream_maximum_size(stream, field);
     // associate bitstream

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -145,13 +145,12 @@ size_t CompressZFP::InverseOperate(const char *bufferIn, const size_t sizeIn,
 
 bool CompressZFP::IsDataTypeValid(const DataType type) const
 {
-#define declare_type(T)                                                        \
-    if (helper::GetDataType<T>() == type)                                      \
-    {                                                                          \
-        return true;                                                           \
+    if (type == DataType::Float || type == DataType::Double ||
+        type == DataType::FloatComplex || type == DataType::DoubleComplex ||
+        type == DataType::Int32 || type == DataType::Int64)
+    {
+        return true;
     }
-    ADIOS2_FOREACH_ZFP_TYPE_1ARG(declare_type)
-#undef declare_type
     return false;
 }
 

--- a/source/adios2/operator/compress/CompressZFP.h
+++ b/source/adios2/operator/compress/CompressZFP.h
@@ -38,12 +38,11 @@ public:
      * @param blockCount
      * @param type
      * @param bufferOut
-     * @param parameters
      * @return size of compressed buffer
      */
     size_t Operate(const char *dataIn, const Dims &blockStart,
-                   const Dims &blockCount, const DataType type, char *bufferOut,
-                   const Params &parameters) final;
+                   const Dims &blockCount, const DataType type,
+                   char *bufferOut) final;
 
     /**
      * @param bufferIn

--- a/source/adios2/operator/compress/CompressorFactory.cpp
+++ b/source/adios2/operator/compress/CompressorFactory.cpp
@@ -9,7 +9,6 @@
  */
 
 #include "CompressorFactory.h"
-#include "adios2/core/Operator.h"
 #include "adios2/helper/adiosFunctions.h"
 #include "adios2/operator/compress/CompressNull.h"
 #include <numeric>
@@ -52,6 +51,73 @@ namespace core
 {
 namespace compress
 {
+
+std::shared_ptr<Operator> MakeOperator(const std::string &type,
+                                       const Params &parameters)
+{
+    std::shared_ptr<Operator> ret = nullptr;
+
+    const std::string typeLowerCase = helper::LowerCase(type);
+
+    if (typeLowerCase == "blosc")
+    {
+#ifdef ADIOS2_HAVE_BLOSC
+        ret = std::make_shared<compress::CompressBlosc>(parameters);
+#endif
+    }
+    else if (typeLowerCase == "bzip2")
+    {
+#ifdef ADIOS2_HAVE_BZIP2
+        ret = std::make_shared<compress::CompressBZIP2>(parameters);
+#endif
+    }
+    else if (typeLowerCase == "libpressio")
+    {
+#ifdef ADIOS2_HAVE_LIBPRESSIO
+        ret = std::make_shared<compress::CompressLibPressio>(parameters);
+#endif
+    }
+    else if (typeLowerCase == "mgard")
+    {
+#ifdef ADIOS2_HAVE_MGARD
+        ret = std::make_shared<compress::CompressMGARD>(parameters);
+#endif
+    }
+    else if (typeLowerCase == "png")
+    {
+#ifdef ADIOS2_HAVE_PNG
+        ret = std::make_shared<compress::CompressPNG>(parameters);
+#endif
+    }
+    else if (typeLowerCase == "sz")
+    {
+#ifdef ADIOS2_HAVE_SZ
+        ret = std::make_shared<compress::CompressSZ>(parameters);
+#endif
+    }
+    else if (typeLowerCase == "zfp")
+    {
+#ifdef ADIOS2_HAVE_ZFP
+        ret = std::make_shared<compress::CompressZFP>(parameters);
+#endif
+    }
+    else
+    {
+        helper::Log("Operator", "CompressorFactory", "MakeOperator",
+                    "ADIOS2 does not support " + typeLowerCase + " operation",
+                    helper::EXCEPTION);
+    }
+
+    if (ret == nullptr)
+    {
+        helper::Log("Operator", "CompressorFactory", "MakeOperator",
+                    "ADIOS2 didn't compile with " + typeLowerCase +
+                        "library, operator not added",
+                    helper::EXCEPTION);
+    }
+
+    return ret;
+}
 
 size_t Compress(const char *dataIn, const Dims &blockStart,
                 const Dims &blockCount, const DataType dataType,

--- a/source/adios2/operator/compress/CompressorFactory.h
+++ b/source/adios2/operator/compress/CompressorFactory.h
@@ -9,6 +9,7 @@
  */
 
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/Operator.h"
 
 namespace adios2
 {
@@ -16,6 +17,9 @@ namespace core
 {
 namespace compress
 {
+
+std::shared_ptr<Operator> MakeOperator(const std::string &type,
+                                       const Params &parameters);
 
 size_t Compress(const char *dataIn, const Dims &blockStart,
                 const Dims &blockCount, const DataType type, char *bufferOut,

--- a/source/adios2/toolkit/format/bp/BPSerializer.tcc
+++ b/source/adios2/toolkit/format/bp/BPSerializer.tcc
@@ -366,7 +366,7 @@ void BPSerializer::PutCharacteristicOperation(
     const typename core::Variable<T>::BPInfo &blockInfo,
     std::vector<char> &buffer) noexcept
 {
-    const std::string type = blockInfo.Operations[0].Op->m_TypeString;
+    const std::string type = blockInfo.Operations[0]->m_TypeString;
     const uint8_t typeLength = static_cast<uint8_t>(type.size());
     helper::InsertToBuffer(buffer, &typeLength);
     helper::InsertToBuffer(buffer, type.c_str(), type.size());
@@ -402,12 +402,11 @@ void BPSerializer::PutOperationPayloadInBuffer(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::BPInfo &blockInfo)
 {
-    const Params &parameters = blockInfo.Operations[0].Parameters;
-
-    const size_t outputSize = blockInfo.Operations[0].Op->Operate(
+    const size_t outputSize = blockInfo.Operations[0]->Operate(
         reinterpret_cast<char *>(blockInfo.Data), blockInfo.Start,
         blockInfo.Count, variable.m_Type,
-        m_Data.m_Buffer.data() + m_Data.m_Position, parameters);
+        m_Data.m_Buffer.data() + m_Data.m_Position,
+        blockInfo.Operations[0]->GetParameters());
 
     m_Data.m_Position += outputSize;
     m_Data.m_AbsolutePosition += outputSize;

--- a/source/adios2/toolkit/format/bp/BPSerializer.tcc
+++ b/source/adios2/toolkit/format/bp/BPSerializer.tcc
@@ -405,8 +405,7 @@ void BPSerializer::PutOperationPayloadInBuffer(
     const size_t outputSize = blockInfo.Operations[0]->Operate(
         reinterpret_cast<char *>(blockInfo.Data), blockInfo.Start,
         blockInfo.Count, variable.m_Type,
-        m_Data.m_Buffer.data() + m_Data.m_Position,
-        blockInfo.Operations[0]->GetParameters());
+        m_Data.m_Buffer.data() + m_Data.m_Position);
 
     m_Data.m_Position += outputSize;
     m_Data.m_AbsolutePosition += outputSize;

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.h
@@ -213,9 +213,9 @@ private:
                      const std::vector<size_t> &blocksIndexOffsets) const;
 
     template <class T>
-    bool IdentityOperation(
-        const std::vector<typename core::Variable<T>::Operation> &operations)
-        const noexcept;
+    bool
+    IdentityOperation(const std::vector<core::Operator *> &operations) const
+        noexcept;
 
     const helper::BlockOperationInfo &InitPostOperatorBlockData(
         const std::vector<helper::BlockOperationInfo> &blockOperationsInfo)

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
@@ -1117,13 +1117,12 @@ BP3Deserializer::BlocksInfoCommon(
 
 template <class T>
 bool BP3Deserializer::IdentityOperation(
-    const std::vector<typename core::Variable<T>::Operation> &operations) const
-    noexcept
+    const std::vector<core::Operator *> &operations) const noexcept
 {
     bool identity = false;
-    for (const typename core::Variable<T>::Operation &op : operations)
+    for (const auto &op : operations)
     {
-        if (op.Op->m_TypeString == "identity")
+        if (op->m_TypeString == "identity")
         {
             identity = true;
         }

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
@@ -17,7 +17,7 @@
 #include <unordered_set>
 
 #include "adios2/helper/adiosFunctions.h"
-#include "adios2/operator/compress/CompressorFactory.h"
+#include "adios2/operator/OperatorFactory.h"
 
 namespace adios2
 {
@@ -520,8 +520,7 @@ void BP3Deserializer::PostDataRead(
         char *preOpData = m_ThreadBuffers[threadID][0].data();
         const char *postOpData = m_ThreadBuffers[threadID][1].data();
 
-        core::compress::Decompress(postOpData, blockOperationInfo.PayloadSize,
-                                   preOpData);
+        core::Decompress(postOpData, blockOperationInfo.PayloadSize, preOpData);
 
         // clip block to match selection
         helper::ClipVector(m_ThreadBuffers[threadID][0],

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
@@ -231,9 +231,9 @@ private:
                      const std::vector<size_t> &blocksIndexOffsets) const;
 
     template <class T>
-    bool IdentityOperation(
-        const std::vector<typename core::Variable<T>::Operation> &operations)
-        const noexcept;
+    bool
+    IdentityOperation(const std::vector<core::Operator *> &operations) const
+        noexcept;
 
     const helper::BlockOperationInfo &InitPostOperatorBlockData(
         const std::vector<helper::BlockOperationInfo> &blockOperationsInfo)

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -20,7 +20,7 @@
 #include <unordered_set>
 
 #include "adios2/helper/adiosFunctions.h"
-#include "adios2/operator/compress/CompressorFactory.h"
+#include "adios2/operator/OperatorFactory.h"
 
 namespace adios2
 {
@@ -524,8 +524,7 @@ void BP4Deserializer::PostDataRead(
         char *preOpData = m_ThreadBuffers[threadID][0].data();
         const char *postOpData = m_ThreadBuffers[threadID][1].data();
 
-        core::compress::Decompress(postOpData, blockOperationInfo.PayloadSize,
-                                   preOpData);
+        core::Decompress(postOpData, blockOperationInfo.PayloadSize, preOpData);
 
         // clip block to match selection
         helper::ClipVector(m_ThreadBuffers[threadID][0],

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -1203,13 +1203,12 @@ BP4Deserializer::BlocksInfoCommon(
 
 template <class T>
 bool BP4Deserializer::IdentityOperation(
-    const std::vector<typename core::Variable<T>::Operation> &operations) const
-    noexcept
+    const std::vector<core::Operator *> &operations) const noexcept
 {
     bool identity = false;
-    for (const typename core::Variable<T>::Operation &op : operations)
+    for (const auto &op : operations)
     {
-        if (op.Op->m_TypeString == "identity")
+        if (op->m_TypeString == "identity")
         {
             identity = true;
         }

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -27,7 +27,7 @@
 #include "adios2/operator/compress/CompressMGARD.h"
 #endif
 
-#include "adios2/operator/compress/CompressorFactory.h"
+#include "adios2/operator/OperatorFactory.h"
 
 #include <float.h>
 #include <limits.h>
@@ -1095,7 +1095,7 @@ void BP5Deserializer::FinalizeGets(std::vector<ReadRequest> Requests)
                                     ->Count[dim * writer_meta_base->Dims];
                         }
                         decompressBuffer.reserve(DestSize);
-                        core::compress::Decompress(
+                        core::Decompress(
                             IncomingData,
                             ((MetaArrayRecOperator *)writer_meta_base)
                                 ->DataLengths[i],

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -440,8 +440,7 @@ BP5Serializer::CreateWriterRec(void *Variable, const char *Name, DataType Type,
         char *OperatorType = NULL;
         if (VB->m_Operations.size())
         {
-            OperatorType =
-                strdup((VB->m_Operations[0]).Op->m_TypeString.data());
+            OperatorType = strdup((VB->m_Operations[0])->m_TypeString.data());
         }
         // Array field.  To Metadata, add FMFields for DimCount, Shape, Count
         // and Offsets matching _MetaArrayRec
@@ -642,7 +641,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name,
             DataOffset = m_PriorDataBufferSizeTotal + pos.globalPos;
             CompressedSize = core::compress::Compress(
                 (const char *)Data, tmpOffsets, tmpCount, (DataType)Rec->Type,
-                CompressedData, VB->m_Operations[0].Parameters,
+                CompressedData, VB->m_Operations[0]->GetParameters(),
                 compressionMethod);
             // use data size to resize allocated buffer
         }

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -626,7 +626,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name,
             DataOffset = m_PriorDataBufferSizeTotal + pos.globalPos;
             CompressedSize = VB->m_Operations[0]->Operate(
                 (const char *)Data, tmpOffsets, tmpCount, (DataType)Rec->Type,
-                CompressedData, VB->m_Operations[0]->GetParameters());
+                CompressedData);
             // use data size to resize allocated buffer
         }
         else if (Span == nullptr)

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -9,26 +9,11 @@
 #include "adios2/core/Attribute.h"
 #include "adios2/core/IO.h"
 #include "adios2/core/VariableBase.h"
+#include "adios2/helper/adiosFunctions.h"
 #include "adios2/helper/adiosMemory.h"
 #include "adios2/toolkit/format/buffer/ffs/BufferFFS.h"
+
 #include <stddef.h> // max_align_t
-
-#ifdef ADIOS2_HAVE_ZFP
-#include "adios2/operator/compress/CompressZFP.h"
-#endif
-#ifdef ADIOS2_HAVE_SZ
-#include "adios2/operator/compress/CompressSZ.h"
-#endif
-#ifdef ADIOS2_HAVE_BZIP2
-#include "adios2/operator/compress/CompressBZIP2.h"
-#endif
-#ifdef ADIOS2_HAVE_MGARD
-#include "adios2/operator/compress/CompressMGARD.h"
-#endif
-
-#include "adios2/operator/compress/CompressorFactory.h"
-
-#include "adios2/helper/adiosFunctions.h"
 
 #include <cstring>
 
@@ -639,10 +624,9 @@ void BP5Serializer::Marshal(void *Variable, const char *Name,
             char *CompressedData =
                 (char *)GetPtr(pos.bufferIdx, pos.posInBuffer);
             DataOffset = m_PriorDataBufferSizeTotal + pos.globalPos;
-            CompressedSize = core::compress::Compress(
+            CompressedSize = VB->m_Operations[0]->Operate(
                 (const char *)Data, tmpOffsets, tmpCount, (DataType)Rec->Type,
-                CompressedData, VB->m_Operations[0]->GetParameters(),
-                compressionMethod);
+                CompressedData, VB->m_Operations[0]->GetParameters());
             // use data size to resize allocated buffer
         }
         else if (Span == nullptr)

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -621,13 +621,15 @@ void DataManSerializer::Log(const int level, const std::string &message,
 }
 
 template <>
-void DataManSerializer::PutData(
-    const std::string *inputData, const std::string &varName,
-    const Dims &varShape, const Dims &varStart, const Dims &varCount,
-    const Dims &varMemStart, const Dims &varMemCount, const std::string &doid,
-    const size_t step, const int rank, const std::string &address,
-    const std::vector<core::VariableBase::Operation> &ops, VecPtr localBuffer,
-    JsonPtr metadataJson)
+void DataManSerializer::PutData(const std::string *inputData,
+                                const std::string &varName,
+                                const Dims &varShape, const Dims &varStart,
+                                const Dims &varCount, const Dims &varMemStart,
+                                const Dims &varMemCount,
+                                const std::string &doid, const size_t step,
+                                const int rank, const std::string &address,
+                                const std::vector<core::Operator *> &ops,
+                                VecPtr localBuffer, JsonPtr metadataJson)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
     Log(1,

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -99,7 +99,7 @@ public:
                  const Dims &varCount, const Dims &varMemStart,
                  const Dims &varMemCount, const std::string &doid,
                  const size_t step, const int rank, const std::string &address,
-                 const std::vector<core::VariableBase::Operation> &ops,
+                 const std::vector<core::Operator *> &ops,
                  VecPtr localBuffer = nullptr, JsonPtr metadataJson = nullptr);
 
     // another wrapper for PutData which accepts adios2::core::Variable

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
@@ -141,10 +141,9 @@ void DataManSerializer::PutData(const T *inputData, const std::string &varName,
                                                  varCount.end(), sizeof(T),
                                                  std::multiplies<size_t>()));
 
-        datasize =
-            ops[0]->Operate(reinterpret_cast<const char *>(inputData), varStart,
-                            varCount, helper::GetDataType<T>(),
-                            m_CompressBuffer.data(), ops[0]->GetParameters());
+        datasize = ops[0]->Operate(reinterpret_cast<const char *>(inputData),
+                                   varStart, varCount, helper::GetDataType<T>(),
+                                   m_CompressBuffer.data());
         compressed = true;
     }
 

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
@@ -12,26 +12,9 @@
 #define ADIOS2_TOOLKIT_FORMAT_DATAMAN_DATAMANSERIALIZER_TCC_
 
 #include "DataManSerializer.h"
-
-#ifdef ADIOS2_HAVE_ZFP
-#include "adios2/operator/compress/CompressZFP.h"
-#endif
-#ifdef ADIOS2_HAVE_SZ
-#include "adios2/operator/compress/CompressSZ.h"
-#endif
-#ifdef ADIOS2_HAVE_BZIP2
-#include "adios2/operator/compress/CompressBZIP2.h"
-#endif
-#ifdef ADIOS2_HAVE_MGARD
-#include "adios2/operator/compress/CompressMGARD.h"
-#endif
-
-#include "adios2/operator/OperatorFactory.h"
-
 #include "adios2/helper/adiosFunctions.h"
-
+#include "adios2/operator/OperatorFactory.h"
 #include <adios2-perfstubs-interface.h>
-
 #include <iostream>
 
 namespace adios2
@@ -158,10 +141,10 @@ void DataManSerializer::PutData(const T *inputData, const std::string &varName,
                                                  varCount.end(), sizeof(T),
                                                  std::multiplies<size_t>()));
 
-        datasize = core::Compress(reinterpret_cast<const char *>(inputData),
-                                  varStart, varCount, helper::GetDataType<T>(),
-                                  m_CompressBuffer.data(),
-                                  ops[0]->GetParameters(), compressionMethod);
+        datasize =
+            ops[0]->Operate(reinterpret_cast<const char *>(inputData), varStart,
+                            varCount, helper::GetDataType<T>(),
+                            m_CompressBuffer.data(), ops[0]->GetParameters());
         compressed = true;
     }
 

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
@@ -26,7 +26,7 @@
 #include "adios2/operator/compress/CompressMGARD.h"
 #endif
 
-#include "adios2/operator/compress/CompressorFactory.h"
+#include "adios2/operator/OperatorFactory.h"
 
 #include "adios2/helper/adiosFunctions.h"
 
@@ -158,10 +158,10 @@ void DataManSerializer::PutData(const T *inputData, const std::string &varName,
                                                  varCount.end(), sizeof(T),
                                                  std::multiplies<size_t>()));
 
-        datasize = core::compress::Compress(
-            reinterpret_cast<const char *>(inputData), varStart, varCount,
-            helper::GetDataType<T>(), m_CompressBuffer.data(),
-            ops[0]->GetParameters(), compressionMethod);
+        datasize = core::Compress(reinterpret_cast<const char *>(inputData),
+                                  varStart, varCount, helper::GetDataType<T>(),
+                                  m_CompressBuffer.data(),
+                                  ops[0]->GetParameters(), compressionMethod);
         compressed = true;
     }
 
@@ -265,8 +265,8 @@ int DataManSerializer::GetData(T *outputData, const std::string &varName,
                 m_OperatorMapMutex.unlock();
                 decompressBuffer.reserve(
                     helper::GetTotalSize(j.count, sizeof(T)));
-                core::compress::Decompress(j.buffer->data() + j.position,
-                                           j.size, decompressBuffer.data());
+                core::Decompress(j.buffer->data() + j.position, j.size,
+                                 decompressBuffer.data());
                 decompressed = true;
                 input_data = decompressBuffer.data();
             }

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
@@ -97,13 +97,14 @@ void DataManSerializer::PutData(const core::Variable<T> &variable,
 }
 
 template <class T>
-void DataManSerializer::PutData(
-    const T *inputData, const std::string &varName, const Dims &varShape,
-    const Dims &varStart, const Dims &varCount, const Dims &varMemStart,
-    const Dims &varMemCount, const std::string &doid, const size_t step,
-    const int rank, const std::string &address,
-    const std::vector<core::VariableBase::Operation> &ops, VecPtr localBuffer,
-    JsonPtr metadataJson)
+void DataManSerializer::PutData(const T *inputData, const std::string &varName,
+                                const Dims &varShape, const Dims &varStart,
+                                const Dims &varCount, const Dims &varMemStart,
+                                const Dims &varMemCount,
+                                const std::string &doid, const size_t step,
+                                const int rank, const std::string &address,
+                                const std::vector<core::Operator *> &ops,
+                                VecPtr localBuffer, JsonPtr metadataJson)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
     Log(1,
@@ -149,7 +150,7 @@ void DataManSerializer::PutData(
     bool compressed = false;
     if (not ops.empty())
     {
-        compressionMethod = ops[0].Op->m_TypeString;
+        compressionMethod = ops[0]->m_TypeString;
         std::transform(compressionMethod.begin(), compressionMethod.end(),
                        compressionMethod.begin(), ::tolower);
 
@@ -160,14 +161,14 @@ void DataManSerializer::PutData(
         datasize = core::compress::Compress(
             reinterpret_cast<const char *>(inputData), varStart, varCount,
             helper::GetDataType<T>(), m_CompressBuffer.data(),
-            ops[0].Parameters, compressionMethod);
+            ops[0]->GetParameters(), compressionMethod);
         compressed = true;
     }
 
     if (compressed)
     {
         metaj["Z"] = compressionMethod;
-        metaj["ZP"] = ops[0].Parameters;
+        metaj["ZP"] = ops[0]->GetParameters();
     }
     else
     {

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
@@ -101,47 +101,45 @@ void PNGAccuracy2D(const std::string compressionLevel)
                                                 adios2::ConstantDims);
 
         // add operations
-        adios2::Operator PNGOp =
-            adios.DefineOperator("PNGCompressor", adios2::ops::LosslessPNG);
 
-        var_i8.AddOperation(PNGOp, {{adios2::ops::png::key::color_type,
+        var_i8.AddOperation("png", {{adios2::ops::png::key::color_type,
                                      adios2::ops::png::value::color_type_GRAY},
                                     {adios2::ops::png::key::compression_level,
                                      compressionLevel}});
 
         var_i16.AddOperation(
-            PNGOp,
+            "png",
             {{adios2::ops::png::key::color_type,
               adios2::ops::png::value::color_type_GRAY_ALPHA},
              {adios2::ops::png::key::compression_level, compressionLevel}});
 
         var_i32.AddOperation(
-            PNGOp,
+            "png",
             {{adios2::ops::png::key::color_type,
               adios2::ops::png::value::color_type_RGB_ALPHA},
              {adios2::ops::png::key::compression_level, compressionLevel}});
 
-        var_u8.AddOperation(PNGOp, {{adios2::ops::png::key::color_type,
+        var_u8.AddOperation("png", {{adios2::ops::png::key::color_type,
                                      adios2::ops::png::value::color_type_GRAY},
                                     {adios2::ops::png::key::compression_level,
                                      compressionLevel}});
 
         var_u16.AddOperation(
-            PNGOp,
+            "png",
             {{adios2::ops::png::key::color_type,
               adios2::ops::png::value::color_type_GRAY_ALPHA},
              {adios2::ops::png::key::compression_level, compressionLevel}});
 
         var_u32.AddOperation(
-            PNGOp,
+            "png",
             {{adios2::ops::png::key::color_type,
               adios2::ops::png::value::color_type_RGB_ALPHA},
              {adios2::ops::png::key::compression_level, compressionLevel}});
 
-        var_u32.AddOperation(PNGOp, {{adios2::ops::png::key::compression_level,
+        var_u32.AddOperation("png", {{adios2::ops::png::key::compression_level,
                                       compressionLevel}});
 
-        var_r32.AddOperation(PNGOp, {{adios2::ops::png::key::compression_level,
+        var_r32.AddOperation("png", {{adios2::ops::png::key::compression_level,
                                       compressionLevel}});
 
         adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
@@ -344,13 +342,11 @@ void PNGAccuracy2DSel(const std::string accuracy)
                                                  adios2::ConstantDims);
 
         // add operations
-        adios2::Operator PNGOp =
-            adios.DefineOperator("PNGCompressor", adios2::ops::LosslessPNG);
 
         var_r32.AddOperation(
-            PNGOp, {{adios2::ops::png::key::compression_level, accuracy}});
+            "png", {{adios2::ops::png::key::compression_level, accuracy}});
         var_r64.AddOperation(
-            PNGOp, {{adios2::ops::png::key::compression_level, accuracy}});
+            "png", {{adios2::ops::png::key::compression_level, accuracy}});
 
         adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
 

--- a/testing/adios2/interface/TestADIOSInterfaceWrite.cpp
+++ b/testing/adios2/interface/TestADIOSInterfaceWrite.cpp
@@ -592,7 +592,7 @@ TEST_F(ADIOSInterfaceWriteTest, Exceptions)
     EXPECT_FALSE(invalidOp);
     EXPECT_THROW(adios.AtIO("IOnull"), std::invalid_argument);
     EXPECT_THROW(adios.DefineOperator("WrongOp", "UnsupportedType"),
-                 std::invalid_argument);
+                 std::string);
 
 #ifdef ADIOS2_HAVE_BZIP2
     EXPECT_NO_THROW(adios.DefineOperator("bzip2Op", "bzip2"));

--- a/testing/adios2/interface/TestADIOSInterfaceWrite.cpp
+++ b/testing/adios2/interface/TestADIOSInterfaceWrite.cpp
@@ -599,22 +599,21 @@ TEST_F(ADIOSInterfaceWriteTest, Exceptions)
     EXPECT_THROW(adios.DefineOperator("bzip2Op", "bzip2"),
                  std::invalid_argument);
 #else
-    EXPECT_THROW(adios.DefineOperator("bzip2Op", "bzip2"),
-                 std::invalid_argument);
+    EXPECT_THROW(adios.DefineOperator("bzip2Op", "bzip2"), std::string);
 #endif
 
 #ifdef ADIOS2_HAVE_ZFP
     EXPECT_NO_THROW(adios.DefineOperator("zfpOp", "zfp"));
     EXPECT_THROW(adios.DefineOperator("zfpOp", "zfp"), std::invalid_argument);
 #else
-    EXPECT_THROW(adios.DefineOperator("zfpOp", "zfp"), std::invalid_argument);
+    EXPECT_THROW(adios.DefineOperator("zfpOp", "zfp"), std::string);
 #endif
 
 #ifdef ADIOS2_HAVE_SZ
     EXPECT_NO_THROW(adios.DefineOperator("szOp", "sz"));
     EXPECT_THROW(adios.DefineOperator("szOp", "sz"), std::invalid_argument);
 #else
-    EXPECT_THROW(adios.DefineOperator("szOp", "sz"), std::invalid_argument);
+    EXPECT_THROW(adios.DefineOperator("szOp", "sz"), std::string);
 #endif
 }
 

--- a/testing/adios2/xml/TestXMLConfig.cpp
+++ b/testing/adios2/xml/TestXMLConfig.cpp
@@ -106,9 +106,10 @@ TEST_F(XMLConfigTest, OpNullException)
                                  "configOpNullException.xml");
 
 #if ADIOS2_USE_MPI
-    EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD), std::string);
+    EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD),
+                 std::invalid_argument);
 #else
-    EXPECT_THROW(adios2::ADIOS adios(configFile), std::string);
+    EXPECT_THROW(adios2::ADIOS adios(configFile), std::invalid_argument);
 #endif
 }
 
@@ -122,7 +123,7 @@ TEST_F(XMLConfigTest, OpNoneException)
     EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD),
                  std::invalid_argument);
 #else
-    EXPECT_THROW(adios2::ADIOS adios(configFile), std::string);
+    EXPECT_THROW(adios2::ADIOS adios(configFile), std::invalid_argument);
 #endif
 }
 

--- a/testing/adios2/xml/TestXMLConfig.cpp
+++ b/testing/adios2/xml/TestXMLConfig.cpp
@@ -92,10 +92,10 @@ TEST_F(XMLConfigTest, OpTypeException)
     if (rank == 0)
     {
         EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_SELF),
-                     std::invalid_argument);
+                     std::string);
     }
 #else
-    EXPECT_THROW(adios2::ADIOS adios(configFile), std::invalid_argument);
+    EXPECT_THROW(adios2::ADIOS adios(configFile), std::string);
 #endif
 }
 
@@ -106,10 +106,9 @@ TEST_F(XMLConfigTest, OpNullException)
                                  "configOpNullException.xml");
 
 #if ADIOS2_USE_MPI
-    EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD),
-                 std::invalid_argument);
+    EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD), std::string);
 #else
-    EXPECT_THROW(adios2::ADIOS adios(configFile), std::invalid_argument);
+    EXPECT_THROW(adios2::ADIOS adios(configFile), std::string);
 #endif
 }
 
@@ -120,10 +119,9 @@ TEST_F(XMLConfigTest, OpNoneException)
                                  "configOpNoneException.xml");
 
 #if ADIOS2_USE_MPI
-    EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD),
-                 std::invalid_argument);
+    EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD), std::string);
 #else
-    EXPECT_THROW(adios2::ADIOS adios(configFile), std::invalid_argument);
+    EXPECT_THROW(adios2::ADIOS adios(configFile), std::string);
 #endif
 }
 

--- a/testing/adios2/xml/TestXMLConfig.cpp
+++ b/testing/adios2/xml/TestXMLConfig.cpp
@@ -92,7 +92,7 @@ TEST_F(XMLConfigTest, OpTypeException)
     if (rank == 0)
     {
         EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_SELF),
-                     std::string);
+                     std::invalid_argument);
     }
 #else
     EXPECT_THROW(adios2::ADIOS adios(configFile), std::invalid_argument);
@@ -122,7 +122,7 @@ TEST_F(XMLConfigTest, OpNoneException)
     EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD),
                  std::invalid_argument);
 #else
-    EXPECT_THROW(adios2::ADIOS adios(configFile), std::invalid_argument);
+    EXPECT_THROW(adios2::ADIOS adios(configFile), std::string);
 #endif
 }
 

--- a/testing/adios2/xml/TestXMLConfig.cpp
+++ b/testing/adios2/xml/TestXMLConfig.cpp
@@ -92,7 +92,7 @@ TEST_F(XMLConfigTest, OpTypeException)
     if (rank == 0)
     {
         EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_SELF),
-                     std::invalid_argument);
+                     std::string);
     }
 #else
     EXPECT_THROW(adios2::ADIOS adios(configFile), std::invalid_argument);
@@ -106,10 +106,9 @@ TEST_F(XMLConfigTest, OpNullException)
                                  "configOpNullException.xml");
 
 #if ADIOS2_USE_MPI
-    EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD),
-                 std::invalid_argument);
+    EXPECT_THROW(adios2::ADIOS adios(configFile, MPI_COMM_WORLD), std::string);
 #else
-    EXPECT_THROW(adios2::ADIOS adios(configFile), std::invalid_argument);
+    EXPECT_THROW(adios2::ADIOS adios(configFile), std::string);
 #endif
 }
 


### PR DESCRIPTION
This PR refactors the Operator framework in the following aspects:

1. In the original Operator framework design, 3 maps were used to describe parameters and properties of an operator: an internal map inside the Operator class, two external maps outside the Operator class but needed to be always carried together with an Operator object in a struct wrapper. This weird combination of procedural programming and object-oriented programming caused a lot of confusions to users and even ADIOS2 developers. Nobody remembers which map is for what. In fact, the internal map has NEVER been used in any Operator implementations. So the only effect it has ever taken so far, is to confuse users. This PR removes such a confusing design, and makes the internal map the only place to configure parameters of an Operator. Thus, an Operator object becomes the only thing that developers and users need to be aware of when they deal with ADIOS2 operations.

2. In the original Operator framework design, adding a new operator needed changes in many places all over the ADIOS2 library. Common sense tells us that this is a good case for implementing a class factory to centralize all the knowledge needed to implement and use a new child class. So future developers don't need to spend a month learning the 1,000 things, but rather just spend an hour going over the Operator base class and the OperatorFactory class.

3. In the original Operator framework design, users had to first define an Operator with an ADIOS object, and then add it to a Variable object. In fact, the only place where an Operator can take effect is inside a Variable object. Even an Engine or a Serializer needs to access an operator through a Variable. There is no point to make constructing an Operator so complicated, which made it unnecessarily difficult to maintain the logic correctly. Since a Variable object is the only place where an Operator object can take effect, it should then be the only place where an Operator can be constructed too. Thus, it makes it much easier to manage the lifecycle of Operator objects, as well as separate configurations between multiple Variables and Operators. It also makes the user API logic crystal clear and extremely simple -- users can now add an Operator on-the-fly to a Variable in a single line of code, never needing to bother keeping an ADIOS object reference across their workflows. Considering the backward compatibility, the old API is still there. But we should encourage users to use the new API.