### PR TITLE
use helper::Throw for all exceptions

### DIFF
--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -55,10 +55,9 @@ ADIOS::ADIOS(const std::string configFile, helper::Comm comm,
     {
         if (!adios2sys::SystemTools::FileExists(configFile))
         {
-            helper::Throw<std::logic_error>(
-                "Core", "ADIOS", "ADIOS",
-                "Config file " + configFile +
-                    " passed to ADIOS does not exist.");
+            helper::Throw<std::logic_error>("Core", "ADIOS", "ADIOS",
+                                            "config file " + configFile +
+                                                " not found");
         }
         if (helper::EndsWith(configFile, ".xml"))
         {
@@ -106,11 +105,7 @@ IO &ADIOS::DeclareIO(const std::string name, const ArrayOrdering ArrayOrder)
         else
         {
             helper::Throw<std::invalid_argument>(
-                "Core", "ADIOS", "DeclareIO",
-                "IO with name " + name +
-                    " previously declared with DeclareIO, name must be "
-                    "unique,"
-                    " in call to DeclareIO");
+                "Core", "ADIOS", "DeclareIO", "IO " + name + " declared twice");
         }
     }
 
@@ -129,11 +124,9 @@ IO &ADIOS::AtIO(const std::string name)
 
     if (itIO == m_IOs.end())
     {
-        helper::Throw<std::invalid_argument>(
-            "Core", "ADIOS", "AtIO",
-            "IO with name " + name +
-                " was not declared, did you previously "
-                "call DeclareIO?, in call to AtIO");
+        helper::Throw<std::invalid_argument>("Core", "ADIOS", "AtIO",
+                                             "IO " + name +
+                                                 " being used is not declared");
     }
     else
     {
@@ -141,9 +134,7 @@ IO &ADIOS::AtIO(const std::string name)
         {
             helper::Throw<std::invalid_argument>(
                 "Core", "ADIOS", "AtIO",
-                "IO with name " + name +
-                    " was not declared, did you previously "
-                    "call DeclareIO ?, in call to AtIO");
+                "IO " + name + " being used is not declared");
         }
     }
 
@@ -220,12 +211,9 @@ void ADIOS::CheckOperator(const std::string name) const
 {
     if (m_Operators.count(name) == 1)
     {
-        helper::Throw<std::invalid_argument>(
-            "Core", "ADIOS", "CheckOperator",
-            "Operator with name " + name +
-                ", is already defined in either config file "
-                "or with call to DefineOperator, name must "
-                "be unique, in call to DefineOperator");
+        helper::Throw<std::invalid_argument>("Core", "ADIOS", "CheckOperator",
+                                             "Operator " + name +
+                                                 " defined twice");
     }
 }
 

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -55,8 +55,10 @@ ADIOS::ADIOS(const std::string configFile, helper::Comm comm,
     {
         if (!adios2sys::SystemTools::FileExists(configFile))
         {
-            throw std::logic_error("Config file " + configFile +
-                                   " passed to ADIOS does not exist.");
+            helper::Throw<std::logic_error>(
+                "Core", "ADIOS", "ADIOS",
+                "Config file " + configFile +
+                    " passed to ADIOS does not exist.");
         }
         if (helper::EndsWith(configFile, ".xml"))
         {
@@ -103,11 +105,12 @@ IO &ADIOS::DeclareIO(const std::string name, const ArrayOrdering ArrayOrder)
         }
         else
         {
-            throw std::invalid_argument(
-                "ERROR: IO with name " + name +
-                " previously declared with DeclareIO, name must be "
-                "unique,"
-                " in call to DeclareIO\n");
+            helper::Throw<std::invalid_argument>(
+                "Core", "ADIOS", "DeclareIO",
+                "IO with name " + name +
+                    " previously declared with DeclareIO, name must be "
+                    "unique,"
+                    " in call to DeclareIO");
         }
     }
 
@@ -126,17 +129,21 @@ IO &ADIOS::AtIO(const std::string name)
 
     if (itIO == m_IOs.end())
     {
-        throw std::invalid_argument("ERROR: IO with name " + name +
-                                    " was not declared, did you previously "
-                                    "call DeclareIO?, in call to AtIO\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "ADIOS", "AtIO",
+            "IO with name " + name +
+                " was not declared, did you previously "
+                "call DeclareIO?, in call to AtIO");
     }
     else
     {
         if (!itIO->second.IsDeclared())
         {
-            throw std::invalid_argument("ERROR: IO with name " + name +
-                                        " was not declared, did you previously "
-                                        "call DeclareIO ?, in call to AtIO\n");
+            helper::Throw<std::invalid_argument>(
+                "Core", "ADIOS", "AtIO",
+                "IO with name " + name +
+                    " was not declared, did you previously "
+                    "call DeclareIO ?, in call to AtIO");
         }
     }
 
@@ -213,11 +220,12 @@ void ADIOS::CheckOperator(const std::string name) const
 {
     if (m_Operators.count(name) == 1)
     {
-        throw std::invalid_argument(
-            "ERROR: Operator with name " + name +
-            ", is already defined in either config file "
-            "or with call to DefineOperator, name must "
-            "be unique, in call to DefineOperator\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "ADIOS", "CheckOperator",
+            "Operator with name " + name +
+                ", is already defined in either config file "
+                "or with call to DefineOperator, name must "
+                "be unique, in call to DefineOperator");
     }
 }
 

--- a/source/adios2/core/Attribute.tcc
+++ b/source/adios2/core/Attribute.tcc
@@ -107,8 +107,7 @@ void Attribute<T>::Modify(const T *data, const size_t elements)
     {
         helper::Throw<std::invalid_argument>(
             "Core", "Attribute", "Modify",
-            "Trying to modify attribute " + this->m_Name +
-                " which has been defined as non-modifiable");
+            "Attribute " + this->m_Name + " being modified is not modifiable");
     }
 }
 
@@ -127,8 +126,7 @@ void Attribute<T>::Modify(const T &data)
     {
         helper::Throw<std::invalid_argument>(
             "Core", "Attribute", "Modify",
-            "Trying to modify attribute " + this->m_Name +
-                " which has been defined as non-modifiable");
+            "Attribute " + this->m_Name + " being modified is not modifiable");
     }
 }
 

--- a/source/adios2/core/Attribute.tcc
+++ b/source/adios2/core/Attribute.tcc
@@ -14,6 +14,7 @@
 #include "Attribute.h"
 
 #include "adios2/helper/adiosFunctions.h" //GetDataType<T>
+#include "adios2/helper/adiosLog.h"
 #include "adios2/helper/adiosType.h"
 
 #include <cstring>
@@ -104,9 +105,10 @@ void Attribute<T>::Modify(const T *data, const size_t elements)
     }
     else
     {
-        throw std::invalid_argument(
-            "ERROR: Trying to modify attribute " + this->m_Name +
-            " which has been defined as non-modifiable\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Attribute", "Modify",
+            "Trying to modify attribute " + this->m_Name +
+                " which has been defined as non-modifiable");
     }
 }
 
@@ -123,9 +125,10 @@ void Attribute<T>::Modify(const T &data)
     }
     else
     {
-        throw std::invalid_argument(
-            "ERROR: Trying to modify attribute " + this->m_Name +
-            " which has been defined as non-modifiable\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Attribute", "Modify",
+            "Trying to modify attribute " + this->m_Name +
+                " which has been defined as non-modifiable");
     }
 }
 

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -198,10 +198,9 @@ size_t Engine::DoSteps() const
 // PRIVATE
 void Engine::ThrowUp(const std::string function) const
 {
-    helper::Throw<std::invalid_argument>(
-        "Core", "Engine", "ThrowUp",
-        "Engine derived class " + m_EngineType +
-            " doesn't implement function " + function);
+    helper::Throw<std::invalid_argument>("Core", "Engine", "ThrowUp",
+                                         "Engine " + m_EngineType +
+                                             " does not support " + function);
 }
 
 void Engine::CheckOpenModes(const std::set<Mode> &modes,
@@ -209,9 +208,9 @@ void Engine::CheckOpenModes(const std::set<Mode> &modes,
 {
     if (modes.count(m_OpenMode) == 0)
     {
-        helper::Throw<std::invalid_argument>(
-            "Core", "Engine", "CheckOpenModes",
-            "Engine Open Mode not valid for function, " + hint);
+        helper::Throw<std::invalid_argument>("Core", "Engine", "CheckOpenModes",
+                                             "Engine open mode not valid for " +
+                                                 hint);
     }
 }
 

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -198,9 +198,10 @@ size_t Engine::DoSteps() const
 // PRIVATE
 void Engine::ThrowUp(const std::string function) const
 {
-    throw std::invalid_argument("ERROR: Engine derived class " + m_EngineType +
-                                " doesn't implement function " + function +
-                                "\n");
+    helper::Throw<std::invalid_argument>(
+        "Core", "Engine", "ThrowUp",
+        "Engine derived class " + m_EngineType +
+            " doesn't implement function " + function);
 }
 
 void Engine::CheckOpenModes(const std::set<Mode> &modes,
@@ -208,8 +209,9 @@ void Engine::CheckOpenModes(const std::set<Mode> &modes,
 {
     if (modes.count(m_OpenMode) == 0)
     {
-        throw std::invalid_argument(
-            "ERROR: Engine Open Mode not valid for function, " + hint);
+        helper::Throw<std::invalid_argument>(
+            "Core", "Engine", "CheckOpenModes",
+            "Engine Open Mode not valid for function, " + hint);
     }
 }
 

--- a/source/adios2/core/Engine.tcc
+++ b/source/adios2/core/Engine.tcc
@@ -31,8 +31,9 @@ typename Variable<T>::Span &Engine::Put(Variable<T> &variable,
                                         ", in call to Variable<T>::Span Put");
     if (!variable.m_Operations.empty())
     {
-        throw std::invalid_argument(
-            "ERROR: span currently not supported with "
+        helper::Throw<std::invalid_argument>(
+            "Core", "Engine", "Put",
+            "span currently not supported with "
             "operations, remove calls to Variable<T>::AddOperation or use "
             "Variable<T>::RemoveOperations, in call to Variable<T>::Span "
             "Engine::Put");
@@ -60,10 +61,11 @@ void Engine::Put(Variable<T> &variable, const T *data, const Mode launch)
         DoPutSync(variable, data);
         break;
     default:
-        throw std::invalid_argument(
-            "ERROR: invalid launch Mode for variable " + variable.m_Name +
-            ", only Mode::Deferred and Mode::Sync are valid, in call to "
-            "Put\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Engine", "Put",
+            "invalid launch Mode for variable " + variable.m_Name +
+                ", only Mode::Deferred and Mode::Sync are valid, in call to "
+                "Put");
     }
 }
 
@@ -106,10 +108,11 @@ void Engine::Get(Variable<T> &variable, T *data, const Mode launch)
         DoGetSync(variable, data);
         break;
     default:
-        throw std::invalid_argument(
-            "ERROR: invalid launch Mode for variable " + variable.m_Name +
-            ", only Mode::Deferred and Mode::Sync are valid, in call to "
-            "Get\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Engine", "Get",
+            "invalid launch Mode for variable " + variable.m_Name +
+                ", only Mode::Deferred and Mode::Sync are valid, in call to "
+                "Get");
     }
 }
 
@@ -151,8 +154,10 @@ void Engine::Get(core::Variable<T> &variable, T **data) const
     }
     else
     {
-        throw std::runtime_error("Currently, only the inline engine implements "
-                                 "Get(core::Variable<T>&, T**)");
+        helper::Throw<std::runtime_error>(
+            "Core", "Engine", "Get",
+            "Currently, only the inline engine implements "
+            "Get(core::Variable<T>&, T**)");
     }
 }
 
@@ -179,10 +184,11 @@ typename Variable<T>::BPInfo *Engine::Get(Variable<T> &variable,
         info = DoGetBlockSync(variable);
         break;
     default:
-        throw std::invalid_argument(
-            "ERROR: invalid launch Mode for variable " + variable.m_Name +
-            ", only Mode::Deferred and Mode::Sync are valid, in call to "
-            "GetBlock\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Engine", "Get",
+            "invalid launch Mode for variable " + variable.m_Name +
+                ", only Mode::Deferred and Mode::Sync are valid, in call to "
+                "GetBlock");
     }
 
     CommonChecks<T>(variable, info->Data, {{Mode::Read}}, "in call to Get");
@@ -254,9 +260,10 @@ Variable<T> &Engine::FindVariable(const std::string &variableName,
     Variable<T> *variable = m_IO.InquireVariable<T>(variableName);
     if (variable == nullptr)
     {
-        throw std::invalid_argument("ERROR: variable " + variableName +
-                                    " not found in IO " + m_IO.m_Name + ", " +
-                                    hint + "\n");
+        helper::Throw<std::invalid_argument>("Core", "Engine", "FindVariable",
+                                             "variable " + variableName +
+                                                 " not found in IO " +
+                                                 m_IO.m_Name + ", " + hint);
     }
     return *variable;
 }

--- a/source/adios2/core/Engine.tcc
+++ b/source/adios2/core/Engine.tcc
@@ -33,10 +33,8 @@ typename Variable<T>::Span &Engine::Put(Variable<T> &variable,
     {
         helper::Throw<std::invalid_argument>(
             "Core", "Engine", "Put",
-            "span currently not supported with "
-            "operations, remove calls to Variable<T>::AddOperation or use "
-            "Variable<T>::RemoveOperations, in call to Variable<T>::Span "
-            "Engine::Put");
+            "Span does not support Operations. Try removing Operations from "
+            "variables using Span");
     }
 
     auto itSpan = variable.m_BlocksSpan.emplace(
@@ -64,8 +62,7 @@ void Engine::Put(Variable<T> &variable, const T *data, const Mode launch)
         helper::Throw<std::invalid_argument>(
             "Core", "Engine", "Put",
             "invalid launch Mode for variable " + variable.m_Name +
-                ", only Mode::Deferred and Mode::Sync are valid, in call to "
-                "Put");
+                ", only Mode::Deferred and Mode::Sync are valid");
     }
 }
 
@@ -111,8 +108,7 @@ void Engine::Get(Variable<T> &variable, T *data, const Mode launch)
         helper::Throw<std::invalid_argument>(
             "Core", "Engine", "Get",
             "invalid launch Mode for variable " + variable.m_Name +
-                ", only Mode::Deferred and Mode::Sync are valid, in call to "
-                "Get");
+                ", only Mode::Deferred and Mode::Sync are valid");
     }
 }
 
@@ -156,8 +152,8 @@ void Engine::Get(core::Variable<T> &variable, T **data) const
     {
         helper::Throw<std::runtime_error>(
             "Core", "Engine", "Get",
-            "Currently, only the inline engine implements "
-            "Get(core::Variable<T>&, T**)");
+            "Engine " + m_EngineType +
+                " does not support Get(core::Variable<T>&, T**)");
     }
 }
 
@@ -187,8 +183,7 @@ typename Variable<T>::BPInfo *Engine::Get(Variable<T> &variable,
         helper::Throw<std::invalid_argument>(
             "Core", "Engine", "Get",
             "invalid launch Mode for variable " + variable.m_Name +
-                ", only Mode::Deferred and Mode::Sync are valid, in call to "
-                "GetBlock");
+                ", only Mode::Deferred and Mode::Sync are valid");
     }
 
     CommonChecks<T>(variable, info->Data, {{Mode::Read}}, "in call to Get");

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -275,11 +275,7 @@ size_t IO::AddTransport(const std::string type, const Params &parameters)
     if (parameters.count("transport") == 1 ||
         parameters.count("Transport") == 1)
     {
-        helper::Throw<std::invalid_argument>(
-            "Core", "IO", "AddTransport",
-            "key Transport (or transport) "
-            "is not valid for transport type " +
-                type + ", in call to AddTransport)");
+        helper::Throw<std::invalid_argument>( "Core", "IO", "AddTransport", "key Transport (or transport) is not allowed in transport parameters);
     }
 
     CheckTransportType(type);
@@ -297,9 +293,8 @@ void IO::SetTransportParameter(const size_t transportIndex,
     {
         helper::Throw<std::invalid_argument>(
             "Core", "IO", "SetTransportParameter",
-            "transportIndex is larger than "
-            "transports created with AddTransport, for key: " +
-                key + ", value: " + value + "in call to SetTransportParameter");
+            "transport Index " + std::to_string(transportIndex) +
+                " does not exist");
     }
 
     m_TransportsParameters[transportIndex][key] = value;
@@ -525,10 +520,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         if (isEngineActive) // check if active
         {
             helper::Throw<std::invalid_argument>(
-                "Core", "IO", "Open",
-                "IO Engine with name " + name +
-                    " already created and is active (Close "
-                    "not called yet), in call to Open");
+                "Core", "IO", "Open", "Engine " + name + " is opened twice");
         }
     }
 
@@ -627,7 +619,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         {
             helper::Throw<std::runtime_error>(
                 "Core", "IO", "Open",
-                "Append mode is not supported for the inline engine.");
+                "Append mode is not supported in the inline engine.");
         }
 
         // See inline.rst:44
@@ -635,7 +627,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
         {
             helper::Throw<std::runtime_error>(
                 "Core", "IO", "Open",
-                "Sync mode is not supported for the inline engine.");
+                "Sync mode is not supported in the inline engine.");
         }
 
         if (m_Engines.size() >= 2)
@@ -683,12 +675,9 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
     }
     else
     {
-        helper::Throw<std::invalid_argument>(
-            "Core", "IO", "Open",
-            "engine " + m_EngineType +
-                " not supported, IO SetEngine must add "
-                "a supported engine, in call to "
-                "Open");
+        helper::Throw<std::invalid_argument>("Core", "IO", "Open",
+                                             "Engine type " + m_EngineType +
+                                                 " is not valid");
     }
 
     auto itEngine = m_Engines.emplace(name, std::move(engine));
@@ -696,9 +685,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
     if (!itEngine.second)
     {
         helper::Throw<std::invalid_argument>(
-            "Core", "IO", "Open",
-            "engine of type " + m_EngineType + " and name " + name +
-                " could not be created, in call to Open");
+            "Core", "IO", "Open", "failed to create Engine " + m_EngineType);
     }
     // return a reference
     return *itEngine.first->second.get();
@@ -720,10 +707,8 @@ Engine &IO::GetEngine(const std::string &name)
     auto itEngine = m_Engines.find(name);
     if (itEngine == m_Engines.end())
     {
-        helper::Throw<std::invalid_argument>(
-            "Core", "IO", "GetEngine",
-            "engine name " + name +
-                " could not be found, in call to GetEngine");
+        helper::Throw<std::invalid_argument>("Core", "IO", "GetEngine",
+                                             "Engine " + name + " not found");
     }
     // return a reference
     return *itEngine->second.get();
@@ -844,7 +829,7 @@ void IO::CheckAttributeCommon(const std::string &name) const
     {
         helper::Throw<std::invalid_argument>(
             "Core", "IO", "CheckAttributeCommon",
-            "attribute " + name + " exists in IO object " + m_Name +
+            "Attribute " + name + " exists in IO " + m_Name +
                 ", in call to DefineAttribute");
     }
 }
@@ -856,8 +841,7 @@ void IO::CheckTransportType(const std::string type) const
         helper::Throw<std::invalid_argument>(
             "Core", "IO", "CheckTransportType",
             "wrong first argument " + type +
-                ", must "
-                "be a single word for a supported transport type, in "
+                ", must be a single word for a supported transport type, in "
                 "call to IO AddTransport");
     }
 }

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -151,7 +151,8 @@ struct ThrowError
     std::shared_ptr<Engine> operator()(IO &, const std::string &, const Mode,
                                        helper::Comm) const
     {
-        throw std::invalid_argument(Err);
+        helper::Throw<std::invalid_argument>("Core", "IO", "Operator", Err);
+        return nullptr;
     }
     std::string Err;
 };
@@ -274,9 +275,11 @@ size_t IO::AddTransport(const std::string type, const Params &parameters)
     if (parameters.count("transport") == 1 ||
         parameters.count("Transport") == 1)
     {
-        throw std::invalid_argument("ERROR: key Transport (or transport) "
-                                    "is not valid for transport type " +
-                                    type + ", in call to AddTransport)");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "AddTransport",
+            "key Transport (or transport) "
+            "is not valid for transport type " +
+                type + ", in call to AddTransport)");
     }
 
     CheckTransportType(type);
@@ -292,10 +295,11 @@ void IO::SetTransportParameter(const size_t transportIndex,
     PERFSTUBS_SCOPED_TIMER("IO::other");
     if (transportIndex >= m_TransportsParameters.size())
     {
-        throw std::invalid_argument(
-            "ERROR: transportIndex is larger than "
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "SetTransportParameter",
+            "transportIndex is larger than "
             "transports created with AddTransport, for key: " +
-            key + ", value: " + value + "in call to SetTransportParameter\n");
+                key + ", value: " + value + "in call to SetTransportParameter");
     }
 
     m_TransportsParameters[transportIndex][key] = value;
@@ -520,9 +524,11 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
     {
         if (isEngineActive) // check if active
         {
-            throw std::invalid_argument("ERROR: IO Engine with name " + name +
-                                        " already created and is active (Close "
-                                        "not called yet), in call to Open.\n");
+            helper::Throw<std::invalid_argument>(
+                "Core", "IO", "Open",
+                "IO Engine with name " + name +
+                    " already created and is active (Close "
+                    "not called yet), in call to Open");
         }
     }
 
@@ -619,14 +625,16 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
     {
         if (mode_to_use == Mode::Append)
         {
-            throw std::runtime_error(
+            helper::Throw<std::runtime_error>(
+                "Core", "IO", "Open",
                 "Append mode is not supported for the inline engine.");
         }
 
         // See inline.rst:44
         if (mode_to_use == Mode::Sync)
         {
-            throw std::runtime_error(
+            helper::Throw<std::runtime_error>(
+                "Core", "IO", "Open",
                 "Sync mode is not supported for the inline engine.");
         }
 
@@ -638,7 +646,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
                    "reader. ";
             msg += "There are already two engines declared, so no more can be "
                    "added.";
-            throw std::runtime_error(msg);
+            helper::Throw<std::runtime_error>("Core", "IO", "Open", msg);
         }
         // Now protect against declaration of two writers, or declaration of
         // two readers:
@@ -653,7 +661,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
                     ". ";
                 msg += "The inline engine requires exactly one writer and one "
                        "reader.";
-                throw std::runtime_error(msg);
+                helper::Throw<std::runtime_error>("Core", "IO", "Open", msg);
             }
         }
     }
@@ -675,19 +683,22 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
     }
     else
     {
-        throw std::invalid_argument("ERROR: engine " + m_EngineType +
-                                    " not supported, IO SetEngine must add "
-                                    "a supported engine, in call to "
-                                    "Open\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "Open",
+            "engine " + m_EngineType +
+                " not supported, IO SetEngine must add "
+                "a supported engine, in call to "
+                "Open");
     }
 
     auto itEngine = m_Engines.emplace(name, std::move(engine));
 
     if (!itEngine.second)
     {
-        throw std::invalid_argument("ERROR: engine of type " + m_EngineType +
-                                    " and name " + name +
-                                    " could not be created, in call to Open\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "Open",
+            "engine of type " + m_EngineType + " and name " + name +
+                " could not be created, in call to Open");
     }
     // return a reference
     return *itEngine.first->second.get();
@@ -709,9 +720,10 @@ Engine &IO::GetEngine(const std::string &name)
     auto itEngine = m_Engines.find(name);
     if (itEngine == m_Engines.end())
     {
-        throw std::invalid_argument(
-            "ERROR: engine name " + name +
-            " could not be found, in call to GetEngine\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "GetEngine",
+            "engine name " + name +
+                " could not be found, in call to GetEngine");
     }
     // return a reference
     return *itEngine->second.get();
@@ -830,9 +842,10 @@ void IO::CheckAttributeCommon(const std::string &name) const
     auto itAttribute = m_Attributes.find(name);
     if (itAttribute != m_Attributes.end())
     {
-        throw std::invalid_argument("ERROR: attribute " + name +
-                                    " exists in IO object " + m_Name +
-                                    ", in call to DefineAttribute\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "CheckAttributeCommon",
+            "attribute " + name + " exists in IO object " + m_Name +
+                ", in call to DefineAttribute");
     }
 }
 
@@ -840,11 +853,12 @@ void IO::CheckTransportType(const std::string type) const
 {
     if (type.empty() || type.find("=") != type.npos)
     {
-        throw std::invalid_argument(
-            "ERROR: wrong first argument " + type +
-            ", must "
-            "be a single word for a supported transport type, in "
-            "call to IO AddTransport \n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "CheckTransportType",
+            "wrong first argument " + type +
+                ", must "
+                "be a single word for a supported transport type, in "
+                "call to IO AddTransport");
     }
 }
 

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -275,7 +275,10 @@ size_t IO::AddTransport(const std::string type, const Params &parameters)
     if (parameters.count("transport") == 1 ||
         parameters.count("Transport") == 1)
     {
-        helper::Throw<std::invalid_argument>( "Core", "IO", "AddTransport", "key Transport (or transport) is not allowed in transport parameters);
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "AddTransport",
+            "key Transport (or transport) is not allowed in transport "
+            "parameters");
     }
 
     CheckTransportType(type);

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -41,9 +41,10 @@ Variable<T> &IO::DefineVariable(const std::string &name, const Dims &shape,
         auto itVariable = m_Variables.find(name);
         if (itVariable != m_Variables.end())
         {
-            throw std::invalid_argument("ERROR: variable " + name +
-                                        " exists in IO object " + m_Name +
-                                        ", in call to DefineVariable\n");
+            helper::Throw<std::invalid_argument>(
+                "Core", "IO", "DefineVariable",
+                "variable " + name + " exists in IO object " + m_Name +
+                    ", in call to DefineVariable");
         }
     }
 
@@ -113,10 +114,11 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T &value,
     if (!variableName.empty() &&
         InquireVariableType(variableName) == DataType::None)
     {
-        throw std::invalid_argument(
-            "ERROR: variable " + variableName +
-            " doesn't exist, can't associate attribute " + name +
-            ", in call to DefineAttribute");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "DefineAttribute",
+            "variable " + variableName +
+                " doesn't exist, can't associate attribute " + name +
+                ", in call to DefineAttribute");
     }
 
     const std::string globalName =
@@ -141,12 +143,13 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T &value,
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: modifiable attribute " + globalName +
-                    " has been defined with type " +
-                    ToString(itExistingAttribute->second->m_Type) +
-                    ". Type cannot be changed to " +
-                    ToString(helper::GetDataType<T>()) + "\n");
+                helper::Throw<std::invalid_argument>(
+                    "Core", "IO", "DefineAttribute",
+                    "modifiable attribute " + globalName +
+                        " has been defined with type " +
+                        ToString(itExistingAttribute->second->m_Type) +
+                        ". Type cannot be changed to " +
+                        ToString(helper::GetDataType<T>()));
             }
         }
         return static_cast<Attribute<T> &>(*itExistingAttribute->second);
@@ -175,10 +178,11 @@ IO::DefineAttribute(const std::string &name, const T *array,
     if (!variableName.empty() &&
         InquireVariableType(variableName) == DataType::None)
     {
-        throw std::invalid_argument(
-            "ERROR: variable " + variableName +
-            " doesn't exist, can't associate attribute " + name +
-            ", in call to DefineAttribute");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "DefineAttribute",
+            "variable " + variableName +
+                " doesn't exist, can't associate attribute " + name +
+                ", in call to DefineAttribute");
     }
 
     const std::string globalName =
@@ -207,12 +211,13 @@ IO::DefineAttribute(const std::string &name, const T *array,
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: modifiable attribute " + globalName +
-                    " has been defined with type " +
-                    ToString(itExistingAttribute->second->m_Type) +
-                    ". Type cannot be changed to " +
-                    ToString(helper::GetDataType<T>()) + "\n");
+                helper::Throw<std::invalid_argument>(
+                    "Core", "IO", "DefineAttribute",
+                    "modifiable attribute " + globalName +
+                        " has been defined with type " +
+                        ToString(itExistingAttribute->second->m_Type) +
+                        ". Type cannot be changed to " +
+                        ToString(helper::GetDataType<T>()));
             }
         }
         return static_cast<Attribute<T> &>(*itExistingAttribute->second);

--- a/source/adios2/core/IOHDF5.cpp
+++ b/source/adios2/core/IOHDF5.cpp
@@ -25,8 +25,10 @@ std::shared_ptr<Engine> MakeEngineHDF5(IO &io, const std::string &name,
 #ifndef H5_HAVE_PARALLEL
     if (comm.IsMPI())
     {
-        throw std::invalid_argument("A serial HDF5 engine cannot be used "
-                                    "with a communicator that is MPI-based.");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IOHDF5", "MakeEngineHDF5",
+            "A serial HDF5 engine cannot be used "
+            "with a communicator that is MPI-based.");
     }
 #endif
     return IO::MakeEngine<T>(io, name, mode, std::move(comm));

--- a/source/adios2/core/IOMPI.cpp
+++ b/source/adios2/core/IOMPI.cpp
@@ -36,8 +36,10 @@ std::shared_ptr<Engine> MakeEngineMPI(IO &io, const std::string &name,
 {
     if (!comm.IsMPI())
     {
-        throw std::invalid_argument("A MPI-only engine cannot be used with a "
-                                    "communicator that is not MPI-based.");
+        helper::Throw<std::invalid_argument>(
+            "Core", "IOMPI", "MakeEngineMPI",
+            "A MPI-only engine cannot be used with a "
+            "communicator that is not MPI-based.");
     }
     return IO::MakeEngine<T>(io, name, mode, std::move(comm));
 }

--- a/source/adios2/core/Operator.cpp
+++ b/source/adios2/core/Operator.cpp
@@ -60,8 +60,8 @@ Dims Operator::ConvertDims(const Dims &dimensions, const DataType type,
 
     if (targetDims < 1)
     {
-        throw(std::invalid_argument(
-            "Operator::ConvertDims only accepts targetDims>0"));
+        helper::Throw<std::invalid_argument>("Core", "Operator", "ConvertDims",
+                                             "only accepts targetDims > 0");
     }
 
     Dims ret = dimensions;
@@ -103,9 +103,10 @@ void Operator::CheckCallbackType(const std::string type) const
 {
     if (m_TypeString != type)
     {
-        throw std::invalid_argument("ERROR: operator of type " + m_TypeString +
-                                    " doesn't match expected callback type " +
-                                    type + " arguments\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Operator", "CheckCallbackType",
+            "operator of type " + m_TypeString +
+                " doesn't match expected callback type " + type + " arguments");
     }
 }
 

--- a/source/adios2/core/Stream.cpp
+++ b/source/adios2/core/Stream.cpp
@@ -91,10 +91,12 @@ void Stream::EndStep()
     }
     else
     {
-        throw std::invalid_argument("ERROR: stream " + m_Name +
-                                    " calling end step function twice (check "
-                                    "if a write function calls it) or "
-                                    "invalid stream\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Stream", "EndStep",
+            "stream " + m_Name +
+                " calling end step function twice (check "
+                "if a write function calls it) or "
+                "invalid stream");
     }
 }
 
@@ -117,9 +119,11 @@ size_t Stream::CurrentStep() const
 
     if (m_Engine == nullptr)
     {
-        throw std::invalid_argument("ERROR: stream with name " + m_Name +
-                                    "is invalid or closed, in call "
-                                    "to CurrentStep");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Stream", "CurrentStep",
+            "stream with name " + m_Name +
+                "is invalid or closed, in call "
+                "to CurrentStep");
     }
 
     return m_Engine->CurrentStep();

--- a/source/adios2/core/Stream.tcc
+++ b/source/adios2/core/Stream.tcc
@@ -14,6 +14,7 @@
 #include "Stream.h"
 
 #include "adios2/core/Variable.h"
+#include "adios2/helper/adiosLog.h"
 
 namespace adios2
 {
@@ -322,9 +323,10 @@ void Stream::CheckPCommon(const std::string &name, const T *values) const
 {
     if (values == nullptr)
     {
-        throw std::runtime_error(
-            "ERROR: passed null values pointer for variable " + name +
-            ", in call to read pointer\n");
+        helper::Throw<std::runtime_error>(
+            "Core", "Stream", "CheckPCommon",
+            "passed null values pointer for variable " + name +
+                ", in call to read pointer");
     }
 }
 
@@ -340,10 +342,11 @@ void Stream::SetBlockSelectionCommon(Variable<T> &variable,
     {
         if (blockID != 0)
         {
-            throw std::invalid_argument(
-                "ERROR: in variable " + variable.m_Name +
-                " only set blockID > 0 for variables "
-                "with ShapeID::LocalArray, in call to read\n");
+            helper::Throw<std::invalid_argument>(
+                "Core", "Stream", "SetBlockSelectionCommon",
+                "in variable " + variable.m_Name +
+                    " only set blockID > 0 for variables "
+                    "with ShapeID::LocalArray, in call to read");
         }
     }
 }

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -54,10 +54,11 @@ Dims Variable<T>::DoCount() const
         if (itStep == m_AvailableStepBlockIndexOffsets.end())
         {
             auto it = m_AvailableStepBlockIndexOffsets.rbegin();
-            throw std::invalid_argument(
-                "ERROR: current relative step start for variable " + m_Name +
-                " is outside the scope of available steps " +
-                std::to_string(it->first - 1) + " in call to Count\n");
+            helper::Throw<std::invalid_argument>(
+                "Core", "Variable", "DoCount",
+                "current relative step start for variable " + m_Name +
+                    " is outside the scope of available steps " +
+                    std::to_string(it->first - 1) + " in call to Count");
         }
         return itStep->first - 1;
     };
