### PR TITLE
Added naive engine mode for SSC

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -171,9 +171,11 @@ if(ADIOS2_HAVE_MPI)
         engine/ssc/SscWriter.cpp
         engine/ssc/SscWriterBase.cpp
         engine/ssc/SscWriterGeneric.cpp
+        engine/ssc/SscWriterNaive.cpp
         engine/ssc/SscReader.cpp
         engine/ssc/SscReaderBase.cpp
         engine/ssc/SscReaderGeneric.cpp
+        engine/ssc/SscReaderNaive.cpp
         )
     set_property(TARGET adios2_core_mpi PROPERTY EXPORT_NAME core_mpi)
     set_property(TARGET adios2_core_mpi PROPERTY OUTPUT_NAME adios2${ADIOS2_LIBRARY_SUFFIX}_core_mpi)

--- a/source/adios2/engine/ssc/SscHelper.h
+++ b/source/adios2/engine/ssc/SscHelper.h
@@ -148,6 +148,10 @@ RankPosMap CalculateOverlap(BlockVecVec &globalPattern,
 
 void SerializeVariables(const BlockVec &input, Buffer &output, const int rank);
 void SerializeAttributes(IO &input, Buffer &output);
+void DeserializeVariable(const Buffer &input, const ShapeID shapeId,
+                         uint64_t &pos, BlockInfo &b, IO &io, const bool regIO);
+void DeserializeAttribute(const Buffer &input, uint64_t &pos, IO &io,
+                          const bool regIO);
 void Deserialize(const Buffer &input, BlockVecVec &output, IO &io,
                  const bool regVars, const bool regAttrs);
 void AggregateMetadata(const Buffer &localBuffer, Buffer &globalBuffer,

--- a/source/adios2/engine/ssc/SscReaderGeneric.cpp
+++ b/source/adios2/engine/ssc/SscReaderGeneric.cpp
@@ -9,7 +9,6 @@
  */
 
 #include "SscReaderGeneric.tcc"
-#include "adios2/helper/adiosMemory.h"
 
 namespace adios2
 {

--- a/source/adios2/engine/ssc/SscReaderGeneric.tcc
+++ b/source/adios2/engine/ssc/SscReaderGeneric.tcc
@@ -8,6 +8,9 @@
  *      Author: Jason Wang
  */
 
+#ifndef ADIOS2_ENGINE_SSCREADERGENERIC_TCC_
+#define ADIOS2_ENGINE_SSCREADERGENERIC_TCC_
+
 #include "SscReaderGeneric.h"
 #include "adios2/helper/adiosMemory.h"
 
@@ -212,3 +215,5 @@ SscReaderGeneric::BlocksInfoCommon(const Variable<T> &variable,
 }
 }
 }
+
+#endif // ADIOS2_ENGINE_SSCREADERGENERIC_TCC_

--- a/source/adios2/engine/ssc/SscReaderNaive.cpp
+++ b/source/adios2/engine/ssc/SscReaderNaive.cpp
@@ -1,0 +1,64 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * SscReaderNaive.cpp
+ *
+ *  Created on: Mar 7, 2022
+ *      Author: Jason Wang
+ */
+
+#include "SscReaderNaive.tcc"
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+namespace ssc
+{
+
+SscReaderNaive::SscReaderNaive(IO &io, const std::string &name, const Mode mode,
+                               MPI_Comm comm)
+: SscReaderBase(io, name, mode, comm)
+{
+}
+
+StepStatus SscReaderNaive::BeginStep(const StepMode stepMode,
+                                     const float timeoutSeconds,
+                                     const bool readerLocked)
+{
+
+    ++m_CurrentStep;
+
+    return StepStatus::OK;
+}
+
+size_t SscReaderNaive::CurrentStep() { return m_CurrentStep; }
+
+void SscReaderNaive::EndStep(const bool readerLocked) {}
+
+void SscReaderNaive::PerformGets() {}
+
+void SscReaderNaive::Close(const int transportIndex) {}
+
+#define declare_type(T)                                                        \
+    void SscReaderNaive::GetDeferred(Variable<T> &variable, T *data)           \
+    {                                                                          \
+        helper::Log("Engine", "SSCReader", "GetDeferred", variable.m_Name, 0,  \
+                    m_ReaderRank, 5, m_Verbosity, helper::LogMode::INFO);      \
+        GetDeferredCommon(variable, data);                                     \
+    }                                                                          \
+    std::vector<typename Variable<T>::BPInfo> SscReaderNaive::BlocksInfo(      \
+        const Variable<T> &variable, const size_t step) const                  \
+    {                                                                          \
+        return BlocksInfoCommon(variable, step);                               \
+    }
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+}
+}
+}
+}

--- a/source/adios2/engine/ssc/SscReaderNaive.cpp
+++ b/source/adios2/engine/ssc/SscReaderNaive.cpp
@@ -32,6 +32,24 @@ StepStatus SscReaderNaive::BeginStep(const StepMode stepMode,
 
     ++m_CurrentStep;
 
+    size_t globalSize;
+
+    if (m_ReaderRank == 0)
+    {
+        MPI_Recv(&globalSize, 1, MPI_UNSIGNED_LONG_LONG,
+                 m_WriterMasterStreamRank, 0, m_StreamComm, MPI_STATUS_IGNORE);
+        m_Buffer.resize(globalSize);
+        MPI_Recv(m_Buffer.data(), globalSize, MPI_UNSIGNED_LONG_LONG,
+                 m_WriterMasterStreamRank, 0, m_StreamComm, MPI_STATUS_IGNORE);
+    }
+
+    MPI_Bcast(&globalSize, 1, MPI_UNSIGNED_LONG_LONG, 0, m_ReaderComm);
+    if (m_ReaderRank != 0)
+    {
+        m_Buffer.resize(globalSize);
+    }
+    MPI_Bcast(m_Buffer.data(), globalSize, MPI_CHAR, 0, m_ReaderComm);
+
     return StepStatus::OK;
 }
 

