### PR TITLE
Find and accept parameters CASE INSENSITIVE 

### DIFF
--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -126,13 +126,13 @@ public:
     MACRO(BeginStepPollingFrequencySecs, Float, float, 1.0f)                   \
     MACRO(StreamReader, Bool, bool, false)                                     \
     MACRO(BurstBufferDrain, Bool, bool, true)                                  \
-    MACRO(BurstBufferPath, String, std::string, (char *)(intptr_t)0)           \
+    MACRO(BurstBufferPath, String, std::string, "")                            \
     MACRO(NodeLocal, Bool, bool, false)                                        \
     MACRO(verbose, Int, int, 0)                                                \
     MACRO(CollectiveMetadata, Bool, bool, true)                                \
     MACRO(NumAggregators, UInt, unsigned int, 0)                               \
     MACRO(AggregatorRatio, UInt, unsigned int, 0)                              \
-    MACRO(NumSubFiles, UInt, unsigned int, 999999)                             \
+    MACRO(NumSubFiles, UInt, unsigned int, 0)                                  \
     MACRO(StripeSize, UInt, unsigned int, 4096)                                \
     MACRO(DirectIO, Bool, bool, false)                                         \
     MACRO(DirectIOAlignOffset, UInt, unsigned int, 512)                        \
@@ -148,7 +148,7 @@ public:
     MACRO(MaxShmSize, SizeBytes, size_t, DefaultMaxShmSize)                    \
     MACRO(BufferVType, BufferVType, int, (int)BufferVType::ChunkVType)         \
     MACRO(AppendAfterSteps, Int, int, INT_MAX)                                 \
-    MACRO(SelectSteps, String, std::string, (char *)(intptr_t)0)               \
+    MACRO(SelectSteps, String, std::string, "")                                \
     MACRO(ReaderShortCircuitReads, Bool, bool, false)
 
     struct BP5Params


### PR DESCRIPTION
(e.g. nUmaggReGatoRs is NumAggregators). Set NumSubFiles default to 0 as other default sets NumAggregators in BP5Writer::InitParameters()