@@ -69,13 +70,16 @@ Dims Variable<T>::DoCount() const
         {
             if (m_BlockID >= MVI->BlocksInfo.size())
             {
-                throw std::invalid_argument(
-                    "ERROR: blockID " + std::to_string(m_BlockID) +
-                    " from SetBlockSelection is out of bounds for available "
-                    "blocks size " +
-                    std::to_string(MVI->BlocksInfo.size()) + " for variable " +
-                    m_Name + " for step " + std::to_string(m_StepsStart) +
-                    ", in call to Variable<T>::Count()");
+                helper::Throw<std::invalid_argument>(
+                    "Core", "Variable", "DoCount",
+                    "blockID " + std::to_string(m_BlockID) +
+                        " from SetBlockSelection is out of bounds for "
+                        "available "
+                        "blocks size " +
+                        std::to_string(MVI->BlocksInfo.size()) +
+                        " for variable " + m_Name + " for step " +
+                        std::to_string(m_StepsStart) +
+                        ", in call to Variable<T>::Count()");
             }
 
             size_t *DimsPtr = (MVI->BlocksInfo)[m_BlockID].Count;
@@ -96,13 +100,14 @@ Dims Variable<T>::DoCount() const
 
         if (m_BlockID >= blocksInfo.size())
         {
-            throw std::invalid_argument(
-                "ERROR: blockID " + std::to_string(m_BlockID) +
-                " from SetBlockSelection is out of bounds for available "
-                "blocks size " +
-                std::to_string(blocksInfo.size()) + " for variable " + m_Name +
-                " for step " + std::to_string(step) +
-                ", in call to Variable<T>::Count()");
+            helper::Throw<std::invalid_argument>(
+                "Core", "Variable", "DoCount",
+                "blockID " + std::to_string(m_BlockID) +
+                    " from SetBlockSelection is out of bounds for available "
+                    "blocks size " +
+                    std::to_string(blocksInfo.size()) + " for variable " +
+                    m_Name + " for step " + std::to_string(step) +
+                    ", in call to Variable<T>::Count()");
         }
 
         return blocksInfo[m_BlockID].Count;
@@ -153,10 +158,11 @@ std::pair<T, T> Variable<T>::DoMinMax(const size_t step) const
         {
             if (m_BlockID >= blocksInfo.size())
             {
-                throw std::invalid_argument(
-                    "ERROR: BlockID " + std::to_string(m_BlockID) +
-                    " does not exist for LocalArray variable " + m_Name +
-                    ", in call to MinMax, Min or Maxn");
+                helper::Throw<std::invalid_argument>(
+                    "Core", "Variable", "DoMinMax",
+                    "BlockID " + std::to_string(m_BlockID) +
+                        " does not exist for LocalArray variable " + m_Name +
+                        ", in call to MinMax, Min or Maxn");
             }
             minMax.first = blocksInfo[m_BlockID].Min;
             minMax.second = blocksInfo[m_BlockID].Max;
@@ -206,18 +212,22 @@ Variable<T>::DoAllStepsBlocksInfo() const
 {
     if (m_Engine == nullptr)
     {
-        throw std::invalid_argument("ERROR: from variable " + m_Name +
-                                    " function is only valid in read mode, in "
-                                    "call to Variable<T>::AllBlocksInfo\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Variable", "DoAllStepsBlocksInfo",
+            "from variable " + m_Name +
+                " function is only valid in read mode, in "
+                "call to Variable<T>::AllBlocksInfo");
     }
 
     if (!m_FirstStreamingStep)
     {
-        throw std::invalid_argument("ERROR: from variable " + m_Name +
-                                    " function is not valid in "
-                                    "random-access read mode "
-                                    "(BeginStep/EndStep), in "
-                                    "call to Variable<T>::AllBlocksInfo\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Variable", "DoAllStepsBlocksInfo",
+            "from variable " + m_Name +
+                " function is not valid in "
+                "random-access read mode "
+                "(BeginStep/EndStep), in "
+                "call to Variable<T>::AllBlocksInfo");
     }
 
     return m_Engine->AllRelativeStepsBlocksInfo(*this);
@@ -229,11 +239,12 @@ void Variable<T>::CheckRandomAccess(const size_t step,
 {
     if (!m_FirstStreamingStep && step != DefaultSizeT)
     {
-        throw std::invalid_argument("ERROR: can't pass a step input in "
-                                    "streaming (BeginStep/EndStep)"
-                                    "mode for variable " +
-                                    m_Name +
-                                    ", in call to Variable<T>::" + hint + "\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Variable", "CheckRandomAccess",
+            "can't pass a step input in "
+            "streaming (BeginStep/EndStep)"
+            "mode for variable " +
+                m_Name + ", in call to Variable<T>::" + hint);
     }
 }
 
@@ -261,10 +272,10 @@ T &Span<T>::At(const size_t position)
 {
     if (position > m_Size)
     {
-        throw std::invalid_argument(
-            "ERROR: position " + std::to_string(position) +
-            " is out of bounds for span of size " + std::to_string(m_Size) +
-            " , in call to T& Span<T>::At\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Variable", "At",
+            "position " + std::to_string(position) +
+                " is out of bounds for span of size " + std::to_string(m_Size));
     }
 
     return (*this)[position];
@@ -275,10 +286,11 @@ const T &Span<T>::At(const size_t position) const
 {
     if (position > m_Size)
     {
-        throw std::invalid_argument(
-            "ERROR: position " + std::to_string(position) +
-            " is out of bounds for span of size " + std::to_string(m_Size) +
-            " , in call to const T& Span<T>::At\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "Variable", "At",
+            "position " + std::to_string(position) +
+                " is out of bounds for span of size " + std::to_string(m_Size) +
+                " , in call to const T& Span<T>::At");
     }
 
     return (*this)[position];

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -73,30 +73,36 @@ void VariableBase::SetShape(const adios2::Dims &shape)
 {
     if (m_Type == helper::GetDataType<std::string>())
     {
-        throw std::invalid_argument("ERROR: string variable " + m_Name +
-                                    " is always LocalValue, can't change "
-                                    "shape, in call to SetShape\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetShape",
+            "string variable " + m_Name +
+                " is always LocalValue, can't change "
+                "shape, in call to SetShape");
     }
 
     if (m_SingleValue)
     {
-        throw std::invalid_argument(
-            "ERROR: selection is not valid for single value variable " +
-            m_Name + ", in call to SetShape\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetShape",
+            "selection is not valid for single value variable " + m_Name +
+                ", in call to SetShape");
     }
 
     if (m_ConstantDims)
     {
-        throw std::invalid_argument(
-            "ERROR: selection is not valid for constant shape variable " +
-            m_Name + ", in call to SetShape\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetShape",
+            "selection is not valid for constant shape variable " + m_Name +
+                ", in call to SetShape");
     }
 
     if (m_ShapeID == ShapeID::LocalArray)
     {
-        throw std::invalid_argument("ERROR: can't assign shape dimensions "
-                                    "to local array variable " +
-                                    m_Name + ", in call to SetShape\n");
+        helper::Throw<std::invalid_argument>("Core", "VariableBase", "SetShape",
+                                             "can't assign shape dimensions "
+                                             "to local array variable " +
+                                                 m_Name +
+                                                 ", in call to SetShape");
     }
 
     m_Shape = shape;
@@ -116,38 +122,46 @@ void VariableBase::SetSelection(const Box<Dims> &boxDims)
     if (m_Type == helper::GetDataType<std::string>() &&
         m_ShapeID != ShapeID::GlobalArray)
     {
-        throw std::invalid_argument("ERROR: string variable " + m_Name +
-                                    " not a GlobalArray, it can't have a "
-                                    "selection, in call to SetSelection\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetSelection",
+            "string variable " + m_Name +
+                " not a GlobalArray, it can't have a "
+                "selection, in call to SetSelection");
     }
 
     if (m_SingleValue && m_ShapeID != ShapeID::GlobalArray)
     {
-        throw std::invalid_argument(
-            "ERROR: selection is not valid for single value variable " +
-            m_Name + ", in call to SetSelection\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetSelection",
+            "selection is not valid for single value variable " + m_Name +
+                ", in call to SetSelection");
     }
 
     if (m_ConstantDims)
     {
-        throw std::invalid_argument(
-            "ERROR: selection is not valid for constant shape variable " +
-            m_Name + ", in call to SetSelection\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetSelection",
+            "selection is not valid for constant shape variable " + m_Name +
+                ", in call to SetSelection");
     }
 
     if (m_ShapeID == ShapeID::GlobalArray &&
         (m_Shape.size() != count.size() || m_Shape.size() != start.size()))
     {
-        throw std::invalid_argument("ERROR: count and start must be the "
-                                    "same size as shape for variable " +
-                                    m_Name + ", in call to SetSelection\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetSelection",
+            "count and start must be the "
+            "same size as shape for variable " +
+                m_Name + ", in call to SetSelection");
     }
 
     if (m_ShapeID == ShapeID::JoinedArray && !start.empty())
     {
-        throw std::invalid_argument("ERROR: start argument must be empty "
-                                    "for joined array variable " +
-                                    m_Name + ", in call to SetSelection\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetSelection",
+            "start argument must be empty "
+            "for joined array variable " +
+                m_Name + ", in call to SetSelection");
     }
 
     m_Start = start;
@@ -162,28 +176,31 @@ void VariableBase::SetMemorySelection(const Box<Dims> &memorySelection)
 
     if (m_SingleValue)
     {
-        throw std::invalid_argument("ERROR: memory start is not valid "
-                                    "for single value variable " +
-                                    m_Name +
-                                    ", in call to SetMemorySelection\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetMemorySelection",
+            "memory start is not valid "
+            "for single value variable " +
+                m_Name + ", in call to SetMemorySelection");
     }
 
     if (m_Start.size() != memoryStart.size())
     {
-        throw std::invalid_argument("ERROR: memoryStart size must be "
-                                    "the same as variable " +
-                                    m_Name + " start size " +
-                                    std::to_string(m_Start.size()) +
-                                    ", in call to SetMemorySelection\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetMemorySelection",
+            "memoryStart size must be "
+            "the same as variable " +
+                m_Name + " start size " + std::to_string(m_Start.size()) +
+                ", in call to SetMemorySelection");
     }
 
     if (m_Count.size() != memoryCount.size())
     {
-        throw std::invalid_argument("ERROR: memoryCount size must be "
-                                    "the same as variable " +
-                                    m_Name + " count size " +
-                                    std::to_string(m_Count.size()) +
-                                    ", in call to SetMemorySelection\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetMemorySelection",
+            "memoryCount size must be "
+            "the same as variable " +
+                m_Name + " count size " + std::to_string(m_Count.size()) +
+                ", in call to SetMemorySelection");
     }
 
     // TODO might have to remove for reading
@@ -195,11 +212,12 @@ void VariableBase::SetMemorySelection(const Box<Dims> &memorySelection)
             const std::string memoryCountStr = std::to_string(memoryCount[i]);
             const std::string countStr = std::to_string(m_Count[i]);
 
-            throw std::invalid_argument(
-                "ERROR: memoyCount[" + indexStr + "]= " + memoryCountStr +
-                " can not be smaller than variable count[" + indexStr +
-                "]= " + countStr + " for variable " + m_Name +
-                ", in call to SetMemorySelection\n");
+            helper::Throw<std::invalid_argument>(
+                "Core", "VariableBase", "SetMemorySelection",
+                "memoyCount[" + indexStr + "]= " + memoryCountStr +
+                    " can not be smaller than variable count[" + indexStr +
+                    "]= " + countStr + " for variable " + m_Name +
+                    ", in call to SetMemorySelection");
         }
     }
 
@@ -221,9 +239,11 @@ void VariableBase::SetStepSelection(const Box<size_t> &boxSteps)
 {
     if (boxSteps.second == 0)
     {
-        throw std::invalid_argument("ERROR: boxSteps.second count argument "
-                                    " can't be zero, from variable " +
-                                    m_Name + ", in call to SetStepSelection\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetStepSelection",
+            "boxSteps.second count argument "
+            " can't be zero, from variable " +
+                m_Name + ", in call to SetStepSelection");
     }
 
     m_StepsStart = boxSteps.first;
@@ -273,10 +293,11 @@ void VariableBase::SetOperationParameter(const size_t operationID,
 {
     if (operationID >= m_Operations.size())
     {
-        throw std::invalid_argument(
-            "ERROR: invalid operationID " + std::to_string(operationID) +
-            ", check returned id from AddOperation, in call to "
-            "SetOperationParameter\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "SetOperationParameter",
+            "invalid operationID " + std::to_string(operationID) +
+                ", check returned id from AddOperation, in call to "
+                "SetOperationParameter");
     }
 
     m_Operations[operationID]->SetParameter(key, value);
@@ -288,11 +309,12 @@ void VariableBase::CheckDimensions(const std::string hint) const
     {
         if (m_Start.empty() || m_Count.empty())
         {
-            throw std::invalid_argument(
-                "ERROR: GlobalArray variable " + m_Name +
-                " start and count dimensions must be defined by either "
-                "IO.DefineVariable or Variable.SetSelection, " +
-                hint + "\n");
+            helper::Throw<std::invalid_argument>(
+                "Core", "VariableBase", "CheckDimensions",
+                "GlobalArray variable " + m_Name +
+                    " start and count dimensions must be defined by either "
+                    "IO.DefineVariable or Variable.SetSelection, " +
+                    hint + "\n");
         }
     }
 
@@ -316,10 +338,12 @@ void VariableBase::CheckRandomAccessConflict(const std::string hint) const
 {
     if (m_RandomAccess && !m_FirstStreamingStep)
     {
-        throw std::invalid_argument("ERROR: can't mix streaming and "
-                                    "random-access (call to SetStepSelection)"
-                                    "for variable " +
-                                    m_Name + ", " + hint);
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "CheckRandomAccessConflict",
+            "can't mix streaming and "
+            "random-access (call to SetStepSelection)"
+            "for variable " +
+                m_Name + ", " + hint);
     }
 }
 
@@ -407,22 +431,26 @@ void VariableBase::InitShapeType()
         {
             if (!m_Start.empty() || !m_Count.empty())
             {
-                throw std::invalid_argument(
-                    "ERROR: GlobalValue string variable " + m_Name +
-                    " can't have Start and Count dimensions, string variables "
-                    "are always defined as a GlobalValue or LocalValue, "
-                    " in call to DefineVariable\n");
+                helper::Throw<std::invalid_argument>(
+                    "Core", "VariableBase", "InitShapeType",
+                    "GlobalValue string variable " + m_Name +
+                        " can't have Start and Count dimensions, string "
+                        "variables "
+                        "are always defined as a GlobalValue or LocalValue, "
+                        " in call to DefineVariable");
             }
         }
         else
         {
             if (m_Shape != Dims{static_cast<size_t>(LocalValueDim)})
             {
-                throw std::invalid_argument(
-                    "ERROR: LocalValue string variable " + m_Name +
-                    " Shape must be equal to {LocalValueDim}, string variables "
-                    "are always defined as a GlobalValue or LocalValue, " +
-                    " in call to DefineVariable\n");
+                helper::Throw<std::invalid_argument>(
+                    "Core", "VariableBase", "InitShapeType",
+                    "LocalValue string variable " + m_Name +
+                        " Shape must be equal to {LocalValueDim}, string "
+                        "variables "
+                        "are always defined as a GlobalValue or LocalValue, " +
+                        " in call to DefineVariable");
             }
         }
     }
@@ -435,11 +463,13 @@ void VariableBase::InitShapeType()
                 static_cast<size_t>(std::count(m_Start.begin(), m_Start.end(),
                                                0)) != m_Start.size())
             {
-                throw std::invalid_argument("ERROR: The Start array must be "
-                                            "empty or full-zero when defining "
-                                            "a Joined Array in call to "
-                                            "DefineVariable " +
-                                            m_Name + "\n");
+                helper::Throw<std::invalid_argument>(
+                    "Core", "VariableBase", "InitShapeType",
+                    "The Start array must be "
+                    "empty or full-zero when defining "
+                    "a Joined Array in call to "
+                    "DefineVariable " +
+                        m_Name);
             }
             m_ShapeID = ShapeID::JoinedArray;
         }
@@ -459,12 +489,13 @@ void VariableBase::InitShapeType()
 
                 if (m_ConstantDims)
                 {
-                    throw std::invalid_argument(
-                        "ERROR: isConstantShape (true) argument is invalid "
+                    helper::Throw<std::invalid_argument>(
+                        "Core", "VariableBase", "InitShapeType",
+                        "isConstantShape (true) argument is invalid "
                         "with empty start and count "
                         "arguments in call to "
                         "DefineVariable " +
-                        m_Name + "\n");
+                            m_Name);
                 }
 
                 m_ShapeID = ShapeID::GlobalArray;
@@ -473,17 +504,19 @@ void VariableBase::InitShapeType()
         else if (m_Shape.size() == m_Start.size() &&
                  m_Shape.size() == m_Count.size())
         {
-            auto lf_LargerThanError =
-                [&](const unsigned int i, const std::string dims1,
-                    const size_t dims1Value, const std::string dims2,
-                    const size_t dims2Value) {
-                    const std::string iString(std::to_string(i));
-                    throw std::invalid_argument(
-                        "ERROR: " + dims1 + "[" + iString +
+            auto lf_LargerThanError = [&](const unsigned int i,
+                                          const std::string dims1,
+                                          const size_t dims1Value,
+                                          const std::string dims2,
+                                          const size_t dims2Value) {
+                const std::string iString(std::to_string(i));
+                helper::Throw<std::invalid_argument>(
+                    "Core", "VariableBase", "InitShapeType",
+                    dims1 + "[" + iString +
                         "] = " + std::to_string(dims1Value) + " > " + dims2 +
                         "[" + iString + "], = " + std::to_string(dims2Value) +
-                        " in DefineVariable " + m_Name + "\n");
-                };
+                        " in DefineVariable " + m_Name);
+            };
 
             for (unsigned int i = 0; i < m_Shape.size(); ++i)
             {
@@ -502,11 +535,13 @@ void VariableBase::InitShapeType()
         }
         else
         {
-            throw std::invalid_argument("ERROR: the "
-                                        "combination of shape, start and count "
-                                        "arguments is inconsistent, in call to "
-                                        "DefineVariable " +
-                                        m_Name + "\n");
+            helper::Throw<std::invalid_argument>(
+                "Core", "VariableBase", "InitShapeType",
+                "the "
+                "combination of shape, start and count "
+                "arguments is inconsistent, in call to "
+                "DefineVariable " +
+                    m_Name);
         }
     }
     else
@@ -525,11 +560,12 @@ void VariableBase::InitShapeType()
         }
         else
         {
-            throw std::invalid_argument(
-                "ERROR: if the "
+            helper::Throw<std::invalid_argument>(
+                "Core", "VariableBase", "InitShapeType",
+                "if the "
                 "shape is empty, start must be empty as well, in call to "
                 "DefineVariable " +
-                m_Name + "\n");
+                    m_Name);
         }
     }
 
@@ -548,10 +584,11 @@ void VariableBase::CheckDimensionsCommon(const std::string hint) const
             (!m_Count.empty() &&
              std::count(m_Count.begin(), m_Count.end(), LocalValueDim) > 0))
         {
-            throw std::invalid_argument(
-                "ERROR: LocalValueDim parameter is only "
+            helper::Throw<std::invalid_argument>(
+                "Core", "VariableBase", "CheckDimensionsCommon",
+                "LocalValueDim parameter is only "
                 "allowed as {LocalValueDim} in Shape dimensions " +
-                hint + "\n");
+                    hint);
         }
     }
 
@@ -562,9 +599,11 @@ void VariableBase::CheckDimensionsCommon(const std::string hint) const
         (!m_Count.empty() &&
          std::count(m_Count.begin(), m_Count.end(), JoinedDim) > 0))
     {
-        throw std::invalid_argument("ERROR: JoinedDim is only allowed once in "
-                                    "Shape and cannot appear in start/count, " +
-                                    hint + "\n");
+        helper::Throw<std::invalid_argument>(
+            "Core", "VariableBase", "CheckDimensionsCommon",
+            "JoinedDim is only allowed once in "
+            "Shape and cannot appear in start/count, " +
+                hint);
     }
 }
 

--- a/source/adios2/engine/bp3/BP3Reader.cpp
+++ b/source/adios2/engine/bp3/BP3Reader.cpp
@@ -35,25 +35,28 @@ StepStatus BP3Reader::BeginStep(StepMode mode, const float timeoutSeconds)
     PERFSTUBS_SCOPED_TIMER("BP3Reader::BeginStep");
     if (mode != StepMode::Read)
     {
-        throw std::invalid_argument(
-            "ERROR: mode is not supported yet, "
+        helper::Throw<std::invalid_argument>(
+            "Engine", "BP3Reader", "BeginStep",
+            "mode is not supported yet, "
             "only Read is valid for "
             "engine BP3 with adios2::Mode::Read, in call to "
-            "BeginStep\n");
+            "BeginStep");
     }
 
     if (!m_BP3Deserializer.m_DeferredVariables.empty())
     {
-        throw std::invalid_argument(
-            "ERROR: existing variables subscribed with "
+        helper::Throw<std::invalid_argument>(
+            "Engine", "BP3Reader", "BeginStep",
+            "existing variables subscribed with "
             "GetDeferred, did you forget to call "
-            "PerformGets() or EndStep()?, in call to BeginStep\n");
+            "PerformGets() or EndStep()?, in call to BeginStep");
     }
 
     if (m_BetweenStepPairs)
     {
-        throw std::logic_error("ERROR: BeginStep() is called a second time "
-                               "without an intervening EndStep()");
+        helper::Throw<std::logic_error>("Engine", "BP3Reader", "BeginStep",
+                                        "BeginStep() is called a second time "
+                                        "without an intervening EndStep()");
     }
 
     m_BetweenStepPairs = true;
@@ -87,8 +90,9 @@ void BP3Reader::EndStep()
 {
     if (!m_BetweenStepPairs)
     {
-        throw std::logic_error(
-            "ERROR: EndStep() is called without a successful BeginStep()");
+        helper::Throw<std::logic_error>(
+            "Engine", "BP3Reader", "EndStep",
+            "EndStep() is called without a successful BeginStep()");
     }
     m_BetweenStepPairs = false;
     PERFSTUBS_SCOPED_TIMER("BP3Reader::EndStep");
@@ -134,8 +138,9 @@ void BP3Reader::Init()
 {
     if (m_OpenMode != Mode::Read)
     {
-        throw std::invalid_argument(
-            "ERROR: BPFileReader only supports OpenMode::Read from" + m_Name);
+        helper::Throw<std::invalid_argument>(
+            "Engine", "BP3Reader", "Init",
+            "BPFileReader only supports OpenMode::Read from" + m_Name);
     }
 
     // if IO was involved in reading before this flag may be true now
@@ -191,7 +196,7 @@ void BP3Reader::InitBuffer()
                               "size, which is " +
                               std::to_string(miniFooterSize) + " bytes." +
                               " It is unlikely that this is a .bp file.";
-            throw std::logic_error(err);
+            helper::Throw<std::logic_error>("Engine", "BP3Reader", "Init", err);
         }
         const size_t miniFooterStart =
             helper::GetDistance(fileSize, miniFooterSize,

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -213,9 +213,11 @@ void BP3Writer::InitBPBuffer()
 {
     if (m_OpenMode == Mode::Append)
     {
-        throw std::invalid_argument("ADIOS2: Mode::Append is only available in "
-                                    "BP4; it is not implemented "
-                                    "for BP3 files.");
+        helper::Throw<std::invalid_argument>(
+            "Engine", "BP3Writer", "InitBPBuffer",
+            "Mode::Append is only available in "
+            "BP4; it is not implemented "
+            "for BP3 files.");
         // TODO: Get last pg timestep and update timestep counter in
     }
     else

--- a/source/adios2/engine/bp3/BP3Writer.tcc
+++ b/source/adios2/engine/bp3/BP3Writer.tcc
@@ -47,10 +47,11 @@ void BP3Writer::PutCommon(Variable<T> &variable,
 
     if (resizeResult == format::BP3Base::ResizeResult::Flush)
     {
-        throw std::invalid_argument(
-            "ERROR: returning a Span can't trigger "
+        helper::Throw<std::invalid_argument>(
+            "Engine", "BP3Writer", "PutCommon",
+            "returning a Span can't trigger "
             "buffer reallocation in BP3 engine, remove "
-            "MaxBufferSize parameter, in call to Put\n");
+            "MaxBufferSize parameter, in call to Put");
     }
 
     // WRITE INDEX to data buffer and metadata structure (in memory)//

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -354,11 +354,12 @@ void BP4Writer::InitBPBuffer()
             IsLittleEndian = (endianness == 0) ? true : false;
             if (helper::IsLittleEndian() != IsLittleEndian)
             {
-                throw std::runtime_error(
-                    "ERROR: previous run generated BigEndian bp file, "
+                helper::Throw<std::runtime_error>(
+                    "Engine", "BP4Writer", "InitBPBuffer",
+                    "previous run generated BigEndian bp file, "
                     "this version of ADIOS2 wasn't compiled "
                     "with the cmake flag -DADIOS2_USE_Endian_Reverse=ON "
-                    "explicitly, in call to Open\n");
+                    "explicitly, in call to Open");
             }
             const size_t pos_last_step = preMetadataIndexFileSize - 64;
             position = pos_last_step;

--- a/source/adios2/engine/bp4/BP4Writer.tcc
+++ b/source/adios2/engine/bp4/BP4Writer.tcc
@@ -47,10 +47,11 @@ void BP4Writer::PutCommon(Variable<T> &variable,
 
     if (resizeResult == format::BP4Serializer::ResizeResult::Flush)
     {
-        throw std::invalid_argument(
-            "ERROR: returning a Span can't trigger "
+        helper::Throw<std::invalid_argument>(
+            "Engine", "BP4Writer", "PutCommon",
+            "returning a Span can't trigger "
             "buffer reallocation in BP4 engine, remove "
-            "MaxBufferSize parameter, in call to Put\n");
+            "MaxBufferSize parameter, in call to Put");
     }
 
     // WRITE INDEX to data buffer and metadata structure (in memory)//

--- a/source/adios2/engine/bp5/BP5Engine.cpp
+++ b/source/adios2/engine/bp5/BP5Engine.cpp
@@ -165,8 +165,9 @@ void BP5Engine::ParseParams(IO &io, struct BP5Params &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown BP5 Boolean parameter \"" + value + "\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "BP5Engine", "ParseParams",
+                    "Unknown BP5 Boolean parameter '" + value + "'");
             }
         }
     };
@@ -254,9 +255,10 @@ void BP5Engine::ParseParams(IO &io, struct BP5Params &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown BP5 BufferVType parameter \"" + value +
-                    "\" (must be \"malloc\" or \"chunk\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "BP5Engine", "ParseParams",
+                    "Unknown BP5 BufferVType parameter \"" + value +
+                        "\" (must be \"malloc\" or \"chunk\"");
             }
         }
     };
@@ -284,10 +286,11 @@ void BP5Engine::ParseParams(IO &io, struct BP5Params &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown BP5 AggregationType parameter \"" + value +
-                    "\" (must be \"auto\", \"everyonewrites\" or "
-                    "\"twolevelshm\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "BP5Engine", "ParseParams",
+                    "Unknown BP5 AggregationType parameter \"" + value +
+                        "\" (must be \"auto\", \"everyonewrites\" or "
+                        "\"twolevelshm\"");
             }
         }
     };
@@ -316,10 +319,12 @@ void BP5Engine::ParseParams(IO &io, struct BP5Params &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown BP5 AsyncWriteMode parameter \"" + value +
-                    "\" (must be \"auto\", \"sync\", \"naive\", \"throttled\" "
-                    "or \"guided\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "BP5Engine", "ParseParams",
+                    "Unknown BP5 AsyncWriteMode parameter \"" + value +
+                        "\" (must be \"auto\", \"sync\", \"naive\", "
+                        "\"throttled\" "
+                        "or \"guided\"");
             }
         }
     };

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -78,21 +78,23 @@ StepStatus BP5Reader::BeginStep(StepMode mode, const float timeoutSeconds)
 
     if (m_OpenMode == Mode::ReadRandomAccess)
     {
-        throw std::logic_error(
-            "ERROR: BeginStep called in random access mode\n");
+        helper::Throw<std::logic_error>(
+            "Engine", "BP5Reader", "BeginStep",
+            "BeginStep called in random access mode");
     }
     if (m_BetweenStepPairs)
     {
-        throw std::logic_error("ERROR: BeginStep() is called a second time "
-                               "without an intervening EndStep()");
+        helper::Throw<std::logic_error>("Engine", "BP5Reader", "BeginStep",
+                                        "BeginStep() is called a second time "
+                                        "without an intervening EndStep()");
     }
 
     if (mode != StepMode::Read)
     {
-        throw std::invalid_argument("ERROR: mode is not supported yet, "
-                                    "only Read is valid for "
-                                    "engine BP5Reader, in call to "
-                                    "BeginStep\n");
+        helper::Throw<std::invalid_argument>(
+            "Engine", "BP5Reader", "BeginStep",
+            "mode is not supported yet, only Read is valid for engine "
+            "BP5Reader, in call to BeginStep");
     }
 
     StepStatus status = StepStatus::OK;
@@ -159,12 +161,14 @@ void BP5Reader::EndStep()
 {
     if (m_OpenMode == Mode::ReadRandomAccess)
     {
-        throw std::logic_error("ERROR: EndStep called in random access mode\n");
+        helper::Throw<std::logic_error>("Engine", "BP5Reader", "EndStep",
+                                        "EndStep called in random access mode");
     }
     if (!m_BetweenStepPairs)
     {
-        throw std::logic_error(
-            "ERROR: EndStep() is called without a successful BeginStep()");
+        helper::Throw<std::logic_error>(
+            "Engine", "BP5Reader", "EndStep",
+            "EndStep() is called without a successful BeginStep()");
     }
     m_BetweenStepPairs = false;
     PERFSTUBS_SCOPED_TIMER("BP5Reader::EndStep");
@@ -240,10 +244,11 @@ void BP5Reader::Init()
 {
     if ((m_OpenMode != Mode::Read) && (m_OpenMode != Mode::ReadRandomAccess))
     {
-        throw std::invalid_argument(
-            "ERROR: BPFileReader only "
-            "supports OpenMode::Read or OpenMode::ReadRandomAccess from" +
-            m_Name);
+        helper::Throw<std::invalid_argument>(
+            "Engine", "BP5Reader", "Init",
+            "BPFileReader only supports OpenMode::Read or "
+            "OpenMode::ReadRandomAccess from" +
+                m_Name);
     }
 
     // if IO was involved in reading before this flag may be true now
@@ -399,29 +404,33 @@ void BP5Reader::OpenFiles(TimePoint &timeoutInstant, const Seconds &pollSeconds,
     {
         if (m_Comm.Rank() == 0 && !lasterrmsg.empty())
         {
-            throw std::ios_base::failure("ERROR: File " + m_Name +
-                                         " cannot be opened: " + lasterrmsg);
+            helper::Throw<std::ios_base::failure>(
+                "Engine", "BP5Reader", "OpenFiles",
+                "File " + m_Name + " cannot be opened: " + lasterrmsg);
         }
         else
         {
-            throw std::ios_base::failure("File " + m_Name +
-                                         " cannot be opened");
+            helper::Throw<std::ios_base::failure>(
+                "Engine", "BP5Reader", "OpenFiles",
+                "File " + m_Name + " cannot be opened");
         }
     }
     else if (flag == 1)
     {
         if (m_Comm.Rank() == 0)
         {
-            throw std::ios_base::failure(
-                "ERROR: File " + m_Name + " could not be found within the " +
-                std::to_string(timeoutSeconds.count()) +
-                "s timeout: " + lasterrmsg);
+            helper::Throw<std::ios_base::failure>(
+                "Engine", "BP5Reader", "OpenFiles",
+                "File " + m_Name + " could not be found within the " +
+                    std::to_string(timeoutSeconds.count()) +
+                    "s timeout: " + lasterrmsg);
         }
         else
         {
-            throw std::ios_base::failure(
-                "ERROR: File " + m_Name + " could not be found within the " +
-                std::to_string(timeoutSeconds.count()) + "s timeout");
+            helper::Throw<std::ios_base::failure>(
+                "Engine", "BP5Reader", "OpenFiles",
+                "File " + m_Name + " could not be found within the " +
+                    std::to_string(timeoutSeconds.count()) + "s timeout");
         }
     }
 
@@ -577,8 +586,9 @@ void BP5Reader::InitBuffer(const TimePoint &timeoutInstant,
             }
             else
             {
-                throw std::ios_base::failure(
-                    "ERROR: File " + m_Name +
+                helper::Throw<std::ios_base::failure>(
+                    "Engine", "BP5Reader", "InitBuffer",
+                    "File " + m_Name +
                     " was found with an index file but md.0 "
                     "has not contained enough data within "
                     "the specified timeout of " +
@@ -651,11 +661,12 @@ void BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL,
 #ifndef ADIOS2_HAVE_ENDIAN_REVERSE
         if (helper::IsLittleEndian() != m_Minifooter.IsLittleEndian)
         {
-            throw std::runtime_error(
-                "ERROR: reader found BigEndian bp file, "
+            helper::Throw<std::runtime_error>(
+                "Engine", "BP5Reader", "ParseMetadataIndex",
+                "reader found BigEndian bp file, "
                 "this version of ADIOS2 wasn't compiled "
                 "with the cmake flag -DADIOS2_USE_Endian_Reverse=ON "
-                "explicitly, in call to Open\n");
+                "explicitly, in call to Open");
         }
 #endif
 
@@ -668,10 +679,11 @@ void BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL,
             buffer, position, m_Minifooter.IsLittleEndian);
         if (m_Minifooter.Version != 5)
         {
-            throw std::runtime_error(
-                "ERROR: ADIOS2 BP5 Engine only supports bp format "
+            helper::Throw<std::runtime_error>(
+                "Engine", "BP5Reader", "ParseMetadataIndex",
+                "ADIOS2 BP5 Engine only supports bp format "
                 "version 5, found " +
-                std::to_string(m_Minifooter.Version) + " version \n");
+                    std::to_string(m_Minifooter.Version) + " version");
         }
 
         // BP minor version, unused
@@ -839,15 +851,16 @@ void BP5Reader::NotifyEngineNoVarsQuery()
 {
     if (!m_BetweenStepPairs)
     {
-        throw std::logic_error(
-            "ERROR: You've called InquireVariable() when the IO is empty and "
+        helper::Throw<std::logic_error>(
+            "Engine", "BP5Reader", "NotifyEngineNoVarsQuery",
+            "You've called InquireVariable() when the IO is empty and "
             "outside a BeginStep/EndStep pair.  If this is code that is newly "
             "transititioning to the BP5 file engine, you may be relying upon "
             "deprecated behaviour.  If you intend to use ADIOS using the "
             "Begin/EndStep interface, move all InquireVariable calls inside "
             "the BeginStep/EndStep pair.  If intending to use random-access "
             "file mode, change your Open() mode parameter to "
-            "Mode::ReadRandomAccess.\n");
+            "Mode::ReadRandomAccess.");
     }
 }
 

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -589,16 +589,17 @@ void BP5Reader::InitBuffer(const TimePoint &timeoutInstant,
                 helper::Throw<std::ios_base::failure>(
                     "Engine", "BP5Reader", "InitBuffer",
                     "File " + m_Name +
-                    " was found with an index file but md.0 "
-                    "has not contained enough data within "
-                    "the specified timeout of " +
-                    std::to_string(timeoutSeconds.count()) +
-                    " seconds. index size = " + std::to_string(newIdxSize) +
-                    " metadata size = " + std::to_string(actualFileSize) +
-                    " expected size = " + std::to_string(expectedMinFileSize) +
-                    ". One reason could be if the reader finds old data "
-                    "while "
-                    "the writer is creating the new files.");
+                        " was found with an index file but md.0 "
+                        "has not contained enough data within "
+                        "the specified timeout of " +
+                        std::to_string(timeoutSeconds.count()) +
+                        " seconds. index size = " + std::to_string(newIdxSize) +
+                        " metadata size = " + std::to_string(actualFileSize) +
+                        " expected size = " +
+                        std::to_string(expectedMinFileSize) +
+                        ". One reason could be if the reader finds old data "
+                        "while "
+                        "the writer is creating the new files.");
             }
         }
 

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -47,8 +47,9 @@ StepStatus BP5Writer::BeginStep(StepMode mode, const float timeoutSeconds)
 {
     if (m_BetweenStepPairs)
     {
-        throw std::logic_error("ERROR: BeginStep() is called a second time "
-                               "without an intervening EndStep()");
+        helper::Throw<std::logic_error>("Engine", "BP5Writer", "BeginStep",
+                                        "BeginStep() is called a second time "
+                                        "without an intervening EndStep()");
     }
 
     Seconds ts = Now() - m_EngineStart;
@@ -221,10 +222,11 @@ void BP5Writer::WriteData(format::BufferV *Data)
             WriteData_TwoLevelShm_Async(Data);
             break;
         default:
-            throw std::invalid_argument(
+            helper::Throw<std::invalid_argument>(
+                "Engine", "BP5Writer", "WriteData",
                 "Aggregation method " +
-                std::to_string(m_Parameters.AggregationType) +
-                "is not supported in BP5");
+                    std::to_string(m_Parameters.AggregationType) +
+                    "is not supported in BP5");
         }
     }
     else
@@ -241,10 +243,11 @@ void BP5Writer::WriteData(format::BufferV *Data)
             WriteData_TwoLevelShm(Data);
             break;
         default:
-            throw std::invalid_argument(
+            helper::Throw<std::invalid_argument>(
+                "Engine", "BP5Writer", "WriteData",
                 "Aggregation method " +
-                std::to_string(m_Parameters.AggregationType) +
-                "is not supported in BP5");
+                    std::to_string(m_Parameters.AggregationType) +
+                    "is not supported in BP5");
         }
         delete Data;
     }