--- a/source/adios2/engine/ssc/SscReaderNaive.cpp
+++ b/source/adios2/engine/ssc/SscReaderNaive.cpp
@@ -75,7 +75,6 @@ StepStatus SscReaderNaive::BeginStep(const StepMode stepMode,
             }
             else
             {
-                int rank = m_Buffer.value<int>(pos);
                 pos += 4;
                 ssc::BlockInfo b;
                 DeserializeVariable(m_Buffer, static_cast<ShapeID>(shapeId),

--- a/source/adios2/engine/ssc/SscReaderNaive.h
+++ b/source/adios2/engine/ssc/SscReaderNaive.h
@@ -1,0 +1,63 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * SscReaderNaive.h
+ *
+ *  Created on: Mar 7, 2022
+ *      Author: Jason Wang
+ */
+
+#ifndef ADIOS2_ENGINE_SSCREADERNAIVE_H_
+#define ADIOS2_ENGINE_SSCREADERNAIVE_H_
+
+#include "SscReaderBase.h"
+#include "adios2/core/IO.h"
+#include <mpi.h>
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+namespace ssc
+{
+
+class SscReaderNaive : public SscReaderBase
+{
+
+public:
+    SscReaderNaive(IO &io, const std::string &name, const Mode mode,
+                   MPI_Comm comm);
+    ~SscReaderNaive() = default;
+
+    StepStatus BeginStep(const StepMode mode, const float timeoutSeconds,
+                         const bool readerLocked) final;
+    size_t CurrentStep() final;
+    void PerformGets() final;
+    void EndStep(const bool readerLocked) final;
+    void Close(const int transportIndex) final;
+
+#define declare_type(T)                                                        \
+    void GetDeferred(Variable<T> &, T *) final;                                \
+    std::vector<typename Variable<T>::BPInfo> BlocksInfo(                      \
+        const Variable<T> &variable, const size_t step) const final;
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+private:
+    template <typename T>
+    std::vector<typename Variable<T>::BPInfo>
+    BlocksInfoCommon(const Variable<T> &variable, const size_t step) const;
+
+    template <class T>
+    void GetDeferredCommon(Variable<T> &variable, T *data);
+};
+
+}
+}
+}
+}
+
+#endif // ADIOS2_ENGINE_SSCREADERNAIVE_H_

--- a/source/adios2/engine/ssc/SscReaderNaive.h
+++ b/source/adios2/engine/ssc/SscReaderNaive.h
@@ -53,6 +53,8 @@ private:
 
     template <class T>
     void GetDeferredCommon(Variable<T> &variable, T *data);
+
+    std::unordered_map<std::string, ssc::BlockVec> m_BlockMap;
 };
 
 }

--- a/source/adios2/engine/ssc/SscReaderNaive.tcc
+++ b/source/adios2/engine/ssc/SscReaderNaive.tcc
@@ -23,13 +23,6 @@ namespace engine
 namespace ssc
 {
 
-template <>
-void SscReaderNaive::GetDeferredCommon(Variable<std::string> &variable,
-                                       std::string *data)
-{
-    variable.SetData(data);
-}
-
 template <class T>
 void SscReaderNaive::GetDeferredCommon(Variable<T> &variable, T *data)
 {

--- a/source/adios2/engine/ssc/SscReaderNaive.tcc
+++ b/source/adios2/engine/ssc/SscReaderNaive.tcc
@@ -1,0 +1,66 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * SscReaderNaive.tcc
+ *
+ *  Created on: Mar 7, 2022
+ *      Author: Jason Wang
+ */
+
+#ifndef ADIOS2_ENGINE_SSCREADERNAIVE_TCC_
+#define ADIOS2_ENGINE_SSCREADERNAIVE_TCC_
+
+#include "SscReaderNaive.h"
+#include "adios2/helper/adiosMemory.h"
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+namespace ssc
+{
+
+template <>
+void SscReaderNaive::GetDeferredCommon(Variable<std::string> &variable,
+                                       std::string *data)
+{
+    variable.SetData(data);
+}
+
+template <class T>
+void SscReaderNaive::GetDeferredCommon(Variable<T> &variable, T *data)
+{
+    variable.SetData(data);
+
+    Dims vStart = variable.m_Start;
+    Dims vCount = variable.m_Count;
+    Dims vShape = variable.m_Shape;
+
+    if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
+    {
+        std::reverse(vStart.begin(), vStart.end());
+        std::reverse(vCount.begin(), vCount.end());
+        std::reverse(vShape.begin(), vShape.end());
+    }
+}
+
+template <typename T>
+std::vector<typename Variable<T>::BPInfo>
+SscReaderNaive::BlocksInfoCommon(const Variable<T> &variable,
+                                 const size_t step) const
+{
+
+    std::vector<typename Variable<T>::BPInfo> ret;
+
+    return ret;
+}
+
+}
+}
+}
+}
+
+#endif // ADIOS2_ENGINE_SSCREADERNAIVE_TCC_

