### PR TITLE
BP5 index format is now record-based: 

### DIFF
--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -59,6 +59,15 @@ public:
     static constexpr size_t m_VersionTagPosition = 0;
     static constexpr size_t m_VersionTagLength = 32;
 
+    static constexpr uint8_t m_BP5MinorVersion = 2;
+
+    /** Index record types */
+    enum IndexRecord
+    {
+        StepRecord = 's',
+        WriterMapRecord = 'w',
+    };
+
     std::vector<std::string>
     GetBPSubStreamNames(const std::vector<std::string> &names,
                         size_t subFileIndex) const noexcept;

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -227,8 +227,8 @@ private:
 
     std::vector<std::vector<size_t>> FlushPosSizeInfo;
 
-    void MakeHeader(format::BufferSTL &b, const std::string fileType,
-                    const bool isActive);
+    void MakeHeader(std::vector<char> &buffer, size_t &position,
+                    const std::string fileType, const bool isActive);
 
     std::vector<uint64_t> m_WriterSubfileMap; // rank => subfile index
 

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1549,8 +1549,8 @@ int doList(const char *path)
         }
         catch (std::exception &e)
         {
-            printf("Failed to open with %s engine: %s\n",
-                   engineName.c_str(), e.what());
+            printf("Failed to open with %s engine: %s\n", engineName.c_str(),
+                   e.what());
         }
         if (fp != nullptr)
             break;

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1549,9 +1549,8 @@ int doList(const char *path)
         }
         catch (std::exception &e)
         {
-            if (verbose > 2)
-                printf("Failed to open with %s engine: %s\n",
-                       engineName.c_str(), e.what());
+            printf("Failed to open with %s engine: %s\n",
+                   engineName.c_str(), e.what());
         }
         if (fp != nullptr)
             break;


### PR DESCRIPTION
1+8 byte for recordID + record length, then content. recordID 's' for Steps, 'w' for writer map
Writer map always PRECEEDS the step record where it was recorded.