### PR TITLE
Force copy DumpDeferredBlocks in PerformPuts() and hence no need for …

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -548,10 +548,8 @@ size_t BP5Serializer::CalcSize(const size_t Count, const size_t *Vals)
 
 void BP5Serializer::PerformPuts(bool forceCopyDeferred)
 {
-    //  Dump data for externs into iovec
-    DumpDeferredBlocks(forceCopyDeferred);
-
-    CurDataBuffer->CopyExternalToInternal();
+    // Copy all data for externs into iovec
+    DumpDeferredBlocks(true);
 }
 
 void BP5Serializer::DumpDeferredBlocks(bool forceCopyDeferred)

--- a/source/adios2/toolkit/format/buffer/BufferV.h
+++ b/source/adios2/toolkit/format/buffer/BufferV.h
@@ -33,12 +33,6 @@ public:
 
     virtual std::vector<core::iovec> DataVec() noexcept = 0;
 
-    /*
-     *  This is used in PerformPuts() to copy externally referenced data so that
-     * it can be modified by the application
-     */
-    virtual void CopyExternalToInternal() = 0;
-
     /**
      * Reset the buffer to initial state (without freeing internal buffers)
      */

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
@@ -41,7 +41,6 @@ public:
 
     virtual void *GetPtr(int bufferIdx, size_t posInBuffer);
 
-    void CopyExternalToInternal();
     void CopyDataToBuffer(const size_t size, const void *buf, size_t pos,
                           MemorySpace MemSpace);
 

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
@@ -40,51 +40,6 @@ void MallocV::Reset()
     DataV.clear();
 }
 
-/*
- *  This is used in PerformPuts() to copy externally referenced data
- *  so that it can be modified by the application. It does *not*
- *  change the metadata offset that was originally returned by
- *  AddToVec.  That is, it relocates the data from application memory
- *  into the internal buffer, but it does not change the position of
- *  that data in the write order, which may result in non-contiguous
- *  writes from the internal buffer.
- */
-void MallocV::CopyExternalToInternal()
-{
-    for (std::size_t i = 0; i < DataV.size(); ++i)
-    {
-        if (DataV[i].External)
-        {
-            size_t size = DataV[i].Size;
-
-            /* force internal buffer alignment */
-            (void)AddToVec(0, NULL, sizeof(max_align_t), true);
-
-            if (m_internalPos + size > m_AllocatedSize)
-            {
-                // need to resize
-                size_t NewSize;
-                if (m_internalPos + size > m_AllocatedSize * m_GrowthFactor)
-                {
-                    // just grow as needed (more than GrowthFactor)
-                    NewSize = m_internalPos + size;
-                }
-                else
-                {
-                    NewSize = (size_t)(m_AllocatedSize * m_GrowthFactor);
-                }
-                m_InternalBlock = (char *)realloc(m_InternalBlock, NewSize);
-                m_AllocatedSize = NewSize;
-            }
-            memcpy(m_InternalBlock + m_internalPos, DataV[i].Base, size);
-            DataV[i].External = false;
-            DataV[i].Base = NULL;
-            DataV[i].Offset = m_internalPos;
-            m_internalPos += size;
-        }
-    }
-}
-
 size_t MallocV::AddToVec(const size_t size, const void *buf, size_t align,
                          bool CopyReqd, MemorySpace MemSpace)
 {

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.h
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.h
@@ -45,8 +45,6 @@ public:
 
     virtual void *GetPtr(int bufferIdx, size_t posInBuffer);
 
-    void CopyExternalToInternal();
-
 private:
     char *m_InternalBlock = NULL;
     size_t m_AllocatedSize = 0;


### PR DESCRIPTION
…BufferV::CopyExternalToInternal at all, which was incorrectly implemented in ChunkV.