### PR TITLE
Make Variable the only place for instantiating Operators

### DIFF
--- a/bindings/C/adios2/c/adios2_c_operator.cpp
+++ b/bindings/C/adios2/c/adios2_c_operator.cpp
@@ -21,10 +21,11 @@ adios2_error adios2_operator_type(char *type, size_t *size,
         adios2::helper::CheckForNullptr(
             op, "for adios2_operator, in call to adios2_operator_type");
 
-        const adios2::core::Operator *opCpp =
-            reinterpret_cast<const adios2::core::Operator *>(op);
+        auto *opCpp =
+            reinterpret_cast<const std::pair<std::string, adios2::Params> *>(
+                op);
 
-        return String2CAPI(opCpp->m_TypeString, type, size);
+        return String2CAPI(opCpp->first, type, size);
     }
     catch (...)
     {

--- a/bindings/C/adios2/c/adios2_c_variable.cpp
+++ b/bindings/C/adios2/c/adios2_c_variable.cpp
@@ -504,11 +504,19 @@ adios2_error adios2_add_operation(size_t *operation_index,
 
         adios2::core::VariableBase *variableBase =
             reinterpret_cast<adios2::core::VariableBase *>(variable);
-        adios2::core::Operator *opCpp =
-            reinterpret_cast<adios2::core::Operator *>(op);
 
-        *operation_index =
-            variableBase->AddOperation(*opCpp, adios2::Params{{key, value}});
+        auto *opCpp =
+            reinterpret_cast<std::pair<std::string, adios2::Params> *>(op);
+
+        auto params = adios2::Params{{key, value}};
+
+        for (const auto &p : opCpp->second)
+        {
+            params[p.first] = p.second;
+        }
+
+        *operation_index = variableBase->AddOperation(opCpp->first, params);
+
         return adios2_error_none;
     }
     catch (...)

--- a/bindings/CXX11/adios2/cxx11/Operator.cpp
+++ b/bindings/CXX11/adios2/cxx11/Operator.cpp
@@ -16,34 +16,26 @@
 namespace adios2
 {
 
-Operator::operator bool() const noexcept
-{
-    return (m_Operator == nullptr) ? false : true;
-}
+Operator::operator bool() const noexcept { return m_Parameters != nullptr; }
 
-std::string Operator::Type() const noexcept
-{
-    if (m_Operator == nullptr)
-    {
-        return "";
-    }
-
-    return m_Operator->m_TypeString;
-}
+std::string Operator::Type() const noexcept { return m_Type; }
 
 void Operator::SetParameter(const std::string key, const std::string value)
 {
-    helper::CheckForNullptr(m_Operator, "in call to Operator::SetParameter");
-    m_Operator->SetParameter(key, value);
+    helper::CheckForNullptr(m_Parameters, "in call to Operator::SetParameter");
+    (*m_Parameters)[key] = value;
 }
 
-Params Operator::Parameters() const
+Params &Operator::Parameters() const
 {
-    helper::CheckForNullptr(m_Operator, "in call to Operator::Parameters");
-    return m_Operator->GetParameters();
+    helper::CheckForNullptr(m_Parameters, "in call to Operator::Parameters");
+    return *m_Parameters;
 }
 
 // PRIVATE
-Operator::Operator(core::Operator *op) : m_Operator(op) {}
+Operator::Operator(const std::string &type, Params *params)
+: m_Parameters(params), m_Type(type)
+{
+}
 
 } // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/Operator.h
+++ b/bindings/CXX11/adios2/cxx11/Operator.h
@@ -71,11 +71,12 @@ public:
      * Inspect current operator parameters
      * @return map of key/value parameters
      */
-    Params Parameters() const;
+    Params &Parameters() const;
 
 private:
-    Operator(core::Operator *op);
-    core::Operator *m_Operator = nullptr;
+    Params *m_Parameters;
+    std::string m_Type;
+    Operator(const std::string &type, Params *params);
 };
 
 } // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/Variable.cpp