@@ -619,10 +622,12 @@ uint64_t BP5Writer::CountStepsInMetadataIndex(format::BufferSTL &bufferSTL)
     if (helper::IsLittleEndian() != IsLittleEndian)
     {
         std::string m = (IsLittleEndian ? "Little" : "Big");
-        throw std::runtime_error(
-            "ERROR: ADIOS2 BP5 Engine only supports appending with the same "
+
+        helper::Throw<std::runtime_error>(
+            "Engine", "BP5Writer", "CountStepsInMetadataIndex",
+            "ADIOS2 BP5 Engine only supports appending with the same "
             "endianness. The existing file is " +
-            m + "Endian\n");
+                m + "Endian");
     }
 
     // BP version
@@ -631,10 +636,11 @@ uint64_t BP5Writer::CountStepsInMetadataIndex(format::BufferSTL &bufferSTL)
         helper::ReadValue<uint8_t>(buffer, position, IsLittleEndian);
     if (Version != 5)
     {
-        throw std::runtime_error(
-            "ERROR: ADIOS2 BP5 Engine only supports bp format "
+        helper::Throw<std::runtime_error>(
+            "Engine", "BP5Writer", "CountStepsInMetadataIndex",
+            "ADIOS2 BP5 Engine only supports bp format "
             "version 5, found " +
-            std::to_string(Version) + " version \n");
+                std::to_string(Version) + " version");
     }
 
     position = m_ColumnMajorFlagPosition;
@@ -645,11 +651,12 @@ uint64_t BP5Writer::CountStepsInMetadataIndex(format::BufferSTL &bufferSTL)
     if (columnMajor != NowColumnMajor)
     {
         std::string m = (columnMajor == 'y' ? "column" : "row");
-        throw std::runtime_error(
-            "ERROR: ADIOS2 BP5 Engine only supports appending with the same "
+        helper::Throw<std::runtime_error>(
+            "Engine", "BP5Writer", "CountStepsInMetadataIndex",
+            "ADIOS2 BP5 Engine only supports appending with the same "
             "column/row major settings as it was written."
             " Existing file is " +
-            m + " major\n");
+                m + " major");
     }
 
     position = m_IndexHeaderSize; // after the header
@@ -994,11 +1001,12 @@ void BP5Writer::MakeHeader(format::BufferSTL &b, const std::string fileType,
     auto &absolutePosition = b.m_AbsolutePosition;
     if (position > 0)
     {
-        throw std::invalid_argument(
-            "ERROR: BP4Serializer::MakeHeader can only be called for an empty "
+        helper::Throw<std::invalid_argument>(
+            "Engine", "BP5Writer", "MakeHeader",
+            "BP4Serializer::MakeHeader can only be called for an empty "
             "buffer. This one for " +
-            fileType + " already has content of " + std::to_string(position) +
-            " bytes.");
+                fileType + " already has content of " +
+                std::to_string(position) + " bytes.");
     }
 
     if (b.GetAvailableSize() < m_IndexHeaderSize)
@@ -1013,7 +1021,8 @@ void BP5Writer::MakeHeader(format::BufferSTL &b, const std::string fileType,
     // byte 0-31: Readable tag
     if (position != m_VersionTagPosition)
     {
-        throw std::runtime_error(
+        helper::Throw<std::runtime_error>(
+            "Engine", "BP5Writer", "MakeHeader",
             "ADIOS Coding ERROR in BP4Serializer::MakeHeader. Version Tag "
             "position mismatch");
     }
@@ -1054,7 +1063,8 @@ void BP5Writer::MakeHeader(format::BufferSTL &b, const std::string fileType,
     // byte 36: endianness
     if (position != m_EndianFlagPosition)
     {
-        throw std::runtime_error(
+        helper::Throw<std::runtime_error>(
+            "Engine", "BP5Writer", "MakeHeader",
             "ADIOS Coding ERROR in BP5Writer::MakeHeader. Endian Flag "
             "position mismatch");
     }
@@ -1064,7 +1074,8 @@ void BP5Writer::MakeHeader(format::BufferSTL &b, const std::string fileType,
     // byte 37: BP Version 5
     if (position != m_BPVersionPosition)
     {
-        throw std::runtime_error(
+        helper::Throw<std::runtime_error>(
+            "Engine", "BP5Writer", "MakeHeader",
             "ADIOS Coding ERROR in BP5Writer::MakeHeader. BP Version "
             "position mismatch");
     }
@@ -1074,7 +1085,8 @@ void BP5Writer::MakeHeader(format::BufferSTL &b, const std::string fileType,
     // byte 38: BP Minor version 1
     if (position != m_BPMinorVersionPosition)
     {
-        throw std::runtime_error(
+        helper::Throw<std::runtime_error>(
+            "Engine", "BP5Writer", "MakeHeader",
             "ADIOS Coding ERROR in BP5Writer::MakeHeader. BP Minor version "
             "position mismatch");
     }
@@ -1084,7 +1096,8 @@ void BP5Writer::MakeHeader(format::BufferSTL &b, const std::string fileType,
     // byte 39: Active flag (used in Index Table only)
     if (position != m_ActiveFlagPosition)
     {
-        throw std::runtime_error(
+        helper::Throw<std::runtime_error>(
+            "Engine", "BP5Writer", "MakeHeader",
             "ADIOS Coding ERROR in BP5Writer::MakeHeader. Active Flag "
             "position mismatch");
     }

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -25,7 +25,10 @@ namespace engine
 #define CHECK_H5_RETURN(returnCode, reason)                                    \
     {                                                                          \
         if (returnCode < 0)                                                    \
-            throw std::runtime_error((reason));                                \
+        {                                                                      \
+            helper::Throw<std::runtime_error>("Engine", "HDF5ReaderP",         \
+                                              "CHECK_H5_RETURN", reason);      \
+        }                                                                      \
     }
 
 HDF5ReaderP::HDF5ReaderP(IO &io, const std::string &name, const Mode openMode,
@@ -34,7 +37,8 @@ HDF5ReaderP::HDF5ReaderP(IO &io, const std::string &name, const Mode openMode,
 {
     if (!helper::IsHDF5File(name, m_Comm, {}))
     {
-        throw std::invalid_argument("!ADIOS2 Error: Invalid HDF5 file found");
+        helper::Throw<std::invalid_argument>(
+            "Engine", "HDF5ReaderP", "HDF5ReaderP", "Invalid HDF5 file found");
     }
 
     Init();
@@ -65,9 +69,10 @@ void HDF5ReaderP::Init()
 {
     if (m_OpenMode != Mode::Read)
     {
-        throw std::invalid_argument(
-            "ERROR: HDF5Reader only supports OpenMode::Read "
-            ", in call to Open\n");
+        helper::Throw<std::invalid_argument>(
+            "Engine", "HDF5ReaderP", "Init",
+            "HDF5Reader only supports OpenMode::Read "
+            ", in call to Open");
     }
 
     m_H5File.Init(m_Name, m_Comm, false);
@@ -78,7 +83,8 @@ void HDF5ReaderP::Init()
 
     if (ts == 0)
     {
-        throw std::runtime_error("This h5 file is NOT written by ADIOS2");
+        helper::Throw<std::runtime_error>( "Engine", "HDF5ReaderP", "Init",
+    "This h5 file is NOT written by ADIOS2");
     }
     */
     m_H5File.ReadAttrToIO(m_IO);

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -55,10 +55,11 @@ void HDF5WriterP::Init()
 {
     if (m_OpenMode != Mode::Write && m_OpenMode != Mode::Append)
     {
-        throw std::invalid_argument(
-            "ERROR: HDF5Writer only support OpenMode::Write or "
+        helper::Throw<std::invalid_argument>(
+            "Engine", "HDF5WriterP", "Init",
+            "HDF5Writer only support OpenMode::Write or "
             "OpenMode::Append "
-            ", in call to ADIOS Open or HDF5Writer constructor\n");
+            ", in call to ADIOS Open or HDF5Writer constructor");
     }
 
     if (m_OpenMode == Mode::Append)

--- a/source/adios2/engine/inline/InlineReader.cpp
+++ b/source/adios2/engine/inline/InlineReader.cpp
@@ -42,8 +42,10 @@ const InlineWriter *InlineReader::GetWriter() const
     const auto &engine_map = m_IO.GetEngines();
     if (engine_map.size() != 2)
     {
-        throw std::runtime_error("There must be exactly one reader and one "
-                                 "writer for the inline engine.");
+        helper::Throw<std::runtime_error>(
+            "Engine", "InlineReader", "GetWriter",
+            "There must be exactly one reader and one "
+            "writer for the inline engine.");
     }
 
     std::shared_ptr<Engine> e = engine_map.begin()->second;
@@ -55,7 +57,8 @@ const InlineWriter *InlineReader::GetWriter() const
     const auto writer = dynamic_cast<InlineWriter *>(e.get());
     if (!writer)
     {
-        throw std::runtime_error(
+        helper::Throw<std::runtime_error>(
+            "Engine", "InlineReader", "GetWriter",
             "dynamic_cast<InlineWriter*> failed; this is very likely a bug.");
     }
     return writer;
@@ -67,8 +70,10 @@ StepStatus InlineReader::BeginStep(const StepMode mode,
     PERFSTUBS_SCOPED_TIMER("InlineReader::BeginStep");
     if (m_InsideStep)
     {
-        throw std::runtime_error("InlineReader::BeginStep was called but the "
-                                 "reader is already inside a step");
+        helper::Throw<std::runtime_error>(
+            "Engine", "InlineReader", "BeginStep",
+            "InlineReader::BeginStep was called but the "
+            "reader is already inside a step");
     }
     // Reader should be on step that writer just completed
     auto writer = GetWriter();
@@ -118,8 +123,10 @@ void InlineReader::EndStep()
     PERFSTUBS_SCOPED_TIMER("InlineReader::EndStep");
     if (!m_InsideStep)
     {
-        throw std::runtime_error("InlineReader::EndStep() cannot be called "
-                                 "without a call to BeginStep() first");
+        helper::Throw<std::runtime_error>(
+            "Engine", "InlineReader", "EndStep",
+            "InlineReader::EndStep() cannot be called "
+            "without a call to BeginStep() first");
     }
     if (m_Verbosity == 5)
     {
@@ -205,10 +212,11 @@ void InlineReader::InitParameters()
         {
             m_Verbosity = std::stoi(value);
             if (m_Verbosity < 0 || m_Verbosity > 5)
-                throw std::invalid_argument(
-                    "ERROR: Method verbose argument must be an "
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "InlineReader", "InitParameters",
+                    "Method verbose argument must be an "
                     "integer in the range [0,5], in call to "
-                    "Open or Engine constructor\n");
+                    "Open or Engine constructor");
         }
     }
 }

--- a/source/adios2/engine/inline/InlineReader.tcc
+++ b/source/adios2/engine/inline/InlineReader.tcc
@@ -58,9 +58,9 @@ void InlineReader::Get(core::Variable<T> &variable, T **data) const
 template <class T>
 void InlineReader::GetDeferredCommon(Variable<T> &variable, T *data)
 {
-    throw std::runtime_error(
-        "ERROR: ADIOS Inline Engine: GetBlockDeferredCommon "
-        "should be used instead of GetDeferredCommon.");
+    helper::Throw<std::runtime_error>(
+        "Engine", "InlineReader", "GetDeferredCommon",
+        "GetBlockDeferredCommon should be used instead of GetDeferredCommon.");
 }
 
 template <class T>
@@ -69,9 +69,10 @@ InlineReader::GetBlockSyncCommon(Variable<T> &variable)
 {
     if (variable.m_BlockID >= variable.m_BlocksInfo.size())
     {
-        throw std::invalid_argument(
-            "ERROR: selected BlockID " + std::to_string(variable.m_BlockID) +
-            " is above range of available blocks in GetBlockSync\n");
+        helper::Throw<std::invalid_argument>(
+            "Engine", "InlineReader", "GetBlockSyncCommon",
+            "selected BlockID " + std::to_string(variable.m_BlockID) +
+                " is above range of available blocks in GetBlockSync");
     }
     if (m_Verbosity == 5)
     {
@@ -91,9 +92,10 @@ InlineReader::GetBlockDeferredCommon(Variable<T> &variable)
 {
     if (variable.m_BlockID >= variable.m_BlocksInfo.size())
     {
-        throw std::invalid_argument(
-            "ERROR: selected BlockID " + std::to_string(variable.m_BlockID) +
-            " is above range of available blocks in GetBlockSync\n");
+        helper::Throw<std::invalid_argument>(
+            "Engine", "InlineReader", "GetBlockDeferredCommon",
+            "selected BlockID " + std::to_string(variable.m_BlockID) +
+                " is above range of available blocks in GetBlockSync");
     }
     if (m_Verbosity == 5)
     {

--- a/source/adios2/engine/inline/InlineWriter.cpp
+++ b/source/adios2/engine/inline/InlineWriter.cpp
@@ -43,8 +43,10 @@ const InlineReader *InlineWriter::GetReader() const
     const auto &engine_map = m_IO.GetEngines();
     if (engine_map.size() != 2)
     {
-        throw std::runtime_error("There must be exactly one reader and one "
-                                 "writer for the inline engine.");
+        helper::Throw<std::runtime_error>(
+            "Engine", "InlineWriter", "GetReader",
+            "There must be exactly one reader and one "
+            "writer for the inline engine.");
     }
 
     std::shared_ptr<Engine> e = engine_map.begin()->second;
@@ -56,7 +58,8 @@ const InlineReader *InlineWriter::GetReader() const
     const auto reader = dynamic_cast<InlineReader *>(e.get());
     if (!reader)
     {
-        throw std::runtime_error(
+        helper::Throw<std::runtime_error>(
+            "Engine", "InlineWriter", "GetReader",
             "dynamic_cast<InlineReader*> failed; this is very likely a bug.");
     }
     return reader;
@@ -67,8 +70,10 @@ StepStatus InlineWriter::BeginStep(StepMode mode, const float timeoutSeconds)
     PERFSTUBS_SCOPED_TIMER("InlineWriter::BeginStep");
     if (m_InsideStep)
     {
-        throw std::runtime_error("InlineWriter::BeginStep was called but the "
-                                 "writer is already inside a step");
+        helper::Throw<std::runtime_error>(
+            "Engine", "InlineWriter", "BeginStep",
+            "InlineWriter::BeginStep was called but the "
+            "writer is already inside a step");
     }
 
     auto reader = GetReader();
@@ -139,8 +144,10 @@ void InlineWriter::EndStep()
     PERFSTUBS_SCOPED_TIMER("InlineWriter::EndStep");
     if (!m_InsideStep)
     {
-        throw std::runtime_error("InlineWriter::EndStep() cannot be called "
-                                 "without a call to BeginStep() first");
+        helper::Throw<std::runtime_error>(
+            "Engine", "InlineWriter", "EndStep",
+            "InlineWriter::EndStep() cannot be called "
+            "without a call to BeginStep() first");
     }
     if (m_Verbosity == 5)
     {
@@ -196,10 +203,11 @@ void InlineWriter::InitParameters()
         {
             m_Verbosity = std::stoi(value);
             if (m_Verbosity < 0 || m_Verbosity > 5)
-                throw std::invalid_argument(
-                    "ERROR: Method verbose argument must be an "
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "InlineWriter", "InitParameters",
+                    "Method verbose argument must be an "
                     "integer in the range [0,5], in call to "
-                    "Open or Engine constructor\n");
+                    "Open or Engine constructor");
         }
     }
 }

--- a/source/adios2/engine/inline/InlineWriter.tcc
+++ b/source/adios2/engine/inline/InlineWriter.tcc
@@ -38,8 +38,9 @@ void InlineWriter::PutSyncCommon(Variable<T> &variable, const T *data)
     }
     else
     {
-        throw std::invalid_argument("ERROR: ADIOS Inline Engine: Put Sync is "
-                                    "not supported.");
+        helper::Throw<std::invalid_argument>("Engine", "InlineWriter",
+                                             "PutSyncCommon",
+                                             "Put Sync is not supported.");
     }
 }
 

--- a/source/adios2/engine/nullcore/NullCoreWriter.cpp
+++ b/source/adios2/engine/nullcore/NullCoreWriter.cpp
@@ -1,6 +1,8 @@
 #include "NullCoreWriter.h"
 #include "NullCoreWriter.tcc"
 
+#include "adios2/helper/adiosLog.h"
+
 namespace adios2
 {
 namespace core
@@ -28,14 +30,16 @@ StepStatus NullCoreWriter::BeginStep(StepMode mode, const float timeoutSeconds)
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullCoreWriter::BeginStep: Engine already closed");
+        helper::Throw<std::runtime_error>(
+            "Engine", "NullCoreWriter", "BeginStep",
+            "NullCoreWriter::BeginStep: Engine already closed");
     }
 
     if (Impl->IsInStep)
     {
-        throw std::runtime_error(
-            "ERROR: NullCoreWriter::BeginStep: Step already active");
+        helper::Throw<std::runtime_error>(
+            "Engine", "NullCoreWriter", "BeginStep",
+            "NullCoreWriter::BeginStep: Step already active");
     }
 
     Impl->IsInStep = true;
@@ -47,8 +51,9 @@ size_t NullCoreWriter::CurrentStep() const
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullCoreWriter::CurrentStep: Engine already closed");
+        helper::Throw<std::runtime_error>(
+            "Engine", "NullCoreWriter", "CurrentStep",
+            "NullCoreWriter::CurrentStep: Engine already closed");
     }
 
     return Impl->CurrentStep;
@@ -58,14 +63,16 @@ void NullCoreWriter::EndStep()
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullCoreWriter::EndStep: Engine already closed");
+        helper::Throw<std::runtime_error>(
+            "Engine", "NullCoreWriter", "EndStep",
+            "NullCoreWriter::EndStep: Engine already closed");
     }
 
     if (!Impl->IsInStep)
     {
-        throw std::runtime_error(
-            "ERROR: NullCoreWriter::EndStep: No active step");
+        helper::Throw<std::runtime_error>(
+            "Engine", "NullCoreWriter", "EndStep",
+            "NullCoreWriter::EndStep: No active step");
     }
 
     Impl->IsInStep = false;
@@ -75,8 +82,9 @@ void NullCoreWriter::PerformPuts()
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullCoreWriter::PerformPuts: Engine already closed");
+        helper::Throw<std::runtime_error>(
+            "Engine", "NullCoreWriter", "PerformPuts",
+            "NullCoreWriter::PerformPuts: Engine already closed");
     }
 
     return;
@@ -86,8 +94,9 @@ void NullCoreWriter::Flush(const int)
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullCoreWriter::Flush: Engine already closed");
+        helper::Throw<std::runtime_error>(
+            "Engine", "NullCoreWriter", "Flush",
+            "NullCoreWriter::Flush: Engine already closed");
     }
 
     return;
@@ -97,8 +106,8 @@ void NullCoreWriter::DoClose(const int)
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullCoreWriter::DoClose: already closed");
+        helper::Throw<std::runtime_error>("Engine", "NullCoreWriter", "DoClose",
+                                          "already closed");
     }
 
     Impl->IsOpen = false;

--- a/source/adios2/engine/plugin/PluginEngine.cpp
+++ b/source/adios2/engine/plugin/PluginEngine.cpp
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "adios2/helper/adiosDynamicBinder.h"
+#include "adios2/helper/adiosLog.h"
 
 #include <adios2sys/SystemTools.hxx>
 
@@ -77,8 +78,9 @@ void PluginEngine::Init()
     auto paramPluginLibraryIt = m_IO.m_Parameters.find("PluginLibrary");
     if (paramPluginLibraryIt == m_IO.m_Parameters.end())
     {
-        throw std::invalid_argument(
-            "PluginEngine: PluginLibrary must be specified in "
+        helper::Throw<std::invalid_argument>(
+            "Engine", "PluginEngine", "Init",
+            "PluginLibrary must be specified in "
             "engine parameters if no PluginName "
             "is specified");
     }
@@ -91,18 +93,22 @@ void PluginEngine::Init()
         m_Impl->m_Binder->GetSymbol("EngineCreate"));
     if (!m_Impl->m_HandleCreate)
     {
-        throw std::runtime_error("PluginEngine: Unable to locate "
-                                 "EngineCreate symbol in specified plugin "
-                                 "library");
+        helper::Throw<std::runtime_error>(
+            "Engine", "PluginEngine", "Init",
+            "Unable to locate "
+            "EngineCreate symbol in specified plugin "
+            "library");
     }
 
     m_Impl->m_HandleDestroy = reinterpret_cast<EngineDestroyPtr>(
         m_Impl->m_Binder->GetSymbol("EngineDestroy"));
     if (!m_Impl->m_HandleDestroy)
     {
-        throw std::runtime_error("PluginEngine: Unable to locate "
-                                 "EngineDestroy symbol in specified plugin "
-                                 "library");
+        helper::Throw<std::runtime_error>(
+            "Engine", "PluginEngine", "Init",
+            "Unable to locate "
+            "EngineDestroy symbol in specified plugin "
+            "library");
     }
 }
 

--- a/source/adios2/engine/skeleton/SkeletonReader.cpp
+++ b/source/adios2/engine/skeleton/SkeletonReader.cpp
@@ -139,10 +139,11 @@ void SkeletonReader::InitParameters()
         {
             m_Verbosity = std::stoi(value);
             if (m_Verbosity < 0 || m_Verbosity > 5)
-                throw std::invalid_argument(
-                    "ERROR: Method verbose argument must be an "
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SkeletonReader", "InitParameters",
+                    "Method verbose argument must be an "
                     "integer in the range [0,5], in call to "
-                    "Open or Engine constructor\n");
+                    "Open or Engine constructor");
         }
     }
 }

--- a/source/adios2/engine/skeleton/SkeletonWriter.cpp
+++ b/source/adios2/engine/skeleton/SkeletonWriter.cpp
@@ -122,10 +122,11 @@ void SkeletonWriter::InitParameters()
         {
             m_Verbosity = std::stoi(value);
             if (m_Verbosity < 0 || m_Verbosity > 5)
-                throw std::invalid_argument(
-                    "ERROR: Method verbose argument must be an "
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SkeletonWriter", "InitParameters",
+                    "Method verbose argument must be an "
                     "integer in the range [0,5], in call to "
-                    "Open or Engine constructor\n");
+                    "Open or Engine constructor");
         }
     }
 }

--- a/source/adios2/engine/ssc/SscHelper.cpp
+++ b/source/adios2/engine/ssc/SscHelper.cpp
@@ -28,13 +28,19 @@ size_t GetTypeSize(DataType type)
 {
     if (type == DataType::None)
     {
-        throw(std::runtime_error("unknown data type"));
+        helper::Throw<std::runtime_error>("Engine", "SscHelper", "GetTypeSize",
+                                          "unknown data type");
     }
 #define declare_type(T)                                                        \
     else if (type == helper::GetDataType<T>()) { return sizeof(T); }
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
-    else { throw(std::runtime_error("unknown data type")); }
+    else
+    {
+        helper::Throw<std::runtime_error>("Engine", "SscHelper", "GetTypeSize",
+                                          "unknown data type");
+    }
+    return 0;
 }
 
 size_t TotalDataSize(const Dims &dims, DataType type, const ShapeID &shapeId)
@@ -48,7 +54,9 @@ size_t TotalDataSize(const Dims &dims, DataType type, const ShapeID &shapeId)
     {
         return GetTypeSize(type);
     }
-    throw(std::runtime_error("ShapeID not supported"));
+    helper::Throw<std::runtime_error>("Engine", "SscHelper", "TotalDataSize",
+                                      "ShapeID not supported");
+    return 0;
 }
 
 size_t TotalDataSize(const BlockVec &bv)
@@ -305,8 +313,9 @@ void Deserialize(const Buffer &input, BlockVecVec &output, IO &io,
 #undef declare_type
                     else
                     {
-                        throw(
-                            std::runtime_error("unknown attribute data type"));
+                        helper::Throw<std::runtime_error>(
+                            "Engine", "SscHelper", "Deserialize",
+                            "unknown attribute data type");
                     }
                 }
             }
@@ -365,7 +374,9 @@ void Deserialize(const Buffer &input, BlockVecVec &output, IO &io,
             {
                 if (b.type == DataType::None)
                 {
-                    throw(std::runtime_error("unknown variable data type"));
+                    helper::Throw<std::runtime_error>(
+                        "Engine", "SscHelper", "Deserialize",
+                        "unknown variable data type");
                 }
 #define declare_type(T)                                                        \
     else if (b.type == helper::GetDataType<T>())                               \
@@ -402,7 +413,9 @@ void Deserialize(const Buffer &input, BlockVecVec &output, IO &io,
 #undef declare_type
                 else
                 {
-                    throw(std::runtime_error("unknown variable data type"));
+                    helper::Throw<std::runtime_error>(
+                        "Engine", "SscHelper", "Deserialize",
+                        "unknown variable data type");
                 }
             }
         }

--- a/source/adios2/engine/ssc/SscHelper.h
+++ b/source/adios2/engine/ssc/SscHelper.h
@@ -13,6 +13,7 @@
 
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/IO.h"
+#include "adios2/helper/adiosLog.h"
 #include <mpi.h>
 #include <unordered_map>
 #include <vector>
@@ -59,7 +60,8 @@ public:
         }
         if (m_Buffer == nullptr)
         {
-            throw("ssc buffer realloc failed");
+            helper::Throw<std::runtime_error>("Engine", "SscHelper", "resize",
+                                              "ssc buffer realloc failed");
         }
     }
     template <typename T>

--- a/source/adios2/engine/sst/SstParamParser.cpp
+++ b/source/adios2/engine/sst/SstParamParser.cpp
@@ -6,6 +6,7 @@
 
 #include "adios2/toolkit/sst/sst.h"
 
+using namespace adios2;
 using namespace adios2::core;
 
 void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
@@ -29,8 +30,9 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown Sst Boolean parameter \"" + value + "\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SstParamParser", "ParseParams",
+                    "Unknown Sst Boolean parameter \"" + value + "\"");
             }
         }
     };
@@ -73,14 +75,17 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
             else if (method == "cloud")
             {
                 parameter = SstRegisterCloud;
-                throw std::invalid_argument("ERROR: Sst RegistrationMethod "
-                                            "\"cloud\" not yet implemented");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SstParamParser", "ParseParams",
+                    "Sst RegistrationMethod "
+                    "\"cloud\" not yet implemented");
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown Sst RegistrationMethod parameter \"" +
-                    method + "\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SstParamParser", "ParseParams",
+                    "Unknown Sst RegistrationMethod parameter \"" + method +
+                        "\"");
             }
             return true;
         }
@@ -105,9 +110,10 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown Sst CompressionMethod parameter \"" +
-                    method + "\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SstParamParser", "ParseParams",
+                    "Unknown Sst CompressionMethod parameter \"" + method +
+                        "\"");
             }
             return true;
         }
@@ -143,9 +149,9 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown Sst MarshalMethod parameter \"" + method +
-                    "\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SstParamParser", "ParseParams",
+                    "Unknown Sst MarshalMethod parameter \"" + method + "\"");
             }
             return true;
         }
@@ -170,9 +176,9 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown Sst CPCommPattern parameter \"" + method +
-                    "\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SstParamParser", "ParseParams",
+                    "Unknown Sst CPCommPattern parameter \"" + method + "\"");
             }
             return true;
         }
@@ -197,9 +203,9 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown Sst QueueFullPolicy parameter \"" + method +
-                    "\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SstParamParser", "ParseParams",
+                    "Unknown Sst QueueFullPolicy parameter \"" + method + "\"");
             }
             return true;
         }
