### PR TITLE
fix gcc9 compile error for ime transport

### DIFF
--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -79,13 +79,13 @@ template <class T>
 void CopyFromGPUToBuffer(std::vector<char> &buffer, size_t &position,
                          const T *source, const size_t elements) noexcept
 {
-	CudaMemCopyToBuffer(buffer.data(), position, source, elements * sizeof(T));
+    CudaMemCopyToBuffer(buffer.data(), position, source, elements * sizeof(T));
     position += elements * sizeof(T);
 }
 
 template <class T>
-void CudaMemCopyToBuffer(char *buffer, size_t position,
-                         const T *source, const size_t size) noexcept
+void CudaMemCopyToBuffer(char *buffer, size_t position, const T *source,
+                         const size_t size) noexcept
 {
     const char *src = reinterpret_cast<const char *>(source);
     MemcpyGPUToBuffer(buffer + position, src, size);

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -30,7 +30,7 @@ namespace adios2
 namespace transport
 {
 
-std::atomic_uint FileIME::client_refcount = 0;
+std::atomic_uint FileIME::client_refcount(0);
 
 FileIME::FileIME(helper::Comm const &comm) : Transport("File", "IME", comm)
 {


### PR DESCRIPTION
This is to fix the following compile error with GCC 9

```
/home/jason/d/a2/source/adios2/toolkit/transport/file/FileIME.cpp:33:45: error: use of deleted function ‘std::atomic<unsigned int>::atomic(const std::atomic<unsigned int>&)’
   33 | std::atomic_uint FileIME::client_refcount = 0;
      |                                             ^
In file included from /home/jason/d/a2/source/adios2/toolkit/transport/file/FileIME.h:14,
                 from /home/jason/d/a2/source/adios2/toolkit/transport/file/FileIME.cpp:10:
/usr/include/c++/9/atomic:778:7: note: declared here
  778 |       atomic(const atomic&) = delete;
      |       ^~~~~~
/usr/include/c++/9/atomic:782:17: note:   after user-defined conversion: ‘constexpr std::atomic<unsigned int>::atomic(std::atomic<unsigned int>::__integral_type)’
  782 |       constexpr atomic(__integral_type __i) noexcept : __base_type(__i) { }
      |                 ^~~~~~
make[2]: *** [source/adios2/CMakeFiles/adios2_core.dir/build.make:1546: source/adios2/CMakeFiles/adios2_core.dir/toolkit/transport/file/FileIME.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....

```