### PR TITLE
Add Direct IO support for BP5 with control parameters bool DirectIO, …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,9 +182,48 @@ if(ADIOS2_HAVE_MPI)
   add_definitions(-DOMPI_SKIP_MPICXX -DMPICH_SKIP_MPICXX)
 endif()
 
+
+#------------------------------------------------------------------------------#
+# POSIX O_DIRECT is only working for Unix in adios for now
+#------------------------------------------------------------------------------#
+if(CYGWIN)
+  #-tb O_DIRECT messes up cygwin
+  set(ADIOS2_HAVE_O_DIRECT 0)
+elseif(MSVC)
+  # Windows has other things but we are not using them
+  set(ADIOS2_HAVE_O_DIRECT 0)
+elseif(APPLE)
+  # Mac has other things but we are not using them
+  set(ADIOS2_HAVE_O_DIRECT 0)
+else()
+
+  message(STATUS "Checking for O_DIRECT")
+  include(CheckCXXSourceCompiles)
+  check_cxx_source_compiles("
+#include <unistd.h>
+#include <fcntl.h>
+int main(int argc, char * argv[]) { argc = O_DIRECT; }
+" O_DIRECT_WORKS)
+
+  if (O_DIRECT_WORKS)
+    set(ADIOS2_HAVE_O_DIRECT 1)
+  else()
+    set(ADIOS2_HAVE_O_DIRECT 0)
+  endif()
+
+endif()
+
+#if(NOT HAVE_O_DIRECT)
+#  message(WARNING " -----  The open() flag O_DIRECT is not available! ---- ")
+#else()
+#  message(STATUS " -----  The open() flag O_DIRECT is available! ---- ")
+#endif()
+
+
 set(ADIOS2_CONFIG_OPTS
-    BP5 DataMan DataSpaces HDF5 HDF5_VOL MHS SST CUDA Fortran MPI Python Blosc BZip2 LIBPRESSIO MGARD PNG SZ ZFP DAOS IME SysVShMem ZeroMQ Profiling Endian_Reverse
+    BP5 DataMan DataSpaces HDF5 HDF5_VOL MHS SST CUDA Fortran MPI Python Blosc BZip2 LIBPRESSIO MGARD PNG SZ ZFP DAOS IME SysVShMem ZeroMQ Profiling Endian_Reverse O_DIRECT
 )
+
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})
 configure_file(
   ${PROJECT_SOURCE_DIR}/CTestCustom.cmake.in
@@ -228,6 +267,7 @@ if(BUILD_SHARED_LIBS AND ADIOS2_RUN_INSTALL_TEST)
     set(CMAKE_INSTALL_RPATH "$ORIGIN/${relative_base}/${CMAKE_INSTALL_LIBDIR}")
   endif()
 endif()
+
 
 #------------------------------------------------------------------------------#
 # Third party libraries

--- a/examples/basics/globalArray/globalArray_write.cpp
+++ b/examples/basics/globalArray/globalArray_write.cpp
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
         io.SetParameter("AggregationType", "TwoLevelShm");
         io.SetParameter("NumAggregators", "1");
         io.SetParameter("NumSubFiles", "1");
-        io.SetParameter("AsyncWrite", "Guided");
+        io.SetParameter("AsyncWrite", "false");
 
         /*
          * Define global array: type, name, global dimensions

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -123,7 +123,10 @@ public:
     MACRO(CollectiveMetadata, Bool, bool, true)                                \
     MACRO(NumAggregators, UInt, unsigned int, 0)                               \
     MACRO(NumSubFiles, UInt, unsigned int, 999999)                             \
-    MACRO(FileSystemPageSize, UInt, unsigned int, 4096)                        \
+    MACRO(StripeSize, UInt, unsigned int, 4096)                                \
+    MACRO(DirectIO, Bool, bool, false)                                         \
+    MACRO(DirectIOAlignOffset, UInt, unsigned int, 512)                        \
+    MACRO(DirectIOAlignBuffer, UInt, unsigned int, 0)                          \
     MACRO(AggregationType, AggregationType, int,                               \
           (int)AggregationType::TwoLevelShm)                                   \
     MACRO(AsyncOpen, Bool, bool, true)                                         \

--- a/source/adios2/engine/bp5/BP5Writer_EveryoneWrites_Async.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_EveryoneWrites_Async.cpp
@@ -242,8 +242,8 @@ void BP5Writer::WriteData_EveryoneWrites_Async(format::BufferV *Data,
     }
 
     // align to PAGE_SIZE
-    m_DataPos += helper::PaddingToAlignOffset(m_DataPos,
-                                              m_Parameters.FileSystemPageSize);
+    m_DataPos +=
+        helper::PaddingToAlignOffset(m_DataPos, m_Parameters.StripeSize);
     m_StartDataPos = m_DataPos;
 
     if (a->m_Comm.Rank() < a->m_Comm.Size() - 1)

--- a/source/adios2/engine/bp5/BP5Writer_TwoLevelShm.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_TwoLevelShm.cpp
@@ -40,8 +40,8 @@ void BP5Writer::WriteData_TwoLevelShm(format::BufferV *Data)
     // to arrive from the rank below
 
     // align to PAGE_SIZE (only valid on master aggregator at this point)
-    m_DataPos += helper::PaddingToAlignOffset(m_DataPos,
-                                              m_Parameters.FileSystemPageSize);
+    m_DataPos +=
+        helper::PaddingToAlignOffset(m_DataPos, m_Parameters.StripeSize);
 
     // Each aggregator needs to know the total size they write
     // This calculation is valid on aggregators only
@@ -59,7 +59,13 @@ void BP5Writer::WriteData_TwoLevelShm(format::BufferV *Data)
 
     if (a->m_Comm.Size() > 1)
     {
-        a->CreateShm(static_cast<size_t>(maxSize), m_Parameters.MaxShmSize);
+        size_t alignment_size = sizeof(max_align_t);
+        if (m_Parameters.DirectIO)
+        {
+            alignment_size = m_Parameters.DirectIOAlignOffset;
+        }
+        a->CreateShm(static_cast<size_t>(maxSize), m_Parameters.MaxShmSize,
+                     alignment_size);
     }
 
     shm::TokenChain<uint64_t> tokenChain(&a->m_Comm);
@@ -74,8 +80,8 @@ void BP5Writer::WriteData_TwoLevelShm(format::BufferV *Data)
                 &m_DataPos, 1, a->m_AggregatorChainComm.Rank() - 1, 0,
                 "AggregatorChain token in BP5Writer::WriteData_TwoLevelShm");
             // align to PAGE_SIZE
-            m_DataPos += helper::PaddingToAlignOffset(
-                m_DataPos, m_Parameters.FileSystemPageSize);
+            m_DataPos += helper::PaddingToAlignOffset(m_DataPos,
+                                                      m_Parameters.StripeSize);
         }
         m_StartDataPos = m_DataPos; // metadata needs this info
         if (a->m_AggregatorChainComm.Rank() <

--- a/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
@@ -214,7 +214,8 @@ void MPIShmChain::HandshakeLinks_Complete(HandshakeStruct &hs)
                         "aggregator, at Open");
 }
 
-void MPIShmChain::CreateShm(size_t blocksize, const size_t maxsegmentsize)
+void MPIShmChain::CreateShm(size_t blocksize, const size_t maxsegmentsize,
+                            const size_t alignment_size)
 {
     if (!m_Comm.IsMPI())
     {
@@ -224,21 +225,20 @@ void MPIShmChain::CreateShm(size_t blocksize, const size_t maxsegmentsize)
     }
     char *ptr;
     size_t structsize = sizeof(ShmSegment);
-    structsize += helper::PaddingToAlignOffset(structsize, sizeof(max_align_t));
+    structsize += helper::PaddingToAlignOffset(structsize, alignment_size);
     if (!m_Rank)
     {
-        blocksize +=
-            helper::PaddingToAlignOffset(blocksize, sizeof(max_align_t));
+        blocksize += helper::PaddingToAlignOffset(blocksize, alignment_size);
         size_t totalsize = structsize + 2 * blocksize;
         if (totalsize > maxsegmentsize)
         {
             // roll back and calculate sizes from maxsegmentsize
-            totalsize = maxsegmentsize - sizeof(max_align_t) + 1;
+            totalsize = maxsegmentsize - alignment_size + 1;
             totalsize +=
-                helper::PaddingToAlignOffset(totalsize, sizeof(max_align_t));
-            blocksize = (totalsize - structsize) / 2 - sizeof(max_align_t) + 1;
+                helper::PaddingToAlignOffset(totalsize, alignment_size);
+            blocksize = (totalsize - structsize) / 2 - alignment_size + 1;
             blocksize +=
-                helper::PaddingToAlignOffset(blocksize, sizeof(max_align_t));
+                helper::PaddingToAlignOffset(blocksize, alignment_size);
             totalsize = structsize + 2 * blocksize;
         }
         m_Win = m_Comm.Win_allocate_shared(totalsize, 1, &ptr);

--- a/source/adios2/toolkit/aggregator/mpi/MPIShmChain.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIShmChain.h
@@ -110,7 +110,8 @@ public:
     void ResetBuffers() noexcept;
 
     // 2*blocksize+some is allocated but only up to maxsegmentsize
-    void CreateShm(size_t blocksize, const size_t maxsegmentsize);
+    void CreateShm(size_t blocksize, const size_t maxsegmentsize,
+                   const size_t alignment_size);
     void DestroyShm();
 
 private:

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -546,10 +546,10 @@ size_t BP5Serializer::CalcSize(const size_t Count, const size_t *Vals)
     return Elems;
 }
 
-void BP5Serializer::PerformPuts()
+void BP5Serializer::PerformPuts(bool forceCopyDeferred)
 {
     //  Dump data for externs into iovec
-    DumpDeferredBlocks();
+    DumpDeferredBlocks(forceCopyDeferred);
 
     CurDataBuffer->CopyExternalToInternal();
 }
@@ -883,7 +883,8 @@ void BP5Serializer::InitStep(BufferV *DataBuffer)
     m_PriorDataBufferSizeTotal = 0;
 }
 
-BufferV *BP5Serializer::ReinitStepData(BufferV *DataBuffer)
+BufferV *BP5Serializer::ReinitStepData(BufferV *DataBuffer,
+                                       bool forceCopyDeferred)
 {
     if (CurDataBuffer == NULL)
     {
@@ -891,10 +892,10 @@ BufferV *BP5Serializer::ReinitStepData(BufferV *DataBuffer)
                                         "ReinitStepData", "without prior Init");
     }
     //  Dump data for externs into iovec
-    DumpDeferredBlocks();
+    DumpDeferredBlocks(forceCopyDeferred);
 
     m_PriorDataBufferSizeTotal += CurDataBuffer->AddToVec(
-        0, NULL, sizeof(max_align_t), true); //  output block size aligned
+        0, NULL, m_BufferBlockSize, true); //  output block size aligned
 
     BufferV *tmp = CurDataBuffer;
     CurDataBuffer = DataBuffer;
@@ -970,7 +971,7 @@ BP5Serializer::TimestepInfo BP5Serializer::CloseTimestep(int timestep,
     DumpDeferredBlocks(forceCopyDeferred);
 
     MBase->DataBlockSize = CurDataBuffer->AddToVec(
-        0, NULL, sizeof(max_align_t), true); //  output block size aligned
+        0, NULL, m_BufferBlockSize, true); //  output block size aligned
 
     MBase->DataBlockSize += m_PriorDataBufferSizeTotal;
 

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.h
@@ -81,10 +81,11 @@ public:
      * those offsets are relative to the entire sequence of data
      * produced by a writer rank.
      */
-    BufferV *ReinitStepData(BufferV *DataBuffer);
+    BufferV *ReinitStepData(BufferV *DataBuffer,
+                            bool forceCopyDeferred = false);
 
     TimestepInfo CloseTimestep(int timestep, bool forceCopyDeferred = false);
-    void PerformPuts();
+    void PerformPuts(bool forceCopyDeferred = false);
 
     core::Engine *m_Engine = NULL;
 
@@ -110,6 +111,10 @@ public:
 
     /* Variables to help appending to existing file */
     size_t m_PreMetaMetadataFileLength = 0;
+
+    size_t m_BufferAlign = 1; // align buffers in memory
+    // align buffers to integer multiples of block size
+    size_t m_BufferBlockSize = sizeof(max_align_t);
 
 private:
     void Init();
@@ -157,6 +162,7 @@ private:
 
     size_t MetadataSize = 0;
     BufferV *CurDataBuffer = NULL;
+
     std::vector<MetaMetaInfoBlock> PreviousMetaMetaInfoBlocks;
 
     size_t m_PriorDataBufferSizeTotal = 0;

--- a/source/adios2/toolkit/format/buffer/BufferV.cpp
+++ b/source/adios2/toolkit/format/buffer/BufferV.cpp
@@ -16,13 +16,10 @@ namespace adios2
 namespace format
 {
 
-char BufferV::zero[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-
-BufferV::BufferV(const std::string type, const bool AlwaysCopy)
-: m_Type(type), m_AlwaysCopy(AlwaysCopy)
+BufferV::BufferV(const std::string type, const bool AlwaysCopy,
+                 const size_t MemAlign, const size_t MemBlockSize)
+: m_Type(type), m_MemAlign(MemAlign), m_MemBlockSize(MemBlockSize),
+  m_AlwaysCopy(AlwaysCopy)
 {
 }
 
@@ -43,8 +40,11 @@ void BufferV::AlignBuffer(const size_t align)
     if (badAlign)
     {
         size_t addAlign = align - badAlign;
-        assert(addAlign < sizeof(max_align_t));
-        AddToVec(addAlign, zero, 1, true);
+        if (addAlign > zero.size())
+        {
+            zero.resize(addAlign);
+        }
+        AddToVec(addAlign, zero.data(), 1, true);
     }
 }
 

--- a/source/adios2/toolkit/format/buffer/BufferV.h
+++ b/source/adios2/toolkit/format/buffer/BufferV.h
@@ -21,10 +21,14 @@ class BufferV
 {
 public:
     const std::string m_Type;
+    const size_t m_MemAlign; // allocate each pointer aligned
+                             // keep each buffer integer multiple of this size
+    const size_t m_MemBlockSize;
 
     uint64_t Size() noexcept;
 
-    BufferV(const std::string type, const bool AlwaysCopy = false);
+    BufferV(const std::string type, const bool AlwaysCopy = false,
+            const size_t MemAlign = 1, const size_t MemBlockSize = 1);
     virtual ~BufferV();
 
     virtual std::vector<core::iovec> DataVec() noexcept = 0;
@@ -68,7 +72,7 @@ public:
     virtual void *GetPtr(int bufferIdx, size_t posInBuffer) = 0;
 
 protected:
-    static char zero[64];
+    std::vector<char> zero;
     const bool m_AlwaysCopy = false;
 
     struct VecEntry

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
@@ -26,6 +26,7 @@ public:
     const size_t m_ChunkSize;
 
     ChunkV(const std::string type, const bool AlwaysCopy = false,
+           const size_t MemAlign = 1, const size_t MemBlockSize = 1,
            const size_t ChunkSize = DefaultBufferChunkSize);
     virtual ~ChunkV();
 
@@ -45,9 +46,21 @@ public:
                           MemorySpace MemSpace);
 
 private:
-    std::vector<char *> m_Chunks;
+    struct Chunk
+    {
+        char *Ptr;          // aligned, do not free
+        void *AllocatedPtr; // original ptr, free this
+        size_t Size;
+    };
+
+    std::vector<Chunk> m_Chunks;
     size_t m_TailChunkPos = 0;
-    char *m_TailChunk = NULL;
+    Chunk *m_TailChunk = nullptr;
+
+    // allocator function, doing aligned allocation of memory
+    // return true if (re)allocation is successful
+    // on failure, VecEntry is unmodified
+    size_t ChunkAlloc(Chunk &v, const size_t size);
 };
 
 } // end namespace format

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
@@ -20,9 +20,10 @@ namespace format
 {
 
 MallocV::MallocV(const std::string type, const bool AlwaysCopy,
+                 const size_t MemAlign, const size_t MemBlockSize,
                  size_t InitialBufferSize, double GrowthFactor)
-: BufferV(type, AlwaysCopy), m_InitialBufferSize(InitialBufferSize),
-  m_GrowthFactor(GrowthFactor)
+: BufferV(type, AlwaysCopy, MemAlign, MemBlockSize),
+  m_InitialBufferSize(InitialBufferSize), m_GrowthFactor(GrowthFactor)
 {
 }
 
@@ -87,13 +88,13 @@ void MallocV::CopyExternalToInternal()
 size_t MallocV::AddToVec(const size_t size, const void *buf, size_t align,
                          bool CopyReqd, MemorySpace MemSpace)
 {
+    AlignBuffer(align); // may call back AddToVec recursively
+    size_t retOffset = CurOffset;
+
     if (size == 0)
     {
         return CurOffset;
     }
-
-    AlignBuffer(align);
-    size_t retOffset = CurOffset;
 
     if (!CopyReqd && !m_AlwaysCopy)
     {

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.h
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.h
@@ -24,6 +24,7 @@ public:
     uint64_t Size() noexcept;
 
     MallocV(const std::string type, const bool AlwaysCopy = false,
+            const size_t MemAlign = 1, const size_t MemBlockSize = 1,
             size_t InitialBufferSize = DefaultInitialBufferSize,
             double GrowthFactor = DefaultBufferGrowthFactor);
     virtual ~MallocV();

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -81,7 +81,8 @@ void Transport::InitProfiler(const Mode openMode, const TimeUnit timeUnit)
 }
 
 void Transport::OpenChain(const std::string &name, const Mode openMode,
-                          const helper::Comm &chainComm, const bool async)
+                          const helper::Comm &chainComm, const bool async,
+                          const bool directio)
 {
     std::invalid_argument("ERROR: " + m_Name + " transport type " + m_Type +
                           " using library " + m_Library +

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -65,7 +65,8 @@ public:
      * @param async
      */
     virtual void Open(const std::string &name, const Mode openMode,
-                      const bool async = false) = 0;
+                      const bool async = false,
+                      const bool directio = false) = 0;
 
     /**
      * Opens transport, possibly asynchronously, in a chain to avoid
@@ -78,7 +79,8 @@ public:
      */
     virtual void OpenChain(const std::string &name, Mode openMode,
                            const helper::Comm &chainComm,
-                           const bool async = false);
+                           const bool async = false,
+                           const bool directio = false);
 
     /**
      * If OS buffered (FILE* or fstream), sets the buffer size

--- a/source/adios2/toolkit/transport/file/FileDaos.cpp
+++ b/source/adios2/toolkit/transport/file/FileDaos.cpp
@@ -518,7 +518,7 @@ void FileDaos::WaitForOpen()
 }
 
 void FileDaos::Open(const std::string &name, const Mode openMode,
-                    const bool async)
+                    const bool async, const bool directio)
 {
 
     int rc;

--- a/source/adios2/toolkit/transport/file/FileDaos.h
+++ b/source/adios2/toolkit/transport/file/FileDaos.h
@@ -35,8 +35,9 @@ public:
 
     void SetParameters(const Params &parameters);
 
+    /** directio option is ignored in this transport */
     void Open(const std::string &name, const Mode openMode,
-              const bool async = false) final;
+              const bool async = false, const bool directio = false) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
 