@@ -228,9 +234,10 @@ void SstParamParser::ParseParams(IO &io, struct _SstParams &Params)
             }
             else
             {
-                throw std::invalid_argument(
-                    "ERROR: Unknown Sst SpeculativePreloadMode parameter \"" +
-                    method + "\"");
+                helper::Throw<std::invalid_argument>(
+                    "Engine", "SstParamParser", "ParseParams",
+                    "Unknown Sst SpeculativePreloadMode parameter \"" + method +
+                        "\"");
             }
             return true;
         }

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -39,11 +39,12 @@ SstReader::SstReader(IO &io, const std::string &name, const Mode mode,
     if (!m_Input)
     {
         delete[] cstr;
-        throw std::runtime_error(
-            "ERROR: SstReader did not find active "
+        helper::Throw<std::runtime_error>(
+            "Engine", "SstReader", "SstReader",
+            "SstReader did not find active "
             "Writer contact info in file \"" +
-            m_Name + SST_POSTFIX +
-            "\".  Timeout or non-current SST contact file?");
+                m_Name + SST_POSTFIX +
+                "\".  Timeout or non-current SST contact file?");
     }
 
     // Maybe need other writer-side params in the future, but for now only
@@ -284,16 +285,18 @@ StepStatus SstReader::BeginStep(StepMode Mode, const float timeout_sec)
     SstStatusValue result;
     if (m_BetweenStepPairs)
     {
-        throw std::logic_error("ERROR: BeginStep() is called a second time "
-                               "without an intervening EndStep()");
+        helper::Throw<std::logic_error>("Engine", "SstReader", "BeginStep",
+                                        "BeginStep() is called a second time "
+                                        "without an intervening EndStep()");
     }
 
     switch (Mode)
     {
     case adios2::StepMode::Append:
     case adios2::StepMode::Update:
-        throw std::invalid_argument(
-            "ERROR: SstReader::BeginStep inappropriate StepMode specified");
+        helper::Throw<std::invalid_argument>(
+            "Engine", "SstReader", "BeginStep",
+            "SstReader::BeginStep inappropriate StepMode specified");
     case adios2::StepMode::Read:
         break;
     }
@@ -444,8 +447,9 @@ void SstReader::EndStep()
 {
     if (!m_BetweenStepPairs)
     {
-        throw std::logic_error(
-            "ERROR: EndStep() is called without a successful BeginStep()");
+        helper::Throw<std::logic_error>(
+            "Engine", "SstReader", "EndStep",
+            "EndStep() is called without a successful BeginStep()");
     }
     m_BetweenStepPairs = false;
     PERFSTUBS_SCOPED_TIMER_FUNC();
@@ -462,8 +466,9 @@ void SstReader::EndStep()
         if (Result != SstSuccess)
         {
             // tentative, until we change EndStep so that it has a return value
-            throw std::runtime_error(
-                "ERROR:  Writer failed before returning data");
+            helper::Throw<std::runtime_error>(
+                "Engine", "SstReader", "EndStep",
+                "Writer failed before returning data");
         }
     }
     else if (m_WriterMarshalMethod == SstMarshalBP)
@@ -514,8 +519,9 @@ void SstReader::Init()
     {                                                                          \
         if (m_BetweenStepPairs == false)                                       \
         {                                                                      \
-            throw std::logic_error(                                            \
-                "ERROR: When using the SST engine in ADIOS2, "                 \
+            helper::Throw<std::logic_error>(                                   \
+                "Engine", "SstReader", "DoGetSync",                            \
+                "When using the SST engine in ADIOS2, "                        \
                 "Get() calls must appear between "                             \
                 "BeginStep/EndStep pairs");                                    \
         }                                                                      \
@@ -571,8 +577,9 @@ void SstReader::Init()
     {                                                                          \
         if (m_BetweenStepPairs == false)                                       \
         {                                                                      \
-            throw std::logic_error(                                            \
-                "ERROR: When using the SST engine in ADIOS2, "                 \
+            helper::Throw<std::logic_error>(                                   \
+                "Engine", "SstReader", "DoGetDeferred",                        \
+                "When using the SST engine in ADIOS2, "                        \
                 "Get() calls must appear between "                             \
                 "BeginStep/EndStep pairs");                                    \
         }                                                                      \
@@ -651,8 +658,9 @@ void SstReader::BP5PerformGets()
     {
         if (SstWaitForCompletion(m_Input, i) != SstSuccess)
         {
-            throw std::runtime_error(
-                "ERROR:  Writer failed before returning data");
+            helper::Throw<std::runtime_error>(
+                "Engine", "SstReader", "BP5PerformGets",
+                "Writer failed before returning data");
         }
     }
 
@@ -706,8 +714,9 @@ void SstReader::PerformGets()
         {
             if (SstWaitForCompletion(m_Input, i) != SstSuccess)
             {
-                throw std::runtime_error(
-                    "ERROR:  Writer failed before returning data");
+                helper::Throw<std::runtime_error>(
+                    "Engine", "SstReader", "PerformGets",
+                    "Writer failed before returning data");
             }
         }
 
@@ -755,8 +764,10 @@ MinVarInfo *SstReader::MinBlocksInfo(const VariableBase &Var,
     {
         return (MinVarInfo *)m_BP5Deserializer->MinBlocksInfo(Var, Step);
     }
-    throw std::invalid_argument(
-        "ERROR: Unknown marshal mechanism in MinBlocksInfo\n");
+    helper::Throw<std::invalid_argument>(
+        "Engine", "SstReader", "MinBlocksInfo",
+        "Unknown marshal mechanism in MinBlocksInfo");
+    return nullptr;
 }
 
 #define declare_type(T)                                                        \
@@ -765,15 +776,19 @@ MinVarInfo *SstReader::MinBlocksInfo(const VariableBase &Var,
     {                                                                          \
         if (m_WriterMarshalMethod == SstMarshalFFS)                            \
         {                                                                      \
-            throw std::invalid_argument("ERROR: SST Engine doesn't implement " \
-                                        "function DoAllStepsBlocksInfo\n");    \
+            helper::Throw<std::invalid_argument>(                              \
+                "Engine", "SstReader", "DoAllStepsBlocksInfo",                 \
+                "SST Engine doesn't implement "                                \
+                "function DoAllStepsBlocksInfo");                              \
         }                                                                      \
         else if (m_WriterMarshalMethod == SstMarshalBP)                        \
         {                                                                      \
             return m_BP3Deserializer->AllStepsBlocksInfo(variable);            \
         }                                                                      \
-        throw std::invalid_argument(                                           \
-            "ERROR: Unknown marshal mechanism in DoAllStepsBlocksInfo\n");     \
+        helper::Throw<std::invalid_argument>(                                  \
+            "Engine", "SstReader", "DoAllStepsBlocksInfo",                     \
+            "Unknown marshal mechanism in DoAllStepsBlocksInfo");              \
+        return std::map<size_t, std::vector<typename Variable<T>::BPInfo>>();  \
     }                                                                          \
                                                                                \
     std::vector<typename Variable<T>::BPInfo> SstReader::DoBlocksInfo(         \
@@ -792,8 +807,10 @@ MinVarInfo *SstReader::MinBlocksInfo(const VariableBase &Var,
             std::vector<typename Variable<T>::BPInfo> tmp;                     \
             return tmp;                                                        \
         }                                                                      \
-        throw std::invalid_argument(                                           \
-            "ERROR: Unknown marshal mechanism in DoBlocksInfo\n");             \
+        helper::Throw<std::invalid_argument>(                                  \
+            "Engine", "SstReader", "DoBlocksInfo",                             \
+            "Unknown marshal mechanism in DoBlocksInfo");                      \
+        return std::vector<typename Variable<T>::BPInfo>();                    \
     }
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -127,8 +127,9 @@ StepStatus SstWriter::BeginStep(StepMode mode, const float timeout_sec)
     m_WriterStep++;
     if (m_BetweenStepPairs)
     {
-        throw std::logic_error("ERROR: BeginStep() is called a second time "
-                               "without an intervening EndStep()");
+        helper::Throw<std::logic_error>("Engine", "SstWriter", "BeginStep",
+                                        "BeginStep() is called a second time "
+                                        "without an intervening EndStep()");
     }
 
     m_BetweenStepPairs = true;
@@ -244,8 +245,9 @@ void SstWriter::EndStep()
     PERFSTUBS_SCOPED_TIMER_FUNC();
     if (!m_BetweenStepPairs)
     {
-        throw std::logic_error(
-            "ERROR: EndStep() is called without a successful BeginStep()");
+        helper::Throw<std::logic_error>(
+            "Engine", "SstWriter", "EndStep",
+            "EndStep() is called without a successful BeginStep()");
     }
     m_BetweenStepPairs = false;
     if (m_WriterDefinitionsLocked && !m_DefinitionsNotified)
@@ -378,9 +380,11 @@ void SstWriter::Init()
 
     if (Params.verbose < 0 || Params.verbose > 5)
     {
-        throw std::invalid_argument("ERROR: Method verbose argument must be an "
-                                    "integer in the range [0,5], in call to "
-                                    "Open or Engine constructor\n");
+        helper::Throw<std::invalid_argument>(
+            "Engine", "SstWriter", "Init",
+            "ERROR: Method verbose argument must be an "
+            "integer in the range [0,5], in call to "
+            "Open or Engine constructor\n");
     }
 }
 

--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -31,9 +31,10 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
 
     if (m_BetweenStepPairs == false)
     {
-        throw std::logic_error("ERROR: When using the SST engine in ADIOS2, "
-                               "Put() calls must appear between "
-                               "BeginStep/EndStep pairs");
+        helper::Throw<std::logic_error>("Engine", "SstWriter", "PutSyncCommon",
+                                        "When using the SST engine in ADIOS2, "
+                                        "Put() calls must appear between "
+                                        "BeginStep/EndStep pairs");
     }
 
     if ((Params.MarshalMethod == SstMarshalFFS) ||
@@ -93,7 +94,9 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
                               " Put adios2::Mode::Sync");
         if (resizeResult == format::BP3Base::ResizeResult::Failure)
         {
-            throw std::runtime_error("Failed to resize BP3 serializer buffer");
+            helper::Throw<std::runtime_error>(
+                "Engine", "SstWriter", "PutSyncCommon",
+                "Failed to resize BP3 serializer buffer");
         }
 
         const bool sourceRowMajor =
@@ -106,7 +109,9 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
     }
     else
     {
-        throw std::invalid_argument("ERROR: unknown marshaling method \n");
+        helper::Throw<std::invalid_argument>("Engine", "SstWriter",
+                                             "PutSyncCommon",
+                                             "unknown marshaling method");
     }
 }
 

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "adiosCommMPI.h"
+#include "adiosLog.h"
 
 #include <algorithm>
 #include <ios> //std::ios_base::failure
@@ -91,7 +92,9 @@ void CheckMPIReturn(const int value, const std::string &hint)
         error = "MPI_ERR number: " + std::to_string(value);
     }
 
-    throw std::runtime_error("ERROR: ADIOS2 detected " + error + ", " + hint);
+    helper::Throw<std::runtime_error>("Helper", "AdiosCommMPI",
+                                      "CheckMPIReturn",
+                                      "ADIOS2 detected " + error + ", " + hint);
 }
 }
 

--- a/source/adios2/helper/adiosDynamicBinder.cpp
+++ b/source/adios2/helper/adiosDynamicBinder.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "adiosDynamicBinder.h"
+#include "adiosLog.h"
 
 #include <algorithm> // for copy
 #include <iostream>  // for operator<<, stringstream, bas...
@@ -103,7 +104,8 @@ DynamicBinder::DynamicBinder(std::string libName, std::string libPath)
         std::copy(searchedLibs.begin(), searchedLibs.end(),
                   std::ostream_iterator<std::string>(errString, " "));
 
-        throw std::runtime_error(errString.str());
+        helper::Throw<std::runtime_error>("Helper", "adiosDynamicBinder",
+                                          "DynamicBinder", errString.str());
     }
 }
 

--- a/source/adios2/helper/adiosLog.h
+++ b/source/adios2/helper/adiosLog.h
@@ -83,6 +83,16 @@ void Throw(const std::string &component, const std::string &source,
     throw(T(m));
 }
 
+template <class T>
+void ThrowNested(const std::string &component, const std::string &source,
+                 const std::string &activity, const std::string &message,
+                 const int commRank = -1)
+{
+    auto m = MakeMessage(component, source, activity, message, commRank,
+                         LogMode::EXCEPTION);
+    throw_with_nested(T(m));
+}
+
 } // end namespace helper
 } // end namespace adios2
 

--- a/source/adios2/helper/adiosMath.cpp
+++ b/source/adios2/helper/adiosMath.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "adiosMath.h"
+#include "adiosLog.h"
 
 #include <algorithm> //std::transform, std::reverse
 #include <cmath>
@@ -367,10 +368,11 @@ size_t GetDistance(const size_t end, const size_t start,
 {
     if (end < start)
     {
-        throw std::invalid_argument(
-            "ERROR: end position: " + std::to_string(end) +
-            " is smaller than start position " + std::to_string(start) + ", " +
-            hint);
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosMath", "GetDistance",
+            "end position: " + std::to_string(end) +
+                " is smaller than start position " + std::to_string(start) +
+                ", " + hint);
     }
 
     return end - start;
@@ -404,8 +406,10 @@ BlockDivisionInfo DivideBlock(const Dims &count, const size_t subblockSize,
 {
     if (divisionMethod != BlockDivisionMethod::Contiguous)
     {
-        throw std::invalid_argument("ERROR: adios2::helper::DivideBlock() only "
-                                    "works with Contiguous division method");
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosMath", "DivideBlock",
+            "adios2::helper::DivideBlock() only "
+            "works with Contiguous division method");
     }
     const size_t ndim = count.size();
     const size_t nElems = helper::GetTotalSize(count);

--- a/source/adios2/helper/adiosString.cpp
+++ b/source/adios2/helper/adiosString.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "adiosString.h"
+#include "adiosLog.h"
 #include "adiosString.tcc"
 
 /// \cond EXCLUDE_FROM_DOXYGEN
@@ -31,8 +32,9 @@ std::string FileToString(const std::string &fileName, const std::string hint)
 
     if (!fileStream)
     {
-        throw std::ios_base::failure("ERROR: file " + fileName +
-                                     " not found, " + hint + "\n");
+        helper::Throw<std::ios_base::failure>(
+            "Helper", "adiosString", "FileToString",
+            "file " + fileName + " not found, " + hint);
     }
 
     std::ostringstream fileSS;
@@ -55,10 +57,11 @@ Params BuildParametersMap(const std::vector<std::string> &parameters,
 
         if (equalPosition == parameter.npos)
         {
-            throw std::invalid_argument(
-                "ERROR: wrong format for IO parameter " + parameter +
-                ", format must be key" + delimKeyValue +
-                "value for each entry \n");
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "BuildParametersMap",
+                "wrong format for IO parameter " + parameter +
+                    ", format must be key" + delimKeyValue +
+                    "value for each entry");
         }
 
         field = parameter.substr(0, equalPosition);
@@ -77,14 +80,16 @@ Params BuildParametersMap(const std::vector<std::string> &parameters,
 
         if (value.length() == 0)
         {
-            throw std::invalid_argument("ERROR: empty value in IO parameter " +
-                                        parameter + ", format must be key" +
-                                        delimKeyValue + "value \n");
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "BuildParametersMap",
+                "empty value in IO parameter " + parameter +
+                    ", format must be key" + delimKeyValue + "value");
         }
         if (parametersOutput.count(field) == 1)
         {
-            throw std::invalid_argument("ERROR: parameter " + field +
-                                        " already exists, must be unique\n");
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "BuildParametersMap",
+                "parameter " + field + " already exists, must be unique");
         }
 
         parametersOutput[field] = value;
@@ -110,10 +115,11 @@ Params BuildParametersMap(const std::string &input, const char delimKeyValue,
         const size_t position = parameter.find(delimKeyValue);
         if (position == parameter.npos)
         {
-            throw std::invalid_argument(
-                "ERROR: wrong format for IO parameter " + parameter +
-                ", format must be key" + delimKeyValue +
-                "value for each entry \n");
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "BuildParametersMap",
+                "wrong format for IO parameter " + parameter +
+                    ", format must be key" + delimKeyValue +
+                    "value for each entry");
         }
 
         std::string key = parameter.substr(0, position);
@@ -122,15 +128,17 @@ Params BuildParametersMap(const std::string &input, const char delimKeyValue,
         lf_Trim(value);
         if (value.length() == 0)
         {
-            throw std::invalid_argument("ERROR: empty value in IO parameter " +
-                                        parameter + ", format must be key" +
-                                        delimKeyValue + "value \n");
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "BuildParametersMap",
+                "empty value in IO parameter " + parameter +
+                    ", format must be key" + delimKeyValue + "value");
         }
         if (parametersOutput.count(key) == 1)
         {
-            throw std::invalid_argument(
-                "ERROR: key " + key +
-                " appears multiple times in the parameters string\n");
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "BuildParametersMap",
+                "key " + key +
+                    " appears multiple times in the parameters string");
         }
 
         parametersOutput[key] = value;
@@ -215,8 +223,9 @@ std::string GetParameter(const std::string key, const Params &params,
     {
         if (isMandatory)
         {
-            throw std::invalid_argument("ERROR: mandatory parameter " + key +
-                                        " not found, " + hint);
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "GetParameter",
+                "mandatory parameter " + key + " not found, " + hint);
         }
     }
     else
@@ -256,9 +265,9 @@ bool GetParameter(const Params &params, const std::string &key, int &value)
         }
         catch (...)
         {
-            std::string error =
-                "Engine parameter " + key + " can only be integer numbers";
-            throw(std::invalid_argument(error));
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "GetParameter",
+                "Engine parameter " + key + " can only be integer numbers");
         }
     }
     return true;
@@ -280,9 +289,9 @@ bool GetParameter(const Params &params, const std::string &key, uint64_t &value)
         }
         catch (...)
         {
-            std::string error =
-                "Engine parameter " + key + " can only be integer numbers";
-            throw(std::invalid_argument(error));
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "GetParameter",
+                "Engine parameter " + key + " can only be integer numbers");
         }
     }
     return true;
@@ -304,9 +313,9 @@ bool GetParameter(const Params &params, const std::string &key, float &value)
         }
         catch (...)
         {
-            std::string error =
-                "Engine parameter " + key + " can only be float numbers";
-            throw(std::invalid_argument(error));
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosString", "GetParameter",
+                "Engine parameter " + key + " can only be float numbers");
         }
     }
     return true;

--- a/source/adios2/helper/adiosString.tcc
+++ b/source/adios2/helper/adiosString.tcc
@@ -16,6 +16,8 @@
 #include <algorithm> //std::transform
 #include <iterator>  //std::inserter
 
+#include "adios2/helper/adiosLog.h"
+
 namespace adios2
 {
 namespace helper
@@ -55,9 +57,10 @@ bool StringTo(const std::string &input, const std::string &hint)
     }
     else
     {
-        throw std::invalid_argument(
-            "ERROR: invalid input value: " + input +
-            " for on/off or true/false bool conversion " + hint + "\n");
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosString", "StringTo",
+            "invalid input value: " + input +
+                " for on/off or true/false bool conversion " + hint);
     }
     return result;
 }
@@ -72,9 +75,11 @@ int32_t StringTo(const std::string &input, const std::string &hint)
     }
     catch (...)
     {
-        std::throw_with_nested(std::invalid_argument(
-            "ERROR: could not cast " + input + " to int32_t " + hint));
+        helper::ThrowNested<std::invalid_argument>(
+            "Helper", "adiosString", "StringTo",
+            "could not cast " + input + " to int32_t " + hint);
     }
+    return 0;
 }
 
 template <>
@@ -87,9 +92,11 @@ uint32_t StringTo(const std::string &input, const std::string &hint)
     }
     catch (...)
     {
-        std::throw_with_nested(std::invalid_argument(
-            "ERROR: could not cast " + input + " to uint32_t " + hint));
+        helper::ThrowNested<std::invalid_argument>(
+            "Helper", "adiosString", "StringTo",
+            "could not cast " + input + " to uint32_t " + hint);
     }
+    return 0;
 }
 
 template <>
@@ -102,9 +109,11 @@ int64_t StringTo(const std::string &input, const std::string &hint)
     }
     catch (...)
     {
-        std::throw_with_nested(std::invalid_argument(
-            "ERROR: could not cast " + input + " to int64_t " + hint));
+        helper::ThrowNested<std::invalid_argument>(
+            "Helper", "adiosString", "StringTo",
+            "could not cast " + input + " to int64_t " + hint);
     }
+    return 0;
 }
 
 template <>
@@ -117,9 +126,11 @@ uint64_t StringTo(const std::string &input, const std::string &hint)
     }
     catch (...)
     {
-        std::throw_with_nested(std::invalid_argument(
-            "ERROR: could not cast " + input + " to uint64_t " + hint));
+        helper::ThrowNested<std::invalid_argument>(
+            "Helper", "adiosString", "StringTo",
+            "could not cast " + input + " to uint64_t " + hint);
     }
+    return 0;
 }
 
 template <>
@@ -132,9 +143,11 @@ float StringTo(const std::string &input, const std::string &hint)
     }
     catch (...)
     {
-        std::throw_with_nested(std::invalid_argument(
-            "ERROR: could not cast " + input + " to float " + hint));
+        helper::ThrowNested<std::invalid_argument>(
+            "Helper", "adiosString", "StringTo",
+            "could not cast " + input + " to float " + hint);
     }
+    return 0;
 }
 
 template <>
@@ -147,9 +160,11 @@ double StringTo(const std::string &input, const std::string &hint)
     }
     catch (...)
     {
-        std::throw_with_nested(std::invalid_argument(
-            "ERROR: could not cast " + input + " to double " + hint));
+        helper::ThrowNested<std::invalid_argument>(
+            "Helper", "adiosString", "StringTo",
+            "could not cast " + input + " to double " + hint);
     }
+    return 0;
 }
 
 } // end namespace helper

--- a/source/adios2/helper/adiosType.cpp
+++ b/source/adios2/helper/adiosType.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "adiosType.h"
+#include "adiosLog.h"
 
 /// \cond EXCLUDE_FROM_DOXYGEN
 #include <algorithm> //std::transform, std::count
@@ -99,7 +100,9 @@ size_t GetDataTypeSize(DataType type)
     }
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
-    throw(std::runtime_error("unknown data type"));
+    helper::Throw<std::runtime_error>("Helper", "adiosType", "GetDataTypeSize",
+                                      "unknown data type");
+    return 0;
 }
 
 std::string DimsToCSV(const Dims &dimensions) noexcept
@@ -212,11 +215,13 @@ TimeUnit StringToTimeUnit(const std::string timeUnitString,
     }
     else
     {
-        throw std::invalid_argument("ERROR: invalid value " + timeUnitString +
-                                    " in Parameter key=ProfileUnits, "
-                                    " must be Microseconds, Milliseconds, "
-                                    "Seconds, Minutes or Hours " +
-                                    hint + "\n");
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosType", "StringToTimeUnit",
+            "invalid value " + timeUnitString +
+                " in Parameter key=ProfileUnits, "
+                " must be Microseconds, Milliseconds, "
+                "Seconds, Minutes or Hours " +
+                hint);
     }
     return timeUnit;
 }
@@ -242,8 +247,9 @@ size_t BytesFactor(const std::string units)
     }
     else
     {
-        throw std::invalid_argument("ERROR: units " + units +
-                                    " not supported in call to BytesFactor\n");
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosType", "BytesFactor",
+            "units " + units + " not supported in call to BytesFactor");
     }
     return factor;
 }

--- a/source/adios2/helper/adiosType.inl
+++ b/source/adios2/helper/adiosType.inl
@@ -18,6 +18,7 @@
 #include <sstream>   //std::ostringstream
 
 #include "adios2/common/ADIOSMacros.h"
+#include "adiosLog.h"
 
 namespace adios2
 {
@@ -239,7 +240,9 @@ void CheckForNullptr(T *pointer, const std::string hint)
 {
     if (pointer == nullptr)
     {
-        throw std::invalid_argument("ERROR: found null pointer " + hint + "\n");
+        helper::Throw<std::invalid_argument>("Helper", "adiosType",
+                                             "CheckForNullPtr",
+                                             "found null pointer " + hint);
     }
 }
 

--- a/source/adios2/helper/adiosXMLUtil.cpp
+++ b/source/adios2/helper/adiosXMLUtil.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "adiosXMLUtil.h"
+#include "adiosLog.h"
 
 #include <iterator>  // std::distance
 #include <stdexcept> //std::invalid_argument
@@ -30,11 +31,11 @@ std::unique_ptr<pugi::xml_document> XMLDocument(const std::string &xmlContents,
 
     if (!parse_result)
     {
-        throw std::invalid_argument(
-            "ERROR: XML: parse error in XML string, description: " +
-            std::string(parse_result.description()) +
-            ", check with any XML editor if format is ill-formed, " + hint +
-            "\n");
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosXMLUtil", "XMLDocument",
+            "parse error in XML string, description: " +
+                std::string(parse_result.description()) +
+                ", check with any XML editor if format is ill-formed, " + hint);
     }
     return document;
 }
@@ -48,8 +49,9 @@ XMLNode(const std::string nodeName, const pugi::xml_document &xmlDocument,
 
     if (isMandatory && !node)
     {
-        throw std::invalid_argument("ERROR: XML: no <" + nodeName +
-                                    "> element found, " + hint);
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosXMLUtil", "XMLNode",
+            "no <" + nodeName + "> element found, " + hint);
     }
 
     if (isUnique)
@@ -59,10 +61,10 @@ XMLNode(const std::string nodeName, const pugi::xml_document &xmlDocument,
                           xmlDocument.children(nodeName.c_str()).end());
         if (nodes > 1)
         {
-            throw std::invalid_argument("ERROR: XML only one <" + nodeName +
-                                        "> element can exist inside " +
-                                        std::string(xmlDocument.name()) + ", " +
-                                        hint + "\n");
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosXMLUtil", "XMLNode",
+                "XML only one <" + nodeName + "> element can exist inside " +
+                    std::string(xmlDocument.name()) + ", " + hint);
         }
     }
     return node;
@@ -77,9 +79,10 @@ XMLNode(const std::string nodeName, const pugi::xml_node &upperNode,
 
     if (isMandatory && !node)
     {
-        throw std::invalid_argument(
-            "ERROR: XML: no <" + nodeName + "> element found, inside <" +
-            std::string(upperNode.name()) + "> element " + hint);
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosXMLUtil", "XMLNode",
+            "no <" + nodeName + "> element found, inside <" +
+                std::string(upperNode.name()) + "> element " + hint);
     }
 
     if (isUnique)
@@ -89,10 +92,10 @@ XMLNode(const std::string nodeName, const pugi::xml_node &upperNode,
                           upperNode.children(nodeName.c_str()).end());
         if (nodes > 1)
         {
-            throw std::invalid_argument("ERROR: XML only one <" + nodeName +
-                                        "> element can exist inside <" +
-                                        std::string(upperNode.name()) +
-                                        "> element, " + hint + "\n");
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosXMLUtil", "XMLNode",
+                "XML only one <" + nodeName + "> element can exist inside <" +
+                    std::string(upperNode.name()) + "> element, " + hint);
         }
     }
     return node;
@@ -109,9 +112,10 @@ XMLAttribute(const std::string attributeName, const pugi::xml_node &node,
     {
         const std::string nodeName(node.name());
 
-        throw std::invalid_argument("ERROR: XML: No attribute " +
-                                    attributeName + " found on <" + nodeName +
-                                    "> element" + hint);
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosXMLUtil", "XMLAttribute",
+            "No attribute " + attributeName + " found on <" + nodeName +
+                "> element" + hint);
     }
     return attribute;
 }

--- a/source/adios2/helper/adiosYAML.cpp
+++ b/source/adios2/helper/adiosYAML.cpp
@@ -30,16 +30,19 @@ YAML::Node YAMLNode(const std::string nodeName, const YAML::Node &upperNode,
 
     if (isMandatory && !node)
     {
-        throw std::invalid_argument(
-            "ERROR: YAML: no " + nodeName +
-            " node found, (is your node key lower case?), " + hint);
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosYAML", "YAMLNode",
+            "no " + nodeName + " node found, (is your node key lower case?), " +
+                hint);
     }
     if (node && node.Type() != nodeType)
     {
-        throw std::invalid_argument("ERROR: YAML: node " + nodeName +
-                                    " is the wrong type, review adios2 "
-                                    "config YAML specs for the node, " +
-                                    hint);
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosYAML", "YAMLNode",
+            "node " + nodeName +
+                " is the wrong type, review adios2 "
+                "config YAML specs for the node, " +
+                hint);
     }
     return node;
 }
@@ -54,9 +57,10 @@ Params YAMLNodeMapToParams(const YAML::Node &node, const std::string &hint)
         auto it = parameters.emplace(key, value);
         if (!it.second)
         {
-            throw std::invalid_argument(
-                "ERROR: YAML: found duplicated key : " + key +
-                ", keys must be unique in a YAML node, " + hint);
+            helper::Throw<std::invalid_argument>(
+                "Helper", "adiosYAML", "YAMLNodeMapToParams",
+                "found duplicated key : " + key +
+                    ", keys must be unique in a YAML node, " + hint);
         }
     }
     return parameters;
@@ -173,11 +177,12 @@ void ParseConfigYAML(core::ADIOS &adios, const std::string &configFileYAML,
 
     if (!document)
     {
-        throw std::invalid_argument(
-            "ERROR: YAML: parser error in file " + configFileYAML +
-            " invalid format check with any YAML editor if format is "
-            "ill-formed, " +
-            hint + "\n");
+        helper::Throw<std::invalid_argument>(
+            "Helper", "adiosYAML", "ParseConfigYAML",
+            "parser error in file " + configFileYAML +
+                " invalid format check with any YAML editor if format is "
+                "ill-formed, " +
+                hint);
     }
 
     for (auto itNode = document.begin(); itNode != document.end(); ++itNode)

--- a/source/adios2/operator/callback/Signature1.cpp
+++ b/source/adios2/operator/callback/Signature1.cpp
@@ -7,7 +7,9 @@
  *  Created on: Oct 19, 2017
  *      Author: William F Godoy godoywf@ornl.gov
  */
+
 #include "Signature1.h"
+#include "adios2/helper/adiosLog.h"
 
 namespace adios2
 {
@@ -43,9 +45,10 @@ ADIOS2_FOREACH_STDTYPE_2ARGS(declare_type)
         }                                                                      \
         else                                                                   \
         {                                                                      \
-            throw std::runtime_error("ERROR: Signature1 with type " +          \
-                                     std::string(#L) +                         \
-                                     " callback function failed\n");           \
+            helper::Throw<std::runtime_error>(                                 \
+                "Operator", "Signature1", "RunCallback1",                      \
+                "Signature1 with type " + std::string(#L) +                    \
+                    " callback function failed");                              \
         }                                                                      \
     }
 ADIOS2_FOREACH_STDTYPE_2ARGS(declare_type)

--- a/source/adios2/operator/callback/Signature2.cpp
+++ b/source/adios2/operator/callback/Signature2.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "Signature2.h"
+#include "adios2/helper/adiosLog.h"
 
 namespace adios2
 {
@@ -38,8 +39,9 @@ void Signature2::RunCallback2(void *arg1, const std::string &arg2,
     }
     else
     {
-        throw std::runtime_error(
-            "ERROR: callback function of Signature2 type failed\n");
+        helper::Throw<std::runtime_error>(
+            "Operator", "Signature2", "RunCallback2",
+            "callback function of Signature2 type failed");
     }
 }
 

--- a/source/adios2/operator/compress/CompressBZIP2.cpp
+++ b/source/adios2/operator/compress/CompressBZIP2.cpp
@@ -66,12 +66,13 @@ size_t CompressBZIP2::Operate(const char *dataIn, const Dims &blockStart,
                                      hint);
         if (blockSize100k < 1 || blockSize100k > 9)
         {
-            throw std::invalid_argument(
-                "ERROR: BlockSize100K must be an "
+            helper::Throw<std::invalid_argument>(
+                "Operator", "CompressBZIP2", "Operate",
+                "BlockSize100K must be an "
                 "integer between 1 (less "
                 "compression, less memory) and 9 "
                 "(more compression, more memory) inclusive, " +
-                hint);
+                    hint);
         }
     }
 
@@ -133,7 +134,9 @@ size_t CompressBZIP2::InverseOperate(const char *bufferIn, const size_t sizeIn,
     }
     else
     {
-        throw("unknown bzip2 buffer version");
+        helper::Throw<std::runtime_error>("Operator", "CompressBZIP2",
+                                          "InverseOperate",
+                                          "unknown bzip2 buffer version");
     }
 
     return 0;
@@ -193,7 +196,9 @@ size_t CompressBZIP2::DecompressV1(const char *bufferIn, const size_t sizeIn,
 
     if (expectedSizeOut != sizeOut)
     {
-        throw("corrupted bzip2 buffer");
+        helper::Throw<std::runtime_error>("Operator", "CompressBZIP2",
+                                          "DecompressV1",
+                                          "corrupted bzip2 buffer");
     }
 
     return sizeOut;
@@ -204,43 +209,54 @@ void CompressBZIP2::CheckStatus(const int status, const std::string hint) const
     switch (status)
     {
     case (BZ_CONFIG_ERROR):
-        throw std::invalid_argument(
-            "ERROR: BZ_CONFIG_ERROR, BZIP2 library is not configured "
+        helper::Throw<std::invalid_argument>(
+            "Operator", "CompressBZIP2", "CheckStatus",
+            "BZ_CONFIG_ERROR, BZIP2 library is not configured "
             "correctly" +
-            hint);
+                hint);
 
     case (BZ_PARAM_ERROR):
-        throw std::invalid_argument(
-            "ERROR: BZ_PARAM_ERROR bufferOut stream might be null" + hint);
+        helper::Throw<std::invalid_argument>(
+            "Operator", "CompressBZIP2", "CheckStatus",
+            "BZ_PARAM_ERROR bufferOut stream might be null" + hint);
 
     case (BZ_MEM_ERROR):
-        throw std::ios_base::failure(
-            "ERROR: BZ_MEM_ERROR BZIP2 detected insufficient memory " + hint);
+        helper::Throw<std::ios_base::failure>(
+            "Operator", "CompressBZIP2", "CheckStatus",
+            "BZ_MEM_ERROR BZIP2 detected insufficient memory " + hint);
 
     case (BZ_OUTBUFF_FULL):
-        throw std::ios_base::failure("ERROR: BZ_OUTBUFF_FULL BZIP2 detected "
-                                     "size of compressed data is larger than "
-                                     "destination length " +
-                                     hint);
+        helper::Throw<std::ios_base::failure>(
+            "Operator", "CompressBZIP2", "CheckStatus",
+            "BZ_OUTBUFF_FULL BZIP2 detected "
+            "size of compressed data is larger than "
+            "destination length " +
+                hint);
 
     // decompression
     case (BZ_DATA_ERROR):
-        throw std::invalid_argument("ERROR: BZ_DATA_ERROR, BZIP2 library "
-                                    "detected integrity errors in compressed "
-                                    "data " +
-                                    hint);
+        helper::Throw<std::invalid_argument>(
+            "Operator", "CompressBZIP2", "CheckStatus",
+            "BZ_DATA_ERROR, BZIP2 library "
+            "detected integrity errors in compressed "
+            "data " +
+                hint);
 
     case (BZ_DATA_ERROR_MAGIC):
-        throw std::invalid_argument("ERROR: BZ_DATA_ERROR_MAGIC, BZIP2 library "
-                                    "detected wrong magic numbers in "
-                                    "compressed data " +
-                                    hint);
+        helper::Throw<std::invalid_argument>(
+            "Operator", "CompressBZIP2", "CheckStatus",
+            "BZ_DATA_ERROR_MAGIC, BZIP2 library "
+            "detected wrong magic numbers in "
+            "compressed data " +
+                hint);
 
     case (BZ_UNEXPECTED_EOF):
-        throw std::invalid_argument("ERROR: BZ_UNEXPECTED_EOF, BZIP2 library "
-                                    "detected unexpected end of "
-                                    "compressed data " +
-                                    hint);
+        helper::Throw<std::invalid_argument>("Operator", "CompressBZIP2",
+                                             "CheckStatus",
+                                             "BZ_UNEXPECTED_EOF, BZIP2 library "
+                                             "detected unexpected end of "
+                                             "compressed data " +
+                                                 hint);
     default:
         break;
     }

--- a/source/adios2/operator/compress/CompressPNG.cpp
+++ b/source/adios2/operator/compress/CompressPNG.cpp
@@ -71,11 +71,12 @@ size_t CompressPNG::Operate(const char *dataIn, const Dims &blockStart,
 
     if (ndims != 3 && ndims != 2)
     {
-        throw std::invalid_argument(
-            "ERROR: image number of dimensions " + std::to_string(ndims) +
-            " is invalid, must be 2 {height,width*bytes_per_pixel} or 3"
-            " {height,width,bytes_per_pixel]} , in call to ADIOS2 PNG "
-            " compression\n");
+        helper::Throw<std::invalid_argument>(
+            "Operator", "CompressPNG", "Operate",
+            "image number of dimensions " + std::to_string(ndims) +
+                " is invalid, must be 2 {height,width*bytes_per_pixel} or 3"
+                " {height,width,bytes_per_pixel]} , in call to ADIOS2 PNG "
+                " compression");
     }
 
     // defaults
@@ -96,12 +97,13 @@ size_t CompressPNG::Operate(const char *dataIn, const Dims &blockStart,
 
             if (compressionLevel < 1 || compressionLevel > 9)
             {
-                throw std::invalid_argument(
-                    "ERROR: compression_level must be an "
+                helper::Throw<std::invalid_argument>(
+                    "Operator", "CompressPNG", "Operate",
+                    "compression_level must be an "
                     "integer between 1 (less "
                     "compression, less memory) and 9 "
                     "(more compression, more memory) inclusive, in call to "
-                    "ADIOS2 PNG Compress\n");
+                    "ADIOS2 PNG Compress");
             }
         }
         else if (key == "color_type")
@@ -110,9 +112,10 @@ size_t CompressPNG::Operate(const char *dataIn, const Dims &blockStart,
 
             if (itColorType == m_ColorTypes.end())
             {
-                throw std::invalid_argument(
-                    "ERROR: invalid color_type, see PNG_COLOR_TYPE_* for "
-                    "available types, in call to ADIOS2 PNG Compress\n");
+                helper::Throw<std::invalid_argument>(
+                    "Operator", "CompressPNG", "Operate",
+                    "invalid color_type, see PNG_COLOR_TYPE_* for "
+                    "available types, in call to ADIOS2 PNG Compress");
             }
 
             colorTypeStr = itColorType->first;
@@ -127,11 +130,12 @@ size_t CompressPNG::Operate(const char *dataIn, const Dims &blockStart,
 
     if (m_BitDepths.at(colorTypeStr).count(static_cast<int32_t>(bitDepth)) == 0)
     {
-        throw std::invalid_argument(
-            "ERROR: bit_depth " + std::to_string(bitDepth) +
-            " and color_type " + colorTypeStr +
-            " combination is not allowed by libpng, in call to ADIOS2 PNG "
-            "compression\n");
+        helper::Throw<std::invalid_argument>(
+            "Operator", "CompressPNG", "Operate",
+            "bit_depth " + std::to_string(bitDepth) + " and color_type " +
+                colorTypeStr +
+                " combination is not allowed by libpng, in call to ADIOS2 PNG "
+                "compression");
     }
 
     png_structp pngWrite = png_create_write_struct(PNG_LIBPNG_VER_STRING,
@@ -151,8 +155,9 @@ size_t CompressPNG::Operate(const char *dataIn, const Dims &blockStart,
 
     if (setjmp(png_jmpbuf(pngWrite)))
     {
-        throw std::invalid_argument(
-            "ERROR: libpng detected an error in ADIOS2 PNG Compress\n");
+        helper::Throw<std::invalid_argument>(
+            "Operator", "CompressPNG", "Operate",
+            "libpng detected an error in ADIOS2 PNG Compress");
     }
 
     png_set_compression_level(pngWrite, compressionLevel);
@@ -210,7 +215,9 @@ size_t CompressPNG::InverseOperate(const char *bufferIn, const size_t sizeIn,
     }
     else
     {
-        throw("unknown png buffer version");
+        helper::Throw<std::invalid_argument>("Operator", "CompressPNG",
+                                             "InverseOperate",
+                                             "unknown png buffer version");
     }
 
     return 0;
@@ -245,20 +252,22 @@ size_t CompressPNG::DecompressV1(const char *bufferIn, const size_t sizeIn,
 
     if (result == 0)
     {
-        throw std::runtime_error(
-            "ERROR: png_image_begin_read_from_memory failed in call "
+        helper::Throw<std::runtime_error>(
+            "Operator", "CompressPNG", "DecompressV1",
+            "png_image_begin_read_from_memory failed in call "
             "to ADIOS2 PNG Decompress." +
-            m_VersionInfo + "\n");
+                m_VersionInfo);
     }
 
     // TODO might be needed from parameters?
     result = png_image_finish_read(&image, nullptr, dataOut, 0, nullptr);
     if (result == 0)
     {
-        throw std::runtime_error(
-            "ERROR: png_image_finish_read_from_memory failed in call "
+        helper::Throw<std::runtime_error>(
+            "Operator", "CompressPNG", "DecompressV1",
+            "png_image_finish_read_from_memory failed in call "
             "to ADIOS2 PNG Decompress." +
-            m_VersionInfo + "\n");
+                m_VersionInfo);
     }
     return outSize;
 }

--- a/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
@@ -9,6 +9,7 @@
  */
 #include "MPIChain.h"
 
+#include "adios2/helper/adiosLog.h"
 #include "adios2/toolkit/format/buffer/heap/BufferSTL.h"
 
 namespace adios2
@@ -117,8 +118,9 @@ MPIChain::IExchangeAbsolutePosition(format::Buffer &buffer, const int step)
 
     if (m_IsInExchangeAbsolutePosition)
     {
-        throw std::runtime_error("ERROR: MPIChain::IExchangeAbsolutePosition: "
-                                 "An existing exchange is still active.");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "aggregator::mpi::MPIChain", "IExchangeAbsolutePosition",
+            "An existing exchange is still active");
     }
 
     const int destination = (step != m_Size - 1) ? step + 1 : 0;
@@ -190,8 +192,9 @@ void MPIChain::WaitAbsolutePosition(ExchangeAbsolutePositionRequests &requests,
 
     if (!m_IsInExchangeAbsolutePosition)
     {
-        throw std::runtime_error("ERROR: MPIChain::WaitAbsolutePosition: An "
-                                 "existing exchange is not active.");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "aggregator::mpi::MPIChain", "WaitAbsolutePosition",
+            "An existing exchange is not active");
     }
 
     const int destination = (step != m_Size - 1) ? step + 1 : 0;
@@ -285,11 +288,12 @@ void MPIChain::ResizeUpdateBuffer(const size_t newSize, format::Buffer &buffer,
     {
         if (newSize > buffer.m_FixedSize)
         {
-            throw std::invalid_argument(
-                "ERROR: requesting new size: " + std::to_string(newSize) +
-                " bytes, for fixed size buffer " +
-                std::to_string(buffer.m_FixedSize) + " of type " +
-                buffer.m_Type + ", allocate more memory\n");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "aggregator::mpi::MPIChain", "ResizeUpdateBuffer",
+                "requesting new size: " + std::to_string(newSize) +
+                    " bytes, for fixed size buffer " +
+                    std::to_string(buffer.m_FixedSize) + " of type " +
+                    buffer.m_Type + ", allocate more memory");
         }
         return; // do nothing if fixed size is enough
     }

--- a/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
@@ -218,8 +218,9 @@ void MPIShmChain::CreateShm(size_t blocksize, const size_t maxsegmentsize)
 {
     if (!m_Comm.IsMPI())
     {
-        throw std::runtime_error("Coding Error: MPIShmChain::CreateShm was "
-                                 "called with a non-MPI communicator");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "aggregator::mpi::MPIShmChain", "CreateShm",
+            "called with a non-MPI communicator");
     }
     char *ptr;
     size_t structsize = sizeof(ShmSegment);

--- a/source/adios2/toolkit/burstbuffer/FileDrainer.cpp
+++ b/source/adios2/toolkit/burstbuffer/FileDrainer.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "FileDrainer.h"
+#include "adios2/helper/adiosLog.h"
 
 #include <chrono>
 #include <cstdio>
@@ -108,9 +109,9 @@ void FileDrainer::AddOperationOpen(const std::string &toFileName, Mode mode)
     }
     else
     {
-        throw std::runtime_error(
-            "ADIOS Coding ERROR: FileDrainer::AddOperationOpen() only supports "
-            "Write and Append modes\n");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "BurstBuffer::FileDrainer", "AddOperationOpen",
+            "only supports Write and Append modes");
     }
 }
 
@@ -245,11 +246,13 @@ std::pair<size_t, double> FileDrainer::Read(InputFile &f, size_t count,
             }
             else
             {
-                throw std::ios_base::failure(
+                helper::Throw<std::ios_base::failure>(
+                    "Toolkit", "BurstBuffer::FileDrainer", "Read",
                     "FileDrainer couldn't read from file " + path +
-                    " offset = " + std::to_string(currentOffset) +
-                    " count = " + std::to_string(count) + " bytes but only " +
-                    std::to_string(totalRead + readSize) + ".\n");
+                        " offset = " + std::to_string(currentOffset) +
+                        " count = " + std::to_string(count) +
+                        " bytes but only " +
+                        std::to_string(totalRead + readSize));
             }
         }
         buffer += readSize;
@@ -266,9 +269,10 @@ size_t FileDrainer::Write(OutputFile &f, size_t count, const char *buffer,
 
     if (f->bad())
     {
-        throw std::ios_base::failure(
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "BurstBuffer::FileDrainer", "Write",
             "FileDrainer couldn't write to file " + path +
-            " count = " + std::to_string(count) + " bytes\n");
+                " count = " + std::to_string(count) + " bytes");
     }
 
     return count;

--- a/source/adios2/toolkit/format/bp/BPBase.cpp
+++ b/source/adios2/toolkit/format/bp/BPBase.cpp
@@ -96,10 +96,11 @@ void BPBase::Init(const Params &parameters, const std::string hint,
             if (parsedParameters.InitialBufferSize <
                 DefaultInitialBufferSize) // 16384b
             {
-                throw std::invalid_argument(
-                    "ERROR: wrong value for Parameter key=InitialBufferSize, "
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "format::bp::BPBase", "Init",
+                    "wrong value for Parameter key=InitialBufferSize, "
                     "it must be larger than 16Kb (minimum default), " +
-                    hint);
+                        hint);
             }
         }
         else if (key == "maxbuffersize")
@@ -125,10 +126,11 @@ void BPBase::Init(const Params &parameters, const std::string hint,
                     value, " in Parameter key=StatsLevel " + hint));
             if (parsedParameters.StatsLevel > 5)
             {
-                throw std::invalid_argument(
-                    "ERROR: value for Parameter key=StatsLevel must be "
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "format::bp::BPBase", "Init",
+                    "value for Parameter key=StatsLevel must be "
                     "an integer in the range [0,5], " +
-                    hint);
+                        hint);
             }
         }
         else if (key == "statsblocksize")