--- a/source/adios2/engine/ssc/SscReaderNaive.tcc
+++ b/source/adios2/engine/ssc/SscReaderNaive.tcc
@@ -23,6 +23,26 @@ namespace engine
 namespace ssc
 {
 
+template <>
+void SscReaderNaive::GetDeferredCommon(Variable<std::string> &variable,
+                                       std::string *data)
+{
+    variable.SetData(data);
+
+    for (const auto &b : m_BlockMap[variable.m_Name])
+    {
+        if (b.name == variable.m_Name)
+        {
+            *data =
+                std::string(m_Buffer.data() + b.bufferStart,
+                            m_Buffer.data() + b.bufferStart + b.bufferCount);
+            variable.m_Value = *data;
+            variable.m_Min = *data;
+            variable.m_Max = *data;
+        }
+    }
+}
+
 template <class T>
 void SscReaderNaive::GetDeferredCommon(Variable<T> &variable, T *data)
 {

--- a/source/adios2/engine/ssc/SscReaderNaive.tcc
+++ b/source/adios2/engine/ssc/SscReaderNaive.tcc
@@ -38,6 +38,22 @@ void SscReaderNaive::GetDeferredCommon(Variable<T> &variable, T *data)
         std::reverse(vCount.begin(), vCount.end());
         std::reverse(vShape.begin(), vShape.end());
     }
+
+    for (const auto &b : m_BlockMap[variable.m_Name])
+    {
+        if (b.shapeId == ShapeID::GlobalArray ||
+            b.shapeId == ShapeID::LocalArray)
+        {
+            helper::NdCopy(m_Buffer.data<char>() + b.bufferStart, b.start,
+                           b.count, true, true, reinterpret_cast<char *>(data),
+                           vStart, vCount, true, true, sizeof(T));
+        }
+        else if (b.shapeId == ShapeID::GlobalValue ||
+                 b.shapeId == ShapeID::LocalValue)
+        {
+            std::memcpy(data, m_Buffer.data() + b.bufferStart, b.bufferCount);
+        }
+    }
 }
 
 template <typename T>

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -10,6 +10,7 @@
 
 #include "SscWriter.h"
 #include "SscWriterGeneric.h"
+#include "SscWriterNaive.h"
 #include "adios2/helper/adiosCommMPI.h"
 #include "adios2/helper/adiosString.h"
 #include <adios2-perfstubs-interface.h>
@@ -37,6 +38,8 @@ SscWriter::SscWriter(IO &io, const std::string &name, const Mode mode,
     }
     else if (m_EngineMode == "naive")
     {
+        m_EngineInstance = std::make_shared<ssc::SscWriterNaive>(
+            io, name, mode, CommAsMPI(m_Comm));
     }
 }
 

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -47,12 +47,14 @@ StepStatus SscWriter::BeginStep(StepMode mode, const float timeoutSeconds)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
+    auto ret = m_EngineInstance->BeginStep(mode, timeoutSeconds,
+                                           m_WriterDefinitionsLocked);
+
     helper::Log("Engine", "SSCWriter", "BeginStep",
                 std::to_string(CurrentStep()), 0, m_Comm.Rank(), 5, m_Verbosity,
                 helper::LogMode::INFO);
 
-    return m_EngineInstance->BeginStep(mode, timeoutSeconds,
-                                       m_WriterDefinitionsLocked);
+    return ret;
 }
 
 size_t SscWriter::CurrentStep() const

--- a/source/adios2/engine/ssc/SscWriterGeneric.h
+++ b/source/adios2/engine/ssc/SscWriterGeneric.h
@@ -2,7 +2,7 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * SscWriterBase.h
+ * SscWriterGeneric.h
  *
  *  Created on: Mar 3, 2022
  *      Author: Jason Wang

--- a/source/adios2/engine/ssc/SscWriterGeneric.tcc
+++ b/source/adios2/engine/ssc/SscWriterGeneric.tcc
@@ -8,6 +8,9 @@
  *      Author: Jason Wang
  */
 
+#ifndef ADIOS2_ENGINE_SSCWRITERGENERIC_TCC_
+#define ADIOS2_ENGINE_SSCWRITERGENERIC_TCC_
+
 #include "SscWriterGeneric.h"
 
 namespace adios2
@@ -145,3 +148,5 @@ void SscWriterGeneric::PutDeferredCommon(Variable<T> &variable, const T *data)
 }
 }
 }
+
+#endif // ADIOS2_ENGINE_SSCWRITERGENERIC_TCC_

--- a/source/adios2/engine/ssc/SscWriterNaive.cpp
+++ b/source/adios2/engine/ssc/SscWriterNaive.cpp
@@ -53,8 +53,6 @@ void SscWriterNaive::EndStep(const bool writerLocked)
         ssc::SerializeAttributes(m_IO, m_Buffer);
     }
 