--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -46,7 +46,7 @@ void FileFStream::WaitForOpen()
 }
 
 void FileFStream::Open(const std::string &name, const Mode openMode,
-                       const bool async)
+                       const bool async, const bool directio)
 {
     auto lf_AsyncOpenWrite = [&](const std::string &name) -> void {
         ProfilerStart("open");
@@ -107,7 +107,8 @@ void FileFStream::Open(const std::string &name, const Mode openMode,
 }
 
 void FileFStream::OpenChain(const std::string &name, Mode openMode,
-                            const helper::Comm &chainComm, const bool async)
+                            const helper::Comm &chainComm, const bool async,
+                            const bool directio)
 {
     auto lf_AsyncOpenWrite = [&](const std::string &name) -> void {
         ProfilerStart("open");

--- a/source/adios2/toolkit/transport/file/FileFStream.h
+++ b/source/adios2/toolkit/transport/file/FileFStream.h
@@ -32,12 +32,13 @@ public:
 
     ~FileFStream() = default;
 
+    /** directio option is ignored in this transport */
     void Open(const std::string &name, const Mode openMode,
-              const bool async = false) final;
+              const bool async = false, const bool directio = false) final;
 
     void OpenChain(const std::string &name, Mode openMode,
-                   const helper::Comm &chainComm,
-                   const bool async = false) final;
+                   const helper::Comm &chainComm, const bool async = false,
+                   const bool directio = false) final;
 
     void SetBuffer(char *buffer, size_t size) final;
 

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -71,7 +71,7 @@ FileIME::~FileIME()
 
 /** Note that async mode is unsupported in FileIME. */
 void FileIME::Open(const std::string &name, const Mode openMode,
-                   const bool async)
+                   const bool async, const bool directio)
 {
     /** DEFAULT_IME_FILE_PREFIX is "ime://" */
     m_Name = DEFAULT_IME_FILE_PREFIX;

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -36,7 +36,7 @@ public:
 
     /** Async option is ignored in FileIME transport */
     void Open(const std::string &name, const Mode openMode,
-              const bool async = false) final;
+              const bool async = false, const bool directio = false) final;
 
     void SetParameters(const Params &parameters) final;
 

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -35,11 +35,11 @@ public:
     ~FilePOSIX();
 
     void Open(const std::string &name, const Mode openMode,
-              const bool async = false) final;
+              const bool async = false, const bool directio = false) final;
 
     void OpenChain(const std::string &name, Mode openMode,
-                   const helper::Comm &chainComm,
-                   const bool async = false) final;
+                   const helper::Comm &chainComm, const bool async = false,
+                   const bool directio = false) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
 