@@ -170,11 +172,12 @@ void BPBase::Init(const Params &parameters, const std::string hint,
                 int n = m_SizeMPI / ratio;
                 if ((m_SizeMPI % ratio))
                 {
-                    throw std::invalid_argument(
-                        "ERROR: value for Parameter key=AggregatorRatio=" +
-                        std::to_string(ratio) + " must be " +
-                        "an integer divisor of the number of processes=" +
-                        std::to_string(m_SizeMPI) + " " + hint);
+                    helper::Throw<std::invalid_argument>(
+                        "Toolkit", "format::bp::BPBase", "Init",
+                        "value for Parameter key=AggregatorRatio=" +
+                            std::to_string(ratio) + " must be " +
+                            "an integer divisor of the number of processes=" +
+                            std::to_string(m_SizeMPI) + " " + hint);
                 }
 
                 if (n < 1)
@@ -287,14 +290,16 @@ BPBase::ResizeResult BPBase::ResizeBuffer(const size_t dataIn,
 
     if (dataIn > maxBufferSize)
     {
-        throw std::runtime_error(
-            "ERROR: data size: " +
-            std::to_string(static_cast<float>(dataIn) / (1024. * 1024.)) +
-            " Mb is too large for adios2 bp MaxBufferSize=" +
-            std::to_string(static_cast<float>(maxBufferSize) /
-                           (1024. * 1024.)) +
-            "Mb, try increasing MaxBufferSize in call to IO SetParameters " +
-            hint + "\n");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BPBase", "ResizeBuffer",
+            "data size: " +
+                std::to_string(static_cast<float>(dataIn) / (1024. * 1024.)) +
+                " Mb is too large for adios2 bp MaxBufferSize=" +
+                std::to_string(static_cast<float>(maxBufferSize) /
+                               (1024. * 1024.)) +
+                "Mb, try increasing MaxBufferSize in call to IO "
+                "SetParameters " +
+                hint);
     }
 
     if (requiredSize <= currentSize)

--- a/source/adios2/toolkit/format/bp/BPBase.tcc
+++ b/source/adios2/toolkit/format/bp/BPBase.tcc
@@ -173,9 +173,9 @@ BPBase::ParseCharacteristics(const std::vector<char> &buffer, size_t &position,
         }
         default:
         {
-            throw std::invalid_argument("ERROR: characteristic ID " +
-                                        std::to_string(id) +
-                                        " not supported\n");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BPBase", "ParseCharacteristics",
+                "characteristic ID " + std::to_string(id) + " not supported");
         }
 
         } // end id switch
@@ -465,9 +465,10 @@ inline void BPBase::ParseCharacteristics(const std::vector<char> &buffer,
                 }
                 case (statistic_hist):
                 {
-                    throw std::invalid_argument(
-                        "ERROR: ADIOS2 default engine doesn't support "
-                        "histogram statistics\n");
+                    helper::Throw<std::invalid_argument>(
+                        "Toolkit", "format::bp::BPBase", "ParseCharacteristics",
+                        "ADIOS2 default engine doesn't support "
+                        "histogram statistics");
                 }
                 case (statistic_cnt):
                 {
@@ -529,9 +530,9 @@ inline void BPBase::ParseCharacteristics(const std::vector<char> &buffer,
 
         default:
         {
-            throw std::invalid_argument("ERROR: characteristic ID " +
-                                        std::to_string(id) +
-                                        " not supported\n");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BPBase", "ParseCharacteristics",
+                "characteristic ID " + std::to_string(id) + " not supported");
         }
 
         } // end switch

--- a/source/adios2/toolkit/format/bp/BPSerializer.cpp
+++ b/source/adios2/toolkit/format/bp/BPSerializer.cpp
@@ -341,9 +341,11 @@ void BPSerializer::UpdateOffsetsInMetadata()
 
             default:
                 // TODO: complex, long double
-                throw std::invalid_argument(
-                    "ERROR: type " + std::to_string(header.DataType) +
-                    " not supported in updating aggregated offsets\n");
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "format::bp::BPSerializer",
+                    "UpdateOffsetsInMetadata",
+                    "type " + std::to_string(header.DataType) +
+                        " not supported in updating aggregated offsets");
 
             } // end switch
         }
@@ -408,9 +410,10 @@ void BPSerializer::MergeSerializeIndices(
         }
 
         default:
-            throw std::invalid_argument(
-                "ERROR: type " + std::to_string(dataType) +
-                " not supported in BP3 Metadata Merge\n");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BPSerializer", "MergeSerializeIndices",
+                "type " + std::to_string(dataType) +
+                    " not supported in BP3 Metadata Merge");
 
         } // end switch
     };
@@ -451,9 +454,11 @@ void BPSerializer::MergeSerializeIndices(
 
             if (header.DataType == std::numeric_limits<uint8_t>::max() - 1)
             {
-                throw std::runtime_error(
-                    "ERROR: invalid data type for variable " + header.Name +
-                    "when writing metadata index\n");
+                helper::Throw<std::runtime_error>(
+                    "Toolkit", "format::bp::BPSerializer",
+                    "MergeSerializeIndices",
+                    "invalid data type for variable " + header.Name +
+                        "when writing metadata index");
             }
 
             // move all positions to headerSize
@@ -568,9 +573,10 @@ void BPSerializer::MergeSerializeIndices(
 
         if (header.DataType == std::numeric_limits<uint8_t>::max() - 1)
         {
-            throw std::runtime_error("ERROR: invalid data type for variable " +
-                                     header.Name +
-                                     "when writing collective metadata\n");
+            helper::Throw<std::runtime_error>(
+                "Toolkit", "format::bp::BPSerializer", "MergeSerializeIndices",
+                "invalid data type for variable " + header.Name +
+                    "when writing collective metadata");
         }
 
         // move all positions to headerSize

--- a/source/adios2/toolkit/format/bp/BPSerializer.tcc
+++ b/source/adios2/toolkit/format/bp/BPSerializer.tcc
@@ -248,9 +248,11 @@ void BPSerializer::UpdateIndexOffsetsCharacteristics(size_t &currentPosition,
         }
         default:
         {
-            throw std::invalid_argument(
-                "ERROR: characteristic ID " + std::to_string(id) +
-                " not supported when updating offsets\n");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BPSerializer",
+                "UpdateIndexOffsetsCharacteristics",
+                "characteristic ID " + std::to_string(id) +
+                    " not supported when updating offsets");
         }
 
         } // end id switch

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
@@ -83,17 +83,19 @@ void BP3Deserializer::ParseMinifooter(const BufferSTL &bufferSTL)
             std::to_string(endianness) +
             "), this indicates the the file is either corrupted, or not a .bp "
             "file.";
-        throw std::runtime_error(err);
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP3Deserializer", "ParseMinifooter", err);
     }
     m_Minifooter.IsLittleEndian = (endianness == 0) ? true : false;
 #ifndef ADIOS2_HAVE_ENDIAN_REVERSE
     if (helper::IsLittleEndian() != m_Minifooter.IsLittleEndian)
     {
-        throw std::runtime_error(
-            "ERROR: reader found BigEndian bp file, "
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP3Deserializer", "ParseMinifooter",
+            "reader found BigEndian bp file, "
             "this version of ADIOS2 wasn't compiled "
             "with the cmake flag -DADIOS2_USE_Endian_Reverse=ON "
-            "explicitly, in call to Open\n");
+            "explicitly, in call to Open");
     }
 #endif
 
@@ -114,10 +116,11 @@ void BP3Deserializer::ParseMinifooter(const BufferSTL &bufferSTL)
         buffer, position, m_Minifooter.IsLittleEndian);
     if (m_Minifooter.Version < 3)
     {
-        throw std::runtime_error("ERROR: ADIOS2 only supports bp format "
-                                 "version 3 and above, found " +
-                                 std::to_string(m_Minifooter.Version) +
-                                 " version \n");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP3Deserializer", "ParseMinifooter",
+            "ADIOS2 only supports bp format "
+            "version 3 and above, found " +
+                std::to_string(m_Minifooter.Version) + " version");
     }
 
     position = bufferSize - m_MetadataSet.MiniFooterSize;

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
@@ -61,12 +61,13 @@ BP3Deserializer::InitVariableBlockInfo(core::Variable<T> &variable,
     const size_t maxStep = indices.rbegin()->first;
     if (stepsStart + 1 > maxStep)
     {
-        throw std::invalid_argument(
-            "ERROR: steps start " + std::to_string(stepsStart) +
-            " from SetStepsSelection or BeginStep is larger than "
-            "the maximum available step " +
-            std::to_string(maxStep - 1) + " for variable " + variable.m_Name +
-            ", in call to Get\n");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "format::bp::BP3Deserializer", "InitVariableBlockInfo",
+            "steps start " + std::to_string(stepsStart) +
+                " from SetStepsSelection or BeginStep is larger than "
+                "the maximum available step " +
+                std::to_string(maxStep - 1) + " for variable " +
+                variable.m_Name + ", in call to Get");
     }
 
     auto itStep = std::next(indices.begin(), stepsStart);
@@ -78,14 +79,17 @@ BP3Deserializer::InitVariableBlockInfo(core::Variable<T> &variable,
     {
         if (itStep == indices.end())
         {
-            throw std::invalid_argument(
-                "ERROR: offset " + std::to_string(i) + " from steps start " +
-                std::to_string(stepsStart) + " in variable " + variable.m_Name +
-                " is beyond the largest available step = " +
-                std::to_string(maxStep - 1) +
-                ", check Variable SetStepSelection argument stepsCount "
-                "(random access), or "
-                "number of BeginStep calls (streaming), in call to Get");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP3Deserializer",
+                "InitVariableBlockInfo",
+                "offset " + std::to_string(i) + " from steps start " +
+                    std::to_string(stepsStart) + " in variable " +
+                    variable.m_Name +
+                    " is beyond the largest available step = " +
+                    std::to_string(maxStep - 1) +
+                    ", check Variable SetStepSelection argument stepsCount "
+                    "(random access), or "
+                    "number of BeginStep calls (streaming), in call to Get");
         }
         ++itStep;
     }
@@ -100,12 +104,14 @@ BP3Deserializer::InitVariableBlockInfo(core::Variable<T> &variable,
 
         if (variable.m_BlockID >= blocksInfo.size())
         {
-            throw std::invalid_argument(
-                "ERROR: invalid blockID " + std::to_string(variable.m_BlockID) +
-                " from steps start " + std::to_string(stepsStart) +
-                " in variable " + variable.m_Name +
-                ", check argument to Variable<T>::SetBlockID, in call "
-                "to Get\n");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP3Deserializer",
+                "InitVariableBlockInfo",
+                "invalid blockID " + std::to_string(variable.m_BlockID) +
+                    " from steps start " + std::to_string(stepsStart) +
+                    " in variable " + variable.m_Name +
+                    ", check argument to Variable<T>::SetBlockID, in call "
+                    "to Get");
         }
 
         // switch to bounding box for global array
@@ -202,12 +208,14 @@ void BP3Deserializer::SetVariableBlockInfo(
         const size_t dimensions = blockCharacteristics.Count.size();
         if (dimensions != blockInfo.Count.size())
         {
-            throw std::invalid_argument(
-                "ERROR: block Count (available) and "
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP3Deserializer",
+                "SetVariableBlockInfo",
+                "block Count (available) and "
                 "selection Count (requested) number of dimensions, do not "
                 "match "
                 "when reading local array variable " +
-                variableName + ", in call to Get");
+                    variableName + ", in call to Get");
         }
 
         const Dims readInCount = m_ReverseDimensions
@@ -223,15 +231,16 @@ void BP3Deserializer::SetVariableBlockInfo(
         {
             if (blockInfoStart[i] + blockInfo.Count[i] > readInCount[i])
             {
-                throw std::invalid_argument(
-                    "ERROR: selection Start " +
-                    helper::DimsToString(blockInfoStart) + " and Count " +
-                    helper::DimsToString(blockInfo.Count) +
-                    " (requested) is out of bounds of (available) local"
-                    " Count " +
-                    helper::DimsToString(readInCount) +
-                    " , when reading local array variable " + variableName +
-                    ", in call to Get");
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "format::bp::BP3Deserializer",
+                    "SetVariableBlockInfo",
+                    "selection Start " + helper::DimsToString(blockInfoStart) +
+                        " and Count " + helper::DimsToString(blockInfo.Count) +
+                        " (requested) is out of bounds of (available) local"
+                        " Count " +
+                        helper::DimsToString(readInCount) +
+                        " , when reading local array variable " + variableName +
+                        ", in call to Get");
             }
         }
 
@@ -361,28 +370,33 @@ void BP3Deserializer::SetVariableBlockInfo(
             const size_t dimensions = readInShape.size();
             if (dimensions != blockInfo.Shape.size())
             {
-                throw std::invalid_argument(
-                    "ERROR: block Shape (available) and "
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "format::bp::BP3Deserializer",
+                    "SetVariableBlockInfo",
+                    "block Shape (available) and "
                     "selection Shape (requested) number of dimensions, do not "
                     "match in step " +
-                    std::to_string(step) +
-                    "when reading global array variable " + variable.m_Name +
-                    ", in call to Get");
+                        std::to_string(step) +
+                        "when reading global array variable " +
+                        variable.m_Name + ", in call to Get");
             }
 
             for (size_t i = 0; i < dimensions; ++i)
             {
                 if (blockInfo.Start[i] + blockInfo.Count[i] > readInShape[i])
                 {
-                    throw std::invalid_argument(
-                        "ERROR: selection Start " +
-                        helper::DimsToString(blockInfo.Start) + " and Count " +
-                        helper::DimsToString(blockInfo.Count) +
-                        " (requested) is out of bounds of (available) "
-                        "Shape " +
-                        helper::DimsToString(readInShape) +
-                        " , when reading global array variable " +
-                        variable.m_Name + ", in call to Get");
+                    helper::Throw<std::invalid_argument>(
+                        "Toolkit", "format::bp::BP3Deserializer",
+                        "SetVariableBlockInfo",
+                        "selection Start " +
+                            helper::DimsToString(blockInfo.Start) +
+                            " and Count " +
+                            helper::DimsToString(blockInfo.Count) +
+                            " (requested) is out of bounds of (available) "
+                            "Shape " +
+                            helper::DimsToString(readInShape) +
+                            " , when reading global array variable " +
+                            variable.m_Name + ", in call to Get");
                 }
             }
             // Get intersections with each block
@@ -435,14 +449,16 @@ void BP3Deserializer::GetValueFromMetadata(core::Variable<T> &variable,
 
         if (blocksStart + blocksCount > positions.size())
         {
-            throw std::invalid_argument(
-                "ERROR: selection Start {" + std::to_string(blocksStart) +
-                "} and Count {" + std::to_string(blocksCount) +
-                "} (requested) is out of bounds of (available) Shape {" +
-                std::to_string(positions.size()) + "} for relative step " +
-                std::to_string(s) +
-                " , when reading 1D global array variable " + variable.m_Name +
-                ", in call to Get");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP3Deserializer",
+                "GetValueFromMetadata",
+                "selection Start {" + std::to_string(blocksStart) +
+                    "} and Count {" + std::to_string(blocksCount) +
+                    "} (requested) is out of bounds of (available) Shape {" +
+                    std::to_string(positions.size()) + "} for relative step " +
+                    std::to_string(s) +
+                    " , when reading 1D global array variable " +
+                    variable.m_Name + ", in call to Get");
         }
 
         for (size_t b = blocksStart; b < blocksStart + blocksCount; ++b)
@@ -537,14 +553,17 @@ void BP3Deserializer::PostDataRead(
     {
         if (endianReverse)
         {
-            throw std::invalid_argument("ERROR: endianReverse "
-                                        "not supported with MemorySelection");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP3Deserializer", "PostDataRead",
+                "endianReverse "
+                "not supported with MemorySelection");
         }
 
         if (m_ReverseDimensions)
         {
-            throw std::invalid_argument(
-                "ERROR: ReverseDimensions not supported with "
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP3Deserializer", "PostDataRead",
+                "ReverseDimensions not supported with "
                 "MemorySelection");
         }
 
@@ -676,10 +695,12 @@ inline void BP3Deserializer::DefineVariableInEngineIO<std::string>(
     }
     else
     {
-
-        throw std::runtime_error("ERROR: variable " + variableName +
-                                 " of type string can't be an array, when "
-                                 "parsing metadata in call to Open");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP3Deserializer",
+            "DefineVariableInEngineIO",
+            "variable " + variableName +
+                " of type string can't be an array, when "
+                "parsing metadata in call to Open");
     }
 
     // going back to get variable index position
@@ -805,9 +826,11 @@ void BP3Deserializer::DefineVariableInEngineIO(const ElementIndexHeader &header,
             break;
         }
         default:
-            throw std::runtime_error(
-                "ERROR: invalid ShapeID or not yet supported for variable " +
-                variableName + ", in call to Open\n");
+            helper::Throw<std::runtime_error>(
+                "Toolkit", "format::bp::BP3Deserializer",
+                "DefineVariableInEngineIO",
+                "invalid ShapeID or not yet supported for variable " +
+                    variableName + ", in call to Open");
         } // end switch
 
         if (characteristics.Statistics.IsValue)

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
@@ -102,11 +102,12 @@ void BP4Deserializer::ParseMetadataIndex(BufferSTL &bufferSTL,
 #ifndef ADIOS2_HAVE_ENDIAN_REVERSE
         if (helper::IsLittleEndian() != m_Minifooter.IsLittleEndian)
         {
-            throw std::runtime_error(
-                "ERROR: reader found BigEndian bp file, "
+            helper::Throw<std::runtime_error>(
+                "Toolkit", "format::bp::BP4Deserializer", "ParseMetadataIndex",
+                "reader found BigEndian bp file, "
                 "this version of ADIOS2 wasn't compiled "
                 "with the cmake flag -DADIOS2_USE_Endian_Reverse=ON "
-                "explicitly, in call to Open\n");
+                "explicitly, in call to Open");
         }
 #endif
 
@@ -119,10 +120,11 @@ void BP4Deserializer::ParseMetadataIndex(BufferSTL &bufferSTL,
             buffer, position, m_Minifooter.IsLittleEndian);
         if (m_Minifooter.Version != 4)
         {
-            throw std::runtime_error(
-                "ERROR: ADIOS2 BP4 Engine only supports bp format "
+            helper::Throw<std::runtime_error>(
+                "Toolkit", "format::bp::BP4Deserializer", "ParseMetadataIndex",
+                "ADIOS2 BP4 Engine only supports bp format "
                 "version 4, found " +
-                std::to_string(m_Minifooter.Version) + " version \n");
+                    std::to_string(m_Minifooter.Version) + " version");
         }
 
         // Writer active flag
@@ -226,10 +228,10 @@ const helper::BlockOperationInfo &BP4Deserializer::InitPostOperatorBlockData(
     m_Minifooter.Version = helper::ReadValue<uint8_t>(buffer, position);
     if (m_Minifooter.Version < 3)
     {
-        throw std::runtime_error("ERROR: ADIOS2 only supports bp format "
-                                 "version 3 and above, found " +
-                                 std::to_string(m_Minifooter.Version) +
-                                 " version \n");
+        helper::Throw<std::runtime_error>( "Toolkit",
+"format::bp::BP4Deserializer", "ParseMinifooter", "ADIOS2 only supports bp
+format " "version 3 and above, found " + std::to_string(m_Minifooter.Version) +
+                                 " version ");
     }
 
     position = bufferSize - m_MetadataSet.MiniFooterSize;
@@ -657,8 +659,9 @@ bool BP4Deserializer::ReadActiveFlag(std::vector<char> &buffer)
 {
     if (buffer.size() < m_ActiveFlagPosition)
     {
-        throw std::runtime_error("BP4Deserializer::ReadActiveFlag() is called "
-                                 "with a buffer smaller than required");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP4Deserializer", "ReadActiveFlag",
+            "called with a buffer smaller than required");
     }
     // Writer active flag
     size_t position = m_ActiveFlagPosition;

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -64,12 +64,13 @@ BP4Deserializer::InitVariableBlockInfo(core::Variable<T> &variable,
     const size_t maxStep = indices.rbegin()->first;
     if (stepsStart + 1 > maxStep)
     {
-        throw std::invalid_argument(
-            "ERROR: steps start " + std::to_string(stepsStart) +
-            " from SetStepsSelection or BeginStep is larger than "
-            "the maximum available step " +
-            std::to_string(maxStep - 1) + " for variable " + variable.m_Name +
-            ", in call to Get\n");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "format::bp::BP4Deserializer", "InitVariableBlockInfo",
+            "steps start " + std::to_string(stepsStart) +
+                " from SetStepsSelection or BeginStep is larger than "
+                "the maximum available step " +
+                std::to_string(maxStep - 1) + " for variable " +
+                variable.m_Name + ", in call to Get");
     }
 
     auto itStep = std::next(indices.begin(), stepsStart);
@@ -81,14 +82,17 @@ BP4Deserializer::InitVariableBlockInfo(core::Variable<T> &variable,
     {
         if (itStep == indices.end())
         {
-            throw std::invalid_argument(
-                "ERROR: offset " + std::to_string(i) + " from steps start " +
-                std::to_string(stepsStart) + " in variable " + variable.m_Name +
-                " is beyond the largest available step = " +
-                std::to_string(maxStep - 1) +
-                ", check Variable SetStepSelection argument stepsCount "
-                "(random access), or "
-                "number of BeginStep calls (streaming), in call to Get");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP4Deserializer",
+                "InitVariableBlockInfo",
+                "offset " + std::to_string(i) + " from steps start " +
+                    std::to_string(stepsStart) + " in variable " +
+                    variable.m_Name +
+                    " is beyond the largest available step = " +
+                    std::to_string(maxStep - 1) +
+                    ", check Variable SetStepSelection argument stepsCount "
+                    "(random access), or "
+                    "number of BeginStep calls (streaming), in call to Get");
         }
         ++itStep;
     }
@@ -103,12 +107,14 @@ BP4Deserializer::InitVariableBlockInfo(core::Variable<T> &variable,
 
         if (variable.m_BlockID >= blocksInfo.size())
         {
-            throw std::invalid_argument(
-                "ERROR: invalid blockID " + std::to_string(variable.m_BlockID) +
-                " from steps start " + std::to_string(stepsStart) +
-                " in variable " + variable.m_Name +
-                ", check argument to Variable<T>::SetBlockID, in call "
-                "to Get\n");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP4Deserializer",
+                "InitVariableBlockInfo",
+                "invalid blockID " + std::to_string(variable.m_BlockID) +
+                    " from steps start " + std::to_string(stepsStart) +
+                    " in variable " + variable.m_Name +
+                    ", check argument to Variable<T>::SetBlockID, in call "
+                    "to Get");
         }
 
         // switch to bounding box for global array
@@ -205,12 +211,14 @@ void BP4Deserializer::SetVariableBlockInfo(
         const size_t dimensions = blockCharacteristics.Count.size();
         if (dimensions != blockInfo.Count.size())
         {
-            throw std::invalid_argument(
-                "ERROR: block Count (available) and "
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP4Deserializer",
+                "SetVariableBlockInfo",
+                "block Count (available) and "
                 "selection Count (requested) number of dimensions, do not "
                 "match "
                 "when reading local array variable " +
-                variableName + ", in call to Get");
+                    variableName + ", in call to Get");
         }
 
         const Dims readInCount = m_ReverseDimensions
@@ -226,15 +234,16 @@ void BP4Deserializer::SetVariableBlockInfo(
         {
             if (blockInfoStart[i] + blockInfo.Count[i] > readInCount[i])
             {
-                throw std::invalid_argument(
-                    "ERROR: selection Start " +
-                    helper::DimsToString(blockInfoStart) + " and Count " +
-                    helper::DimsToString(blockInfo.Count) +
-                    " (requested) is out of bounds of (available) local"
-                    " Count " +
-                    helper::DimsToString(readInCount) +
-                    " , when reading local array variable " + variableName +
-                    ", in call to Get");
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "format::bp::BP4Deserializer",
+                    "SetVariableBlockInfo",
+                    "selection Start " + helper::DimsToString(blockInfoStart) +
+                        " and Count " + helper::DimsToString(blockInfo.Count) +
+                        " (requested) is out of bounds of (available) local"
+                        " Count " +
+                        helper::DimsToString(readInCount) +
+                        " , when reading local array variable " + variableName +
+                        ", in call to Get");
             }
         }
 
@@ -364,29 +373,34 @@ void BP4Deserializer::SetVariableBlockInfo(
             const size_t dimensions = readInShape.size();
             if (dimensions != blockInfo.Shape.size())
             {
-                throw std::invalid_argument(
-                    "ERROR: variable Shape (available) and "
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "format::bp::BP4Deserializer",
+                    "SetVariableBlockInfo",
+                    "variable Shape (available) and "
                     "selection Shape (requested) number of dimensions, do not "
                     "match in step " +
-                    std::to_string(step) +
-                    " when reading global array variable " + variable.m_Name +
-                    ", in call to Get");
+                        std::to_string(step) +
+                        " when reading global array variable " +
+                        variable.m_Name + ", in call to Get");
             }
 
             for (size_t i = 0; i < dimensions; ++i)
             {
                 if (blockInfo.Start[i] + blockInfo.Count[i] > readInShape[i])
                 {
-                    throw std::invalid_argument(
-                        "ERROR: selection Start " +
-                        helper::DimsToString(blockInfo.Start) + " and Count " +
-                        helper::DimsToString(blockInfo.Count) +
-                        " (requested) is out of bounds of (available) "
-                        "Shape " +
-                        helper::DimsToString(readInShape) +
-                        " , when reading global array variable " +
-                        variable.m_Name + " in step " + std::to_string(step) +
-                        ", in call to Get");
+                    helper::Throw<std::invalid_argument>(
+                        "Toolkit", "format::bp::BP4Deserializer",
+                        "SetVariableBlockInfo",
+                        "selection Start " +
+                            helper::DimsToString(blockInfo.Start) +
+                            " and Count " +
+                            helper::DimsToString(blockInfo.Count) +
+                            " (requested) is out of bounds of (available) "
+                            "Shape " +
+                            helper::DimsToString(readInShape) +
+                            " , when reading global array variable " +
+                            variable.m_Name + " in step " +
+                            std::to_string(step) + ", in call to Get");
                 }
             }
             // Get intersections with each block
@@ -439,14 +453,16 @@ void BP4Deserializer::GetValueFromMetadata(core::Variable<T> &variable,
 
         if (blocksStart + blocksCount > positions.size())
         {
-            throw std::invalid_argument(
-                "ERROR: selection Start {" + std::to_string(blocksStart) +
-                "} and Count {" + std::to_string(blocksCount) +
-                "} (requested) is out of bounds of (available) Shape {" +
-                std::to_string(positions.size()) + "} for relative step " +
-                std::to_string(s) +
-                " , when reading 1D global array variable " + variable.m_Name +
-                ", in call to Get");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP4Deserializer",
+                "GetValueFromMetadata",
+                "selection Start {" + std::to_string(blocksStart) +
+                    "} and Count {" + std::to_string(blocksCount) +
+                    "} (requested) is out of bounds of (available) Shape {" +
+                    std::to_string(positions.size()) + "} for relative step " +
+                    std::to_string(s) +
+                    " , when reading 1D global array variable " +
+                    variable.m_Name + ", in call to Get");
         }
 
         for (size_t b = blocksStart; b < blocksStart + blocksCount; ++b)
@@ -698,9 +714,12 @@ inline void BP4Deserializer::DefineVariableInEngineIOPerStep<std::string>(
     }
     else
     {
-        throw std::runtime_error("ERROR: variable " + variableName +
-                                 " of type string can't be an array, when "
-                                 "parsing metadata in call to Open");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP4Deserializer",
+            "DefineVariableInEngineIOPerStep",
+            "variable " + variableName +
+                " of type string can't be an array, when "
+                "parsing metadata in call to Open");
     }
 
     // going back to get variable index position
@@ -902,9 +921,11 @@ void BP4Deserializer::DefineVariableInEngineIOPerStep(
             break;
         }
         default:
-            throw std::runtime_error(
-                "ERROR: invalid ShapeID or not yet supported for variable " +
-                variableName + ", in call to Open\n");
+            helper::Throw<std::runtime_error>(
+                "Toolkit", "format::bp::BP4Deserializer",
+                "DefineVariableInEngineIOPerStep",
+                "invalid ShapeID or not yet supported for variable " +
+                    variableName + ", in call to Open");
         } // end switch
 
         if (characteristics.Statistics.IsValue)

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
@@ -49,11 +49,12 @@ void BP4Serializer::MakeHeader(BufferSTL &b, const std::string fileType,
     auto &absolutePosition = b.m_AbsolutePosition;
     if (position > 0)
     {
-        throw std::invalid_argument(
-            "ERROR: BP4Serializer::MakeHeader can only be called for an empty "
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "format::bp::BP4Serializer", "MakeHeader",
+            "can only be called for an empty "
             "buffer. This one for " +
-            fileType + " already has content of " + std::to_string(position) +
-            " bytes.");
+                fileType + " already has content of " +
+                std::to_string(position) + " bytes.");
     }
 
     if (b.GetAvailableSize() < 64)