-    m_Buffer.value<uint64_t>() = m_Buffer.size();
-
     int localSize = static_cast<int>(m_Buffer.value<uint64_t>());
     std::vector<int> localSizes(m_WriterSize);
     MPI_Gather(&localSize, 1, MPI_INT, localSizes.data(), 1, MPI_INT, 0,

--- a/source/adios2/engine/ssc/SscWriterNaive.cpp
+++ b/source/adios2/engine/ssc/SscWriterNaive.cpp
@@ -30,6 +30,10 @@ StepStatus SscWriterNaive::BeginStep(const StepMode mode,
                                      const bool writerLocked)
 {
     ++m_CurrentStep;
+
+    m_Buffer.clear();
+    m_Metadata.clear();
+
     return StepStatus::OK;
 }
 
@@ -37,7 +41,45 @@ size_t SscWriterNaive::CurrentStep() { return m_CurrentStep; }
 
 void SscWriterNaive::PerformPuts() {}
 
-void SscWriterNaive::EndStep(const bool writerLocked) {}
+void SscWriterNaive::EndStep(const bool writerLocked)
+{
+    m_Buffer.value<uint64_t>() = m_Buffer.size();
+    m_Buffer.value<uint64_t>(8) = m_Buffer.size();
+
+    ssc::SerializeVariables(m_Metadata, m_Buffer, m_WriterRank);
+
+    if (m_WriterRank == 0)
+    {
+        ssc::SerializeAttributes(m_IO, m_Buffer);
+    }
+
+    m_Buffer.value<uint64_t>() = m_Buffer.size();
+
+    int localSize = static_cast<int>(m_Buffer.value<uint64_t>());
+    std::vector<int> localSizes(m_WriterSize);
+    MPI_Gather(&localSize, 1, MPI_INT, localSizes.data(), 1, MPI_INT, 0,
+               m_WriterComm);
+    size_t globalSize =
+        std::accumulate(localSizes.begin(), localSizes.end(), 0);
+    ssc::Buffer globalBuffer(globalSize);
+
+    std::vector<int> displs(m_WriterSize);
+    for (size_t i = 1; i < static_cast<size_t>(m_WriterSize); ++i)
+    {
+        displs[i] = displs[i - 1] + localSizes[i - 1];
+    }
+
+    MPI_Gatherv(m_Buffer.data(), localSize, MPI_CHAR, globalBuffer.data(),
+                localSizes.data(), displs.data(), MPI_CHAR, 0, m_WriterComm);
+
+    if (m_WriterRank == 0)
+    {
+        MPI_Send(&globalSize, 1, MPI_UNSIGNED_LONG_LONG,
+                 m_ReaderMasterStreamRank, 0, m_StreamComm);
+        MPI_Send(globalBuffer.data(), globalSize, MPI_CHAR,
+                 m_ReaderMasterStreamRank, 0, m_StreamComm);
+    }
+}
 
 void SscWriterNaive::Close(const int transportIndex) {}
 

--- a/source/adios2/engine/ssc/SscWriterNaive.cpp
+++ b/source/adios2/engine/ssc/SscWriterNaive.cpp
@@ -1,0 +1,55 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * SscWriterNaive.cpp
+ *
+ *  Created on: Mar 7, 2022
+ *      Author: Jason Wang
+ */
+
+#include "SscWriterNaive.tcc"
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+namespace ssc
+{
+
+SscWriterNaive::SscWriterNaive(IO &io, const std::string &name, const Mode mode,
+                               MPI_Comm comm)
+: SscWriterBase(io, name, mode, comm)
+{
+}
+
+StepStatus SscWriterNaive::BeginStep(const StepMode mode,
+                                     const float timeoutSeconds,
+                                     const bool writerLocked)
+{
+    ++m_CurrentStep;
+    return StepStatus::OK;
+}
+
+size_t SscWriterNaive::CurrentStep() { return m_CurrentStep; }
+
+void SscWriterNaive::PerformPuts() {}
+
+void SscWriterNaive::EndStep(const bool writerLocked) {}
+
+void SscWriterNaive::Close(const int transportIndex) {}
+
+#define declare_type(T)                                                        \
+    void SscWriterNaive::PutDeferred(Variable<T> &variable, const T *data)     \
+    {                                                                          \
+        PutDeferredCommon(variable, data);                                     \
+    }
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+}
+}
+}
+}

--- a/source/adios2/engine/ssc/SscWriterNaive.h
+++ b/source/adios2/engine/ssc/SscWriterNaive.h
@@ -1,0 +1,56 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * SscWriterNaive.h
+ *
+ *  Created on: Mar 7, 2022
+ *      Author: Jason Wang
+ */
+
+#ifndef ADIOS2_ENGINE_SSCWRITERNAIVE_H_
+#define ADIOS2_ENGINE_SSCWRITERNAIVE_H_
+
+#include "SscWriterBase.h"
+#include "adios2/core/IO.h"
+#include <mpi.h>
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+namespace ssc
+{
+
+class SscWriterNaive : public SscWriterBase
+{
+
+public:
+    SscWriterNaive(IO &io, const std::string &name, const Mode mode,
+                   MPI_Comm comm);
+    ~SscWriterNaive() = default;
+
+    StepStatus BeginStep(const StepMode mode, const float timeoutSeconds,
+                         const bool writerLocked) final;
+    size_t CurrentStep() final;
+    void PerformPuts() final;
+    void EndStep(const bool writerLocked) final;
+    void Close(const int transportIndex) final;
+
+#define declare_type(T) void PutDeferred(Variable<T> &, const T *) final;
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+private:
+    template <class T>
+    void PutDeferredCommon(Variable<T> &variable, const T *values);
+};
+
+}
+}
+}
+}
+
+#endif // ADIOS2_ENGINE_SSCWRITENAIVE_H_

--- a/source/adios2/engine/ssc/SscWriterNaive.h
+++ b/source/adios2/engine/ssc/SscWriterNaive.h
@@ -46,6 +46,8 @@ public:
 private:
     template <class T>
     void PutDeferredCommon(Variable<T> &variable, const T *values);
+
+    ssc::BlockVec m_Metadata;
 };
 
 }

--- a/source/adios2/engine/ssc/SscWriterNaive.tcc
+++ b/source/adios2/engine/ssc/SscWriterNaive.tcc
@@ -1,0 +1,62 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * SscWriterNaive.tcc
+ *
+ *  Created on: Mar 7, 2022
+ *      Author: Jason Wang
+ */
+
+#ifndef ADIOS2_ENGINE_SSCWRITERNAIVE_TCC_
+#define ADIOS2_ENGINE_SSCWRITERNAIVE_TCC_
+
+#include "SscWriterNaive.h"
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+namespace ssc
+{
+
+template <>
+void SscWriterNaive::PutDeferredCommon(Variable<std::string> &variable,
+                                       const std::string *data)
+{
+    variable.SetData(data);
+}
+
+template <class T>
+void SscWriterNaive::PutDeferredCommon(Variable<T> &variable, const T *data)
+{
+
+    if ((variable.m_ShapeID == ShapeID::GlobalValue ||
+         variable.m_ShapeID == ShapeID::LocalValue ||
+         variable.m_Type == DataType::String) &&
+        m_WriterRank != 0)
+    {
+        return;
+    }
+
+    variable.SetData(data);
+
+    Dims vStart = variable.m_Start;
+    Dims vCount = variable.m_Count;
+    Dims vShape = variable.m_Shape;
+
+    if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
+    {
+        std::reverse(vStart.begin(), vStart.end());
+        std::reverse(vCount.begin(), vCount.end());
+        std::reverse(vShape.begin(), vShape.end());
+    }
+}
+}
+}
+}
+}
+
+#endif // ADIOS2_ENGINE_SSCWRITERNAIVE_TCC_