@@ -76,6 +76,7 @@ private:
     int m_Errno = 0;
     bool m_IsOpening = false;
     std::future<int> m_OpenFuture;
+    bool m_DirectIO = false;
 
     /**
      * Check if m_FileDescriptor is -1 after an operation

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -61,7 +61,7 @@ void FileStdio::WaitForOpen()
 }
 
 void FileStdio::Open(const std::string &name, const Mode openMode,
-                     const bool async)
+                     const bool async, const bool directio)
 {
     auto lf_AsyncOpenWrite = [&](const std::string &name) -> FILE * {
         errno = 0;
@@ -112,7 +112,8 @@ void FileStdio::Open(const std::string &name, const Mode openMode,
 }
 
 void FileStdio::OpenChain(const std::string &name, Mode openMode,
-                          const helper::Comm &chainComm, const bool async)
+                          const helper::Comm &chainComm, const bool async,
+                          const bool directio)
 {
     auto lf_AsyncOpenWrite = [&](const std::string &name) -> FILE * {
         errno = 0;

--- a/source/adios2/toolkit/transport/file/FileStdio.h
+++ b/source/adios2/toolkit/transport/file/FileStdio.h
@@ -34,12 +34,13 @@ public:
 
     ~FileStdio();
 
+    /** directio option is ignored in this transport */
     void Open(const std::string &name, const Mode openMode,
-              const bool async = false) final;
+              const bool async = false, const bool directio = false) final;
 
     void OpenChain(const std::string &name, Mode openMode,
-                   const helper::Comm &chainComm,
-                   const bool async = false) final;
+                   const helper::Comm &chainComm, const bool async = false,
+                   const bool directio = false) final;
 
     void SetBuffer(char *buffer, size_t size) final;
 