@@ -68,8 +69,9 @@ void BP4Serializer::MakeHeader(BufferSTL &b, const std::string fileType,
     // byte 0-31: Readable tag
     if (position != m_VersionTagPosition)
     {
-        throw std::runtime_error(
-            "ADIOS Coding ERROR in BP4Serializer::MakeHeader. Version Tag "
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP4Serializer", "MakeHeader",
+            "Version Tag "
             "position mismatch");
     }
     std::string versionLongTag("ADIOS-BP v" + majorVersion + "." +
@@ -109,8 +111,9 @@ void BP4Serializer::MakeHeader(BufferSTL &b, const std::string fileType,
     // byte 36: endianness
     if (position != m_EndianFlagPosition)
     {
-        throw std::runtime_error(
-            "ADIOS Coding ERROR in BP4Serializer::MakeHeader. Endian Flag "
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP4Serializer", "MakeHeader",
+            "Endian Flag "
             "position mismatch");
     }
     const uint8_t endianness = helper::IsLittleEndian() ? 0 : 1;
@@ -119,8 +122,9 @@ void BP4Serializer::MakeHeader(BufferSTL &b, const std::string fileType,
     // byte 37: BP Version 4
     if (position != m_BPVersionPosition)
     {
-        throw std::runtime_error(
-            "ADIOS Coding ERROR in BP4Serializer::MakeHeader. Active Flag "
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP4Serializer", "MakeHeader",
+            "Active Flag "
             "position mismatch");
     }
     const uint8_t version = 4;
@@ -129,8 +133,9 @@ void BP4Serializer::MakeHeader(BufferSTL &b, const std::string fileType,
     // byte 38: Active flag (used in Index Table only)
     if (position != m_ActiveFlagPosition)
     {
-        throw std::runtime_error(
-            "ADIOS Coding ERROR in BP4Serializer::MakeHeader. Active Flag "
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::bp::BP4Serializer", "MakeHeader",
+            "Active Flag "
             "position mismatch");
     }
     const uint8_t activeFlag = (isActive ? 1 : 0);
@@ -726,9 +731,11 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
         }
 
         default:
-            throw std::invalid_argument(
-                "ERROR: type " + std::to_string(dataType) +
-                " not supported in BP4 Metadata Merge\n");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP4Serializer",
+                "AggregateCollectiveMetadataIndices",
+                "type " + std::to_string(dataType) +
+                    " not supported in BP4 Metadata Merge");
 
         } // end switch
     };

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -494,8 +494,10 @@ void BP5Deserializer::InstallMetaData(void *MetadataBlock, size_t BlockLen,
         FFSTypeHandle_from_encode(ReaderFFSContext, (char *)MetadataBlock);
     if (!FFSformat)
     {
-        throw std::logic_error("Internal error or file corruption, no know "
-                               "format for Metadata Block");
+        helper::Throw<std::logic_error>("Toolkit", "format::BP5Deserializer",
+                                        "InstallMetaData",
+                                        "Internal error or file corruption, no "
+                                        "know format for Metadata Block");
     }
     if (!FFShas_conversion(FFSformat))
     {
@@ -743,8 +745,10 @@ void BP5Deserializer::InstallAttributeData(void *AttributeBlock,
         FFSTypeHandle_from_encode(ReaderFFSContext, (char *)AttributeBlock);
     if (!FFSformat)
     {
-        throw std::logic_error("Internal error or file corruption, no know "
-                               "format for Attribute Block");
+        helper::Throw<std::logic_error>(
+            "Toolkit", "format::BP5Deserializer", "InstallAttributeData",
+            "Internal error or file corruption, no know "
+            "format for Attribute Block");
     }
     if (!FFShas_conversion(FFSformat))
     {
@@ -882,16 +886,18 @@ bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData)
         if (variable.m_StepsStart + variable.m_StepsCount >
             variable.m_AvailableStepsCount)
         {
-            throw std::invalid_argument(
-                "ERROR: offset " + std::to_string(variable.m_StepsCount) +
-                " from steps start " + std::to_string(variable.m_StepsStart) +
-                " in variable " + variable.m_Name +
-                " is beyond the largest available step = " +
-                std::to_string(variable.m_AvailableStepsCount +
-                               variable.m_AvailableStepsStart) +
-                ", check Variable SetStepSelection argument stepsCount "
-                "(random access), or "
-                "number of BeginStep calls (streaming), in call to Get");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::BP5Deserializer", "QueueGet",
+                "offset " + std::to_string(variable.m_StepsCount) +
+                    " from steps start " +
+                    std::to_string(variable.m_StepsStart) + " in variable " +
+                    variable.m_Name +
+                    " is beyond the largest available step = " +
+                    std::to_string(variable.m_AvailableStepsCount +
+                                   variable.m_AvailableStepsStart) +
+                    ", check Variable SetStepSelection argument stepsCount "
+                    "(random access), or "
+                    "number of BeginStep calls (streaming)");
         }
         size_t Step = variable.m_AvailableStepsStart;
         size_t GotCount = 0;
@@ -1897,7 +1903,8 @@ bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
     {
         if (VarRec->MinMaxOffset == SIZE_MAX)
         {
-            throw std::logic_error(
+            helper::Throw<std::logic_error>(
+                "Toolkit", "format::BP5Deserializer", "VariableMinMax",
                 "Min or Max requests for Variable for which Min/Max was not "
                 "supplied by the writer.  Specify parameter StatsLevel > 0 to "
                 "include writer-side data statistics.");

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -673,8 +673,8 @@ void BP5Serializer::Marshal(void *Variable, const char *Name,
         MetaEntry->Dims = DimCount;
         if (CurDataBuffer == NULL)
         {
-            throw std::logic_error(
-                "BP5Serializer:: Marshall without Prior Init");
+            helper::Throw<std::logic_error>("Toolkit", "format::BP5Serializer",
+                                            "Marshal", "without prior Init");
         }
 
         MinMaxStruct MinMax;
@@ -876,7 +876,8 @@ void BP5Serializer::InitStep(BufferV *DataBuffer)
 {
     if (CurDataBuffer != NULL)
     {
-        throw std::logic_error("BP5Serializer:: InitStep without prior close");
+        helper::Throw<std::logic_error>("Toolkit", "format::BP5Serializer",
+                                        "InitStep", "without prior Close");
     }
     CurDataBuffer = DataBuffer;
     m_PriorDataBufferSizeTotal = 0;
@@ -886,7 +887,8 @@ BufferV *BP5Serializer::ReinitStepData(BufferV *DataBuffer)
 {
     if (CurDataBuffer == NULL)
     {
-        throw std::logic_error("BP5Serializer:: ReinitStep without prior Init");
+        helper::Throw<std::logic_error>("Toolkit", "format::BP5Serializer",
+                                        "ReinitStepData", "without prior Init");
     }
     //  Dump data for externs into iovec
     DumpDeferredBlocks();
@@ -960,8 +962,8 @@ BP5Serializer::TimestepInfo BP5Serializer::CloseTimestep(int timestep,
 
     if (CurDataBuffer == NULL)
     {
-        throw std::logic_error(
-            "BP5Serializer:: CloseTimestep without Prior Init");
+        helper::Throw<std::logic_error>("Toolkit", "format::BP5Serializer",
+                                        "CloseTimestep", "without prior Init");
     }
 
     //  Dump data for externs into iovec

--- a/source/adios2/toolkit/format/buffer/Buffer.cpp
+++ b/source/adios2/toolkit/format/buffer/Buffer.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "Buffer.h"
+#include "adios2/helper/adiosLog.h"
 
 namespace adios2
 {
@@ -22,14 +23,16 @@ Buffer::Buffer(const std::string type, const size_t fixedSize)
 
 void Buffer::Resize(const size_t size, const std::string hint)
 {
-    throw std::invalid_argument("ERROR: buffer memory of type " + m_Type +
-                                " can't call Resize " + hint + "\n");
+    helper::Throw<std::invalid_argument>("Toolkit", "format::Buffer", "Resize",
+                                         "buffer memory of type " + m_Type +
+                                             " can't call Resize " + hint);
 }
 
 void Buffer::Reset(const bool resetAbsolutePosition, const bool zeroInitialize)
 {
-    throw std::invalid_argument("ERROR: buffer memory of type " + m_Type +
-                                " can't call Reset\n");
+    helper::Throw<std::invalid_argument>("Toolkit", "format::Buffer", "Reset",
+                                         "buffer memory of type " + m_Type +
+                                             " can't call Reset");
 }
 
 char *Buffer::Data() noexcept { return nullptr; }
@@ -47,8 +50,9 @@ size_t Buffer::GetAvailableSize() const
 
 void Buffer::Delete()
 {
-    throw std::invalid_argument("ERROR: buffer memory of type " + m_Type +
-                                " can't call Delete\n");
+    helper::Throw<std::invalid_argument>("Toolkit", "format::Buffer", "Delete",
+                                         "buffer memory of type " + m_Type +
+                                             " can't call Delete");
 }
 
 } // end namespace format

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
@@ -228,10 +228,12 @@ void *ChunkV::GetPtr(int bufferIdx, size_t posInBuffer)
     else if (static_cast<size_t>(bufferIdx) > DataV.size() ||
              DataV[bufferIdx].External)
     {
-        throw std::invalid_argument(
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "format::ChunkV", "GetPtr",
             "ChunkV::GetPtr(" + std::to_string(bufferIdx) + ", " +
-            std::to_string(posInBuffer) +
-            ") refers to a non-existing or deferred memory chunk.");
+                std::to_string(posInBuffer) +
+                ") refers to a non-existing or deferred memory chunk.");
+        return nullptr;
     }
     else
     {

--- a/source/adios2/toolkit/format/buffer/ipc/BufferSystemV.cpp
+++ b/source/adios2/toolkit/format/buffer/ipc/BufferSystemV.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "BufferSystemV.h"
+#include "adios2/helper/adiosLog.h"
 
 #include <assert.h>
 #include <cstring> //std::memcpy
@@ -33,17 +34,20 @@ BufferSystemV::BufferSystemV(const size_t fixedSize, const std::string &name,
                      IPC_CREAT | 0666);
     if (m_ShmID == -1)
     {
-        throw std::ios_base::failure(
-            "ERROR: could not create shared memory buffer of size " +
-            std::to_string(fixedSize) + " with shmget \n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "format::buffer::ipc::BufferSystemV", "BufferSystemV",
+            "could not create shared memory buffer of size " +
+                std::to_string(fixedSize) + " with shmget");
     }
 
     void *data = shmat(m_ShmID, nullptr, 0);
     int *status = reinterpret_cast<int *>(data);
     if (*status == -1)
     {
-        throw std::runtime_error("ERROR: could not attach shared memory buffer "
-                                 "to address with shmat\n");
+        helper::Throw<std::runtime_error>(
+            "Toolkit", "format::buffer::ipc::BufferSystemV", "BufferSystemV",
+            "could not attach shared memory buffer "
+            "to address with shmat");
     }
     m_Data = static_cast<char *>(data);
 }

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -52,7 +52,9 @@ const std::string HDF5Common::PARAMETER_HAS_IDLE_WRITER_RANK = "IdleH5Writer";
 #define CHECK_H5_RETURN(returnCode, reason)                                    \
     {                                                                          \
         if (returnCode < 0)                                                    \
-            throw std::runtime_error((reason));                                \
+            helper::Throw<std::runtime_error>("Toolkit",                       \
+                                              "interop::hdf5::HDF5Common",     \
+                                              "CHECK_H5_RETURN", reason);      \
     }
 /*
    //need to know ndim before defining this.
@@ -177,14 +179,16 @@ void HDF5Common::Append(const std::string &name, helper::Comm const &comm)
             m_IsGeneratedByAdios = true;
         }
         if (!m_IsGeneratedByAdios)
-            throw std::ios_base::failure(
-                "HDF5Engine Append error. Likely no such file." + name);
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "interop::hdf5::HDF5Common", "Append",
+                "Likely no such file." + name);
 
         GetNumAdiosSteps(); // read how many steps exists in this file
 
         if (0 == m_NumAdiosSteps)
-            throw std::ios_base::failure(
-                "HDF5Engine Append error. No valid steps found in " + name);
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "interop::hdf5::HDF5Common", "Append",
+                "No valid steps found in " + name);
         if (1 == m_NumAdiosSteps)
             m_GroupId = H5Gopen(m_FileId, ts0.c_str(), H5P_DEFAULT);
         else
@@ -194,8 +198,9 @@ void HDF5Common::Append(const std::string &name, helper::Comm const &comm)
         Advance();
     }
     else
-        throw std::ios_base::failure(
-            "HDF5Engine Append error. Likely no such file." + name);
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "interop::hdf5::HDF5Common", "Append",
+            "Likely no such file." + name);
 }
 
 void HDF5Common::Init(const std::string &name, helper::Comm const &comm,
@@ -230,9 +235,9 @@ void HDF5Common::Init(const std::string &name, helper::Comm const &comm,
 
             if (m_GroupId < 0)
             {
-                throw std::ios_base::failure(
-                    "ERROR: Unable to create HDF5 group " + ts0 +
-                    " in call to Open\n");
+                helper::Throw<std::ios_base::failure>(
+                    "Toolkit", "interop::hdf5::HDF5Common", "Init",
+                    "Unable to create HDF5 group " + ts0 + " in call to Open");
             }
         }
     }
@@ -257,8 +262,10 @@ void HDF5Common::WriteAdiosSteps()
 {
     if (m_FileId < 0)
     {
-        throw std::invalid_argument("ERROR: invalid HDF5 file to record "
-                                    "steps, in call to Write\n");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "interop::hdf5::HDF5Common", "WriteAdiosSteps",
+            "invalid HDF5 file to record "
+            "steps, in call to Write");
     }
 
     if (!m_WriteMode)
@@ -298,8 +305,9 @@ unsigned int HDF5Common::GetNumAdiosSteps()
 
     if (m_FileId < 0)
     {
-        throw std::invalid_argument(
-            "ERROR: invalid HDF5 file to read step attribute.\n");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "interop::hdf5::HDF5Common", "GetNumAdiosSteps",
+            "invalid HDF5 file to read step attribute");
     }
 
     if (!m_IsGeneratedByAdios)
@@ -417,7 +425,8 @@ herr_t result = H5Gget_info(hid, &group_info);
 
 if (result < 0) {
   // error
-  throw std::ios_base::failure("Unable to get group info.");
+  helper::Throw<std::ios_base::failure>( "Toolkit", "interop::hdf5::HDF5Common",
+"ReadNativeGroup", "Unable to get group info");
 }
 
 if (group_info.nlinks == 0) {
@@ -430,7 +439,8 @@ hsize_t idx;
 for (idx=0; idx<group_info.nlinks; idx++) {
   int currType = H5Gget_objtype_by_idx(hid, idx);
   if (currType < 0) {
-    throw std::ios_base::failure("unable to get type info of idx"+idx);
+  helper::Throw<std::ios_base::failure>( "Toolkit", "interop::hdf5::HDF5Common",
+"ReadNativeGroup", "unable to get type info of idx"+idx);
   }
 
 
@@ -793,19 +803,22 @@ void HDF5Common::Close()
 void HDF5Common::SetAdiosStep(int step)
 {
     if (m_WriteMode)
-        throw std::ios_base::failure(
-            "ERROR: unable to change step at Write MODE.");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "interop::hdf5::HDF5Common", "SetAdiosStep",
+            "unable to change step at Write MODE");
 
     if (step < 0)
-        throw std::ios_base::failure(
-            "ERROR: unable to change to negative step.");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "interop::hdf5::HDF5Common", "SetAdiosStep",
+            "unable to change to negative step");
 
     GetNumAdiosSteps();
 
     unsigned int ustep = static_cast<unsigned int>(step);
     if (ustep >= m_NumAdiosSteps)
-        throw std::ios_base::failure(
-            "ERROR: given time step is more than actual known steps.");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "interop::hdf5::HDF5Common", "SetAdiosStep",
+            "given time step is more than actual known steps");
 
     if (m_CurrentAdiosStep == ustep)
     {
@@ -820,8 +833,10 @@ void HDF5Common::SetAdiosStep(int step)
     m_GroupId = H5Gopen(m_FileId, stepName.c_str(), H5P_DEFAULT);
     if (m_GroupId < 0)
     {
-        throw std::ios_base::failure("ERROR: unable to open HDF5 group " +
-                                     stepName + ", in call to Open\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "interop::hdf5::HDF5Common", "SetAdiosStep",
+            "ERROR: unable to open HDF5 group " + stepName +
+                ", in call to Open");
     }
 
     m_CurrentAdiosStep = ustep;
@@ -901,8 +916,9 @@ void HDF5Common::Advance()
         m_GroupId = H5Gopen(m_FileId, stepName.c_str(), H5P_DEFAULT);
         if (m_GroupId < 0)
         {
-            throw std::ios_base::failure("ERROR: unable to open HDF5 group " +
-                                         stepName + ", in call to Open\n");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "interop::hdf5::HDF5Common", "Advance",
+                "unable to open HDF5 group " + stepName + ", in call to Open");
         }
     }
     ++m_CurrentAdiosStep;
@@ -928,8 +944,9 @@ void HDF5Common::CheckWriteGroup()
 
     if (m_GroupId < 0)
     {
-        throw std::ios_base::failure("ERROR: HDF5: Unable to create group " +
-                                     stepName);
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "interop::hdf5::HDF5Common", "CheckWriteGroup",
+            "Unable to create group " + stepName);
     }
 }
 

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -69,7 +69,9 @@ public:
         m_Type = type;
         if (key < 0)
         {
-            throw std::ios_base::failure("ERROR: HDF5 failure detected.");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "interop::hdf5::HDF5Common::HDF5TypeGuard",
+                "HDF5TypeGuard", "HDF5 failure detected");
         }
     }
 

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
@@ -223,8 +223,9 @@ void HDF5Common::Write(core::Variable<T> &variable, const T *values)
 
     if (status < 0)
     {
-        throw std::ios_base::failure(
-            "ERROR: HDF5 file Write failed, in call to Write\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "interop::hdf5::HDF5Common", "Write",
+            "HDF5 file Write failed");
     }
 
 #ifdef NO_STAT

--- a/source/adios2/toolkit/profiling/iochrono/Timer.cpp
+++ b/source/adios2/toolkit/profiling/iochrono/Timer.cpp
@@ -69,8 +69,9 @@ int64_t Timer::GetElapsedTime()
 {
     if (!m_InitialTimeSet)
     {
-        throw std::invalid_argument("ERROR: Resume() in process " + m_Process +
-                                    " not called\n");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "profiling::iochrono::Timer", "GetElapsedTime",
+            "Resume() in process " + m_Process + " not called");
     }
 
     int64_t time = -1;

--- a/source/adios2/toolkit/query/JsonWorker.cpp
+++ b/source/adios2/toolkit/query/JsonWorker.cpp
@@ -58,8 +58,9 @@ void ConstructTree(adios2::query::RangeTree &host, nlohmann::json &opO)
 void LoadVarQuery(QueryVar *q, nlohmann::json &varO)
 {
     if (!adios2::query::JsonUtil::HasEntry(varO, "op"))
-        throw std::ios_base::failure("No op entry specified for var:" +
-                                     q->m_VarName);
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::JsonWorker", "LoadVarQuery",
+            "No op entry specified for var:" + q->m_VarName);
 
     if (adios2::query::JsonUtil::HasEntry(varO, "boundingbox"))
     {
@@ -87,12 +88,16 @@ void JsonWorker::ParseJson()
     auto lf_assertArray = [&](nlohmann::json &jsonO,
                               const std::string &name) -> void {
         if (!jsonO.is_array())
-            throw std::ios_base::failure("Expecting Array for node:" + name);
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "query::JsonWorker", "ParseJson",
+                "Expecting Array for node:" + name);
     }; // lf assert
 
     auto lf_parseVar = [&](nlohmann::json &varO) -> QueryVar * {
         if (!adios2::query::JsonUtil::HasEntry(varO, "name"))
-            throw std::ios_base::failure("No var name specified!!");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "query::JsonWorker", "ParseJson",
+                "No var name specified!!");
         auto varName = (varO)["name"];
         adios2::core::IO &currIO = m_SourceReader->m_IO;
         const DataType varType = currIO.InquireVariableType(varName);
@@ -121,17 +126,19 @@ void JsonWorker::ParseJson()
 
     if (!adios2::query::JsonUtil::HasEntry(jsonObj, "io"))
     {
-        helper::Log("Query", "JsonWorker", "ParseJson",
-                    "No io node in json query file", helper::LogMode::ERROR);
-        throw std::ios_base::failure("Expecting the io node: " +
-                                     m_SourceReader->m_IO.m_Name);
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::JsonWorker", "ParseJson",
+            "No io node in json query file. Expecting the io node: " +
+                m_SourceReader->m_IO.m_Name);
     }
 
     auto ioO = jsonObj.find("io");
     std::string const ioName = (*ioO)["name"];
     if (m_SourceReader->m_IO.m_Name.compare(ioName) != 0)
-        throw std::ios_base::failure("invalid query io. Expecting io name = " +
-                                     m_SourceReader->m_IO.m_Name);
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::JsonWorker", "ParseJson",
+            "invalid query io. Expecting io name = " +
+                m_SourceReader->m_IO.m_Name);
     if (adios2::query::JsonUtil::HasEntry(*ioO, "var"))
     {
         auto varO = (*ioO).find("var");
@@ -140,8 +147,9 @@ void JsonWorker::ParseJson()
         return;
     }
     if (!adios2::query::JsonUtil::HasEntry(*ioO, "query"))
-        throw std::ios_base::failure(
-            "no query entry was defined for composite query. ");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::JsonWorker", "ParseJson",
+            "no query entry was defined for composite query");
     auto queryO = (*ioO)["query"];
     auto relationO = queryO["op"];
     QueryComposite *result =

--- a/source/adios2/toolkit/query/Query.cpp
+++ b/source/adios2/toolkit/query/Query.cpp
@@ -89,7 +89,8 @@ bool QueryComposite::AddNode(QueryBase *var)
         // if (m_Nodes.size() > 0) return false;
         // don't want to support NOT for composite queries
         // return false;
-        throw std::ios_base::failure(
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::QueryComposite", "AddNode",
             "Currently NOT is not suppprted for composite query");
     }
     m_Nodes.push_back(var);
@@ -266,7 +267,8 @@ void QueryVar::LoadSelection(const std::string &startStr,
 
     if (start.size() != count.size())
     {
-        throw std::ios_base::failure(
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::QueryVar", "LoadSelection",
             "dim of startcount does match in the bounding box definition");
     }
 
@@ -275,7 +277,8 @@ void QueryVar::LoadSelection(const std::string &startStr,
         this->m_Selection.second; // set at the creation for default
     this->SetSelection(start, count);
     if (!this->IsSelectionValid(shape))
-        throw std::ios_base::failure(
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::QueryVar", "LoadSelection",
             "invalid selections for selection of var: " + this->GetVarName());
 }
 

--- a/source/adios2/toolkit/query/Worker.cpp
+++ b/source/adios2/toolkit/query/Worker.cpp
@@ -43,8 +43,9 @@ Worker *GetWorker(const std::string &configFile,
 
     if (!fileStream)
     {
-        throw std::ios_base::failure("ERROR: file " + configFile +
-                                     " not found. ");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::Worker", "GetWorker",
+            "file " + configFile + " not found");
     }
 
     if (adios2::query::IsFileNameXML(configFile))
@@ -58,8 +59,10 @@ Worker *GetWorker(const std::string &configFile,
         return new JsonWorker(configFile, adiosEngine);
     }
 #endif
-    throw std::invalid_argument("ERROR: Unable to construct xml  query.");
-    // return nullptr;
+    helper::Throw<std::invalid_argument>("Toolkit", "query::Worker",
+                                         "GetWorker",
+                                         "Unable to construct xml query");
+    return nullptr;
 }
 
 QueryVar *Worker::GetBasicVarQuery(adios2::core::IO &currentIO,
@@ -98,7 +101,9 @@ void Worker::GetResultCoverage(const adios2::Box<adios2::Dims> &outputRegion,
 
     if (!m_Query->UseOutputRegion(outputRegion))
     {
-        throw std::invalid_argument("Unable to use the output region.");
+        helper::Throw<std::invalid_argument>("Toolkit", "query::Worker",
+                                             "GetResultCoverage",
+                                             "Unable to use the output region");
     }
 
     if (m_Query && m_SourceReader)

--- a/source/adios2/toolkit/query/XmlWorker.cpp
+++ b/source/adios2/toolkit/query/XmlWorker.cpp
@@ -15,8 +15,9 @@ void XmlWorker::ParseMe()
         std::ifstream fileStream(configXML);
         if (!fileStream)
         {
-            throw std::ios_base::failure("ERROR: file " + configXML +
-                                         " not found. ");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "query::XmlWorker", "ParseMe",
+                "file " + configXML + " not found");
         }
         std::ostringstream fileSS;
         fileSS << fileStream.rdbuf();
@@ -24,7 +25,9 @@ void XmlWorker::ParseMe()
 
         if (fileSS.str().empty())
         {
-            throw std::invalid_argument("ERROR: config xml file is empty.");
+            helper::Throw<std::invalid_argument>("Toolkit", "query::XmlWorker",
+                                                 "ParseMe",
+                                                 "config xml file is empty");
         }
 
         return fileSS.str();
@@ -79,9 +82,10 @@ void XmlWorker::ParseIONode(const pugi::xml_node &ioNode)
         adios2::helper::XMLAttribute("name", ioNode, "in query");
     if (m_SourceReader->m_IO.m_Name.compare(ioName->value()) != 0)
     {
-        throw std::ios_base::failure("invalid query io. Expecting io name = " +
-                                     m_SourceReader->m_IO.m_Name +
-                                     " found:" + ioName->value());
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::XmlWorker", "ParseIONode",
+            "invalid query io. Expecting io name = " +
+                m_SourceReader->m_IO.m_Name + " found:" + ioName->value());
     }
 #endif
 
@@ -104,8 +108,9 @@ void XmlWorker::ParseIONode(const pugi::xml_node &ioNode)
         }
         else if (!q->IsCompatible(ref))
         {
-            throw std::ios_base::failure("impactible query found on var:" +
-                                         q->GetVarName());
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "query::XmlWorker", "ParseIONode",
+                "impactible query found on var:" + q->GetVarName());
         }
         subqueries[name->value()] = q;
     }
@@ -146,7 +151,9 @@ QueryVar *XmlWorker::ParseVarNode(const pugi::xml_node &node,
         helper::Log("Query", "XmlWorker", "ParseVarNode",
                     "No such variable: " + variableName,
                     helper::LogMode::ERROR);
-        throw std::ios_base::failure("No such variable: " + variableName);
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "query::XmlWorker", "ParseVarNode",
+            "variable: " + variableName + " not found");
     }
 #define declare_type(T)                                                        \
     if (varType == helper::GetDataType<T>())                                   \
@@ -209,7 +216,8 @@ void XmlWorker::ConstructQuery(QueryVar &simpleQ, const pugi::xml_node &node)
 
         if (start.size() != count.size())
         {
-            throw std::ios_base::failure(
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "query::XmlWorker", "ConstructQuery",
                 "dim of startcount does match in the bounding box definition");
         }
 
@@ -219,9 +227,10 @@ void XmlWorker::ConstructQuery(QueryVar &simpleQ, const pugi::xml_node &node)
         simpleQ.SetSelection(start, count);
         if (!simpleQ.IsSelectionValid(shape))
         {
-            throw std::ios_base::failure(
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "query::XmlWorker", "ConstructQuery",
                 "invalid selections for selection of var: " +
-                simpleQ.GetVarName());
+                    simpleQ.GetVarName());
         }
     }
 

--- a/source/adios2/toolkit/shm/TokenChain.h
+++ b/source/adios2/toolkit/shm/TokenChain.h
@@ -140,11 +140,12 @@ public:
     {
         if (m_Rank != m_Shm->currentRank)
         {
-            throw std::runtime_error(
-                "ADIOS2 Programming error: TokenChain::SendToken can only be "
+            helper::Throw<std::runtime_error>(
+                "Toolkit", "shm::TokenChain", "SendToken",
+                "function can only be "
                 "called by the Rank who last called "
                 "RecvToken, rank = " +
-                std::to_string(m_Rank));
+                    std::to_string(m_Rank));
         }
         assert(0 <= m_Shm->currentRank && m_Shm->currentRank < m_nProc);
         m_Shm->token = token;

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -23,12 +23,6 @@ Transport::Transport(const std::string type, const std::string library,
 {
 }
 
-void Transport::IWrite(const char *buffer, size_t size, Status &status,
-                       size_t start)
-{
-    throw std::invalid_argument("ERROR: this class doesn't implement IWrite\n");
-}
-
 void Transport::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
 {
     if (iovcnt > 0)
@@ -44,11 +38,6 @@ void Transport::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
     {
         Seek(start);
     }
-}
-
-void Transport::IRead(char *buffer, size_t size, Status &status, size_t start)
-{
-    throw std::invalid_argument("ERROR: this class doesn't implement IRead\n");
 }
 
 void Transport::InitProfiler(const Mode openMode, const TimeUnit timeUnit)
@@ -137,8 +126,9 @@ void Transport::CheckName() const
 {
     if (m_Name.empty())
     {
-        throw std::invalid_argument("ERROR: name can't be empty for " +
-                                    m_Library + " transport \n");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "transport::Transport", "CheckName",
+            "name can't be empty for " + m_Library + " transport ");
     }
 }
 

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -104,9 +104,6 @@ public:
     virtual void Write(const char *buffer, size_t size,
                        size_t start = MaxSizeT) = 0;
 
-    virtual void IWrite(const char *buffer, size_t size, Status &status,
-                        size_t start = MaxSizeT);
-
     /**
      * Writes to transport, writev version. Note that size is non-const due to
      * the nature of underlying transport libraries
@@ -129,9 +126,6 @@ public:
      * current stream position
      */
     virtual void Read(char *buffer, size_t size, size_t start = MaxSizeT) = 0;
-
-    virtual void IRead(char *buffer, size_t size, Status &status,
-                       size_t start = MaxSizeT);
 
     /**
      * Returns the size of current data in transport

--- a/source/adios2/toolkit/transport/file/FileDaos.cpp
+++ b/source/adios2/toolkit/transport/file/FileDaos.cpp
@@ -6,6 +6,7 @@
  *
  */
 #include "FileDaos.h"
+#include "adios2/helper/adiosLog.h"
 
 #include <cstdio>      // remove
 #include <cstdlib>     // malloc
@@ -46,14 +47,16 @@ void GetUUIDFromEnv(const std::string &env, uuid_t &uuidValue)
     {
         if (!uuid_parse(uuidEnv, uuidValue))
         {
-            throw std::invalid_argument("Error: Unable to parse " + env +
-                                        " environment variable");
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "transport::file::FileDaos", "GetUUIDFromEnv",
+                "Error: Unable to parse " + env + " environment variable");
         }
     }
     else
     {
-        throw std::invalid_argument("Error: " + env +
-                                    " environment variable not found");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "transport::file::FileDaos", "GetUUIDFromEnv",
+            "Error: " + env + " environment variable not found");
     }
 }
 
@@ -63,8 +66,10 @@ void CheckDAOSReturnCodeF(int rc, const char *file, int line)
     {
         std::string daosErr(d_errstr(rc));
         std::string theFile(file);
-        throw std::ios_base::failure("ERROR: DAOS: " + daosErr + " " + theFile +
-                                     " " + std::to_string(line));
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileDaos", "CheckDAOSReturnCodeF",
+            "ERROR: DAOS: " + daosErr + " " + theFile + " " +
+                std::to_string(line));
     }
 }
 }
@@ -154,8 +159,9 @@ public:
 
         if (Mount)
         {
-            throw std::ios_base::failure(
-                "ERROR: FileDaos: Mount handle already exists");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileDaos", "InitMount",
+                "Mount handle already exists");
         }
 
         // std::cout << "rank " << comm.Rank() << ": start daos_init..." <<
@@ -412,14 +418,16 @@ void FileDaos::SetParameters(const Params &params)
         {
             if (!uuid_parse(param->second.c_str(), m_Impl->UUID))
             {
-                throw std::invalid_argument(
-                    "ERROR: Unable to parse daos_pool_uuid parameter");
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "transport::file::FileDaos", "SetParameters",
+                    "Unable to parse daos_pool_uuid parameter");
             }
         }
         if (uuid_is_null(m_Impl->UUID))
         {
-            throw std::ios_base::failure(
-                "ERROR: FileDaos: DAOS UUID is empty or not set");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileDaos", "SetParameters",
+                "DAOS UUID is empty or not set");
         }
     }
 
