### PR TITLE
Fix bug in calculating min values using CUDA

### DIFF
--- a/source/adios2/helper/adiosCUDAReduceImpl.h
+++ b/source/adios2/helper/adiosCUDAReduceImpl.h
@@ -197,7 +197,7 @@ __global__ void reduce(const T *__restrict__ g_idata, T *__restrict__ g_odata,
     maskLength = (maskLength > 0) ? (32 - maskLength) : maskLength;
     const unsigned int mask = (0xffffffff) >> maskLength;
 
-    T mySum = 0;
+    T mySum = g_idata[0];
 
     // we reduce multiple elements per thread.  The number is determined by the
     // number of active thread blocks (via gridDim).  More blocks will result
@@ -229,7 +229,7 @@ __global__ void reduce(const T *__restrict__ g_idata, T *__restrict__ g_odata,
         }
     }
 
-    mySum = warpReduceSum<T, Op>(mask, mySum, op);
+    mySum = warpReduceSum<T, Op>(0xffffffff, mySum, op);
 
     // each thread puts its local sum into shared memory
     if ((tid % warpSize) == 0)
@@ -245,8 +245,9 @@ __global__ void reduce(const T *__restrict__ g_idata, T *__restrict__ g_odata,
     if (tid < shmem_extent)
     {
         mySum = sdata[tid];
-        mySum = warpReduceSum<T, Op>(ballot_result, mySum, op);
     }
+
+    mySum = warpReduceSum<T, Op>(0xffffffff, mySum, op);
 
     // write result for this block to global mem
     if (tid == 0)
@@ -419,6 +420,7 @@ T reduce(const size_t size, int maxThreads, int maxBlocks,
          int cpuFinalThreshold, const T *d_idata)
 {
 
+    Op op;
     T gpu_result = 0;
     int numBlocks = 0;
     int numThreads = 0;
@@ -453,7 +455,7 @@ T reduce(const size_t size, int maxThreads, int maxBlocks,
                                    cudaMemcpyDeviceToHost));
         for (int i = 0; i < s; i++)
         {
-            gpu_result += h_odata[i];
+            gpu_result = op(gpu_result, h_odata[i]);
         }
         needReadBack = false;
     }

--- a/source/adios2/helper/adiosCUDAReduceImpl.h
+++ b/source/adios2/helper/adiosCUDAReduceImpl.h
@@ -193,9 +193,6 @@ __global__ void reduce(const T *__restrict__ g_idata, T *__restrict__ g_odata,
     // reading from global memory, writing to shared memory
     unsigned int tid = threadIdx.x;
     unsigned int gridSize = blockSize * gridDim.x;
-    unsigned int maskLength = (blockSize & 31); // 31 = warpSize-1
-    maskLength = (maskLength > 0) ? (32 - maskLength) : maskLength;
-    const unsigned int mask = (0xffffffff) >> maskLength;
 
     T mySum = g_idata[0];
 
@@ -241,7 +238,8 @@ __global__ void reduce(const T *__restrict__ g_idata, T *__restrict__ g_odata,
 
     const unsigned int shmem_extent =
         (blockSize / warpSize) > 0 ? (blockSize / warpSize) : 1;
-    const unsigned int ballot_result = __ballot_sync(mask, tid < shmem_extent);
+    const unsigned int ballot_result =
+        __ballot_sync(0xffffffff, tid < shmem_extent);
     if (tid < shmem_extent)
     {
         mySum = sdata[tid];


### PR DESCRIPTION
This PR fixes an issue that causes the min value not to be correctly calculated using CUDA. When ADIOS is linked with the CUDA version of ZFP and the CUDA version of MGARD, the following tests can pass:

```
jieyang@jieyang-Thelio:~/dev/ADIOS2/build$ ctest -R CUDA
Test project /home/jieyang/dev/ADIOS2/build
    Start 883: Engine.BP.*/BPWRZFPCUDA.ADIOS2BPWRZFPCUDA/*.BP4.Serial
1/2 Test #883: Engine.BP.*/BPWRZFPCUDA.ADIOS2BPWRZFPCUDA/*.BP4.Serial ...   Passed    0.77 sec
    Start 884: Engine.BP.*/BPWRZFPCUDA.ADIOS2BPWRZFPCUDA/*.BP4.MPI
2/2 Test #884: Engine.BP.*/BPWRZFPCUDA.ADIOS2BPWRZFPCUDA/*.BP4.MPI ......   Passed    2.20 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   3.01 sec
```
```
jieyang@jieyang-Thelio:~/dev/ADIOS2/build$ ctest -R MGARD
Test project /home/jieyang/dev/ADIOS2/build
      Start 885: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP3.Serial
 1/12 Test #885: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP3.Serial ...   Passed    3.87 sec
      Start 886: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP3.Serial
 2/12 Test #886: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP3.Serial ...   Passed    1.03 sec
      Start 887: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP3.MPI
 3/12 Test #887: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP3.MPI ......   Passed    3.93 sec
      Start 888: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP3.MPI
 4/12 Test #888: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP3.MPI ......   Passed    4.24 sec
      Start 889: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP4.Serial
 5/12 Test #889: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP4.Serial ...   Passed    0.94 sec
      Start 890: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP4.Serial
 6/12 Test #890: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP4.Serial ...   Passed    0.99 sec
      Start 891: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP4.MPI
 7/12 Test #891: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP4.MPI ......   Passed    3.87 sec
      Start 892: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP4.MPI
 8/12 Test #892: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP4.MPI ......   Passed    4.21 sec
      Start 893: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP5.Serial
 9/12 Test #893: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP5.Serial ...   Passed    0.92 sec
      Start 894: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP5.Serial
10/12 Test #894: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP5.Serial ...   Passed    1.00 sec
      Start 895: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP5.MPI
11/12 Test #895: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD2D/*.BP5.MPI ......   Passed    4.06 sec
      Start 896: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP5.MPI
12/12 Test #896: Engine.BP.*/BPWriteReadMGARD.BPWRMGARD3D/*.BP5.MPI ......   Passed    4.13 sec

100% tests passed, 0 tests failed out of 12

Total Test time (real) =  33.25 sec

```