--- a/testing/adios2/engine/ssc/TestSsc7d.cpp
+++ b/testing/adios2/engine/ssc/TestSsc7d.cpp
@@ -192,36 +192,72 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
 TEST_F(SscEngineTest, TestSsc7d)
 {
-    std::string filename = "TestSsc7d";
-    adios2::Params engineParams = {};
-
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-    int mpiGroup = worldRank / (worldSize / 2);
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    Dims shape = {10, 2, 2, (size_t)mpiSize, 2, 8, 10};
-    Dims start = {0, 0, 0, (size_t)mpiRank, 0, 0, 0};
-    Dims count = {10, 2, 2, 1, 2, 8, 10};
-    size_t steps = 20;
-
-    if (mpiGroup == 0)
     {
-        Writer(shape, start, count, steps, engineParams, filename);
+        std::string filename = "TestSsc7d";
+        adios2::Params engineParams = {};
+
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {10, 2, 2, (size_t)mpiSize, 2, 8, 10};
+        Dims start = {0, 0, 0, (size_t)mpiRank, 0, 0, 0};
+        Dims count = {10, 2, 2, 1, 2, 8, 10};
+        size_t steps = 20;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    if (mpiGroup == 1)
     {
-        Reader(shape, start, count, steps, engineParams, filename);
-    }
+        std::string filename = "TestSsc7dNaive";
+        adios2::Params engineParams = {{"Verbose", "0"},
+                                       {"EngineMode", "naive"}};
 
-    MPI_Barrier(MPI_COMM_WORLD);
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {10, 2, 2, (size_t)mpiSize, 2, 8, 10};
+        Dims start = {0, 0, 0, (size_t)mpiRank, 0, 0, 0};
+        Dims count = {10, 2, 2, 1, 2, 8, 10};
+        size_t steps = 20;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/ssc/TestSscBase.cpp
+++ b/testing/adios2/engine/ssc/TestSscBase.cpp
@@ -242,36 +242,57 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
 TEST_F(SscEngineTest, TestSscBase)
 {
-    std::string filename = "TestSscBase";
-    adios2::Params engineParams = {{"Verbose", "0"}};
-
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-    int mpiGroup = worldRank / (worldSize / 2);
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    Dims shape = {10, (size_t)mpiSize * 2};
-    Dims start = {2, (size_t)mpiRank * 2};
-    Dims count = {5, 2};
-    size_t steps = 100;
-
-    if (mpiGroup == 0)
     {
-        Writer(shape, start, count, steps, engineParams, filename);
+        std::string filename = "TestSscBase";
+        adios2::Params engineParams = {{"Verbose", "0"}};
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+        Dims shape = {10, (size_t)mpiSize * 2};
+        Dims start = {2, (size_t)mpiRank * 2};
+        Dims count = {5, 2};
+        size_t steps = 100;
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
     }
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    if (mpiGroup == 1)
     {
-        Reader(shape, start, count, steps, engineParams, filename);
+        std::string filename = "TestSscBaseNaive";
+        adios2::Params engineParams = {{"Verbose", "0"},
+                                       {"EngineMode", "naive"}};
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+        Dims shape = {10, (size_t)mpiSize * 2};
+        Dims start = {2, (size_t)mpiRank * 2};
+        Dims count = {5, 2};
+        size_t steps = 100;
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
     }
-
-    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/ssc/TestSscSingleStep.cpp
+++ b/testing/adios2/engine/ssc/TestSscSingleStep.cpp
@@ -243,36 +243,72 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
 TEST_F(SscEngineTest, TestSscSingleStep)
 {
-    std::string filename = "TestSscSingleStep";
-    adios2::Params engineParams = {{"Verbose", "0"}};
-
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-    int mpiGroup = worldRank / (worldSize / 2);
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    Dims shape = {10, (size_t)mpiSize * 2};
-    Dims start = {2, (size_t)mpiRank * 2};
-    Dims count = {5, 2};
-    size_t steps = 1;
-
-    if (mpiGroup == 0)
     {
-        Writer(shape, start, count, steps, engineParams, filename);
+        std::string filename = "TestSscSingleStep";
+        adios2::Params engineParams = {{"Verbose", "0"}};
+
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {10, (size_t)mpiSize * 2};
+        Dims start = {2, (size_t)mpiRank * 2};
+        Dims count = {5, 2};
+        size_t steps = 1;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    if (mpiGroup == 1)
     {
-        Reader(shape, start, count, steps, engineParams, filename);
-    }
+        std::string filename = "TestSscSingleStepNaive";
+        adios2::Params engineParams = {{"Verbose", "0"},
+                                       {"EngineMode", "naive"}};
 
-    MPI_Barrier(MPI_COMM_WORLD);
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {10, (size_t)mpiSize * 2};
+        Dims start = {2, (size_t)mpiRank * 2};
+        Dims count = {5, 2};
+        size_t steps = 1;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/ssc/TestSscSuperLarge.cpp
+++ b/testing/adios2/engine/ssc/TestSscSuperLarge.cpp
@@ -242,36 +242,72 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
 TEST_F(SscEngineTest, TestSscSuperLarge)
 {
-    std::string filename = "TestSscSuperLarge";
-    adios2::Params engineParams = {{"Verbose", "0"}};
-
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-    int mpiGroup = worldRank / (worldSize / 2);
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    Dims shape = {100, (size_t)mpiSize * 10};
-    Dims start = {10, (size_t)mpiRank * 10};
-    Dims count = {90, 10};
-    size_t steps = 50;
-
-    if (mpiGroup == 0)
     {
-        Writer(shape, start, count, steps, engineParams, filename);
+        std::string filename = "TestSscSuperLarge";
+        adios2::Params engineParams = {{"Verbose", "0"}};
+
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {100, (size_t)mpiSize * 10};
+        Dims start = {10, (size_t)mpiRank * 10};
+        Dims count = {90, 10};
+        size_t steps = 50;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    if (mpiGroup == 1)
     {
-        Reader(shape, start, count, steps, engineParams, filename);
-    }
+        std::string filename = "TestSscSuperLargeNaive";
+        adios2::Params engineParams = {{"Verbose", "0"},
+                                       {"EngineMode", "naive"}};
 
-    MPI_Barrier(MPI_COMM_WORLD);
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {100, (size_t)mpiSize * 10};
+        Dims start = {10, (size_t)mpiRank * 10};
+        Dims count = {90, 10};
+        size_t steps = 50;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/ssc/TestSscUnbalanced.cpp
+++ b/testing/adios2/engine/ssc/TestSscUnbalanced.cpp
@@ -215,38 +215,76 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
 TEST_F(SscEngineTest, TestSscUnbalanced)
 {
-    std::string filename = "TestSscUnbalanced";
-    adios2::Params engineParams = {{"Verbose", "0"}};
-
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-    int mpiGroup = worldRank / (worldSize / 2);
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    Dims shape = {10, (size_t)mpiSize * 2};
-    Dims start = {2, (size_t)mpiRank * 2};
-    Dims count = {5, 2};
-    size_t steps = 100;
-
-    if (mpiGroup == 0)
     {
-        Writer(shape, start, count, steps, engineParams, filename);
+        std::string filename = "TestSscUnbalanced";
+        adios2::Params engineParams = {{"Verbose", "0"}};
+
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {10, (size_t)mpiSize * 2};
+        Dims start = {2, (size_t)mpiRank * 2};
+        Dims count = {5, 2};
+        size_t steps = 100;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            start = {2, 0};
+            count = {5, 2};
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    if (mpiGroup == 1)
     {
-        start = {2, 0};
-        count = {5, 2};
-        Reader(shape, start, count, steps, engineParams, filename);
-    }
+        std::string filename = "TestSscUnbalancedNaive";
+        adios2::Params engineParams = {{"Verbose", "0"},
+                                       {"EngineMode", "naive"}};
 
-    MPI_Barrier(MPI_COMM_WORLD);
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {10, (size_t)mpiSize * 2};
+        Dims start = {2, (size_t)mpiRank * 2};
+        Dims count = {5, 2};
+        size_t steps = 100;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            start = {2, 0};
+            count = {5, 2};
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
+++ b/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
@@ -288,36 +288,72 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
 TEST_F(SscEngineTest, TestSscVaryingSteps)
 {
-    std::string filename = "TestSscVaryingSteps";
-    adios2::Params engineParams = {};
-
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-    int mpiGroup = worldRank / (worldSize / 2);
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    Dims shape = {1, (size_t)mpiSize * 2};
-    Dims start = {0, (size_t)mpiRank * 2};
-    Dims count = {1, 2};
-    size_t steps = 100;
-
-    if (mpiGroup == 0)
     {
-        Writer(shape, start, count, steps, engineParams, filename);
+        std::string filename = "TestSscVaryingSteps";
+        adios2::Params engineParams = {};
+
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {1, (size_t)mpiSize * 2};
+        Dims start = {0, (size_t)mpiRank * 2};
+        Dims count = {1, 2};
+        size_t steps = 100;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    if (mpiGroup == 1)
     {
-        Reader(shape, start, count, steps, engineParams, filename);
-    }
+        std::string filename = "TestSscVaryingStepsNaive";
+        adios2::Params engineParams = {{"Verbose", "0"},
+                                       {"EngineMode", "naive"}};
 
-    MPI_Barrier(MPI_COMM_WORLD);
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        Dims shape = {1, (size_t)mpiSize * 2};
+        Dims start = {0, (size_t)mpiRank * 2};
+        Dims count = {1, 2};
+        size_t steps = 100;
+
+        if (mpiGroup == 0)
+        {
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/ssc/TestSscWriterMultiblock.cpp
+++ b/testing/adios2/engine/ssc/TestSscWriterMultiblock.cpp
@@ -255,39 +255,78 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
 TEST_F(SscEngineTest, TestSscWriterMultiblock)
 {
-    std::string filename = "TestSscWriterMultiblock";
-    adios2::Params engineParams = {{"Verbose", "0"}};
-
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-    int mpiGroup = worldRank / (worldSize / 2);
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    size_t steps = 100;
-
-    if (mpiGroup == 0)
     {
-        Dims shape = {(size_t)mpiSize * 2, 10};
-        Dims start = {(size_t)mpiRank * 2, 0};
-        Dims count = {1, 10};
-        Writer(shape, start, count, steps, engineParams, filename);
+        std::string filename = "TestSscWriterMultiblock";
+        adios2::Params engineParams = {{"Verbose", "0"}};
+
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        size_t steps = 100;
+
+        if (mpiGroup == 0)
+        {
+            Dims shape = {(size_t)mpiSize * 2, 10};
+            Dims start = {(size_t)mpiRank * 2, 0};
+            Dims count = {1, 10};
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Dims shape = {(size_t)mpiSize * 2, 10};
+            Dims start = {0, 0};
+            Dims count = {(size_t)mpiSize * 2, 10};
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    if (mpiGroup == 1)
     {
-        Dims shape = {(size_t)mpiSize * 2, 10};
-        Dims start = {0, 0};
-        Dims count = {(size_t)mpiSize * 2, 10};
-        Reader(shape, start, count, steps, engineParams, filename);
-    }
+        std::string filename = "TestSscWriterMultiblockNaive";
+        adios2::Params engineParams = {{"Verbose", "0"},
+                                       {"EngineMode", "naive"}};
 
-    MPI_Barrier(MPI_COMM_WORLD);
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+        int mpiGroup = worldRank / (worldSize / 2);
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        size_t steps = 100;
+
+        if (mpiGroup == 0)
+        {
+            Dims shape = {(size_t)mpiSize * 2, 10};
+            Dims start = {(size_t)mpiRank * 2, 0};
+            Dims count = {1, 10};
+            Writer(shape, start, count, steps, engineParams, filename);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        if (mpiGroup == 1)
+        {
+            Dims shape = {(size_t)mpiSize * 2, 10};
+            Dims start = {0, 0};
+            Dims count = {(size_t)mpiSize * 2, 10};
+            Reader(shape, start, count, steps, engineParams, filename);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/ssc/TestSscXgc2Way.cpp
+++ b/testing/adios2/engine/ssc/TestSscXgc2Way.cpp
@@ -130,57 +130,115 @@ void gene(const Dims &shape, const Dims &start, const Dims &count,
 TEST_F(SscEngineTest, TestSscXgc2Way)
 {
 
-    Dims start, count, shape;
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-
-    if (worldSize < 6)
     {
-        return;
+        Dims start, count, shape;
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+
+        if (worldSize < 6)
+        {
+            return;
+        }
+
+        if (worldRank < 2)
+        {
+            mpiGroup = 0;
+        }
+        else
+        {
+            mpiGroup = 1;
+        }
+
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        size_t steps = 20;
+
+        if (mpiGroup == 0)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "2"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"Verbose", "0"}};
+            xgc(shape, start, count, steps, engineParams);
+        }
+
+        if (mpiGroup == 1)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "2"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"Verbose", "0"}};
+            gene(shape, start, shape, steps, engineParams);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    if (worldRank < 2)
     {
-        mpiGroup = 0;
+        Dims start, count, shape;
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+
+        if (worldSize < 6)
+        {
+            return;
+        }
+
+        if (worldRank < 2)
+        {
+            mpiGroup = 0;
+        }
+        else
+        {
+            mpiGroup = 1;
+        }
+
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        size_t steps = 20;
+
+        if (mpiGroup == 0)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "2"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"EngineMode", "naive"},
+                                           {"Verbose", "0"}};
+            xgc(shape, start, count, steps, engineParams);
+        }
+
+        if (mpiGroup == 1)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "2"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"EngineMode", "naive"},
+                                           {"Verbose", "0"}};
+            gene(shape, start, shape, steps, engineParams);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
-    else
-    {
-        mpiGroup = 1;
-    }
-
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    size_t steps = 20;
-
-    if (mpiGroup == 0)
-    {
-        shape = {(size_t)mpiSize, 10};
-        start = {(size_t)mpiRank, 0};
-        count = {1, 10};
-        adios2::Params engineParams = {{"RendezvousAppCount", "2"},
-                                       {"MaxStreamsPerApp", "2"},
-                                       {"OpenTimeoutSecs", "3"},
-                                       {"Verbose", "0"}};
-        xgc(shape, start, count, steps, engineParams);
-    }
-
-    if (mpiGroup == 1)
-    {
-        shape = {(size_t)mpiSize, 10};
-        start = {(size_t)mpiRank, 0};
-        count = {1, 10};
-        adios2::Params engineParams = {{"RendezvousAppCount", "2"},
-                                       {"MaxStreamsPerApp", "2"},
-                                       {"OpenTimeoutSecs", "3"},
-                                       {"Verbose", "0"}};
-        gene(shape, start, shape, steps, engineParams);
-    }
-
-    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/ssc/TestSscXgc3Way.cpp
+++ b/testing/adios2/engine/ssc/TestSscXgc3Way.cpp
@@ -223,73 +223,146 @@ void gene(const Dims &shape, const Dims &start, const Dims &count,
 TEST_F(SscEngineTest, TestSscXgc3Way)
 {
 
-    Dims start, count, shape;
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-
-    if (worldSize < 4)
     {
-        return;
+        Dims start, count, shape;
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+
+        if (worldSize < 4)
+        {
+            return;
+        }
+
+        if (worldRank == 0)
+        {
+            mpiGroup = 0;
+        }
+        else if (worldRank == 1)
+        {
+            mpiGroup = 1;
+        }
+        else
+        {
+            mpiGroup = 2;
+        }
+
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        size_t steps = 20;
+
+        if (mpiGroup == 0)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"Verbose", "0"}};
+            coupler(shape, start, count, steps, engineParams);
+        }
+
+        if (mpiGroup == 1)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"Verbose", "0"}};
+            gene(shape, start, shape, steps, engineParams);
+        }
+
+        if (mpiGroup == 2)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"Verbose", "0"}};
+            xgc(shape, start, count, steps, engineParams);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    if (worldRank == 0)
     {
-        mpiGroup = 0;
+        Dims start, count, shape;
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+
+        if (worldSize < 4)
+        {
+            return;
+        }
+
+        if (worldRank == 0)
+        {
+            mpiGroup = 0;
+        }
+        else if (worldRank == 1)
+        {
+            mpiGroup = 1;
+        }
+        else
+        {
+            mpiGroup = 2;
+        }
+
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        size_t steps = 20;
+
+        if (mpiGroup == 0)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"EngineMode", "naive"},
+                                           {"Verbose", "0"}};
+            coupler(shape, start, count, steps, engineParams);
+        }
+
+        if (mpiGroup == 1)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"EngineMode", "naive"},
+                                           {"Verbose", "0"}};
+            gene(shape, start, shape, steps, engineParams);
+        }
+
+        if (mpiGroup == 2)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"EngineMode", "naive"},
+                                           {"Verbose", "0"}};
+            xgc(shape, start, count, steps, engineParams);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
     }
