### PR TITLE
CUDA: set MAXWELL as the default architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,8 +167,8 @@ if(ADIOS2_HAVE_CUDA)
     set(CMAKE_CUDA_STANDARD 11)
     set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
     if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-        # default 70 to match Summit V100
-        set(CMAKE_CUDA_ARCHITECTURES 70)
+        # Mininum common non-deprecated architecture
+        set(CMAKE_CUDA_ARCHITECTURES 52)
     endif()
 endif()
 


### PR DESCRIPTION
Fixes: #2979

The issue was that we were only compiling for physical archs higher than our computers arch.

We must let the users to specify the CUDA arch passing `-DCMAKE_CUDA_ARCHITECUTRES="xxyyzz"` 

When it comes to decide for a good default arch, `compute_52` is the oldest non-deprecated CUDA virtual architecture, thus, is a good candidate for a base architecture to support. Setting this as the default `CMAKE_CUDA_ARCHITECTURE` arch resolves the error with the CUDA unit tests.

@JasonRuonanWang 