--- a/source/adios2/toolkit/transport/null/NullTransport.cpp
+++ b/source/adios2/toolkit/transport/null/NullTransport.cpp
@@ -33,7 +33,7 @@ NullTransport::NullTransport(helper::Comm const &comm)
 NullTransport::~NullTransport() = default;
 
 void NullTransport::Open(const std::string &name, const Mode openMode,
-                         const bool async)
+                         const bool async, const bool directio)
 {
     if (Impl->IsOpen)
     {

--- a/source/adios2/toolkit/transport/null/NullTransport.h
+++ b/source/adios2/toolkit/transport/null/NullTransport.h
@@ -35,7 +35,7 @@ public:
     virtual ~NullTransport();
 
     void Open(const std::string &name, const Mode openMode,
-              const bool async = false) override;
+              const bool async = false, const bool directio = false) override;
 
     void SetBuffer(char *buffer, size_t size) override;
 

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
@@ -49,7 +49,7 @@ ShmSystemV::~ShmSystemV() // this might not be correct
 }
 
 void ShmSystemV::Open(const std::string &name, const Mode openMode,
-                      const bool async)
+                      const bool async, const bool directio)
 {
     m_Name = name;
     CheckName();

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.h
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.h
@@ -39,7 +39,7 @@ public:
     ~ShmSystemV();
 
     void Open(const std::string &name, const Mode openMode,
-              const bool async = false) final;
+              const bool async = false, const bool directio = false) final;
 
     void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
 

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -632,6 +632,13 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(
         return helper::StringTo<bool>(AsyncOpen, "");
     };
 