-    else if (worldRank == 1)
-    {
-        mpiGroup = 1;
-    }
-    else
-    {
-        mpiGroup = 2;
-    }
-
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    size_t steps = 20;
-
-    if (mpiGroup == 0)
-    {
-        shape = {(size_t)mpiSize, 10};
-        start = {(size_t)mpiRank, 0};
-        count = {1, 10};
-        adios2::Params engineParams = {{"RendezvousAppCount", "2"},
-                                       {"MaxStreamsPerApp", "4"},
-                                       {"OpenTimeoutSecs", "3"},
-                                       {"Verbose", "0"}};
-        coupler(shape, start, count, steps, engineParams);
-    }
-
-    if (mpiGroup == 1)
-    {
-        shape = {(size_t)mpiSize, 10};
-        start = {(size_t)mpiRank, 0};
-        count = {1, 10};
-        adios2::Params engineParams = {{"RendezvousAppCount", "2"},
-                                       {"MaxStreamsPerApp", "4"},
-                                       {"OpenTimeoutSecs", "3"},
-                                       {"Verbose", "0"}};
-        gene(shape, start, shape, steps, engineParams);
-    }
-
-    if (mpiGroup == 2)
-    {
-        shape = {(size_t)mpiSize, 10};
-        start = {(size_t)mpiRank, 0};
-        count = {1, 10};
-        adios2::Params engineParams = {{"RendezvousAppCount", "2"},
-                                       {"MaxStreamsPerApp", "4"},
-                                       {"OpenTimeoutSecs", "3"},
-                                       {"Verbose", "0"}};
-        xgc(shape, start, count, steps, engineParams);
-    }
-
-    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/ssc/TestSscXgc3WayMatchedSteps.cpp
+++ b/testing/adios2/engine/ssc/TestSscXgc3WayMatchedSteps.cpp
@@ -219,73 +219,148 @@ void gene(const Dims &shape, const Dims &start, const Dims &count,
 TEST_F(SscEngineTest, TestSscXgc3WayMatchedSteps)
 {
 
-    Dims start, count, shape;
-    int worldRank, worldSize;
-    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
-    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-
-    if (worldSize < 4)
     {
-        return;
+        Dims start, count, shape;
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+
+        if (worldSize < 4)
+        {
+            return;
+        }
+
+        if (worldRank == 0)
+        {
+            mpiGroup = 0;
+        }
+        else if (worldRank == 1)
+        {
+            mpiGroup = 1;
+        }
+        else
+        {
+            mpiGroup = 2;
+        }
+
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        size_t steps = 20;
+
+        if (mpiGroup == 0)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"Verbose", "0"}};
+            coupler(shape, start, count, steps, engineParams);
+        }
+
+        if (mpiGroup == 1)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"Verbose", "0"}};
+            gene(shape, start, shape, steps, engineParams);
+        }
+
+        if (mpiGroup == 2)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"Verbose", "0"}};
+            xgc(shape, start, count, steps, engineParams);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
 
