### PR TITLE
String parameter SelectSteps added to BP5 so that a reader only sees …

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(adios2_core
   helper/adiosXMLUtil.cpp
   helper/adiosYAML.cpp
   helper/adiosLog.cpp
+  helper/adiosRangeFilter.cpp
 
 #engine derived classes
   engine/bp3/BP3Reader.cpp engine/bp3/BP3Reader.tcc

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -27,7 +27,13 @@ class BP5Engine
 {
 public:
     int m_RankMPI = 0;
-    /* metadata index table*/
+    /* metadata index table
+            0: pos in memory for step (after filtered read)
+            1: size of metadata
+            2: flush count
+            3: pos in index where data offsets are enumerated
+            4: abs. pos in metadata File for step
+    */
     std::unordered_map<uint64_t, std::vector<uint64_t>> m_MetadataIndexTable;
 
     struct Minifooter
@@ -129,6 +135,7 @@ public:
     MACRO(MaxShmSize, SizeBytes, size_t, DefaultMaxShmSize)                    \
     MACRO(BufferVType, BufferVType, int, (int)BufferVType::ChunkVType)         \
     MACRO(AppendAfterSteps, Int, int, INT_MAX)                                 \
+    MACRO(SelectSteps, String, std::string, (char *)(intptr_t)0)               \
     MACRO(ReaderShortCircuitReads, Bool, bool, false)
 
     struct BP5Params

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -16,6 +16,7 @@
 #include "adios2/core/Engine.h"
 #include "adios2/engine/bp5/BP5Engine.h"
 #include "adios2/helper/adiosComm.h"
+#include "adios2/helper/adiosRangeFilter.h"
 #include "adios2/toolkit/format/bp5/BP5Deserializer.h"
 #include "adios2/toolkit/transportman/TransportMan.h"
 
@@ -95,6 +96,12 @@ private:
     size_t m_StepsCount = 0;
     bool m_FirstStep = true;
     bool m_IdxHeaderParsed = false; // true after first index parsing
+
+    /** used to filter steps */
+    helper::RangeFilter m_SelectedSteps;
+
+    // offset/size pairs to read sections of metadata from file in InitBuffer
+    std::vector<std::pair<uint64_t, uint64_t>> m_FilteredMetadataInfo;
 
     Minifooter m_Minifooter;
 

--- a/source/adios2/helper/adiosRangeFilter.cpp
+++ b/source/adios2/helper/adiosRangeFilter.cpp
@@ -1,0 +1,154 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosRangeFilter.cpp
+ *
+ *  Created on: Feb 4, 2021
+ *      Author: Norbert Podhorszki pnorbert@ornl.gov
+ */
+
+#include "adiosRangeFilter.h"
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+//#include <iostream>
+#include <sstream>
+#include <stdexcept> // std::invalid_argument
+/// \endcond
+
+#include "adios2/helper/adiosString.h"
+
+namespace adios2
+{
+namespace helper
+{
+
+void RangeFilter::ParseSelection(const std::string &selection)
+{
+    std::stringstream ss(selection);
+    std::string item;
+
+    m_Selection.clear();
+    m_UnlimitedRules.clear();
+
+    while (std::getline(ss, item, ' '))
+    {
+        if (!item.empty())
+        {
+            // std::cout << "  Parse def [" << item << "]" << std::endl;
+            std::stringstream ss(item);
+            std::string start, end, steps;
+            std::getline(ss, start, ':');
+            std::getline(ss, end, ':');
+            if (!end.empty())
+            {
+                std::getline(ss, steps, ':');
+            }
+            /*std::cout << "  start [" << start << "]"
+                      << "  end [" << end << "]"
+                      << "  steps [" << steps << "]" << std::endl;*/
+
+            size_t n = ToSizeT(start);
+            size_t m = n;
+            if (!end.empty())
+            {
+                if (end == "n" || end == "N")
+                {
+                    m = MaxSizeT;
+                }
+                else
+                {
+                    m = ToSizeT(end);
+                }
+            }
+
+            size_t s = 1;
+            if (!steps.empty())
+            {
+                s = ToSizeT(steps);
+            }
+            /*std::cout << "  start = " << n << "  end = " << m
+                      << "  steps = " << s << std::endl;*/
+
+            if (m < MaxSizeT)
+            {
+                if (m_Selection.size() < m + 1)
+                {
+                    m_Selection.resize(m + 1);
+                }
+                for (size_t i = n; i <= m; i = i + s)
+                {
+                    m_Selection[i] = true;
+                }
+            }
+            else
+            {
+                if (m_Selection.size() < n + 1)
+                {
+                    m_Selection.resize(n + 1);
+                }
+                m_Selection[n] = true;
+                m_UnlimitedRules.push_back(std::make_pair(n, s));
+            }
+        }
+    }
+
+    // process unlimited selections to fill up existing selection size
+    for (auto u : m_UnlimitedRules)
+    {
+        for (size_t i = u.first; i < m_Selection.size(); i = i + u.second)
+        {
+            m_Selection[i] = true;
+        }
+    }
+}
+
+bool RangeFilter::IsSelected(size_t n)
+{
+    size_t selSize = m_Selection.size();
+    if (selSize == 0 && m_UnlimitedRules.size() == 0)
+    {
+        // uninitialized filter returns true for everything
+        return true;
+    }
+    if (m_Selection.size() > n)
+    {
+        return m_Selection[n];
+    }
+    else
+    {
+        for (auto u : m_UnlimitedRules)
+        {
+            size_t k =
+                n - u.first; // > 0 beacuse u.first was placed in m_Selection
+            if (k % u.second == 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+size_t RangeFilter::ToSizeT(const std::string &input)
+{
+    try
+    {
+        size_t pos;
+        const size_t out = static_cast<size_t>(std::stoul(input, &pos));
+        if (pos < input.size())
+        {
+            std::throw_with_nested(std::invalid_argument(
+                "ERROR: could not cast string '" + input + "' to number "));
+        }
+        return out;
+    }
+    catch (...)
+    {
+        std::throw_with_nested(std::invalid_argument(
+            "ERROR: could not cast string '" + input + "' to number "));
+    }
+}
+
+} // end namespace helper
+} // end namespace adios2

--- a/source/adios2/helper/adiosRangeFilter.h
+++ b/source/adios2/helper/adiosRangeFilter.h
@@ -1,0 +1,68 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosRangeFilter.h a simple range filter
+ *
+ *  Created on: Feb 4, 2021
+ *      Author: Norbert Podhorszki pnorbert@ornl.gov
+ */
+
+#ifndef ADIOS2_HELPER_RANGEFILTER_H_
+#define ADIOS2_HELPER_RANGEFILTER_H_
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <string>
+#include <vector>
+/// \endcond
+
+namespace adios2
+{
+namespace helper
+{
+
+constexpr size_t MaxAllowedNumber = 9999999ULL;
+
+class RangeFilter
+{
+public:
+    RangeFilter(){};
+    ~RangeFilter() = default;
+
+    /** Create a rangefilter from a list of range definitions.
+     * @param selection string of space-separated list of range definitions in
+     * the form of "start:end:step". Indexing starts from 0. If 'end' is 'n' or
+     * 'N', then it is an unlimited range expression. Range definitions are
+     * adding up.
+     * Examples:
+     * "0 6 3 2" selected 4 steps indexed 0,2,3 and 6
+     * "1:5" selects 5 consecutive steps, skipping step 0, and starting from 1
+     * "2:n" selects all steps from step 2
+     * "0:n:2" selects every other steps from the beginning (0,2,4,6...)
+     * "0:n:3  10:n:5" selects every third step from the beginning and
+     * additionally every fifth steps from step 10.
+     * RangeFilters that are not initialized will return true for everything
+     * @return Will throw an invalid_argument exception if the selection
+     * does not conform to the specification
+     */
+    void ParseSelection(const std::string &selection);
+
+    /**
+     * Checks if an element is present in the selection
+     * @param n non-negative integer
+     * @return true if 'element' was in the selection
+     */
+    bool IsSelected(size_t n);
+
+private:
+    // true: element was in selection, false: was not in selection
+    std::vector<bool> m_Selection;
+    // unlimited selection rules (pair of Start and Steps)
+    std::vector<std::pair<size_t, size_t>> m_UnlimitedRules;
+    size_t ToSizeT(const std::string &input);
+}; // class
+
+} // end namespace helper
+} // end namespace adios2
+
+#endif /* ADIOS2_HELPER_RANGEFILTER_H_ */

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -121,9 +121,11 @@ if(ADIOS2_HAVE_MPI)
 endif()
 
 # BP5 only for now
-gtest_add_tests_helper(ParameterSelectSteps MPI_ALLOW BP Engine.BP. .BP5
-  WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
+if(ADIOS2_HAVE_BP5)
+  gtest_add_tests_helper(ParameterSelectSteps MPI_ALLOW BP Engine.BP. .BP5
+    WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
 )
+endif(ADIOS2_HAVE_BP5)
 
 # BP3 only for now
 gtest_add_tests_helper(WriteNull MPI_ALLOW BP Engine.BP. .BP3

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -120,6 +120,11 @@ if(ADIOS2_HAVE_MPI)
   bp_gtest_add_tests_helper(WriteAggregateRead MPI_ONLY)
 endif()
 
+# BP5 only for now
+gtest_add_tests_helper(ParameterSelectSteps MPI_ALLOW BP Engine.BP. .BP5
+  WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
+)
+
 # BP3 only for now
 gtest_add_tests_helper(WriteNull MPI_ALLOW BP Engine.BP. .BP3
   WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3"

--- a/testing/adios2/engine/bp/TestBPParameterSelectSteps.cpp
+++ b/testing/adios2/engine/bp/TestBPParameterSelectSteps.cpp
@@ -1,0 +1,196 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * Test "SelectSteps" parameter for reading a BP file
+ *
+ *  Created on: Feb 4, 2021
+ *      Author: Norbert Podhorszki
+ */
+
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#include "../SmallTestData.h"
+
+std::string engineName; // comes from command line
+constexpr std::size_t NSteps = 10;
+const std::size_t Nx = 10;
+using DataArray = std::array<int32_t, Nx>;
+
+class BPParameterSelectSteps : public ::testing::Test
+{
+public:
+    BPParameterSelectSteps() = default;
+
+    DataArray GenerateData(int step, int rank, int size)
+    {
+        DataArray d;
+        int j = rank + 1 + step * size;
+        for (size_t i = 0; i < d.size(); ++i)
+        {
+            d[i] = j;
+        }
+        return d;
+    }
+
+    std::string ArrayToString(int32_t *data, size_t nelems)
+    {
+        std::stringstream ss;
+        ss << "[";
+        for (size_t i = 0; i < nelems; ++i)
+        {
+            ss << data[i];
+            if (i < nelems - 1)
+            {
+                ss << " ";
+            }
+        }
+        ss << "]";
+        return ss.str();
+    }
+
+    bool OutputWritten = false;
+
+    void CreateOutput()
+    {
+        // This is not really a test but to create a dataset for all read tests
+        if (OutputWritten)
+        {
+            return;
+        }
+        int mpiRank = 0, mpiSize = 1;
+#if ADIOS2_USE_MPI
+        MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+#if ADIOS2_USE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+        adios2::ADIOS adios;
+#endif
+        std::string filename =
+            "ParameterSelectSteps" + std::to_string(mpiSize) + ".bp";
+        adios2::IO ioWrite = adios.DeclareIO("TestIOWrite");
+        ioWrite.SetEngine(engineName);
+        adios2::Engine engine = ioWrite.Open(filename, adios2::Mode::Write);
+        // Number of elements per process
+        const std::size_t Nx = 10;
+        adios2::Dims shape{static_cast<unsigned int>(mpiSize * Nx)};
+        adios2::Dims start{static_cast<unsigned int>(mpiRank * Nx)};
+        adios2::Dims count{static_cast<unsigned int>(Nx)};
+
+        auto var0 = ioWrite.DefineVariable<int32_t>("var", shape, start, count);
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            int s = static_cast<int>(step);
+            auto d = GenerateData(s, mpiRank, mpiSize);
+            engine.BeginStep();
+            engine.Put(var0, d.data());
+            engine.EndStep();
+        }
+        engine.Close();
+        OutputWritten = true;
+    }
+};
+
+class BPParameterSelectStepsP
+: public BPParameterSelectSteps,
+  public ::testing::WithParamInterface<
+      std::tuple<std::string, std::vector<size_t>>>
+{
+protected:
+    std::string GetSelectionString() { return std::get<0>(GetParam()); };
+    std::vector<size_t> GetSteps() { return std::get<1>(GetParam()); };
+};
+
+TEST_P(BPParameterSelectStepsP, Read)
+{
+    int mpiRank = 0, mpiSize = 1;
+    std::string selection = GetSelectionString();
+    // with this selection these are the original (absolute) steps
+    // that this reader will now see as steps 0,1,2,...
+    std::vector<size_t> absoluteSteps = GetSteps();
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+#if ADIOS2_USE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+    adios2::ADIOS adios;
+#endif
+    CreateOutput();
+    std::string filename =
+        "ParameterSelectSteps" + std::to_string(mpiSize) + ".bp";
+    adios2::IO ioRead = adios.DeclareIO("TestIORead");
+    ioRead.SetEngine(engineName);
+    ioRead.SetParameter("SelectSteps", selection);
+    adios2::Engine engine_s =
+        ioRead.Open(filename, adios2::Mode::ReadRandomAccess);
+    EXPECT_TRUE(engine_s);
+
+    const size_t nsteps = engine_s.Steps();
+    EXPECT_EQ(nsteps, absoluteSteps.size());
+
+    adios2::Variable<int> var = ioRead.InquireVariable<int32_t>("var");
+
+    for (size_t step = 0; step < nsteps; step++)
+    {
+        var.SetStepSelection(adios2::Box<size_t>(step, 1));
+        std::vector<int> res;
+        var.SetSelection({{Nx * mpiRank}, {Nx}});
+        engine_s.Get<int>(var, res, adios2::Mode::Sync);
+        int s = static_cast<int>(absoluteSteps[step]);
+        auto d = GenerateData(s, mpiRank, mpiSize);
+        EXPECT_EQ(res[0], d[0]);
+    }
+
+    engine_s.Close();
+#if ADIOS2_USE_MPI
+    MPI_Barrier(MPI_COMM_WORLD);
+#endif
+}
+
+const std::vector<size_t> s_0n1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+const std::vector<size_t> s_152 = {1, 3, 5};
+const std::vector<size_t> s_1n2_0n2 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+INSTANTIATE_TEST_SUITE_P(BPParameterSelectSteps, BPParameterSelectStepsP,
+                         ::testing::Values(std::make_tuple("0:n:1", s_0n1),
+                                           std::make_tuple("1:5:2", s_152),
+                                           std::make_tuple("1:n:2 0:n:2",
+                                                           s_1n2_0n2)));
+
+int main(int argc, char **argv)
+{
+#if ADIOS2_USE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+
+    result = RUN_ALL_TESTS();
+
+#if ADIOS2_USE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}

--- a/testing/adios2/helper/CMakeLists.txt
+++ b/testing/adios2/helper/CMakeLists.txt
@@ -6,4 +6,6 @@
 gtest_add_tests_helper(Strings MPI_NONE Helper Helper. "")
 gtest_add_tests_helper(DivideBlock MPI_NONE "" Helper. "")
 gtest_add_tests_helper(MinMaxs MPI_NONE "" Helper. "")
+gtest_add_tests_helper(RangeFilter MPI_NONE "" Helper. "")
 gtest_add_tests_helper(ReadNonBPFile MPI_NONE "" Helper. "")
+

--- a/testing/adios2/helper/TestRangeFilter.cpp
+++ b/testing/adios2/helper/TestRangeFilter.cpp
@@ -1,0 +1,112 @@
+#include <adios2/helper/adiosRangeFilter.h>
+#include <fstream>
+#include <gtest/gtest.h>
+
+TEST(ADIOS2RangeFilter, Elements)
+{
+    adios2::helper::RangeFilter r;
+
+    r.ParseSelection("2");
+    EXPECT_FALSE(r.IsSelected(0));
+    EXPECT_FALSE(r.IsSelected(1));
+    EXPECT_TRUE(r.IsSelected(2));
+    EXPECT_FALSE(r.IsSelected(3));
+
+    r.ParseSelection("2 3 0");
+    EXPECT_TRUE(r.IsSelected(0));
+    EXPECT_FALSE(r.IsSelected(1));
+    EXPECT_TRUE(r.IsSelected(2));
+    EXPECT_TRUE(r.IsSelected(3));
+}
+
+TEST(ADIOS2RangeFilter, Ranges)
+{
+    adios2::helper::RangeFilter r;
+
+    r.ParseSelection("1:2");
+    EXPECT_FALSE(r.IsSelected(0));
+    EXPECT_TRUE(r.IsSelected(1));
+    EXPECT_TRUE(r.IsSelected(2));
+    EXPECT_FALSE(r.IsSelected(3));
+
+    r.ParseSelection("1:2:1");
+    EXPECT_FALSE(r.IsSelected(0));
+    EXPECT_TRUE(r.IsSelected(1));
+    EXPECT_TRUE(r.IsSelected(2));
+    EXPECT_FALSE(r.IsSelected(3));
+
+    r.ParseSelection("1:2:2");
+    EXPECT_FALSE(r.IsSelected(0));
+    EXPECT_TRUE(r.IsSelected(1));
+    EXPECT_FALSE(r.IsSelected(2));
+    EXPECT_FALSE(r.IsSelected(3));
+
+    r.ParseSelection("1:6:3");
+    EXPECT_FALSE(r.IsSelected(0));
+    EXPECT_TRUE(r.IsSelected(1));
+    EXPECT_FALSE(r.IsSelected(2));
+    EXPECT_FALSE(r.IsSelected(3));
+    EXPECT_TRUE(r.IsSelected(4));
+    EXPECT_FALSE(r.IsSelected(5));
+    EXPECT_FALSE(r.IsSelected(6));
+
+    r.ParseSelection("1:3:2 0:4:2");
+    EXPECT_TRUE(r.IsSelected(0));
+    EXPECT_TRUE(r.IsSelected(1));
+    EXPECT_TRUE(r.IsSelected(2));
+    EXPECT_TRUE(r.IsSelected(3));
+    EXPECT_TRUE(r.IsSelected(4));
+    EXPECT_FALSE(r.IsSelected(5));
+    EXPECT_FALSE(r.IsSelected(6));
+}
+
+TEST(ADIOS2RangeFilter, UnlimitedRanges)
+{
+    adios2::helper::RangeFilter r;
+
+    r.ParseSelection("2:n");
+    EXPECT_FALSE(r.IsSelected(0));
+    EXPECT_FALSE(r.IsSelected(1));
+    EXPECT_TRUE(r.IsSelected(2));
+    EXPECT_TRUE(r.IsSelected(3000));
+
+    r.ParseSelection("2:N:1");
+    EXPECT_FALSE(r.IsSelected(0));
+    EXPECT_FALSE(r.IsSelected(1));
+    EXPECT_TRUE(r.IsSelected(2));
+    EXPECT_TRUE(r.IsSelected(3000));
+
+    r.ParseSelection("1:n:2");
+    EXPECT_FALSE(r.IsSelected(0));
+    EXPECT_TRUE(r.IsSelected(1));
+    EXPECT_FALSE(r.IsSelected(2));
+    EXPECT_TRUE(r.IsSelected(3));
+    EXPECT_FALSE(r.IsSelected(3000));
+    EXPECT_TRUE(r.IsSelected(3001));
+
+    r.ParseSelection("1:n:2   0:N:2");
+    EXPECT_TRUE(r.IsSelected(0));
+    EXPECT_TRUE(r.IsSelected(1));
+    EXPECT_TRUE(r.IsSelected(2));
+    EXPECT_TRUE(r.IsSelected(3));
+    EXPECT_TRUE(r.IsSelected(4));
+    EXPECT_TRUE(r.IsSelected(5));
+    EXPECT_TRUE(r.IsSelected(6));
+    EXPECT_TRUE(r.IsSelected(3000));
+    EXPECT_TRUE(r.IsSelected(3001));
+}
+
+TEST(ADIOS2RangeFilter, InvalidSelection)
+{
+    adios2::helper::RangeFilter r;
+
+    EXPECT_THROW(r.ParseSelection("b"), std::invalid_argument);
+    EXPECT_THROW(r.ParseSelection("n"), std::invalid_argument);
+    EXPECT_THROW(r.ParseSelection("1:n:2,3"), std::invalid_argument);
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
…the selected steps. The selection can contain multiple range selections in the form of start:end:step form, as a space-separated list. Unlimited selections can be defined using 'n' or 'N' for the end part of the range. Steps start from 0. For example: "0:n:3  2:n:3  1:n:3" is a valid selection spec for getting all steps. Memory requirement is std::vector<bool>(M) where M is the largest number in the spec (unlimited spec uses 16 bytes per unlimited range). There is NO protection from users specifying 64bit large numbers and run out of memory. Note that a reader always sees the available steps as step 0, 1, 2 and so on. This feature picks which steps in a file/stream will become visible.