### PR TITLE
BP4 GPU aware for Get calls

### DIFF
--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -184,7 +184,8 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
                           const Box<Dims> &intersectionBox,
                           const bool isRowMajor = true,
                           const bool reverseDimensions = false,
-                          const bool endianReverse = false);
+                          const bool endianReverse = false,
+                          const bool isGPU = false);
 
 template <class T>
 void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
@@ -193,11 +194,13 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
                           const Box<Dims> &intersectionBox,
                           const bool isRowMajor = true,
                           const bool reverseDimensions = false,
-                          const bool endianReverse = false);
+                          const bool endianReverse = false,
+                          const bool isGPU = false);
 
 template <class T>
 void CopyContiguousMemory(const char *src, const size_t stride, T *dest,
-                          const bool endianReverse = false);
+                          const bool endianReverse = false,
+                          const bool isGPU = false);
 
 /**
  * Clips a vector returning the sub-vector between start and end (end is

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -95,8 +95,8 @@ template <class T>
 void CudaMemCopyFromBuffer(T *GPUbuffer, size_t position, const char *source,
                            const size_t size) noexcept
 {
-    const char *src = reinterpret_cast<const char *>(source + position);
-    MemcpyBufferToGPU(GPUbuffer, src, size);
+    char *dest = reinterpret_cast<char *>(GPUbuffer);
+    MemcpyBufferToGPU(dest, source + position, size);
 }
 #endif
 

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -611,8 +611,9 @@ void CopyContiguousMemory(const char *src, const size_t payloadStride, T *dest,
     if (isGPU)
     {
         if (endianReverse)
-            std::cout << "Endian Reverse is not surrported with GPU buffers"
-                      << std::endl;
+            helper::Throw<std::invalid_argument>(
+                "Helper", "Memory", "CopyContiguousMemory",
+                "Direct byte order reversal not supported for GPU buffers");
 #ifdef ADIOS2_HAVE_CUDA
         CudaMemCopyFromBuffer(dest, 0, src, payloadStride);
         return;

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -371,13 +371,14 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
                           const Box<Dims> &blockBox,
                           const Box<Dims> &intersectionBox,
                           const bool isRowMajor, const bool reverseDimensions,
-                          const bool endianReverse)
+                          const bool endianReverse, const bool isGPU)
 {
     auto lf_ClipRowMajor =
         [](T *dest, const Dims &destStart, const Dims &destCount,
            const char *contiguousMemory, const Box<Dims> &blockBox,
            const Box<Dims> &intersectionBox, const bool isRowMajor,
-           const bool reverseDimensions, const bool endianReverse)
+           const bool reverseDimensions, const bool endianReverse,
+           const bool isGPU)
 
     {
         const Dims &istart = intersectionBox.first;
@@ -434,7 +435,7 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
                 helper::LinearIndex(selectionBox, currentPoint, true);
 
             CopyContiguousMemory(contiguousMemory + contiguousStart, stride,
-                                 dest + variableStart, endianReverse);
+                                 dest + variableStart, endianReverse, isGPU);
 
             // Here update each non-contiguous dim recursively
             if (nContDim >= dimensions)
@@ -473,7 +474,8 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
         [](T *dest, const Dims &destStart, const Dims &destCount,
            const char *contiguousMemory, const Box<Dims> &blockBox,
            const Box<Dims> &intersectionBox, const bool isRowMajor,
-           const bool reverseDimensions, const bool endianReverse)
+           const bool reverseDimensions, const bool endianReverse,
+           const bool isGPU)
 
     {
         const Dims &istart = intersectionBox.first;
@@ -525,7 +527,7 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
                 helper::LinearIndex(selectionBox, currentPoint, false);
 
             CopyContiguousMemory(contiguousMemory + contiguousStart, stride,
-                                 dest + variableStart, endianReverse);
+                                 dest + variableStart, endianReverse, isGPU);
 
             // Here update each non-contiguous dim recursively.
             if (nContDim >= dimensions)
@@ -570,7 +572,7 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
         const size_t stride = (end.back() - start.back() + 1) * sizeof(T);
 
         CopyContiguousMemory(contiguousMemory, stride, dest + normalizedStart,
-                             endianReverse);
+                             endianReverse, isGPU);
         return;
     }
 
@@ -578,13 +580,13 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
     {
         lf_ClipRowMajor(dest, destStart, destCount, contiguousMemory, blockBox,
                         intersectionBox, isRowMajor, reverseDimensions,
-                        endianReverse);
+                        endianReverse, isGPU);
     }
     else // stored with Fortran, R
     {
         lf_ClipColumnMajor(dest, destStart, destCount, contiguousMemory,
                            blockBox, intersectionBox, isRowMajor,
-                           reverseDimensions, endianReverse);
+                           reverseDimensions, endianReverse, isGPU);
     }
 }
 
@@ -594,17 +596,17 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
                           const Box<Dims> &blockBox,
                           const Box<Dims> &intersectionBox,
                           const bool isRowMajor, const bool reverseDimensions,
-                          const bool endianReverse)
+                          const bool endianReverse, const bool isGPU)
 {
 
     ClipContiguousMemory(dest, destStart, destCount, contiguousMemory.data(),
                          blockBox, intersectionBox, isRowMajor,
-                         reverseDimensions, endianReverse);
+                         reverseDimensions, endianReverse, isGPU);
 }
 
 template <class T>
 void CopyContiguousMemory(const char *src, const size_t payloadStride, T *dest,
-                          const bool endianReverse)
+                          const bool endianReverse, const bool isGPU)
 {
 #ifdef ADIOS2_HAVE_ENDIAN_REVERSE
     if (endianReverse)

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -608,6 +608,16 @@ template <class T>
 void CopyContiguousMemory(const char *src, const size_t payloadStride, T *dest,
                           const bool endianReverse, const bool isGPU)
 {
+    if (isGPU)
+    {
+        if (endianReverse)
+            std::cout << "Endian Reverse is not surrported with GPU buffers"
+                      << std::endl;
+#ifdef ADIOS2_HAVE_CUDA
+        CudaMemCopyFromBuffer(dest, 0, src, payloadStride);
+        return;
+#endif
+    }
 #ifdef ADIOS2_HAVE_ENDIAN_REVERSE
     if (endianReverse)
     {

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -567,7 +567,7 @@ void BP4Deserializer::PostDataRead(
         blockInfo.Data, blockInfoStart, blockInfo.Count,
         m_ThreadBuffers[threadID][0].data(), subStreamBoxInfo.BlockBox,
         subStreamBoxInfo.IntersectionBox, m_IsRowMajor, m_ReverseDimensions,
-        endianReverse);
+        endianReverse, blockInfo.IsGPU);
 }
 
 template <class T>


### PR DESCRIPTION
While testing BP5 and BP4 with GPU I realized I forgot to push the changes to make the read side of BP4 CUDA aware. 

I will update the Testing function to include BP4 in the tests so we can officially test GPU buffers, but so far this code passed my offline tests.