-    if (worldRank == 0)
     {
-        mpiGroup = 0;
+        Dims start, count, shape;
+        int worldRank, worldSize;
+        MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+        MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+
+        if (worldSize < 4)
+        {
+            return;
+        }
+
+        if (worldRank == 0)
+        {
+            mpiGroup = 0;
+        }
+        else if (worldRank == 1)
+        {
+            mpiGroup = 1;
+        }
+        else
+        {
+            mpiGroup = 2;
+        }
+
+        MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
+
+        MPI_Comm_rank(mpiComm, &mpiRank);
+        MPI_Comm_size(mpiComm, &mpiSize);
+
+        size_t steps = 20;
+
+        if (mpiGroup == 0)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"EngineMode", "naive"},
+                                           {"Verbose", "0"}};
+            coupler(shape, start, count, steps, engineParams);
+        }
+
+        if (mpiGroup == 1)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"EngineMode", "naive"},
+                                           {"Verbose", "0"}};
+            gene(shape, start, shape, steps, engineParams);
+        }
+
+        if (mpiGroup == 2)
+        {
+            shape = {(size_t)mpiSize, 10};
+            start = {(size_t)mpiRank, 0};
+            count = {1, 10};
+            adios2::Params engineParams = {{"RendezvousAppCount", "2"},
+                                           {"MaxStreamsPerApp", "4"},
+                                           {"OpenTimeoutSecs", "3"},
+                                           {"EngineMode", "naive"},
+                                           {"Verbose", "0"}};
+            xgc(shape, start, count, steps, engineParams);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
     }
