### PR TITLE
Add exception for unsupported Operation with Variable<T>::Span Engine::Put Signature

### DIFF
--- a/source/adios2/core/Engine.tcc
+++ b/source/adios2/core/Engine.tcc
@@ -29,6 +29,14 @@ typename Variable<T>::Span &Engine::Put(Variable<T> &variable,
 {
     CheckOpenModes({{Mode::Write}}, " for variable " + variable.m_Name +
                                         ", in call to Variable<T>::Span Put");
+    if (!variable.m_Operations.empty())
+    {
+        throw std::invalid_argument(
+            "ERROR: span currently not supported with "
+            "operations, remove calls to Variable<T>::AddOperation or use "
+            "Variable<T>::RemoveOperations, in call to Variable<T>::Span "
+            "Engine::Put");
+    }
 
     auto itSpan = variable.m_BlocksSpan.emplace(
         variable.m_BlocksInfo.size(),

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -1516,6 +1516,7 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8FillValue)
     }
 }
 
+#ifdef ADIOS2_HAVE_BZIP2
 TEST_F(BPWriteReadSpan, BPWriteSpanOperatorException)
 {
     const std::string fname("BPWriteSpanOperatorException.bp");
@@ -1571,7 +1572,8 @@ TEST_F(BPWriteReadSpan, BPWriteSpanOperatorException)
         {
             bpWriter.BeginStep();
 
-            // using bzip2, it could have been any operator
+            // using bzip2, it could have been any operator to generate an
+            // exception
             var_r32.AddOperation(
                 BZIP2Op, {{adios2::ops::bzip2::key::blockSize100k, "1e-4"}});
             var_r64.AddOperation(
@@ -1591,6 +1593,7 @@ TEST_F(BPWriteReadSpan, BPWriteSpanOperatorException)
         bpWriter.Close();
     }
 }
+#endif
 
 int main(int argc, char **argv)
 {

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -1516,6 +1516,82 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8FillValue)
     }
 }
 
+TEST_F(BPWriteReadSpan, BPWriteSpanOperatorException)
+{
+    const std::string fname("BPWriteSpanOperatorException.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 8;
+
+    // Number of steps
+    const size_t NSteps = 3;
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+    // Write test data using BP
+
+#if ADIOS2_USE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+    adios2::ADIOS adios;
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            io.SetEngine("BP3");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize)};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
+        const adios2::Dims count{Nx};
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count,
+                                                adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count,
+                                                 adios2::ConstantDims);
+        adios2::Operator BZIP2Op =
+            adios.DefineOperator("BZIP2Compressor", adios2::ops::LosslessBZIP2);
+
+        (void)var_r32;
+        (void)var_r64;
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+
+            // using bzip2, it could have been any operator
+            var_r32.AddOperation(
+                BZIP2Op, {{adios2::ops::bzip2::key::blockSize100k, "1e-4"}});
+            var_r64.AddOperation(
+                BZIP2Op, {{adios2::ops::bzip2::key::blockSize100k, "1e-4"}});
+
+            EXPECT_THROW(adios2::Variable<float>::Span r32Span = bpWriter.Put(
+                             var_r32, true, static_cast<float>(step)),
+                         std::invalid_argument);
+
+            EXPECT_THROW(adios2::Variable<double>::Span r64Span = bpWriter.Put(
+                             var_r64, true, static_cast<double>(step)),
+                         std::invalid_argument);
+
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+}
+
 int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -1579,12 +1579,10 @@ TEST_F(BPWriteReadSpan, BPWriteSpanOperatorException)
             var_r64.AddOperation(
                 BZIP2Op, {{adios2::ops::bzip2::key::blockSize100k, "1e-4"}});
 
-            EXPECT_THROW(adios2::Variable<float>::Span r32Span = bpWriter.Put(
-                             var_r32, true, static_cast<float>(step)),
+            EXPECT_THROW(bpWriter.Put(var_r32, true, static_cast<float>(step)),
                          std::invalid_argument);
 
-            EXPECT_THROW(adios2::Variable<double>::Span r64Span = bpWriter.Put(
-                             var_r64, true, static_cast<double>(step)),
+            EXPECT_THROW(bpWriter.Put(var_r64, true, static_cast<double>(step)),
                          std::invalid_argument);
 
             bpWriter.EndStep();


### PR DESCRIPTION
`Variable<T>::Span Engine::Put` with existing Variable Operations currently not supported as specified in the [docs](https://adios2.readthedocs.io/en/latest/components/components.html?highlight=Span#put-modes-and-memory-contracts). 
This PR adds an exception with error friendly message to this use case.
Prevents faulty data as reported in #2965
CC: @franzpoeschel 
