### PR TITLE
Base modifications to make BP5 GPU aware on the Read side

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1256,6 +1256,19 @@ static int FindOffsetCM(size_t Dims, const size_t *Size, const size_t *Index)
  * *******************************
  */
 
+void BP5Deserializer::MemCopyData(char *OutData, const char *InData,
+                                  size_t Size, MemorySpace MemSpace)
+{
+#ifdef ADIOS2_HAVE_CUDA
+    if (MemSpace == MemorySpace::CUDA)
+    {
+        helper::CudaMemCopyToBuffer(OutData, 0, InData, Size);
+        return;
+    }
+#endif
+    memcpy(OutData, InData, Size);
+}
+
 // Row major version
 void BP5Deserializer::ExtractSelectionFromPartialRM(
     int ElementSize, size_t Dims, const size_t *GlobalDims,
@@ -1343,7 +1356,7 @@ void BP5Deserializer::ExtractSelectionFromPartialRM(
     size_t i;
     for (i = 0; i < BlockCount; i++)
     {
-        memcpy(OutData, InData, BlockSize * ElementSize);
+        MemCopyData(OutData, InData, BlockSize * ElementSize, MemSpace);
         InData += SourceBlockStride;
         OutData += DestBlockStride;
     }
@@ -1444,7 +1457,7 @@ void BP5Deserializer::ExtractSelectionFromPartialCM(
     OutData += DestBlockStartOffset;
     for (int i = 0; i < BlockCount; i++)
     {
-        memcpy(OutData, InData, BlockSize * ElementSize);
+        MemCopyData(OutData, InData, BlockSize * ElementSize, MemSpace);
         InData += SourceBlockStride;
         OutData += DestBlockStride;
     }

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -10,6 +10,7 @@
 #include "adios2/core/Engine.h"
 #include "adios2/core/IO.h"
 #include "adios2/core/VariableBase.h"
+#include "adios2/helper/adiosFunctions.h"
 
 #include "BP5Deserializer.h"
 #include "BP5Deserializer.tcc"
@@ -927,6 +928,7 @@ bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable,
         Req.Count = variable.m_Count;
         Req.Start = variable.m_Start;
         Req.Step = Step;
+        Req.MemSpace = variable.m_MemorySpace;
         Req.Data = DestData;
         PendingRequests.push_back(Req);
     }
@@ -1168,14 +1170,14 @@ void BP5Deserializer::FinalizeGets(std::vector<ReadRequest> Requests)
                         ExtractSelectionFromPartialRM(
                             ElementSize, DimCount, GlobalDimensions, RankOffset,
                             RankSize, SelOffset, SelSize, IncomingData,
-                            (char *)Req.Data);
+                            (char *)Req.Data, Req.MemSpace);
                     }
                     else
                     {
                         ExtractSelectionFromPartialCM(
                             ElementSize, DimCount, GlobalDimensions, RankOffset,
                             RankSize, SelOffset, SelSize, IncomingData,
-                            (char *)Req.Data);
+                            (char *)Req.Data, Req.MemSpace);
                     }
                 }
             }
@@ -1259,7 +1261,7 @@ void BP5Deserializer::ExtractSelectionFromPartialRM(
     int ElementSize, size_t Dims, const size_t *GlobalDims,
     const size_t *PartialOffsets, const size_t *PartialCounts,
     const size_t *SelectionOffsets, const size_t *SelectionCounts,
-    const char *InData, char *OutData)
+    const char *InData, char *OutData, MemorySpace MemSpace)
 {
     size_t BlockSize;
     size_t SourceBlockStride = 0;
@@ -1353,7 +1355,7 @@ void BP5Deserializer::ExtractSelectionFromPartialCM(
     int ElementSize, size_t Dims, const size_t *GlobalDims,
     const size_t *PartialOffsets, const size_t *PartialCounts,
     const size_t *SelectionOffsets, const size_t *SelectionCounts,
-    const char *InData, char *OutData)
+    const char *InData, char *OutData, MemorySpace MemSpace)
 {
     int BlockSize;
     int SourceBlockStride = 0;

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -171,20 +171,18 @@ private:
     bool GetSingleValueFromMetadata(core::VariableBase &variable,
                                     BP5VarRec *VarRec, void *DestData,
                                     size_t Step, size_t WriterRank);
-    void ExtractSelectionFromPartialRM(int ElementSize, size_t Dims,
-                                       const size_t *GlobalDims,
-                                       const size_t *PartialOffsets,
-                                       const size_t *PartialCounts,
-                                       const size_t *SelectionOffsets,
-                                       const size_t *SelectionCounts,
-                                       const char *InData, char *OutData);
-    void ExtractSelectionFromPartialCM(int ElementSize, size_t Dims,
-                                       const size_t *GlobalDims,
-                                       const size_t *PartialOffsets,
-                                       const size_t *PartialCounts,
-                                       const size_t *SelectionOffsets,
-                                       const size_t *SelectionCounts,
-                                       const char *InData, char *OutData);
+    void ExtractSelectionFromPartialRM(
+        int ElementSize, size_t Dims, const size_t *GlobalDims,
+        const size_t *PartialOffsets, const size_t *PartialCounts,
+        const size_t *SelectionOffsets, const size_t *SelectionCounts,
+        const char *InData, char *OutData,
+        MemorySpace MemSpace = MemorySpace::Host);
+    void ExtractSelectionFromPartialCM(
+        int ElementSize, size_t Dims, const size_t *GlobalDims,
+        const size_t *PartialOffsets, const size_t *PartialCounts,
+        const size_t *SelectionOffsets, const size_t *SelectionCounts,
+        const char *InData, char *OutData,
+        MemorySpace MemSpace = MemorySpace::Host);
 
     enum RequestTypeEnum
     {
@@ -200,6 +198,7 @@ private:
         size_t BlockID;
         Dims Start;
         Dims Count;
+        MemorySpace MemSpace;
         void *Data;
     };
     std::vector<BP5ArrayRequest> PendingRequests;

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -171,6 +171,8 @@ private:
     bool GetSingleValueFromMetadata(core::VariableBase &variable,
                                     BP5VarRec *VarRec, void *DestData,
                                     size_t Step, size_t WriterRank);
+    void MemCopyData(char *OutData, const char *InData, size_t Size,
+                     MemorySpace MemSpace);
     void ExtractSelectionFromPartialRM(
         int ElementSize, size_t Dims, const size_t *GlobalDims,
         const size_t *PartialOffsets, const size_t *PartialCounts,


### PR DESCRIPTION
Testing includes Deferred and Sync modes for buffers with continuous allocated memory on the GPU. We need to add CI for this in the future.

Still needs implementation and testing for all other corner cases (Random access, non-continuous buffers, single values (? would applications really used this on the GPU?), etc.)