+++ b/bindings/CXX11/adios2/cxx11/Variable.cpp
@@ -168,7 +168,12 @@ namespace adios2
             throw std::invalid_argument("ERROR: invalid operator, in call to " \
                                         "Variable<T>::AddOperator");           \
         }                                                                      \
-        return m_Variable->AddOperation(*op.m_Operator, parameters);           \
+        auto params = op.Parameters();                                         \
+        for (const auto &p : parameters)                                       \
+        {                                                                      \
+            params[p.first] = p.second;                                        \
+        }                                                                      \
+        return m_Variable->AddOperation(op.m_Type, params);                    \
     }                                                                          \
                                                                                \
     template <>                                                                \
@@ -185,10 +190,10 @@ namespace adios2
                                 "in call to Variable<T>::Operations");         \
         std::vector<Operator> operations;                                      \
         operations.reserve(m_Variable->m_Operations.size());                   \
-                                                                               \
         for (const auto &op : m_Variable->m_Operations)                        \
         {                                                                      \
-            operations.push_back(Operator(op));                                \
+            operations.push_back(                                              \
+                Operator(op->m_TypeString, &op->GetParameters()));             \
         }                                                                      \
         return operations;                                                     \
     }                                                                          \

--- a/bindings/Python/py11ADIOS.cpp
+++ b/bindings/Python/py11ADIOS.cpp
@@ -41,13 +41,15 @@ Operator ADIOS::DefineOperator(const std::string name, const std::string type,
 {
     CheckPointer("for operator name " + name +
                  ", in call to ADIOS::DefineOperator");
-    return Operator(&m_ADIOS->DefineOperator(name, type, parameters));
+    auto op = &m_ADIOS->DefineOperator(name, type, parameters);
+    return Operator(op->first, &op->second);
 }
 
 Operator ADIOS::InquireOperator(const std::string name)
 {
     CheckPointer("for operator name " + name + ", in call to InquireOperator");
-    return Operator(m_ADIOS->InquireOperator(name));
+    auto op = m_ADIOS->InquireOperator(name);
+    return Operator(op->first, &op->second);
 }
 
 void ADIOS::FlushAll()

--- a/bindings/Python/py11Operator.cpp
+++ b/bindings/Python/py11Operator.cpp
@@ -17,33 +17,42 @@ namespace adios2
 namespace py11
 {
 
-Operator::Operator(core::Operator *op) : m_Operator(op) {}
-
-Operator::operator bool() const noexcept
-{
-    return (m_Operator == nullptr) ? false : true;
-}
+Operator::operator bool() const noexcept { return m_Parameters != nullptr; }
 
 std::string Operator::Type() const noexcept
 {
-    if (m_Operator == nullptr)
+    if (m_Parameters == nullptr)
     {
-        return "";
+        helper::Log("PythonAPI", "Operator", "Type()", "Operator is nullptr",
+                    helper::LogMode::EXCEPTION);
     }
-
-    return m_Operator->m_TypeString;
+    return m_Type;
 }
 
 void Operator::SetParameter(const std::string key, const std::string value)
 {
-    helper::CheckForNullptr(m_Operator, "in call to Operator::SetParameter");
-    return m_Operator->SetParameter(key, value);
+    if (m_Parameters == nullptr)
+    {
+        helper::Log("PythonAPI", "Operator", "SetParameter()",
+                    "Operator is nullptr", helper::LogMode::EXCEPTION);
+    }
+    (*m_Parameters)[key] = value;
 }
 
-Params Operator::Parameters() const
+Params &Operator::Parameters() const
 {
-    helper::CheckForNullptr(m_Operator, "in call to Operator::Parameters");
-    return m_Operator->GetParameters();
+    if (m_Parameters == nullptr)
+    {
+        helper::Log("PythonAPI", "Operator", "Parameter()",
+                    "Operator is nullptr", helper::LogMode::EXCEPTION);
+    }
+    return *m_Parameters;
+}
+
+// PRIVATE
+Operator::Operator(const std::string &type, Params *params)
+: m_Parameters(params), m_Type(type)
+{
 }
 
 } // end namespace py11

--- a/bindings/Python/py11Operator.h
+++ b/bindings/Python/py11Operator.h
@@ -41,11 +41,12 @@ public:
 
     void SetParameter(const std::string key, const std::string value);
 
-    Params Parameters() const;
+    Params &Parameters() const;
 
 private:
-    Operator(core::Operator *op);
-    core::Operator *m_Operator = nullptr;
+    Params *m_Parameters;
+    std::string m_Type;
+    Operator(const std::string &type, Params *params);
 };
 
 } // end namespace py11