-    else if (worldRank == 1)
-    {
-        mpiGroup = 1;
-    }
-    else
-    {
-        mpiGroup = 2;
-    }
-
-    MPI_Comm_split(MPI_COMM_WORLD, mpiGroup, worldRank, &mpiComm);
-
-    MPI_Comm_rank(mpiComm, &mpiRank);
-    MPI_Comm_size(mpiComm, &mpiSize);
-
-    size_t steps = 20;
-
-    if (mpiGroup == 0)
-    {
-        shape = {(size_t)mpiSize, 10};
-        start = {(size_t)mpiRank, 0};
-        count = {1, 10};
-        adios2::Params engineParams = {{"RendezvousAppCount", "2"},
-                                       {"MaxStreamsPerApp", "4"},
-                                       {"OpenTimeoutSecs", "3"},
-                                       {"Verbose", "0"}};
-        coupler(shape, start, count, steps, engineParams);
-    }
-
-    if (mpiGroup == 1)
-    {
-        shape = {(size_t)mpiSize, 10};
-        start = {(size_t)mpiRank, 0};
-        count = {1, 10};
-        adios2::Params engineParams = {{"RendezvousAppCount", "2"},
-                                       {"MaxStreamsPerApp", "4"},
-                                       {"OpenTimeoutSecs", "3"},
-                                       {"Verbose", "0"}};
-        gene(shape, start, shape, steps, engineParams);
-    }
-
-    if (mpiGroup == 2)
-    {
-        shape = {(size_t)mpiSize, 10};
-        start = {(size_t)mpiRank, 0};
-        count = {1, 10};
-        adios2::Params engineParams = {{"RendezvousAppCount", "2"},
-                                       {"MaxStreamsPerApp", "4"},
-                                       {"OpenTimeoutSecs", "3"},
-                                       {"Verbose", "0"}};
-        xgc(shape, start, count, steps, engineParams);
-    }
-
-    MPI_Barrier(MPI_COMM_WORLD);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
NAIVE mode in SSC is implemented for use cases where a huge number of writers need to send data to a small number of readers, and the entire global data arrays can fit into the system memory of a single rank. 

In these scenarios, metadata and data can be aggregated within a single MPI collective call. The entire workflow only uses ordinary MPI function calls, no one-sided MPI needed. All these simplifications will largely improve SSC's scalability on world's leading computing facilities. 