### PR TITLE
CUDA: set CUDA dependencies private

### DIFF
--- a/examples/cuda/CMakeLists.txt
+++ b/examples/cuda/CMakeLists.txt
@@ -6,5 +6,5 @@
 enable_language(CUDA)
 
 add_executable(GPUWriteRead_cuda cudaWriteRead.cu)
-target_link_libraries(GPUWriteRead_cuda PUBLIC adios2::cxx11 CUDA::cudart CUDA::cuda_driver)
+target_link_libraries(GPUWriteRead_cuda PUBLIC adios2::cxx11 CUDA::cudart)
 set_target_properties(GPUWriteRead_cuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON)

--- a/examples/cuda/cudaWriteRead.cu
+++ b/examples/cuda/cudaWriteRead.cu
@@ -10,7 +10,6 @@
 
 #include <adios2.h>
 
-#include <cuda.h>
 #include <cuda_runtime.h>
 
 __global__ void update_array(float *vect, int val) {

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -107,7 +107,7 @@ set_property(TARGET adios2_core PROPERTY OUTPUT_NAME adios2${ADIOS2_LIBRARY_SUFF
 
 if(ADIOS2_HAVE_CUDA)
   enable_language(CUDA)
-  target_link_libraries(adios2_core PUBLIC CUDA::cudart CUDA::cuda_driver)
+  target_link_libraries(adios2_core PRIVATE CUDA::cudart)
   set_target_properties(adios2_core PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 endif()
 

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -25,7 +25,6 @@
 #include "adios2/operator/OperatorFactory.h"
 
 #ifdef ADIOS2_HAVE_CUDA
-#include <cuda.h>
 #include <cuda_runtime.h>
 #endif
 

--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -16,7 +16,6 @@
 #include "adios2/helper/adiosType.h"
 
 #ifdef ADIOS2_HAVE_CUDA
-#include <cuda.h>
 #include <cuda_runtime.h>
 #endif
 

--- a/testing/adios2/engine/bp/operations/CMakeLists.txt
+++ b/testing/adios2/engine/bp/operations/CMakeLists.txt
@@ -41,9 +41,10 @@ if(ADIOS2_HAVE_ZFP)
     gtest_add_tests_helper(WriteReadZfpCuda MPI_ALLOW BP Engine.BP. .BP4
       WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4"
       )
-    set_source_files_properties(CudaRoutines.cu PROPERTIES LANGUAGE CUDA)
+
     foreach(tgt ${Test.Engine.BP.WriteReadZfpCuda-TARGETS})
       target_sources(${tgt} PRIVATE CudaRoutines.cu)
+      target_link_libraries(${tgt} CUDA::cudart)
     endforeach()
   endif()
 endif()

--- a/testing/adios2/engine/bp/operations/CudaRoutines.h
+++ b/testing/adios2/engine/bp/operations/CudaRoutines.h
@@ -1,7 +1,6 @@
 #ifndef __TESTING_ADIOS2_CUDA_ROUTINES_H__
 #define __TESTING_ADIOS2_CUDA_ROUTINES_H__
 
-#include <cuda.h>
 #include <cuda_runtime.h>
 
 void cuda_increment(int M, int N, int offset, float *vec, float val);

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "CudaRoutines.h"
+
 #include <adios2.h>
 
 #include <algorithm>


### PR DESCRIPTION
The CUDA dependency must be private so that it does not propagate.