--- a/bindings/Python/py11Variable.cpp
+++ b/bindings/Python/py11Variable.cpp
@@ -80,7 +80,12 @@ size_t Variable::AddOperation(const Operator op, const Params &parameters)
 {
     helper::CheckForNullptr(m_VariableBase,
                             "in call to Variable::AddOperation");
-    return m_VariableBase->AddOperation(*op.m_Operator, parameters);
+    auto params = op.Parameters();
+    for (const auto &p : parameters)
+    {
+        params[p.first] = p.second;
+    }
+    return m_VariableBase->AddOperation(op.m_Type, params);
 }
 
 std::vector<Operator> Variable::Operations() const
@@ -91,7 +96,7 @@ std::vector<Operator> Variable::Operations() const
 
     for (const auto &op : m_VariableBase->m_Operations)
     {
-        operations.push_back(Operator(op));
+        operations.push_back(Operator(op->m_TypeString, &op->GetParameters()));
     }
     return operations;
 }

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -151,57 +151,28 @@ void ADIOS::FlushAll()
     }
 }
 
-Operator &ADIOS::DefineOperator(const std::string &name, const std::string type,
-                                const Params &parameters)
+std::pair<std::string, Params> &ADIOS::DefineOperator(const std::string &name,
+                                                      const std::string type,
+                                                      const Params &parameters)
 {
     CheckOperator(name);
-    auto itPair = m_Operators.emplace(name, MakeOperator(type, parameters));
-    return *itPair.first->second.get();
+    MakeOperator(type, parameters);
+    m_Operators[name] = {type, parameters};
+    return m_Operators[name];
 }
 
-Operator *ADIOS::InquireOperator(const std::string &name) noexcept
+std::pair<std::string, Params> *
+ADIOS::InquireOperator(const std::string &name) noexcept
 {
-    std::shared_ptr<Operator> *op = helper::InquireKey(name, m_Operators);
-    if (op == nullptr)
+    auto it = m_Operators.find(name);
+    if (it == m_Operators.end())
     {
         return nullptr;
     }
-    return op->get();
-}
-
-#define declare_type(T)                                                        \
-    Operator &ADIOS::DefineCallBack(                                           \
-        const std::string name,                                                \
-        const std::function<void(const T *, const std::string &,               \
-                                 const std::string &, const std::string &,     \
-                                 const size_t, const Dims &, const Dims &,     \
-                                 const Dims &)> &function,                     \
-        const Params &parameters)                                              \
-    {                                                                          \
-        CheckOperator(name);                                                   \
-        std::shared_ptr<Operator> callbackOperator =                           \
-            std::make_shared<callback::Signature1>(function, parameters);      \
-                                                                               \
-        auto itPair = m_Operators.emplace(name, std::move(callbackOperator));  \
-        return *itPair.first->second;                                          \
+    else
+    {
+        return &it->second;
     }
-
-ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
-#undef declare_type
-
-Operator &ADIOS::DefineCallBack(
-    const std::string name,
-    const std::function<void(void *, const std::string &, const std::string &,
-                             const std::string &, const size_t, const Dims &,
-                             const Dims &, const Dims &)> &function,
-    const Params &parameters)
-{
-    CheckOperator(name);
-    std::shared_ptr<Operator> callbackOperator =
-        std::make_shared<callback::Signature2>(function, parameters);
-
-    auto itPair = m_Operators.emplace(name, std::move(callbackOperator));
-    return *itPair.first->second;
 }
 
 bool ADIOS::RemoveIO(const std::string name)
@@ -236,7 +207,7 @@ void ADIOS::XMLInit(const std::string &configFileXML)
 
 void ADIOS::YAMLInit(const std::string &configFileYAML)
 {
-    helper::ParseConfigYAML(*this, configFileYAML, m_IOs, m_Operators);
+    helper::ParseConfigYAML(*this, configFileYAML, m_IOs);
 }
 
 } // end namespace core

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -12,9 +12,9 @@
 
 /// \cond EXCLUDE_FROM_DOXYGEN
 #include <functional> //std::function
