### PR TITLE
added mutex in sz operator

### DIFF
--- a/source/adios2/operator/compress/CompressSZ.h
+++ b/source/adios2/operator/compress/CompressSZ.h
@@ -12,6 +12,7 @@
 #define ADIOS2_OPERATOR_COMPRESS_COMPRESSSZ_H_
 
 #include "adios2/core/Operator.h"
+#include <mutex>
 
 namespace adios2
 {
@@ -80,6 +81,7 @@ private:
                         char *dataOut);
 
     std::string m_VersionInfo;
+    static std::mutex m_Mutex;
 };
 
 } // end namespace compress

--- a/testing/adios2/engine/dataman/TestDataMan2DSz.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan2DSz.cpp
@@ -311,7 +311,7 @@ TEST_F(DataManEngineTest, 2D_Sz)
     Dims start = {0, 0};
     Dims count = {10, 10};
 
-    size_t steps = 100;
+    size_t steps = 5000;
     adios2::Params engineParams = {
         {"IPAddress", "127.0.0.1"}, {"Port", "12330"}, {"Verbose", "0"}};
 


### PR DESCRIPTION
The SZ 1.x library does not provide a thread-safe API. This PR is to add a mutex at the ADIOS2 SZ operator layer to prevent unpredictable behaviors when multiple threads use SZ compressor simultaneously.