+    auto lf_GetDirectIO = [&](const std::string defaultValue,
+                              const Params &parameters) -> bool {
+        std::string directio = defaultValue;
+        helper::SetParameterValue("DirectIO", parameters, directio);
+        return helper::StringTo<bool>(directio, "");
+    };
+
     // BODY OF FUNCTION starts here
     std::shared_ptr<Transport> transport;
     lf_SetFileTransport(lf_GetLibrary(DefaultFileLibrary, parameters),
@@ -650,12 +657,14 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(
     if (useComm)
     {
         transport->OpenChain(fileName, openMode, chainComm,
-                             lf_GetAsyncOpen("true", parameters));
+                             lf_GetAsyncOpen("false", parameters),
+                             lf_GetDirectIO("false", parameters));
     }
     else
     {
         transport->Open(fileName, openMode,
-                        lf_GetAsyncOpen("false", parameters));
+                        lf_GetAsyncOpen("false", parameters),
+                        lf_GetDirectIO("false", parameters));
     }
     return transport;
 }

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -125,7 +125,7 @@ if(ADIOS2_HAVE_BP5)
   gtest_add_tests_helper(ParameterSelectSteps MPI_ALLOW BP Engine.BP. .BP5
     WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
   )
-  gtest_add_tests_helper(DirectIO MPI_ALLOW BP Engine.BP. .BP5
+  gtest_add_tests_helper(DirectIO MPI_NONE BP Engine.BP. .BP5
     WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
   )
 endif(ADIOS2_HAVE_BP5)

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -124,7 +124,10 @@ endif()
 if(ADIOS2_HAVE_BP5)
   gtest_add_tests_helper(ParameterSelectSteps MPI_ALLOW BP Engine.BP. .BP5
     WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
-)
+  )
+  gtest_add_tests_helper(DirectIO MPI_ALLOW BP Engine.BP. .BP5
+    WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
+  )
 endif(ADIOS2_HAVE_BP5)
 
 # BP3 only for now