-#include <map>
-#include <memory> //std::shared_ptr
+#include <memory>     //std::shared_ptr
 #include <string>
+#include <unordered_map>
 #include <vector>
 /// \endcond
 
@@ -27,7 +27,6 @@ namespace adios2
 {
 namespace core
 {
-
 class IO;
 
 /** @brief Point of entry class for an application.
@@ -119,37 +118,17 @@ public:
      * @exception std::invalid_argument if Operator with unique name is already
      * defined
      */
-    Operator &DefineOperator(const std::string &name, const std::string type,
-                             const Params &parameters = Params());
+    std::pair<std::string, Params> &
+    DefineOperator(const std::string &name, const std::string type,
+                   const Params &parameters = Params());
     /**
      * Retrieve a reference pointer to an existing Operator object
      * created with DefineOperator.
      * @return if IO exists returns a reference to existing IO object inside
      * ADIOS, otherwise a nullptr
      */
-    Operator *InquireOperator(const std::string &name) noexcept;
-
-/** define CallBack1 */
-#define declare_type(T)                                                        \
-    Operator &DefineCallBack(                                                  \
-        const std::string name,                                                \
-        const std::function<void(const T *, const std::string &,               \
-                                 const std::string &, const std::string &,     \
-                                 const size_t, const Dims &, const Dims &,     \
-                                 const Dims &)> &function,                     \
-        const Params &parameters);
-
-    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
-#undef declare_type
-
-    /** define CallBack2 */
-    Operator &DefineCallBack(
-        const std::string name,
-        const std::function<void(void *, const std::string &,
-                                 const std::string &, const std::string &,
-                                 const size_t, const Dims &, const Dims &,
-                                 const Dims &)> &function,
-        const Params &parameters);
+    std::pair<std::string, Params> *
+    InquireOperator(const std::string &name) noexcept;
 
     /**
      * DANGER ZONE: removes a particular IO. This will effectively eliminate any
@@ -185,7 +164,7 @@ private:
     std::map<std::string, IO> m_IOs;
 
     /** operators created with DefineOperator */
-    std::map<std::string, std::shared_ptr<Operator>> m_Operators;
+    std::unordered_map<std::string, std::pair<std::string, Params>> m_Operators;
 
     void CheckOperator(const std::string name) const;
 

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -497,10 +497,7 @@ void IO::AddOperation(const std::string &variable,
                       const Params &parameters) noexcept
 {
     PERFSTUBS_SCOPED_TIMER("IO::other");
-    auto params = helper::LowerCaseParams(parameters);
-    Operator *op = &m_ADIOS.DefineOperator(
-        m_Name + "_" + variable + "_" + operatorType, operatorType, params);
-    m_VarOpsPlaceholder[variable].emplace_back(Operation{op, params, Params()});
+    m_VarOpsPlaceholder[variable].push_back({operatorType, parameters});
 }
 
 Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -67,14 +67,6 @@ public:
     /** From AddTransport, parameters in map for each transport in vector */
     std::vector<Params> m_TransportsParameters;
 
-    /** Carries information about operations added with AddOperation */
-    struct Operation
-    {
-        Operator *Op;
-        Params Parameters;
-        Params Info;
-    };
-
     /** BP3 engine default if unknown */
     std::string m_EngineType = "File";
 
@@ -87,7 +79,8 @@ public:
 
     /** placeholder when reading XML file variable operations, executed until
      * DefineVariable in code */
-    std::map<std::string, std::vector<Operation>> m_VarOpsPlaceholder;
+    std::unordered_map<std::string, std::vector<std::pair<std::string, Params>>>
+        m_VarOpsPlaceholder;
 
     /** true: prefix variables/attributes are cached per variable
      *   when function m_IsPrefixedNames called */

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -59,10 +59,9 @@ Variable<T> &IO::DefineVariable(const std::string &name, const Dims &shape,
     if (itOperations != m_VarOpsPlaceholder.end())
     {
         variable.m_Operations.reserve(itOperations->second.size());
-
         for (auto &operation : itOperations->second)
         {
-            variable.AddOperation(*operation.Op, operation.Parameters);
+            variable.AddOperation(operation.first, operation.second);
         }
     }
 

--- a/source/adios2/core/Stream.tcc
+++ b/source/adios2/core/Stream.tcc
@@ -98,14 +98,7 @@ void Stream::Write(const std::string &name, const T *data, const Dims &shape,
         variable->m_Operations.clear();
         for (const auto &operation : operations)
         {
-            const std::string opType = operation.first;
-            Operator *op = m_ADIOS->InquireOperator(opType);
-            if (op == nullptr)
-            {
-                op = &m_ADIOS->DefineOperator(opType, opType);
-            }
-
-            variable->AddOperation(*op, operation.second);
+            variable->AddOperation(operation.first, operation.second);
         }
     }
 

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -95,7 +95,7 @@ public:
         Dims Count;
         Dims MemoryStart;
         Dims MemoryCount;
-        std::vector<Operator *> Operations;
+        std::vector<std::shared_ptr<Operator>> Operations;
         size_t Step = 0;
         size_t StepsStart = 0;
         size_t StepsCount = 0;

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -247,8 +247,7 @@ size_t VariableBase::AddOperation(const std::string &type,
     auto op = MakeOperator(type, parameters);
     if (op->IsDataTypeValid(m_Type))
     {
-        m_PrivateOperations.push_back(op);
-        m_Operations.push_back(m_PrivateOperations.back().get());
+        m_Operations.push_back(op);
     }
     else
     {
@@ -261,33 +260,13 @@ size_t VariableBase::AddOperation(const std::string &type,
     return m_Operations.size() - 1;
 }
 
-size_t VariableBase::AddOperation(Operator &op,
-                                  const Params &parameters) noexcept
+size_t VariableBase::AddOperation(std::shared_ptr<core::Operator> op) noexcept
 {
-    if (op.IsDataTypeValid(m_Type))
-    {
-        for (const auto &p : parameters)
-        {
-            op.SetParameter(helper::LowerCase(p.first), p.second);
-        }
-        m_Operations.push_back(&op);
-    }
-    else
-    {
-        helper::Log("Variable", "VariableBase", "AddOperation",
-                    "Operator " + op.m_TypeString +
-                        " does not support data type " + ToString(m_Type) +
-                        ", operator not added",
-                    helper::LogMode::WARNING);
-    }
+    m_Operations.push_back(op);
     return m_Operations.size() - 1;
 }
 
-void VariableBase::RemoveOperations() noexcept
-{
-    m_PrivateOperations.clear();
-    m_Operations.clear();
-}
+void VariableBase::RemoveOperations() noexcept { m_Operations.clear(); }
 
 void VariableBase::SetOperationParameter(const size_t operationID,
                                          const std::string key,

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -244,8 +244,20 @@ void VariableBase::SetStepSelection(const Box<size_t> &boxSteps)
 size_t VariableBase::AddOperation(const std::string &type,
                                   const Params &parameters) noexcept
 {
-    m_PrivateOperations.emplace_back(MakeOperator(type, parameters));
-    m_Operations.push_back(m_PrivateOperations.back().get());
+    auto op = MakeOperator(type, parameters);
+    if (op->IsDataTypeValid(m_Type))
+    {
+        m_PrivateOperations.push_back(op);
+        m_Operations.push_back(m_PrivateOperations.back().get());
+    }
+    else
+    {
+        helper::Log("Variable", "VariableBase", "AddOperation",
+                    "Operator " + op->m_TypeString +
+                        " does not support data type " + ToString(m_Type) +
+                        ", operator not added",
+                    helper::LogMode::WARNING);
+    }
     return m_Operations.size() - 1;
 }
 
@@ -262,9 +274,11 @@ size_t VariableBase::AddOperation(Operator &op,
     }
     else
     {
-        std::cerr << "ADIOS2 ERROR: Operator " << op.m_TypeString
-                  << " does not support data type " << m_Type
-                  << ", operator not added" << std::endl;
+        helper::Log("Variable", "VariableBase", "AddOperation",
+                    "Operator " + op.m_TypeString +
+                        " does not support data type " + ToString(m_Type) +
+                        ", operator not added",
+                    helper::LogMode::WARNING);
     }
     return m_Operations.size() - 1;
 }

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -74,8 +74,7 @@ public:
      * already encountered in previous step */
     bool m_FirstStreamingStep = true;
 
-    /** Registered transforms */
-    std::vector<Operator *> m_Operations;
+    std::vector<std::shared_ptr<Operator>> m_Operations;
 
     size_t m_AvailableStepsStart = 0;
     size_t m_AvailableStepsCount = 0;
@@ -167,8 +166,7 @@ public:
      * @param parameters operation specific parameters
      * @return operator handler
      */
-    size_t AddOperation(core::Operator &op,
-                        const Params &parameters = Params()) noexcept;
+    size_t AddOperation(std::shared_ptr<core::Operator> op) noexcept;
 
     size_t AddOperation(const std::string &op,
                         const Params &parameters = Params()) noexcept;
@@ -227,8 +225,6 @@ protected:
     bool m_ConstantDims = false; ///< true: fix m_Shape, m_Start, m_Count
 
     unsigned int m_DeferredCounter = 0;
-
-    std::vector<std::shared_ptr<Operator>> m_PrivateOperations;
 
     void InitShapeType();
 

--- a/source/adios2/engine/mhs/MhsWriter.tcc
+++ b/source/adios2/engine/mhs/MhsWriter.tcc
@@ -61,7 +61,7 @@ void MhsWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
         itVar = m_TransportMap.find(variable.m_Name);
         if (itVar != m_TransportMap.end())
         {
-            var0->AddOperation(*itVar->second, {});
+            var0->AddOperation(itVar->second);
         }
     }
 
@@ -77,7 +77,7 @@ void MhsWriter::PutDeferredCommon(Variable<T> &variable, const T *data)
             {
                 var = &m_SubIOs[i]->DefineVariable<T>(variable.m_Name,
                                                       variable.m_Shape);
-                var->AddOperation(*itVar->second, {});
+                var->AddOperation(itVar->second);
             }
             var->SetSelection({variable.m_Start, variable.m_Count});
             m_SubEngines[i]->Put(*var, data, Mode::Sync);

--- a/source/adios2/helper/adiosXML.h
+++ b/source/adios2/helper/adiosXML.h
@@ -29,7 +29,7 @@ namespace helper
 void ParseConfigXML(
     core::ADIOS &adios, const std::string &configFile,
     std::map<std::string, core::IO> &ios,
-    std::map<std::string, std::shared_ptr<core::Operator>> &operators);
+    std::unordered_map<std::string, std::pair<std::string, Params>> &operators);
 
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/helper/adiosYAML.cpp
+++ b/source/adios2/helper/adiosYAML.cpp
@@ -64,10 +64,8 @@ Params YAMLNodeMapToParams(const YAML::Node &node, const std::string &hint)
 
 } // end empty  namespace
 
-void ParseConfigYAML(
-    core::ADIOS &adios, const std::string &configFileYAML,
-    std::map<std::string, core::IO> &ios,
-    std::map<std::string, std::shared_ptr<core::Operator>> &operators)
+void ParseConfigYAML(core::ADIOS &adios, const std::string &configFileYAML,
+                     std::map<std::string, core::IO> &ios)
 {
     const std::string hint = "when parsing config file " + configFileYAML +
                              " in call to ADIOS constructor";
@@ -99,23 +97,12 @@ void ParseConfigYAML(
                     YAMLNode("Type", *it, errorMessage, isMandatory,
                              YAML::NodeType::Scalar);
 
-                core::Operator *op = nullptr;
-
                 Params parameters = YAMLNodeMapToParams(*it, hint);
-
                 const std::string operatorType =
                     EraseKey<std::string>("Type", parameters);
 
-                const std::string operatorName =
-                    "__" + currentIO.m_Name + "_" + operatorType;
-
-                auto itOperator = operators.find(operatorName);
-                op = (itOperator == operators.end())
-                         ? &adios.DefineOperator(operatorName, operatorType)
-                         : itOperator->second.get();
-
                 currentIO.m_VarOpsPlaceholder[variableName].push_back(
-                    core::IO::Operation{op, parameters, Params()});
+                    {operatorType, parameters});
             }
         }
     };

