### PR TITLE
Add StatsLevel parameter to BP5 so that minmax can be turned off. Min…

### DIFF
--- a/docs/user_guide/source/engines/bp5.rst
+++ b/docs/user_guide/source/engines/bp5.rst
@@ -121,6 +121,10 @@ This engine allows the user to fine tune the buffering operations through the fo
 
    #. **DirectIOAlignBuffer**: Alignment for memory pointers. Default is to be same as *DirectIOAlignOffset*. 
 
+#. Miscellaneous
+
+   #. **StatsLevel**: 1 turns on *Min/Max* calculation for every variable, 0 turns this off. Default is 1. It has some cost to generate this metadata so it can be turned off if there is no need for this information.
+
 
 ============================== ===================== ===========================================================
  **Key**                       **Value Format**      **Default** and Examples
@@ -145,6 +149,7 @@ This engine allows the user to fine tune the buffering operations through the fo
  DirectIO                       string On/Off         **Off**, On, true, false
  DirectIOAlignOffset            integer               **512**
  DirectIOAlignBuffer            integer               set to DirectIOAlignOffset if unset
+ StatsLevel                     integer, 0 or 1       **1**, ``0``
 ============================== ===================== ===========================================================
 
 

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -23,6 +23,13 @@ namespace core
 namespace engine
 {
 
+/**
+ * sub-block size for min/max calculation of large arrays in number of
+ * elements (not bytes). The default big number per Put() default will
+ * result in the original single min/max value-pair per block
+ */
+constexpr size_t DefaultStatsBlockSize = 1125899906842624ULL;
+
 class BP5Engine
 {
 public:
@@ -149,7 +156,9 @@ public:
     MACRO(BufferVType, BufferVType, int, (int)BufferVType::ChunkVType)         \
     MACRO(AppendAfterSteps, Int, int, INT_MAX)                                 \
     MACRO(SelectSteps, String, std::string, "")                                \
-    MACRO(ReaderShortCircuitReads, Bool, bool, false)
+    MACRO(ReaderShortCircuitReads, Bool, bool, false)                          \
+    MACRO(StatsLevel, UInt, unsigned int, 1)                                   \
+    MACRO(StatsBlockSize, SizeBytes, size_t, DefaultStatsBlockSize)
 
     struct BP5Params
     {

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -647,6 +647,8 @@ void BP5Writer::InitParameters()
             m_Parameters.BufferChunkSize = k * m_Parameters.DirectIOAlignOffset;
         }
     }
+
+    m_BP5Serializer.m_StatsLevel = m_Parameters.StatsLevel;
 }
 
 uint64_t BP5Writer::CountStepsInMetadataIndex(format::BufferSTL &bufferSTL)

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1710,11 +1710,8 @@ bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
     {
         if (VarRec->MinMaxOffset == SIZE_MAX)
         {
-            helper::Throw<std::logic_error>(
-                "Toolkit", "format::BP5Deserializer", "VariableMinMax",
-                "Min or Max requests for Variable for which Min/Max was not "
-                "supplied by the writer.  Specify parameter StatsLevel > 0 to "
-                "include writer-side data statistics.");
+            std::memset(&MinMax, 0, sizeof(struct MinMaxStruct));
+            return true;
         }
     }
 


### PR DESCRIPTION
…Max structure returns 0/0 when variable does not have this information, which is not correct, but works the same way as always had in adios engines.