--- a/testing/adios2/engine/bp/TestBPDirectIO.cpp
+++ b/testing/adios2/engine/bp/TestBPDirectIO.cpp
@@ -1,0 +1,140 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <limits>
+#include <stdexcept>
+
+#include <adios2.h>
+#include <adios2/common/ADIOSTypes.h>
+
+#include <gtest/gtest.h>
+
+std::string engineName; // comes from command line
+
+class ADIOSReadDirectIOTest : public ::testing::Test
+{
+public:
+    ADIOSReadDirectIOTest() = default;
+};
+
+TEST_F(ADIOSReadDirectIOTest, BufferResize)
+{
+    /* Test proper buffer sizes when one chunk cannot hold all variables,
+       and the last chunck is resized back. It should be properly aligned
+       to not cause any problems at writing that chunk.
+    */
+    std::string filename = "ADIOSDirectIO.bp";
+
+    int mpiRank = 0, mpiSize = 1;
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+    // Write test data using BP
+    {
+#if ADIOS2_USE_MPI
+        adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+        adios2::ADIOS adios;
+#endif
+        adios2::IO ioWrite = adios.DeclareIO("TestIOWrite");
+        ioWrite.SetEngine(engineName);
+        ioWrite.SetParameter("DirectIO", "true");
+        ioWrite.SetParameter("DirectIOAlignOffset", "4096");
+        ioWrite.SetParameter("DirectIOAlignBuffer", "4096");
+        ioWrite.SetParameter("StripeSize", "9999");
+        ioWrite.SetParameter("BufferChunkSize", "7111");
+        // BufferChunkSize should be adjusted to 2*4096 by engine
+        // StripeSize should be adjusted to 3*4096 by engine
+
+        adios2::Engine engine = ioWrite.Open(filename, adios2::Mode::Write);
+        // Number of elements per process
+        const std::size_t Nx = 2000;
+        // two variables fit in one Chunk but not three
+        adios2::Dims shape{static_cast<unsigned int>(mpiSize * Nx)};
+        adios2::Dims start{static_cast<unsigned int>(mpiRank * Nx)};
+        adios2::Dims count{static_cast<unsigned int>(Nx)};
+
+        auto var0 = ioWrite.DefineVariable<char>("var0", shape, start, count);
+        auto var1 = ioWrite.DefineVariable<char>("var1", shape, start, count);
+        auto var2 = ioWrite.DefineVariable<char>("var2", shape, start, count);
+
+        std::vector<char> a0(Nx, 'a');
+        std::vector<char> a1(Nx, 'b');
+        std::vector<char> a2(Nx, 'c');
+
+        engine.BeginStep();
+        engine.Put(var0, a0.data());
+        engine.Put(var1, a1.data());
+        engine.Put(var2, a2.data());
+        engine.EndStep();
+        engine.Close();
+
+#if ADIOS2_USE_MPI
+        MPI_Barrier(MPI_COMM_WORLD);
+#endif
+        adios2::IO ioRead = adios.DeclareIO("TestIORead");
+        ioRead.SetEngine(engineName);
+        adios2::Engine engine_s = ioRead.Open(filename, adios2::Mode::Read);
+        EXPECT_TRUE(engine_s);
+        try
+        {
+            engine_s.BeginStep();
+            adios2::Variable<char> var0 = ioRead.InquireVariable<char>("var0");
+            adios2::Variable<char> var1 = ioRead.InquireVariable<char>("var1");
+            adios2::Variable<char> var2 = ioRead.InquireVariable<char>("var2");
+
+            EXPECT_TRUE(var0);
+            EXPECT_TRUE(var1);
+            EXPECT_TRUE(var2);
+
+            std::vector<char> res0;
+            var0.SetSelection({{Nx * mpiRank}, {Nx}});
+            engine_s.Get<char>(var0, res0, adios2::Mode::Sync);
+            EXPECT_EQ(res0, a0);
+
+            std::vector<char> res1;
+            var1.SetSelection({{Nx * mpiRank}, {Nx}});
+            engine_s.Get<char>(var1, res1, adios2::Mode::Sync);
+            EXPECT_EQ(res1, a1);
+
+            std::vector<char> res2;
+            var2.SetSelection({{Nx * mpiRank}, {Nx}});
+            engine_s.Get<char>(var2, res2, adios2::Mode::Sync);
+            EXPECT_EQ(res2, a2);
+
+            engine_s.EndStep();
+        }
+        catch (std::exception &e)
+        {
+            std::cout << "Exception " << e.what() << std::endl;
+        }
+        engine_s.Close();
+    }
+}
+
+int main(int argc, char **argv)
+{
+#if ADIOS2_USE_MPI
+    MPI_Init(nullptr, nullptr);
+#endif
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+
+    int result = RUN_ALL_TESTS();
+#if ADIOS2_USE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}


### PR DESCRIPTION
…uint DirectIOAlignOffset and uint DirectIOAlignBuffer. This feature is only available on UNIX for FilePOSIX transport; it is ignored everywhere else.

Memory (re)allocations in ChunkV are aligned to the requested buffer alignment size. Chunk sizes are kept to be multiple of buffer block size.
Added a directio test where one chunk is shrunk before filling another chunk.
