### PR TITLE
remove template instantiation in header files

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Engine.h
+++ b/bindings/CXX11/adios2/cxx11/Engine.h
@@ -458,48 +458,6 @@ private:
     core::Engine *m_Engine = nullptr;
 };
 
-#define declare_template_instantiation(T)                                      \
-                                                                               \
-    extern template typename Variable<T>::Span Engine::Put(                    \
-        Variable<T>, const bool, const T &);                                   \
-    extern template typename Variable<T>::Span Engine::Put(Variable<T>);       \
-    extern template void Engine::Get(Variable<T>, T **) const;
-
-ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
-
-#define declare_template_instantiation(T)                                      \
-    extern template void Engine::Put<T>(Variable<T>, const T *, const Mode);   \
-    extern template void Engine::Put<T>(const std::string &, const T *,        \
-                                        const Mode);                           \
-    extern template void Engine::Put<T>(Variable<T>, const T &, const Mode);   \
-    extern template void Engine::Put<T>(const std::string &, const T &,        \
-                                        const Mode);                           \
-                                                                               \
-    extern template void Engine::Get<T>(Variable<T>, T *, const Mode);         \
-    extern template void Engine::Get<T>(const std::string &, T *, const Mode); \
-    extern template void Engine::Get<T>(Variable<T>, T &, const Mode);         \
-    extern template void Engine::Get<T>(const std::string &, T &, const Mode); \
-                                                                               \
-    extern template void Engine::Get<T>(Variable<T>, std::vector<T> &,         \
-                                        const Mode);                           \
-    extern template void Engine::Get<T>(const std::string &, std::vector<T> &, \
-                                        const Mode);                           \
-                                                                               \
-    extern template void Engine::Get<T>(                                       \
-        Variable<T>, typename Variable<T>::Info & info, const Mode);           \
-    extern template void Engine::Get<T>(                                       \
-        const std::string &, typename Variable<T>::Info &info, const Mode);    \
-                                                                               \
-    extern template std::map<size_t, std::vector<typename Variable<T>::Info>>  \
-    Engine::AllStepsBlocksInfo(const Variable<T> variable) const;              \
-                                                                               \
-    extern template std::vector<typename Variable<T>::Info>                    \
-    Engine::BlocksInfo(const Variable<T> variable, const size_t step) const;
-
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
-
 std::string ToString(const Engine &engine);
 
 } // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/Group.h
+++ b/bindings/CXX11/adios2/cxx11/Group.h
@@ -135,11 +135,5 @@ public:
      */
     DataType AttributeType(const std::string &name) const;
 };
-// Explicit declaration of the public template methods
-// Limits the types
-#define declare_template_instantiation(T)                                      \
-    extern template Variable<T> Group::InquireVariable<T>(const std::string &);
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
 }
 #endif // ADIOS2_BINDINGS_CXX11_CXX11_GROUP_H_

--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -364,32 +364,6 @@ private:
     core::IO *m_IO = nullptr;
 };
 
-// Explicit declaration of the public template methods
-// Limits the types
-#define declare_template_instantiation(T)                                      \
-    extern template Variable<T> IO::DefineVariable(const std::string &,        \
-                                                   const Dims &, const Dims &, \
-                                                   const Dims &, const bool);  \
-                                                                               \
-    extern template Variable<T> IO::InquireVariable<T>(const std::string &);
-
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
-
-#define declare_template_instantiation(T)                                      \
-    extern template Attribute<T> IO::DefineAttribute(                          \
-        const std::string &, const T *, const size_t, const std::string &,     \
-        const std::string, const bool);                                        \
-                                                                               \
-    extern template Attribute<T> IO::DefineAttribute(                          \
-        const std::string &, const T &, const std::string &,                   \
-        const std::string, const bool);                                        \
-                                                                               \
-    extern template Attribute<T> IO::InquireAttribute<T>(                      \
-        const std::string &, const std::string &, const std::string);
-ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
-
 std::string ToString(const IO &io);
 
 } // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/Types.h
+++ b/bindings/CXX11/adios2/cxx11/Types.h
@@ -22,13 +22,5 @@ namespace adios2
 template <class T>
 std::string GetType() noexcept;
 
-// LIMIT TEMPLATE TYPES FOR adios2::GetType
-#define declare_template_instantiation(T)                                      \
-                                                                               \
-    extern template std::string GetType<T>() noexcept;
-
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
-
 } // end namespace adios2
 #endif /* ADIOS2_BINDINGS_CXX11_TYPES_H_ */

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -397,12 +397,6 @@ private:
     DoAllStepsBlocksInfoMap() const;
 };
 
-#define declare_template_instantiation(T)                                      \
-    extern template std::vector<typename Variable<T>::Info>                    \
-    Variable<T>::ToBlocksInfoMin(const MinVarInfo *coreVarInfo) const;
-ADIOS2_FOREACH_TYPE_1ARG(declare_template_instantiation)
-#undef declare_template_instantiation
-
 template <typename T>
 std::string ToString(const Variable<T> &variable);
 


### PR DESCRIPTION
These template instantiations only need to be in cpp files. No need to put in header files. 