@@ -432,8 +440,9 @@ void FileDaos::SetParameters(const Params &params)
         }
         if (m_Impl->Group.empty())
         {
-            throw std::ios_base::failure(
-                "ERROR: FileDaos: DAOS Group is empty or not set");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileDaos", "SetParameters",
+                "DAOS Group is empty or not set");
         }
     }
 
@@ -444,14 +453,16 @@ void FileDaos::SetParameters(const Params &params)
         {
             if (!uuid_parse(param->second.c_str(), m_Impl->CUUID))
             {
-                throw std::invalid_argument(
-                    "ERROR: Unable to parse daos_cont_uuid parameter");
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "transport::file::FileDaos", "SetParameters",
+                    "Unable to parse daos_cont_uuid parameter");
             }
         }
         if (uuid_is_null(m_Impl->CUUID))
         {
-            throw std::ios_base::failure(
-                "ERROR: FileDaos: DAOS CUUID is empty or not set");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileDaos", "SetParameters",
+                "DAOS CUUID is empty or not set");
         }
     }
 }
@@ -686,9 +697,10 @@ void FileDaos::Write(const char *buffer, size_t size, size_t start)
         CheckDAOSReturnCode(rc);
         if (rc)
         {
-            throw std::ios_base::failure("ERROR: couldn't write to file " +
-                                         m_Name + ", in call to Daos Write" +
-                                         SysErrMsg());
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileDaos", "Write",
+                "couldn't write to file " + m_Name + ", in call to Daos Write" +
+                    SysErrMsg());
         }
         // std::cout << "rank " << m_Comm.Rank() << ": dfs_write succeeded!" <<
         // std::endl;
@@ -712,8 +724,9 @@ void FileDaos::Write(const char *buffer, size_t size, size_t start)
         //	    CheckDAOSReturnCode(rc);
         //            if (rc)
         //            {
-        //                throw std::ios_base::failure(
-        //                    "ERROR: couldn't write to file " + m_Name +
+        // helper::Throw<std::ios_base::failure>( "Toolkit",
+        // "transport::file::FileDaos", "Write",
+        //                    "couldn't write to file " + m_Name +
         //                    ", in call to Daos Write" + SysErrMsg());
         //            }
         //	    //std::cout << "rank " << m_Comm.Rank() << ": dfs_write
@@ -726,8 +739,9 @@ void FileDaos::Write(const char *buffer, size_t size, size_t start)
         //                {
         //                    continue;
         //                }
-        //                throw std::ios_base::failure(
-        //                    "ERROR: couldn't write to file " + m_Name +
+        // helper::Throw<std::ios_base::failure>( "Toolkit",
+        // "transport::file::FileDaos", "Write",
+        //                    "couldn't write to file " + m_Name +
         //                    ", in call to Daos Write" + SysErrMsg());
         //            }*/
         //
@@ -793,9 +807,10 @@ void FileDaos::Read(char *buffer, size_t size, size_t start)
 
         if (rc)
         {
-            throw std::ios_base::failure("ERROR: couldn't read from file " +
-                                         m_Name + ", in call to Daos Read" +
-                                         SysErrMsg());
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileDaos", "Read",
+                "couldn't read from file " + m_Name + ", in call to Daos Read" +
+                    SysErrMsg());
         }
         // std::cout << "rank " << m_Comm.Rank() << ": dfs_read succeeded!" <<
         // std::endl;
@@ -818,7 +833,9 @@ void FileDaos::Read(char *buffer, size_t size, size_t start)
         //
         //            if (rc)
         //            {
-        //                throw std::ios_base::failure("ERROR: couldn't read
+        // helper::Throw<std::ios_base::failure>( "Toolkit",
+        // "transport::file::FileDaos", "Read",
+        //                "couldn't read
         //                from file " +
         //                                             m_Name + ", in call to
         //                                             Daos Read" +
@@ -873,7 +890,8 @@ size_t FileDaos::GetSize()
     /*if (fstat(m_FileDescriptor, &fileStat) == -1)
     {
         m_Errno = errno;
-        throw std::ios_base::failure("ERROR: couldn't get size of file " +
+         helper::Throw<std::ios_base::failure>( "Toolkit",
+    "transport::file::FileDaos", "GetSize", "couldn't get size of file " +
                                      m_Name + SysErrMsg());
                                      }*/
     m_Errno = rc;
@@ -896,9 +914,10 @@ void FileDaos::Close()
 
     if (rc)
     {
-        throw std::ios_base::failure("ERROR: couldn't close file " + m_Name +
-                                     ", in call to Daos IO close" +
-                                     SysErrMsg());
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileDaos", "Close",
+            "couldn't close file " + m_Name + ", in call to Daos IO close" +
+                SysErrMsg());
     }
 
     m_IsOpen = false;
@@ -920,7 +939,9 @@ void FileDaos::CheckFile(const std::string hint) const
 {
     if (!m_DAOSOpenSucceed)
     {
-        throw std::ios_base::failure("ERROR: " + hint + SysErrMsg());
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileDaos", "CheckFile",
+            "ERROR: " + hint + SysErrMsg());
     }
 }
 
@@ -948,7 +969,9 @@ void FileDaos::Seek(const size_t start)
 
 void FileDaos::Truncate(const size_t length)
 {
-    throw std::ios_base::failure("ERROR: Daos Truncate is not implemented yet");
+    helper::Throw<std::ios_base::failure>(
+        "Toolkit", "transport::file::FileDaos", "Truncate",
+        "Daos Truncate is not implemented yet");
 }
 
 } // end namespace transport

--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -8,6 +8,7 @@
  *      Author: William F Godoy godoywf@ornl.gov
  */
 #include "FileFStream.h"
+#include "adios2/helper/adiosLog.h"
 #include <cstdio> // remove
 
 /// \cond EXCLUDE_FROM_DOXYGEN
@@ -191,7 +192,8 @@ void FileFStream::SetBuffer(char *buffer, size_t size)
 {
     if (!buffer && size != 0)
     {
-        throw std::invalid_argument(
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "transport::file::FileFStream", "SetBuffer",
             "buffer size must be 0 when using a NULL buffer");
     }
     m_FileStream.rdbuf()->pubsetbuf(buffer, size);
@@ -281,8 +283,9 @@ size_t FileFStream::GetSize()
     const std::streampos size = m_FileStream.tellg();
     if (static_cast<int>(size) == -1)
     {
-        throw std::ios_base::failure("ERROR: couldn't get size of " + m_Name +
-                                     " file\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileFStream", "GetSize",
+            "couldn't get size of " + m_Name + " file");
     }
     m_FileStream.seekg(currentPosition);
     return static_cast<size_t>(size);
@@ -323,7 +326,8 @@ void FileFStream::CheckFile(const std::string hint) const
 {
     if (!m_FileStream)
     {
-        throw std::ios_base::failure("ERROR: " + hint + "\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileFStream", "CheckFile", hint);
     }
 }
 

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -154,9 +154,9 @@ void FileIME::Write(const char *buffer, size_t size, size_t start)
                     continue;
                 }
 
-                throw std::ios_base::failure(
-                    "ERROR: couldn't write to file " + m_Name +
-                    ", in call to FileDescriptor Write\n");
+                helper::Throw<std::ios_base::failure>(
+                    "Toolkit", "transport::file::FileIME", "Write",
+                    "couldn't write to file " + m_Name);
             }
 
             buffer += writtenSize;
@@ -171,10 +171,10 @@ void FileIME::Write(const char *buffer, size_t size, size_t start)
 
         if (static_cast<size_t>(newPosition) != start)
         {
-            throw std::ios_base::failure(
-                "ERROR: couldn't move to start position " +
-                std::to_string(start) + " in file " + m_Name +
-                ", in call to IME lseek\n");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileIME", "Write",
+                "couldn't move to start position " + std::to_string(start) +
+                    " in file " + m_Name);
         }
     }
 
@@ -214,9 +214,9 @@ void FileIME::Read(char *buffer, size_t size, size_t start)
                     continue;
                 }
 
-                throw std::ios_base::failure("ERROR: couldn't read from file " +
-                                             m_Name +
-                                             ", in call to IME IO read\n");
+                helper::Throw<std::ios_base::failure>(
+                    "Toolkit", "transport::file::FileIME", "Read",
+                    "ERROR: couldn't read from file " + m_Name);
             }
 
             buffer += readSize;
@@ -231,10 +231,10 @@ void FileIME::Read(char *buffer, size_t size, size_t start)
 
         if (static_cast<size_t>(newPosition) != start)
         {
-            throw std::ios_base::failure(
-                "ERROR: couldn't move to start position " +
-                std::to_string(start) + " in file " + m_Name +
-                ", in call to IME lseek errno " + std::to_string(errno) + "\n");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileIME", "Read",
+                "couldn't move to start position " + std::to_string(start) +
+                    " in file " + m_Name + ", errno " + std::to_string(errno));
         }
     }
 
@@ -262,8 +262,9 @@ size_t FileIME::GetSize()
     struct stat fileStat;
     if (fstat(m_FileDescriptor, &fileStat) == -1)
     {
-        throw std::ios_base::failure("ERROR: couldn't get size of file " +
-                                     m_Name + "\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileIME", "GetSize",
+            "couldn't get size of file " + m_Name);
     }
     return static_cast<size_t>(fileStat.st_size);
 }
@@ -290,8 +291,9 @@ void FileIME::Close()
 
     if (status == -1)
     {
-        throw std::ios_base::failure("ERROR: couldn't close file " + m_Name +
-                                     ", in call to IME IO close\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileIME", "Close",
+            "ERROR: couldn't close file " + m_Name);
     }
 
     m_IsOpen = false;
@@ -310,7 +312,8 @@ void FileIME::CheckFile(const std::string hint) const
 {
     if (m_FileDescriptor == -1)
     {
-        throw std::ios_base::failure("ERROR: " + hint + "\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileIME", "CheckFile", hint);
     }
 }
 
@@ -319,9 +322,9 @@ void FileIME::SeekToEnd()
     const int status = ime_client_native2_lseek(m_FileDescriptor, 0, SEEK_END);
     if (status == -1)
     {
-        throw std::ios_base::failure(
-            "ERROR: couldn't seek to the end of file " + m_Name +
-            ", in call to IME IO lseek\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileIME", "SeekToEnd",
+            "couldn't seek to the end of file " + m_Name);
     }
 }
 
@@ -330,9 +333,9 @@ void FileIME::SeekToBegin()
     const int status = ime_client_native2_lseek(m_FileDescriptor, 0, SEEK_SET);
     if (status == -1)
     {
-        throw std::ios_base::failure(
-            "ERROR: couldn't seek to the begin of file " + m_Name +
-            ", in call to IME IO lseek\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileIME", "SeekToBegin",
+            "couldn't seek to the begin of file " + m_Name);
     }
 }
 
@@ -344,9 +347,10 @@ void FileIME::Seek(const size_t start)
             ime_client_native2_lseek(m_FileDescriptor, start, SEEK_SET);
         if (status == -1)
         {
-            throw std::ios_base::failure(
-                "ERROR: couldn't seek to offset " + std::to_string(start) +
-                " of file " + m_Name + ", in call to IME IO lseek\n");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileIME", "Seek",
+                "couldn't seek to offset " + std::to_string(start) +
+                    " of file " + m_Name);
         }
     }
     else
@@ -357,7 +361,9 @@ void FileIME::Seek(const size_t start)
 
 void FileIME::Truncate(const size_t length)
 {
-    throw std::ios_base::failure("ERROR: Daos Truncate is not implemented yet");
+    helper::Throw<std::ios_base::failure>(
+        "Toolkit", "transport::file::FileIME", "Truncate",
+        "IME Truncate is not implemented yet");
 }
 
 void FileIME::MkDir(const std::string &fileName) {}

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -8,6 +8,7 @@
  *      Author: William F Godoy godoywf@ornl.gov
  */
 #include "FilePOSIX.h"
+#include "adios2/helper/adiosLog.h"
 
 #include <cstdio>      // remove
 #include <cstring>     // strerror
@@ -237,9 +238,9 @@ void FilePOSIX::Write(const char *buffer, size_t size, size_t start)
                     continue;
                 }
 
-                throw std::ios_base::failure(
-                    "ERROR: couldn't write to file " + m_Name +
-                    ", in call to POSIX Write" + SysErrMsg());
+                helper::Throw<std::ios_base::failure>(
+                    "Toolkit", "transport::file::FilePOSIX", "Write",
+                    "couldn't write to file " + m_Name + " " + SysErrMsg());
             }
 
             buffer += writtenSize;
@@ -256,10 +257,10 @@ void FilePOSIX::Write(const char *buffer, size_t size, size_t start)
 
         if (static_cast<size_t>(newPosition) != start)
         {
-            throw std::ios_base::failure(
-                "ERROR: couldn't move to start position " +
-                std::to_string(start) + " in file " + m_Name +
-                ", in call to POSIX lseek" + SysErrMsg());
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FilePOSIX", "Write",
+                "couldn't move to start position " + std::to_string(start) +
+                    " in file " + m_Name + " " + SysErrMsg());
         }
     }
     else
@@ -308,9 +309,9 @@ void FilePOSIX::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
         {
             if (errno != EINTR)
             {
-                throw std::ios_base::failure(
-                    "ERROR: couldn't write to file " + m_Name +
-                    ", in call to POSIX Write(iovec)" + SysErrMsg());
+                helper::Throw<std::ios_base::failure>(
+                    "Toolkit", "transport::file::FilePOSIX", "WriteV",
+                    "couldn't write to file " + m_Name + " " + SysErrMsg());
             }
             written = 0;
         }
@@ -360,10 +361,10 @@ void FilePOSIX::WriteV(const core::iovec *iov, const int iovcnt, size_t start)
 
         if (static_cast<size_t>(newPosition) != start)
         {
-            throw std::ios_base::failure(
-                "ERROR: couldn't move to start position " +
-                std::to_string(start) + " in file " + m_Name +
-                ", in call to POSIX lseek" + SysErrMsg());
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FilePOSIX", "WriteV",
+                "couldn't move to start position " + std::to_string(start) +
+                    " in file " + m_Name + " " + SysErrMsg());
         }
     }
 
@@ -399,9 +400,9 @@ void FilePOSIX::Read(char *buffer, size_t size, size_t start)
                     continue;
                 }
 
-                throw std::ios_base::failure(
-                    "ERROR: couldn't read from file " + m_Name +
-                    ", in call to POSIX IO read" + SysErrMsg());
+                helper::Throw<std::ios_base::failure>(
+                    "Toolkit", "transport::file::FilePOSIX", "Read",
+                    "couldn't read from file " + m_Name + " " + SysErrMsg());
             }
 
             buffer += readSize;
@@ -419,10 +420,10 @@ void FilePOSIX::Read(char *buffer, size_t size, size_t start)
 
         if (static_cast<size_t>(newPosition) != start)
         {
-            throw std::ios_base::failure(
-                "ERROR: couldn't move to start position " +
-                std::to_string(start) + " in file " + m_Name +
-                ", in call to POSIX lseek" + SysErrMsg());
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FilePOSIX", "Read",
+                "couldn't move to start position " + std::to_string(start) +
+                    " in file " + m_Name + " " + SysErrMsg());
         }
     }
 
@@ -453,8 +454,9 @@ size_t FilePOSIX::GetSize()
     if (fstat(m_FileDescriptor, &fileStat) == -1)
     {
         m_Errno = errno;
-        throw std::ios_base::failure("ERROR: couldn't get size of file " +
-                                     m_Name + SysErrMsg());
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FilePOSIX", "GetSize",
+            "couldn't get size of file " + m_Name + SysErrMsg());
     }
     m_Errno = errno;
     return static_cast<size_t>(fileStat.st_size);
@@ -484,9 +486,9 @@ void FilePOSIX::Close()
 
     if (status == -1)
     {
-        throw std::ios_base::failure("ERROR: couldn't close file " + m_Name +
-                                     ", in call to POSIX IO close" +
-                                     SysErrMsg());
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FilePOSIX", "Close",
+            "couldn't close file " + m_Name + " " + SysErrMsg());
     }
 
     m_IsOpen = false;
@@ -506,7 +508,9 @@ void FilePOSIX::CheckFile(const std::string hint) const
 {
     if (m_FileDescriptor == -1)
     {
-        throw std::ios_base::failure("ERROR: " + hint + SysErrMsg());
+        helper::Throw<std::ios_base::failure>("Toolkit",
+                                              "transport::file::FilePOSIX",
+                                              "CheckFile", hint + SysErrMsg());
     }
 }
 
@@ -524,9 +528,9 @@ void FilePOSIX::SeekToEnd()
     m_Errno = 0;
     if (status == -1)
     {
-        throw std::ios_base::failure(
-            "ERROR: couldn't seek to the end of file " + m_Name +
-            ", in call to POSIX IO lseek" + SysErrMsg());
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FilePOSIX", "SeekToEnd",
+            "couldn't seek to the end of file " + m_Name + " " + SysErrMsg());
     }
 }
 
@@ -538,9 +542,9 @@ void FilePOSIX::SeekToBegin()
     m_Errno = errno;
     if (status == -1)
     {
-        throw std::ios_base::failure(
-            "ERROR: couldn't seek to the begin of file " + m_Name +
-            ", in call to POSIX IO lseek" + SysErrMsg());
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FilePOSIX", "SeekToBegin",
+            "couldn't seek to the begin of file " + m_Name + " " + SysErrMsg());
     }
 }
 
@@ -554,10 +558,10 @@ void FilePOSIX::Seek(const size_t start)
         m_Errno = errno;
         if (status == -1)
         {
-            throw std::ios_base::failure(
-                "ERROR: couldn't seek to offset " + std::to_string(start) +
-                " of file " + m_Name + ", in call to POSIX IO lseek" +
-                SysErrMsg());
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FilePOSIX", "Seek",
+                "couldn't seek to offset " + std::to_string(start) +
+                    " of file " + m_Name + " " + SysErrMsg());
         }
     }
     else
@@ -574,10 +578,10 @@ void FilePOSIX::Truncate(const size_t length)
     m_Errno = errno;
     if (status == -1)
     {
-        throw std::ios_base::failure(
-            "ERROR: couldn't truncate to " + std::to_string(length) +
-            " bytes of file " + m_Name + ", in call to POSIX IO truncate" +
-            SysErrMsg());
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FilePOSIX", "Truncate",
+            "couldn't truncate to " + std::to_string(length) +
+                " bytes of file " + m_Name + " " + SysErrMsg());
     }
 }
 

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "FileStdio.h"
+#include "adios2/helper/adiosLog.h"
 
 /// \cond EXCLUDE_FROM_DOXYGEN
 #include <cerrno>
@@ -96,8 +97,9 @@ void FileStdio::Open(const std::string &name, const Mode openMode,
         m_File = std::fopen(name.c_str(), "rb");
         break;
     default:
-        throw std::ios_base::failure("ERROR: unknown open mode for file " +
-                                     m_Name + ", in call to stdio fopen");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "Open",
+            "unknown open mode for file " + m_Name);
     }
 
     if (!m_IsOpening)
@@ -131,7 +133,8 @@ void FileStdio::SetBuffer(char *buffer, size_t size)
     {
         if (size != 0)
         {
-            throw std::invalid_argument(
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "transport::file::FileStdio", "SetBuffer",
                 "buffer size must be 0 when using a NULL buffer");
         }
         status = std::setvbuf(m_File, NULL, _IONBF, 0);
@@ -139,9 +142,10 @@ void FileStdio::SetBuffer(char *buffer, size_t size)
 
     if (status)
     {
-        throw std::ios_base::failure(
-            "ERROR: could not set FILE* buffer in file " + m_Name +
-            ", in call to stdio setvbuf\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "SetBuffer",
+            "could not set FILE* buffer in file " + m_Name +
+                ", in call to stdio setvbuf");
     }
 }
 
@@ -158,10 +162,11 @@ void FileStdio::Write(const char *buffer, size_t size, size_t start)
 
         if (writtenSize != size)
         {
-            throw std::ios_base::failure(
-                "ERROR: written size + " + std::to_string(writtenSize) +
-                " is not equal to intended size " + std::to_string(size) +
-                " in file " + m_Name + ", in call to stdio fwrite\n");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileStdio", "Write",
+                "written size + " + std::to_string(writtenSize) +
+                    " is not equal to intended size " + std::to_string(size) +
+                    " in file " + m_Name + ", in call to stdio fwrite");
         }
     };
 
@@ -172,9 +177,10 @@ void FileStdio::Write(const char *buffer, size_t size, size_t start)
             std::fseek(m_File, static_cast<long int>(start), SEEK_SET);
         if (status != 0)
         {
-            throw std::ios_base::failure(
-                "ERROR: couldn't move position of " + m_Name +
-                " file, in call to FileStdio Write fseek\n");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileStdio", "Write",
+                "couldn't move position of " + m_Name +
+                    " file, in call to FileStdio Write fseek");
         }
 
         CheckFile("couldn't move to start position " + std::to_string(start) +
@@ -212,10 +218,11 @@ void FileStdio::Read(char *buffer, size_t size, size_t start)
 
         if (readSize != size)
         {
-            throw std::ios_base::failure(
-                "ERROR: read size of " + std::to_string(readSize) +
-                " is not equal to intended size " + std::to_string(size) +
-                " in file " + m_Name + ", in call to stdio fread\n");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileStdio", "Read",
+                "read size of " + std::to_string(readSize) +
+                    " is not equal to intended size " + std::to_string(size) +
+                    " in file " + m_Name + ", in call to stdio fread");
         }
     };
 
@@ -255,18 +262,20 @@ size_t FileStdio::GetSize()
     const auto currentPosition = ftell(m_File);
     if (currentPosition == -1L)
     {
-        throw std::ios_base::failure(
-            "ERROR: couldn't get current position of " + m_Name +
-            " file, in call to FileStdio GetSize ftell\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "GetSize",
+            "couldn't get current position of " + m_Name +
+                " file, in call to FileStdio GetSize ftell");
     }
 
     fseek(m_File, 0, SEEK_END);
     const auto size = ftell(m_File);
     if (size == -1)
     {
-        throw std::ios_base::failure(
-            "ERROR: couldn't get size of " + m_Name +
-            " file, in call to FileStdio GetSize ftell\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "GetSize",
+            "couldn't get size of " + m_Name +
+                " file, in call to FileStdio GetSize ftell");
     }
     fseek(m_File, currentPosition, SEEK_SET);
     return static_cast<size_t>(size);
@@ -281,8 +290,9 @@ void FileStdio::Flush()
 
     if (status == EOF)
     {
-        throw std::ios_base::failure("ERROR: couldn't flush file " + m_Name +
-                                     ", in call to stdio fflush\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "Flush",
+            "couldn't flush file " + m_Name + ", in call to stdio fflush");
     }
 }
 
@@ -295,8 +305,9 @@ void FileStdio::Close()
 
     if (status == EOF)
     {
-        throw std::ios_base::failure("ERROR: couldn't close file " + m_Name +
-                                     ", in call to stdio fclose\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "Close",
+            "couldn't close file " + m_Name + ", in call to stdio fclose");
     }
 
     m_IsOpen = false;
@@ -321,11 +332,15 @@ void FileStdio::CheckFile(const std::string hint) const
         {
             errmsg = std::strerror(errno);
         }
-        throw std::ios_base::failure("ERROR: " + hint + ":" + errmsg + "\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "CheckFile",
+            "ERROR: " + hint + ":" + errmsg);
     }
     else if (std::ferror(m_File))
     {
-        throw std::ios_base::failure("ERROR: " + hint + "\n");
+        helper::Throw<std::ios_base::failure>("Toolkit",
+                                              "transport::file::FileStdio",
+                                              "CheckFile", "ERROR: " + hint);
     }
 }
 
@@ -335,9 +350,9 @@ void FileStdio::SeekToEnd()
     const auto status = std::fseek(m_File, 0, SEEK_END);
     if (status == -1)
     {
-        throw std::ios_base::failure(
-            "ERROR: couldn't seek to the end of file " + m_Name +
-            ", in call to stdio fseek\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "SeekToEnd",
+            "couldn't seek to the end of file " + m_Name);
     }
 }
 
@@ -347,9 +362,9 @@ void FileStdio::SeekToBegin()
     const auto status = std::fseek(m_File, 0, SEEK_SET);
     if (status == -1)
     {
-        throw std::ios_base::failure(
-            "ERROR: couldn't seek to the begin of file " + m_Name +
-            ", in call to stdio fseek\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "SeekToBegin",
+            "couldn't seek to the begin of file " + m_Name);
     }
 }
 
@@ -361,9 +376,10 @@ void FileStdio::Seek(const size_t start)
         const auto status = std::fseek(m_File, 0, SEEK_SET);
         if (status == -1)
         {
-            throw std::ios_base::failure("ERROR: couldn't seek to offset " +
-                                         std::to_string(start) + " of file " +
-                                         m_Name + ", in call to stdio fseek\n");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileStdio", "Seek",
+                "couldn't seek to offset " + std::to_string(start) +
+                    " of file " + m_Name);
         }
     }
     else
@@ -375,8 +391,9 @@ void FileStdio::Seek(const size_t start)
 #ifdef _WIN32
 void FileStdio::Truncate(const size_t length)
 {
-    throw std::ios_base::failure(
-        "ERROR: FileStdio::Truncate is not supported in Windows\n");
+    helper::Throw<std::ios_base::failure>(
+        "Toolkit", "transport::file::FileStdio", "Truncate",
+        "This is not supported on Windows");
 }
 #else
 #include <unistd.h> // ftruncate
@@ -388,9 +405,10 @@ void FileStdio::Truncate(const size_t length)
     const auto status = ftruncate(fd, length);
     if (status == -1)
     {
-        throw std::ios_base::failure("ERROR: couldn't truncate to " +
-                                     std::to_string(length) + " of file " +
-                                     m_Name + ", in call to stdio Truncate\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::file::FileStdio", "Truncate",
+            "couldn't truncate to " + std::to_string(length) + " of file " +
+                m_Name);
     }
 }
 #endif

--- a/source/adios2/toolkit/transport/null/NullTransport.cpp
+++ b/source/adios2/toolkit/transport/null/NullTransport.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "NullTransport.h"
+#include "adios2/helper/adiosLog.h"
 
 #include <cstring> // std::memset
 
@@ -36,8 +37,8 @@ void NullTransport::Open(const std::string &name, const Mode openMode,
 {
     if (Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullTransport::Open: The transport is already open.");
+        helper::Throw<std::runtime_error>("Toolkit", "transport::NullTransport",
+                                          "Open", "transport is already open");
     }
 
     ProfilerStart("open");
@@ -53,8 +54,8 @@ void NullTransport::Write(const char *buffer, size_t size, size_t start)
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullTransport::Write: The transport is not open.");
+        helper::Throw<std::runtime_error>("Toolkit", "transport::NullTransport",
+                                          "Write", "transport is not open yet");
     }
 
     ProfilerStart("write");
@@ -70,15 +71,15 @@ void NullTransport::Read(char *buffer, size_t size, size_t start)
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullTransport::Read: The transport is not open.");
+        helper::Throw<std::runtime_error>("Toolkit", "transport::NullTransport",
+                                          "Read", "transport is not open yet");
     }
 
     ProfilerStart("read");
     if (start + size > Impl->Capacity)
     {
-        throw std::out_of_range(
-            "ERROR: NullTransport::Read: size+start exceeds capacity");
+        helper::Throw<std::out_of_range>("Toolkit", "transport::NullTransport",
+                                         "Read", "size+start exceeds capacity");
     }
     std::memset(buffer, 0, size);
     Impl->CurPos = start + size;
@@ -91,8 +92,8 @@ void NullTransport::Flush()
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullTransport::Flush: The transport is not open.");
+        helper::Throw<std::runtime_error>("Toolkit", "transport::NullTransport",
+                                          "Flush", "transport is not open yet");
     }
 }
 
@@ -100,8 +101,8 @@ void NullTransport::Close()
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullTransport::Close: The transport is not open.");
+        helper::Throw<std::runtime_error>("Toolkit", "transport::NullTransport",
+                                          "Close", "transport is not open yet");
     }
 
     Impl->CurPos = 0;
@@ -115,8 +116,9 @@ void NullTransport::SeekToEnd()
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullTransport::SeekToEnd: The transport is not open.");
+        helper::Throw<std::runtime_error>("Toolkit", "transport::NullTransport",
+                                          "SeekToEnd",
+                                          "transport is not open yet");
     }
     Impl->CurPos = Impl->Capacity - 1;
 }
@@ -125,8 +127,9 @@ void NullTransport::SeekToBegin()
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullTransport::SeekToEnd: The transport is not open.");
+        helper::Throw<std::runtime_error>("Toolkit", "transport::NullTransport",
+                                          "SeekToBegin",
+                                          "transport is not open yet");
     }
     Impl->CurPos = 0;
 }
@@ -135,8 +138,8 @@ void NullTransport::Seek(const size_t start)
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullTransport::SeekToEnd: The transport is not open.");
+        helper::Throw<std::runtime_error>("Toolkit", "transport::NullTransport",
+                                          "Seek", "transport is not open yet");
     }
     Impl->CurPos = start;
 }
@@ -145,8 +148,9 @@ void NullTransport::Truncate(const size_t length)
 {
     if (!Impl->IsOpen)
     {
-        throw std::runtime_error(
-            "ERROR: NullTransport::Truncate: The transport is not open.");
+        helper::Throw<std::runtime_error>("Toolkit", "transport::NullTransport",
+                                          "Truncate",
+                                          "transport is not open yet");
     }
     Impl->Capacity = length;
 }

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "ShmSystemV.h"
+#include "adios2/helper/adiosLog.h"
 
 #include <cstring> //std::memcpy
 
@@ -28,8 +29,9 @@ ShmSystemV::ShmSystemV(const unsigned int projectID, const size_t size,
 {
     if (projectID == 0)
     {
-        throw std::invalid_argument(
-            "ERROR: projectID can't be zero, in shared memory segment\n");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "transport::shm::ShmSystemV", "ShmSystemV",
+            "projectID can't be zero, in shared memory segment");
     }
 }
 
@@ -77,9 +79,9 @@ void ShmSystemV::Open(const std::string &name, const Mode openMode,
         break;
 
     default:
-        throw std::invalid_argument(
-            "ERROR: unknown open mode for shared memory segment " + m_Name +
-            ", in call to SystemV Open");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "transport::shm::ShmSystemV", "Open",
+            "unknown open mode for shared memory segment " + m_Name);
     }
 
     CheckShmID("in call to ShmSystemV shmget at Open");
@@ -112,10 +114,10 @@ void ShmSystemV::Close()
     ProfilerStop("close");
     if (result < 1)
     {
-        throw std::ios_base::failure(
-            "ERROR: failed to detach shared memory segment of size " +
-            std::to_string(m_Size) + " and name " + m_Name +
-            ", in call to SystemV shmdt Close\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::shm::ShmSystemV", "Close",
+            "failed to detach shared memory segment of size " +
+                std::to_string(m_Size) + " and name " + m_Name);
     }
 
     if (m_RemoveAtClose)
@@ -125,10 +127,10 @@ void ShmSystemV::Close()
         ProfilerStop("close");
         if (remove < 1)
         {
-            throw std::ios_base::failure(
-                "ERROR: failed to remove shared memory segment of size " +
-                std::to_string(m_Size) + " and name " + m_Name +
-                ", in call to SystemV shmctl Close\n");
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::shm::ShmSystemV", "Close",
+                "failed to remove shared memory segment of size " +
+                    std::to_string(m_Size) + " and name " + m_Name);
         }
     }
 
@@ -155,10 +157,10 @@ void ShmSystemV::CheckShmID(const std::string hint) const
 {
     if (m_ShmID < 0)
     {
-        throw std::ios_base::failure(
-            "ERROR: Failed shared memory segment of size " +
-            std::to_string(m_Size) + " and name " + m_Name + ", " + hint +
-            "\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::shm::ShmSystemV", "CheckShmID",
+            "Failed shared memory segment of size " + std::to_string(m_Size) +
+                " and name " + m_Name + ", " + hint);
     }
 }
 
@@ -166,9 +168,10 @@ void ShmSystemV::CheckBuffer(const std::string hint) const
 {
     if (m_Buffer == nullptr)
     {
-        throw std::ios_base::failure(
-            "ERROR: nullptr shared memory segment of size " +
-            std::to_string(m_Size) + " and name " + m_Name + " " + hint + "\n");
+        helper::Throw<std::ios_base::failure>(
+            "Toolkit", "transport::shm::ShmSystemV", "CheckBuffer",
+            "nullptr shared memory segment of size " + std::to_string(m_Size) +
+                " and name " + m_Name + " " + hint);
     }
 }
 