--- a/source/adios2/helper/adiosYAML.h
+++ b/source/adios2/helper/adiosYAML.h
@@ -26,10 +26,8 @@ namespace adios2
 namespace helper
 {
 
-void ParseConfigYAML(
-    core::ADIOS &adios, const std::string &configFile,
-    std::map<std::string, core::IO> &ios,
-    std::map<std::string, std::shared_ptr<core::Operator>> &operators);
+void ParseConfigYAML(core::ADIOS &adios, const std::string &configFile,
+                     std::map<std::string, core::IO> &ios);
 
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.h
@@ -213,8 +213,8 @@ private:
                      const std::vector<size_t> &blocksIndexOffsets) const;
 
     template <class T>
-    bool
-    IdentityOperation(const std::vector<core::Operator *> &operations) const
+    bool IdentityOperation(
+        const std::vector<std::shared_ptr<core::Operator>> &operations) const
         noexcept;
 
     const helper::BlockOperationInfo &InitPostOperatorBlockData(

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
@@ -1116,7 +1116,8 @@ BP3Deserializer::BlocksInfoCommon(
 
 template <class T>
 bool BP3Deserializer::IdentityOperation(
-    const std::vector<core::Operator *> &operations) const noexcept
+    const std::vector<std::shared_ptr<core::Operator>> &operations) const
+    noexcept
 {
     bool identity = false;
     for (const auto &op : operations)

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
@@ -231,8 +231,8 @@ private:
                      const std::vector<size_t> &blocksIndexOffsets) const;
 
     template <class T>
-    bool
-    IdentityOperation(const std::vector<core::Operator *> &operations) const
+    bool IdentityOperation(
+        const std::vector<std::shared_ptr<core::Operator>> &operations) const
         noexcept;
 
     const helper::BlockOperationInfo &InitPostOperatorBlockData(

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -1202,7 +1202,8 @@ BP4Deserializer::BlocksInfoCommon(
 
 template <class T>
 bool BP4Deserializer::IdentityOperation(
-    const std::vector<core::Operator *> &operations) const noexcept
+    const std::vector<std::shared_ptr<core::Operator>> &operations) const
+    noexcept
 {
     bool identity = false;
     for (const auto &op : operations)

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -621,15 +621,13 @@ void DataManSerializer::Log(const int level, const std::string &message,
 }
 
 template <>
-void DataManSerializer::PutData(const std::string *inputData,
-                                const std::string &varName,
-                                const Dims &varShape, const Dims &varStart,
-                                const Dims &varCount, const Dims &varMemStart,
-                                const Dims &varMemCount,
-                                const std::string &doid, const size_t step,
-                                const int rank, const std::string &address,
-                                const std::vector<core::Operator *> &ops,
-                                VecPtr localBuffer, JsonPtr metadataJson)
+void DataManSerializer::PutData(
+    const std::string *inputData, const std::string &varName,
+    const Dims &varShape, const Dims &varStart, const Dims &varCount,
+    const Dims &varMemStart, const Dims &varMemCount, const std::string &doid,
+    const size_t step, const int rank, const std::string &address,
+    const std::vector<std::shared_ptr<core::Operator>> &ops, VecPtr localBuffer,
+    JsonPtr metadataJson)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
     Log(1,

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -99,7 +99,7 @@ public:
                  const Dims &varCount, const Dims &varMemStart,
                  const Dims &varMemCount, const std::string &doid,
                  const size_t step, const int rank, const std::string &address,
-                 const std::vector<core::Operator *> &ops,
+                 const std::vector<std::shared_ptr<core::Operator>> &ops,
                  VecPtr localBuffer = nullptr, JsonPtr metadataJson = nullptr);
 
     // another wrapper for PutData which accepts adios2::core::Variable

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
@@ -80,14 +80,13 @@ void DataManSerializer::PutData(const core::Variable<T> &variable,
 }
 
 template <class T>
-void DataManSerializer::PutData(const T *inputData, const std::string &varName,
-                                const Dims &varShape, const Dims &varStart,
-                                const Dims &varCount, const Dims &varMemStart,
-                                const Dims &varMemCount,
-                                const std::string &doid, const size_t step,
-                                const int rank, const std::string &address,
-                                const std::vector<core::Operator *> &ops,
-                                VecPtr localBuffer, JsonPtr metadataJson)
+void DataManSerializer::PutData(
+    const T *inputData, const std::string &varName, const Dims &varShape,
+    const Dims &varStart, const Dims &varCount, const Dims &varMemStart,
+    const Dims &varMemCount, const std::string &doid, const size_t step,
+    const int rank, const std::string &address,
+    const std::vector<std::shared_ptr<core::Operator>> &ops, VecPtr localBuffer,
+    JsonPtr metadataJson)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
     Log(1,


### PR DESCRIPTION
There are several vital issues in defining operators in the ADIOS object. 

1. An operator has to have a global unique name, which lives throughout the entire lifecycle of the ADIOS object. This makes it very difficult for use cases where there is a large number of variables and operators defined. Users have to consider how to keep the names of operators real unique, and they have to write an exception handling logic to deal with cases where they accidentally re-define operators with existing names. This issue becomes critical when users want to re-use the ADIOS object for a large number of sub-workflows.

2. In the original design, the ADIOS class doesn't provide a RemoveOperator method. In case a large number of operators are needed but each of them is only used for a short period over the entire workflow, there is no way to release the operators that are no longer needed. It's difficult to provide such a RemoveOperator method too, because there is no easy way to handle cases where a deleted operator is used again. Imagine a user deletes an operator after adding it to a variable, it would cause serious problems to the engines and serializers, and in the original design which extracts a regular pointer from an operator's shared pointer and then pass it to the variables, there is no way to even check in the engines whether these operator pointers are still valid. 

3. In the original design, different language bindings and different API levels define the unique operator names in different ways, which makes the naming space very chaotic. It is difficult to unify and maintain too, because there are so many things, and once you change a single byte in somewhere, you need to touch 1,000 things elsewhere. 

This PR removes such a weird design, and makes Variable the only place for instantiating operators. This eliminates all worries about the operator naming mechanism, as well as all worries about memory leaks. Now the lifecycle of an operator is 100% managed by the variable object that instantiates it. Once a variable is destructed, it will release all operators it owns too. For backward compatibility, the original DefineOperator method in ADIOS is not removed, but instead of instantiating an operator object, now it only keeps static information, i.e. the operator type and parameters, which are required to instantiate an operator. 