### PR TITLE
CMAKE: silence find_package(CUDA)

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -167,7 +167,7 @@ set(mpi_find_components C)
 
 # Cuda
 if(ADIOS2_USE_CUDA STREQUAL AUTO)
-  find_package(CUDAToolkit)
+  find_package(CUDAToolkit QUIET)
 elseif(ADIOS2_USE_CUDA)
   find_package(CUDAToolkit REQUIRED)
 endif()


### PR DESCRIPTION
I tried to replicate error message when trying to find CUDA in the CI machines, I found this cmake message:

```
 -- Could not find nvcc, please set CUDAToolkit_ROOT
```

@pnorbert I wonder if this is the error message that you mentioned earlier, if so, this MR silence this if the user has not set `ADIOS2_ENABLE_CUDA=ON`