@@ -177,11 +180,12 @@ void ShmSystemV::CheckSizes(const size_t start, const size_t size,
 {
     if (start + size > m_Size)
     {
-        throw std::invalid_argument(
-            "ERROR: final position (start + size) = (" + std::to_string(start) +
-            " + " + std::to_string(size) +
-            " ) exceeding shared memory pre-allocated size:" +
-            std::to_string(m_Size) + "," + hint + "\n");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "transport::shm::ShmSystemV", "CheckSizes",
+            "final position (start + size) = (" + std::to_string(start) +
+                " + " + std::to_string(size) +
+                " ) exceeding shared memory pre-allocated size:" +
+                std::to_string(m_Size) + "," + hint);
     }
 }
 

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -177,12 +177,13 @@ std::vector<std::string> TransportMan::GetFilesBaseNames(
         {
             if (itType->second.count(name) == 1)
             {
-                throw std::invalid_argument(
-                    "ERROR: two IO AddTransport of the same type can't "
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "TransportMan", "OpenFileID",
+                    "two IO AddTransport of the same type can't "
                     "have the same name : " +
-                    name +
-                    ", use Name=value parameter, in "
-                    "call to Open");
+                        name +
+                        ", use Name=value parameter, in "
+                        "call to Open");
             }
         }
         typeTransportNames[type].insert(name);
@@ -531,10 +532,11 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(
             std::stringstream ss(bufferedValueStr);
             if (!(ss >> std::boolalpha >> bufferedValue))
             {
-                throw std::invalid_argument(
-                    "ERROR: invalid value for \"buffered\" transport "
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "TransportMan", "OpenFileTransport",
+                    "invalid value for \"buffered\" transport "
                     "parameter: " +
-                    bufferedValueStr);
+                        bufferedValueStr);
             }
         }
         return bufferedValue;
@@ -564,9 +566,9 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(
             transport = std::make_shared<transport::FilePOSIX>(m_Comm);
             if (lf_GetBuffered("false"))
             {
-                throw std::invalid_argument(
-                    "ERROR: " + library +
-                    " transport does not support buffered I/O.");
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "TransportMan", "OpenFileTransport",
+                    library + " transport does not support buffered I/O.");
             }
         }
 #endif
@@ -576,9 +578,9 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(
             transport = std::make_shared<transport::FileDaos>(m_Comm);
             if (lf_GetBuffered("false"))
             {
-                throw std::invalid_argument(
-                    "ERROR: " + library +
-                    " transport does not support buffered I/O.");
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "TransportMan", "OpenFileTransport",
+                    library + " transport does not support buffered I/O.");
             }
         }
 #endif
@@ -593,15 +595,16 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(
             transport = std::make_shared<transport::NullTransport>(m_Comm);
             if (lf_GetBuffered("false"))
             {
-                throw std::invalid_argument(
-                    "ERROR: " + library +
-                    " transport does not support buffered I/O.");
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "TransportMan", "OpenFileTransport",
+                    library + " transport does not support buffered I/O.");
             }
         }
         else
         {
-            throw std::invalid_argument(
-                "ERROR: invalid IO AddTransport library " + library);
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "TransportMan", "OpenFileTransport",
+                "invalid IO AddTransport library " + library);
         }
     };
 
@@ -664,14 +667,17 @@ void TransportMan::CheckFile(
 {
     if (itTransport == m_Transports.end())
     {
-        throw std::invalid_argument("ERROR: invalid transport " + hint + "\n");
+        helper::Throw<std::invalid_argument>("Toolkit", "TransportMan",
+                                             "CheckFile",
+                                             "invalid transport " + hint);
     }
 
     if (itTransport->second->m_Type != "File")
     {
-        throw std::invalid_argument("ERROR: invalid type " +
-                                    itTransport->second->m_Library +
-                                    ", must be file " + hint + "\n");
+        helper::Throw<std::invalid_argument>(
+            "Toolkit", "TransportMan", "CheckFile",
+            "invalid type " + itTransport->second->m_Library +
+                ", must be file " + hint);
     }
 }
 

--- a/source/adios2/toolkit/zmq/zmqpubsub/ZmqPubSub.cpp
+++ b/source/adios2/toolkit/zmq/zmqpubsub/ZmqPubSub.cpp
@@ -15,6 +15,7 @@
 #include <zmq.h>
 
 #include "ZmqPubSub.h"
+#include "adios2/helper/adiosLog.h"
 
 namespace adios2
 {
@@ -40,19 +41,25 @@ void ZmqPubSub::OpenPublisher(const std::string &address)
     m_ZmqContext = zmq_ctx_new();
     if (not m_ZmqContext)
     {
-        throw std::runtime_error("creating zmq context failed");
+        helper::Throw<std::runtime_error>("Toolkit", "ZmqPubSub",
+                                          "OpenPublisher",
+                                          "creating zmq context failed");
     }
 
     m_ZmqSocket = zmq_socket(m_ZmqContext, ZMQ_PUB);
     if (not m_ZmqSocket)
     {
-        throw std::runtime_error("creating zmq socket failed");
+        helper::Throw<std::runtime_error>("Toolkit", "ZmqPubSub",
+                                          "OpenPublisher",
+                                          "creating zmq socket failed");
     }
 
     int error = zmq_bind(m_ZmqSocket, address.c_str());
     if (error)
     {
-        throw std::runtime_error("binding zmq socket failed");
+        helper::Throw<std::runtime_error>("Toolkit", "ZmqPubSub",
+                                          "OpenPublisher",
+                                          "binding zmq socket failed");
     }
 }
 
@@ -62,19 +69,25 @@ void ZmqPubSub::OpenSubscriber(const std::string &address,
     m_ZmqContext = zmq_ctx_new();
     if (not m_ZmqContext)
     {
-        throw std::runtime_error("creating zmq context failed");
+        helper::Throw<std::runtime_error>("Toolkit", "ZmqPubSub",
+                                          "OpenSubscriber",
+                                          "creating zmq context failed");
     }
 
     m_ZmqSocket = zmq_socket(m_ZmqContext, ZMQ_SUB);
     if (not m_ZmqSocket)
     {
-        throw std::runtime_error("creating zmq socket failed");
+        helper::Throw<std::runtime_error>("Toolkit", "ZmqPubSub",
+                                          "OpenSubscriber",
+                                          "creating zmq socket failed");
     }
 
     int error = zmq_connect(m_ZmqSocket, address.c_str());
     if (error)
     {
-        throw std::runtime_error("connecting zmq socket failed");
+        helper::Throw<std::runtime_error>("Toolkit", "ZmqPubSub",
+                                          "OpenSubscriber",
+                                          "connecting zmq socket failed");
     }
 
     zmq_setsockopt(m_ZmqSocket, ZMQ_SUBSCRIBE, "", 0);

--- a/source/adios2/toolkit/zmq/zmqreqrep/ZmqReqRep.cpp
+++ b/source/adios2/toolkit/zmq/zmqreqrep/ZmqReqRep.cpp
@@ -24,7 +24,8 @@ ZmqReqRep::ZmqReqRep()
     m_Context = zmq_ctx_new();
     if (not m_Context)
     {
-        throw std::runtime_error("creating zmq context failed");
+        helper::Throw<std::runtime_error>("Toolkit", "ZmqReqRep", "ZmqReqRep",
+                                          "creating zmq context failed");
     }
 }
 
@@ -84,13 +85,15 @@ void ZmqReqRep::OpenReplier(const std::string &address, const int timeout,
     m_Socket = zmq_socket(m_Context, ZMQ_REP);
     if (not m_Socket)
     {
-        throw std::runtime_error("creating zmq socket failed");
+        helper::Throw<std::runtime_error>("Toolkit", "ZmqReqRep", "OpenReplier",
+                                          "creating zmq socket failed");
     }
 
     int error = zmq_bind(m_Socket, address.c_str());
     if (error)
     {
-        throw std::runtime_error("binding zmq socket failed");
+        helper::Throw<std::runtime_error>("Toolkit", "ZmqReqRep", "OpenReplier",
+                                          "binding zmq socket failed");
     }
 
     zmq_setsockopt(m_Socket, ZMQ_RCVTIMEO, &m_Timeout, sizeof(m_Timeout));

--- a/source/utils/adios_iotest/CMakeLists.txt
+++ b/source/utils/adios_iotest/CMakeLists.txt
@@ -8,7 +8,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/iotest-config
 )
 
 add_executable(adios_iotest settings.cpp decomp.cpp processConfig.cpp ioGroup.cpp stream.cpp adiosStream.cpp adios_iotest.cpp)
-target_link_libraries(adios_iotest adios2::cxx11_mpi MPI::MPI_C)
+target_link_libraries(adios_iotest adios2::cxx11_mpi MPI::MPI_C adios2_core_mpi)
 if(WIN32)
   target_link_libraries(adios_iotest getopt)
 endif()
@@ -16,6 +16,7 @@ set_property(TARGET adios_iotest PROPERTY OUTPUT_NAME adios2_iotest${ADIOS2_EXEC
 
 if(ADIOS2_HAVE_HDF5 AND HDF5_IS_PARALLEL)
   target_compile_definitions(adios_iotest PRIVATE ADIOS2_HAVE_HDF5_PARALLEL)
+
   if(HDF5_C_INCLUDE_DIRS)
     target_include_directories(adios_iotest PRIVATE ${HDF5_C_INCLUDE_DIRS})
   else()
@@ -26,12 +27,6 @@ if(ADIOS2_HAVE_HDF5 AND HDF5_IS_PARALLEL)
 
   target_link_libraries(adios_iotest ${HDF5_C_LIBRARIES})
 
-  if(ADIOS2_HAVE_MPI)
-    target_link_libraries(adios_iotest ${HDF5_C_LIBRARIES} adios2_core_mpi)
-  else()
-    target_link_libraries(adios_iotest ${HDF5_C_LIBRARIES} adios2_core)
-  endif()
-
 endif()
 
 
@@ -39,6 +34,6 @@ install(TARGETS adios_iotest EXPORT adios2
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_tools-runtime
 )
 
-install(DIRECTORY iotest-config/ 
+install(DIRECTORY iotest-config/
    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/iotest-config COMPONENT adios2_tools-data
 )

--- a/source/utils/adios_iotest/CMakeLists.txt
+++ b/source/utils/adios_iotest/CMakeLists.txt
@@ -25,6 +25,13 @@ if(ADIOS2_HAVE_HDF5 AND HDF5_IS_PARALLEL)
   target_sources(adios_iotest PRIVATE hdf5Stream.cpp)
 
   target_link_libraries(adios_iotest ${HDF5_C_LIBRARIES})
+
+  if(ADIOS2_HAVE_MPI)
+    target_link_libraries(adios_iotest ${HDF5_C_LIBRARIES} adios2_core_mpi)
+  else()
+    target_link_libraries(adios_iotest ${HDF5_C_LIBRARIES} adios2_core)
+  endif()
+
 endif()
 
 

--- a/source/utils/adios_iotest/hdf5Stream.cpp
+++ b/source/utils/adios_iotest/hdf5Stream.cpp
@@ -15,6 +15,8 @@
 #include <string>
 #include <vector>
 
+#include "adios2/helper/adiosLog.h"
+
 hdf5Stream::hdf5Stream(const std::string &streamName, const adios2::Mode mode,
                        MPI_Comm comm)
 : Stream(streamName, mode), comm(comm)
@@ -25,7 +27,9 @@ hdf5Stream::hdf5Stream(const std::string &streamName, const adios2::Mode mode,
 
     if (ret < 0)
     {
-        throw std::runtime_error("Unable to call set_fapl_mpio");
+        adios2::helper::Throw<std::runtime_error>(
+            "Utils::adios_iotest", "hdf5Stream", "hdf5Stream",
+            "Unable to call set_fapl_mpio");
     }
     // int myRank;
     // MPI_Comm_rank(comm, &myRank);
@@ -62,7 +66,9 @@ hdf5Stream::hdf5Stream(const std::string &streamName, const adios2::Mode mode,
     ret = H5Pclose(acc_tpl);
     if (ret < 0)
     {
-        throw std::runtime_error("Unable to call set_fapl_mpio");
+        adios2::helper::Throw<std::runtime_error>(
+            "Utils::adios_iotest", "hdf5Stream", "hdf5Stream",
+            "Unable to call set_fapl_mpio");
     }
 }
 

--- a/source/utils/adios_iotest/processConfig.cpp
+++ b/source/utils/adios_iotest/processConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * processConfig.h
+ * processConfig.cpp
  *
  *  Created on: Oct 2018
  *      Author: Norbert Podhorszki
@@ -18,6 +18,8 @@
 
 #include "decomp.h"
 #include "processConfig.h"
+
+#include "adios2/helper/adiosLog.h"
 
 Command::Command(Operation operation) : op(operation) {}
 Command::~Command() {}
@@ -82,10 +84,11 @@ size_t stringToSizet(std::vector<std::string> &words, size_t pos,
 {
     if (words.size() < pos + 1)
     {
-        throw std::invalid_argument(
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "processConfig", "stringToSizet",
             "Line for " + lineID +
-            " is invalid. Missing value at word position " +
-            std::to_string(pos + 1));
+                " is invalid. Missing value at word position " +
+                std::to_string(pos + 1));
     }
 
     char *end;
@@ -93,8 +96,9 @@ size_t stringToSizet(std::vector<std::string> &words, size_t pos,
     size_t n = static_cast<size_t>(std::strtoull(words[pos].c_str(), &end, 10));
     if (end[0] || errno == ERANGE)
     {
-        throw std::invalid_argument("Invalid value given for " + lineID + ": " +
-                                    words[pos]);
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "processConfig", "stringToSizet",
+            "Invalid value given for " + lineID + ": " + words[pos]);
     }
     return n;
 }
@@ -104,10 +108,11 @@ double stringToDouble(std::vector<std::string> &words, size_t pos,
 {
     if (words.size() < pos + 1)
     {
-        throw std::invalid_argument(
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "processConfig", "stringToDouble",
             "Line for " + lineID +
-            " is invalid. Missing floating point value at word position " +
-            std::to_string(pos + 1));
+                " is invalid. Missing floating point value at word position " +
+                std::to_string(pos + 1));
     }
 
     char *end;
@@ -115,8 +120,10 @@ double stringToDouble(std::vector<std::string> &words, size_t pos,
     double d = static_cast<double>(std::strtod(words[pos].c_str(), &end));
     if (end[0] || errno == ERANGE)
     {
-        throw std::invalid_argument("Invalid floating point value given for " +
-                                    lineID + ": " + words[pos]);
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "processConfig", "stringToDouble",
+            "Invalid floating point value given for " + lineID + ": " +
+                words[pos]);
     }
     return d;
 }
@@ -204,10 +211,12 @@ size_t processDecomp(std::string &word, const Settings &settings,
         }
         else
         {
-            throw std::invalid_argument(
+            adios2::helper::Throw<std::invalid_argument>(
+                "Utils::adios_iotest", "processConfig", "processDecomp",
                 "Invalid identifier '" + std::string(1, c) + "' for " +
-                decompID + " in character position " + std::to_string(i + 1) +
-                ". Only accepted characters are XYZVW and 1");
+                    decompID + " in character position " +
+                    std::to_string(i + 1) +
+                    ". Only accepted characters are XYZVW and 1");
         }
     }
     return decomp;
@@ -222,7 +231,10 @@ size_t getTypeSize(std::string &type)
             return t.second;
         }
     }
-    throw std::invalid_argument("Type '" + type + "' is invalid. ");
+    adios2::helper::Throw<std::invalid_argument>(
+        "Utils::adios_iotest", "processConfig", "getTypeSize",
+        "Type '" + type + "' is invalid. ");
+    return 0;
 }
 
 VariableInfo processArray(std::vector<std::string> &words,
@@ -230,9 +242,10 @@ VariableInfo processArray(std::vector<std::string> &words,
 {
     if (words.size() < 4)
     {
-        throw std::invalid_argument("Line for array definition is invalid. "
-                                    "There must be at least 4 words "
-                                    "in the line (array type name ndim)");
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "processConfig", "processArray",
+            "Line for array definition is invalid. There must be at least 4 "
+            "words in the line (array type name ndim)");
     }
     VariableInfo ov;
     ov.shapeID = adios2::ShapeID::GlobalArray;
@@ -245,11 +258,11 @@ VariableInfo processArray(std::vector<std::string> &words,
 
     if (words.size() < 4 + 2 * ov.ndim)
     {
-        throw std::invalid_argument(
-            "Line for array definition is invalid. "
-            "There must be at least 4 + 2*N words where N is the 4th word ndim "
-            "in the line (array type name ndim dim1 ... dimN decomp1 ... "
-            "decompN)");
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "processConfig", "processArray",
+            "Line for array definition is invalid. There must be at least 4 + "
+            "2*N words where N is the 4th word ndim in the line (array type "
+            "name ndim dim1 ... dimN decomp1 ... decompN)");
     }
 
     for (size_t i = 0; i < ov.ndim; i++)
@@ -276,12 +289,13 @@ VariableInfo processArray(std::vector<std::string> &words,
     }
     if (nprocDecomp != settings.nProc)
     {
-        throw std::invalid_argument(
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "processConfig", "processArray",
             "Invalid decomposition for array '" + ov.name +
-            "'. The product of the decompositions (here " +
-            std::to_string(nprocDecomp) +
-            ") must equal the number of processes (here " +
-            std::to_string(settings.nProc) + ")");
+                "'. The product of the decompositions (here " +
+                std::to_string(nprocDecomp) +
+                ") must equal the number of processes (here " +
+                std::to_string(settings.nProc) + ")");
     }
     return ov;
 }
@@ -400,9 +414,10 @@ void globalChecks(const Config &cfg, const Settings &settings)
         {
             if (cfg.condMap.find(cmd->conditionalStream) == cfg.condMap.end())
             {
-                throw std::invalid_argument(
+                adios2::helper::Throw<std::invalid_argument>(
+                    "Utils::adios_iotest", "processConfig", "globalChecks",
                     "Name used in conditional is not a read stream: '" +
-                    cmd->conditionalStream + "'");
+                        cmd->conditionalStream + "'");
             }
         }
     }
@@ -410,9 +425,10 @@ void globalChecks(const Config &cfg, const Settings &settings)
     {
         if (cfg.condMap.find(it.first) == cfg.condMap.end())
         {
-            throw std::invalid_argument(
+            adios2::helper::Throw<std::invalid_argument>(
+                "Utils::adios_iotest", "processConfig", "globalChecks",
                 "Name used in step over command is not a read stream: '" +
-                it.first + "' ");
+                    it.first + "' ");
         }
     }
 }
@@ -424,8 +440,9 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
     std::ifstream configFile(settings.configFileName);
     if (!configFile.is_open())
     {
-        throw std::invalid_argument(settings.configFileName +
-                                    " cannot be opened ");
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "processConfig", "processConfig",
+            settings.configFileName + " cannot be opened ");
     }
     if (verbose0)
     {
@@ -458,19 +475,19 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
             {
                 if (words.size() < 2)
                 {
-                    throw std::invalid_argument(
-                        "Line for 'cond' is invalid. "
-                        "Missing group name at word position "
-                        "2");
+                    adios2::helper::Throw<std::invalid_argument>(
+                        "Utils::adios_iotest", "processConfig", "processConfig",
+                        "Line for 'cond' is invalid. Missing group name at "
+                        "word position 2");
                 }
                 conditionalStream = words[1];
 
                 if (words.size() < 3)
                 {
-                    throw std::invalid_argument(
-                        "Line for 'cond' is invalid. "
-                        "Missing command from word position "
-                        "3");
+                    adios2::helper::Throw<std::invalid_argument>(
+                        "Utils::adios_iotest", "processConfig", "processConfig",
+                        "Line for 'cond' is invalid. Missing command from word "
+                        "position 3");
                 }
                 words.erase(words.begin(), words.begin() + 2);
                 key = words[0];
@@ -481,9 +498,10 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
             {
                 if (words.size() < 2)
                 {
-                    throw std::invalid_argument("Line for group is invalid. "
-                                                "Missing name at word position "
-                                                "2");
+                    adios2::helper::Throw<std::invalid_argument>(
+                        "Utils::adios_iotest", "processConfig", "processConfig",
+                        "Line for group is invalid. Missing name at word "
+                        "position 2");
                 }
 
                 currentGroup = words[1];
@@ -586,18 +604,22 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
                 {
                     if (words.size() < 3)
                     {
-                        throw std::invalid_argument(
-                            "Line for 'write' is invalid. "
-                            "Need at least output name and group name ");
+                        adios2::helper::Throw<std::invalid_argument>(
+                            "Utils::adios_iotest", "processConfig",
+                            "processConfig",
+                            "Line for 'write' is invalid. Need at least output "
+                            "name and group name ");
                     }
                     std::string fileName(words[1]);
                     std::string groupName(words[2]);
                     auto grpIt = cfg.groupVariablesMap.find(groupName);
                     if (grpIt == cfg.groupVariablesMap.end())
                     {
-                        throw std::invalid_argument(
+                        adios2::helper::Throw<std::invalid_argument>(
+                            "Utils::adios_iotest", "processConfig",
+                            "processConfig",
                             "Group '" + groupName +
-                            "' used in 'write' command is undefined. ");
+                                "' used in 'write' command is undefined. ");
                     }
 
                     if (verbose0)
@@ -617,12 +639,13 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
                         auto vIt = grpIt->second.find(words[widx]);
                         if (vIt == grpIt->second.end())
                         {
-                            throw std::invalid_argument("Group '" + groupName +
-                                                        "' used in 'write' "
-                                                        "command has no "
-                                                        "variable '" +
-                                                        words[widx] +
-                                                        "' defined.");
+                            adios2::helper::Throw<std::invalid_argument>(
+                                "Utils::adios_iotest", "processConfig",
+                                "processConfig",
+                                "Group '" + groupName +
+                                    "' used in 'write' command has no variable "
+                                    "'" +
+                                    words[widx] + "' defined.");
                         }
                         cmd->variables.push_back(vIt->second);
                         ++widx;
@@ -647,11 +670,11 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
                 {
                     if (words.size() < 4)
                     {
-                        throw std::invalid_argument(
-                            "Line for 'read' is invalid. "
-                            "Need at least 3 arguments: "
-                            "mode, output name, group "
-                            "name ");
+                        adios2::helper::Throw<std::invalid_argument>(
+                            "Utils::adios_iotest", "processConfig",
+                            "processConfig",
+                            "Line for 'read' is invalid. Need at least 3 "
+                            "arguments: mode, output name, group name ");
                     }
                     std::string mode(words[1]);
                     std::transform(mode.begin(), mode.end(), mode.begin(),
@@ -665,15 +688,19 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
                     auto grpIt = cfg.groupVariablesMap.find(groupName);
                     if (grpIt == cfg.groupVariablesMap.end())
                     {
-                        throw std::invalid_argument(
+                        adios2::helper::Throw<std::invalid_argument>(
+                            "Utils::adios_iotest", "processConfig",
+                            "processConfig",
                             "Group '" + groupName +
-                            "' used in 'read' command is undefined. ");
+                                "' used in 'read' command is undefined. ");
                     }
                     if (mode != "next" && mode != "latest")
                     {
-                        throw std::invalid_argument(
-                            "Mode (1st argument) for 'read' is invalid. "
-                            "It must be either 'next' or 'latest'");
+                        adios2::helper::Throw<std::invalid_argument>(
+                            "Utils::adios_iotest", "processConfig",
+                            "processConfig",
+                            "Mode (1st argument) for 'read' is invalid. It "
+                            "must be either 'next' or 'latest'");
                     }
 
                     double d = -1.0;
@@ -715,12 +742,13 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
                         auto vIt = grpIt->second.find(words[widx]);
                         if (vIt == grpIt->second.end())
                         {
-                            throw std::invalid_argument("Group '" + groupName +
-                                                        "' used in 'write' "
-                                                        "command has no "
-                                                        "variable '" +
-                                                        words[widx] +
-                                                        "' defined.");
+                            adios2::helper::Throw<std::invalid_argument>(
+                                "Utils::adios_iotest", "processConfig",
+                                "processConfig",
+                                "Group '" + groupName +
+                                    "' used in 'write' command has no variable "
+                                    "'" +
+                                    words[widx] + "' defined.");
                         }
                         if (verbose0)
                         {
@@ -835,17 +863,19 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
             {
                 if (words.size() < 3)
                 {
-                    throw std::invalid_argument("Line for 'link' is invalid. "
-                                                "Need at least 2 words: "
-                                                "group <group_name> ");
+                    adios2::helper::Throw<std::invalid_argument>(
+                        "Utils::adios_iotest", "processConfig", "processConfig",
+                        "Line for 'link' is invalid. Need at least 2 words: "
+                        "group <group_name> ");
                 }
                 std::string groupName = words[2];
                 auto grpIt = cfg.groupVariablesMap.find(groupName);
                 if (grpIt == cfg.groupVariablesMap.end())
                 {
-                    throw std::invalid_argument(
+                    adios2::helper::Throw<std::invalid_argument>(
+                        "Utils::adios_iotest", "processConfig", "processConfig",
                         "Group '" + groupName +
-                        "' used in 'link' command is undefined. ");
+                            "' used in 'link' command is undefined. ");
                 }
 
                 if (verbose0)
@@ -863,12 +893,13 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
                         auto vIt = grpIt->second.find(words[widx]);
                         if (vIt == grpIt->second.end())
                         {
-                            throw std::invalid_argument("Group '" + groupName +
-                                                        "' used in 'link' "
-                                                        "command has no "
-                                                        "variable '" +
-                                                        words[widx] +
-                                                        "' defined.");
+                            adios2::helper::Throw<std::invalid_argument>(
+                                "Utils::adios_iotest", "processConfig",
+                                "processConfig",
+                                "Group '" + groupName +
+                                    "' used in 'link' command has no variable "
+                                    "'" +
+                                    words[widx] + "' defined.");
                         }
                         if (verbose0)
                         {
@@ -901,8 +932,9 @@ Config processConfig(const Settings &settings, size_t *currentConfigLineNumber)
             }
             else
             {
-                throw std::invalid_argument("Unrecognized keyword '" + key +
-                                            "'.");
+                adios2::helper::Throw<std::invalid_argument>(
+                    "Utils::adios_iotest", "processConfig", "processConfig",
+                    "Unrecognized keyword '" + key + "'.");
             }
         }
     }

--- a/source/utils/adios_iotest/settings.cpp
+++ b/source/utils/adios_iotest/settings.cpp
@@ -17,6 +17,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "adios2/helper/adiosLog.h"
+
 struct option options[] = {{"help", no_argument, NULL, 'h'},
                            {"verbose", no_argument, NULL, 'v'},
                            {"appid", required_argument, NULL, 'a'},
@@ -84,8 +86,9 @@ size_t Settings::stringToNumber(const std::string &varName,
     size_t retval = static_cast<size_t>(std::strtoull(arg, &end, 10));
     if (end[0] || errno == ERANGE)
     {
-        throw std::invalid_argument("Invalid value given for " + varName +
-                                    ": " + std::string(arg));
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "settings", "stringToNumber",
+            "Invalid value given for " + varName + ": " + std::string(arg));
     }
     return retval;
 }
@@ -135,7 +138,8 @@ int Settings::rescaleDecomp()
         }
     }
 
-    throw std::invalid_argument(
+    adios2::helper::Throw<std::invalid_argument>(
+        "Utils::adios_iotest", "settings", "rescaleDecomp",
         "decomposition ratios must scale up to process count");
 }
 
@@ -162,8 +166,9 @@ int Settings::processArgs(int argc, char *argv[])
         case 'd':
             if (decompDefined && isRatioDecomp)
             {
-                throw std::invalid_argument(
-                    "Cannot have -D and -d used at the same time ");
+                adios2::helper::Throw<std::invalid_argument>(
+                    "Utils::adios_iotest", "settings", "processArgs",
+                    "Cannot have -D and -d used at the same time");
             }
             if (strchr(optarg, ','))
             {
@@ -180,8 +185,9 @@ int Settings::processArgs(int argc, char *argv[])
         case 'D':
             if (decompDefined && !isRatioDecomp)
             {
-                throw std::invalid_argument(
-                    "Cannot have -D and -d used at the same time ");
+                adios2::helper::Throw<std::invalid_argument>(
+                    "Utils::adios_iotest", "settings", "processArgs",
+                    "Cannot have -D and -d used at the same time");
             }
             if (strchr(optarg, ','))
             {
@@ -213,8 +219,9 @@ int Settings::processArgs(int argc, char *argv[])
         case 's':
             if (scalingDefined && !isStrongScaling)
             {
-                throw std::invalid_argument(
-                    "Cannot have -w and -s used at the same time ");
+                adios2::helper::Throw<std::invalid_argument>(
+                    "Utils::adios_iotest", "settings", "processArgs",
+                    "Cannot have -w and -s used at the same time");
             }
             isStrongScaling = true;
             scalingDefined = true;
@@ -225,8 +232,9 @@ int Settings::processArgs(int argc, char *argv[])
         case 'w':
             if (scalingDefined && isStrongScaling)
             {
-                throw std::invalid_argument(
-                    "Cannot have -s and -w used at the same time ");
+                adios2::helper::Throw<std::invalid_argument>(
+                    "Utils::adios_iotest", "settings", "processArgs",
+                    "Cannot have -s and -w used at the same time");
             }
             isStrongScaling = false;
             scalingDefined = true;
@@ -253,14 +261,16 @@ int Settings::processArgs(int argc, char *argv[])
             }
             else
             {
-                throw std::invalid_argument("Invalid argument " +
-                                            std::string(optarg));
+                adios2::helper::Throw<std::invalid_argument>(
+                    "Utils::adios_iotest", "settings", "processArgs",
+                    "Invalid argument " + std::string(optarg));
             }
             break;
 
         default:
-            throw std::invalid_argument("Invalid argument option " +
-                                        std::string(optarg));
+            adios2::helper::Throw<std::invalid_argument>(
+                "Utils::adios_iotest", "settings", "processArgs",
+                "Invalid argument option " + std::string(optarg));
         } /* end switch */
         if (c != 1)
         {
@@ -277,26 +287,31 @@ int Settings::processArgs(int argc, char *argv[])
             s += std::string(argv[optind]) + " ";
             ++optind;
         }
-        throw std::invalid_argument("There are unknown arguments: " + s);
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "settings", "processArgs",
+            "There are unknown arguments: " + s);
     }
 
     /* Check if we have a everything defined */
     if (!appIdDefined)
     {
-        throw std::invalid_argument("Missing argument for application ID, "
-                                    "which must be unique for each application "
-                                    "(see -a option)");
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "settings", "processArgs",
+            "Missing argument for application ID, which must be unique for "
+            "each application (see -a option)");
     }
     if (configFileName.empty())
     {
-        throw std::invalid_argument(
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "settings", "processArgs",
             "Missing argument for config file (see -c option)");
     }
     if (!scalingDefined)
     {
-        throw std::invalid_argument("Missing argument for scaling, "
-                                    "which must be set to Strong or Weak "
-                                    "(see -s, -w options)");
+        adios2::helper::Throw<std::invalid_argument>(
+            "Utils::adios_iotest", "settings", "processArgs",
+            "Missing argument for scaling, which must be set to Strong or Weak "
+            "(see -s, -w options)");
     }
 
     return 0;

--- a/source/utils/adios_iotest/settings.cpp
+++ b/source/utils/adios_iotest/settings.cpp
@@ -141,6 +141,7 @@ int Settings::rescaleDecomp()
     adios2::helper::Throw<std::invalid_argument>(
         "Utils::adios_iotest", "settings", "rescaleDecomp",
         "decomposition ratios must scale up to process count");
+    return 0;
 }
 
 int Settings::processArgs(int argc, char *argv[])

--- a/source/utils/adios_reorganize/Reorganize.cpp
+++ b/source/utils/adios_reorganize/Reorganize.cpp
@@ -64,8 +64,9 @@ Reorganize::Reorganize(int argc, char *argv[])
     if (argc < 7)
     {
         PrintUsage();
-        throw std::invalid_argument(
-            "ERROR: Not enough arguments. At least 6 are required\n");
+        helper::Throw<std::invalid_argument>(
+            "Utils", "AdiosReorganize", "Reorganize",
+            "Not enough arguments. At least 6 are required");
     }
     infilename = std::string(argv[1]);
     outfilename = std::string(argv[2]);
@@ -87,7 +88,8 @@ Reorganize::Reorganize(int argc, char *argv[])
                 "ERROR: Invalid decomposition number in argument " +
                 std::to_string(j) + ": '" + std::string(argv[j]) + "'\n");
             PrintUsage();
-            throw std::invalid_argument(errmsg);
+            helper::Throw<std::invalid_argument>("Utils", "AdiosReorganize",
+                                                 "Reorganize", errmsg);
         }
         nd++;
         j++;
@@ -95,8 +97,9 @@ Reorganize::Reorganize(int argc, char *argv[])
 
     if (argc > j)
     {
-        throw std::invalid_argument(
-            "ERROR: Up to 6 decomposition arguments are supported\n");
+        helper::Throw<std::invalid_argument>(
+            "Utils", "AdiosReorganize", "Reorganize",
+            "Up to 6 decomposition arguments are supported");
     }
 
     int prod = 1;
@@ -114,7 +117,8 @@ Reorganize::Reorganize(int argc, char *argv[])
                            std::to_string(prod) + " > number of processes " +
                            std::to_string(m_Size) + "\n");
         PrintUsage();
-        throw std::invalid_argument(errmsg);
+        helper::Throw<std::invalid_argument>("Utils", "AdiosReorganize",
+                                             "Reorganize", errmsg);
     }
 }
 

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -30,6 +30,8 @@
 
 #include <errno.h>
 
+#include "adios2/helper/adiosLog.h"
+
 #if defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
 /* pre GCC 4.9 cannot handle the C++ regex implementation. Will use C-lib
@@ -2792,10 +2794,10 @@ bool print_data_xml(const char *s, const size_t length)
     auto parse_result = document.load_buffer(s, length);
     if (!parse_result)
     {
-        /*throw std::invalid_argument(
-            "ERROR: XML: parse error in XML string, description: " +
-            std::string(parse_result.description()) +
-            ", check with any XML editor if format is ill-formed\n ");*/
+        //   helper::Throw<std::invalid_argument>( "Utils", "bpls",
+        //   "print_data_xml", "ERROR: XML: parse error in XML string,
+        //   description: " + std::string(parse_result.description()) + ", check
+        //   with any XML editor if format is ill-formed");
         return true;
     }
     std::cout << std::endl;


### PR DESCRIPTION
Exceptions in ADIOS2 have developed more and more messy and confusing. A lot of them are written in a way that no users would ever understand what's going on. This PR attempts to make it easier for developers and users to understand where these exceptions come from. Thus, whenever there is anything going wrong, users can provide meaningful information to developers in the first place.