### PR TITLE
Syntax fix in declarations for C++20 compliance

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Attribute.h
+++ b/bindings/CXX11/adios2/cxx11/Attribute.h
@@ -43,8 +43,8 @@ public:
      * attributes from IO:DefineAttribute<T> or IO:InquireAttribute<T>.
      * Can be used with STL containers.
      */
-    Attribute<T>() = default;
-    ~Attribute<T>() = default;
+    Attribute() = default;
+    ~Attribute() = default;
 
     /** Checks if object is valid, e.g. if( attribute ) { //..valid } */
     explicit operator bool() const noexcept;
@@ -74,7 +74,7 @@ public:
     bool IsValue() const;
 
 private:
-    Attribute<T>(core::Attribute<IOType> *attribute);
+    Attribute(core::Attribute<IOType> *attribute);
     core::Attribute<IOType> *m_Attribute = nullptr;
 };
 

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -141,10 +141,10 @@ public:
      * variables from IO:DefineVariable<T> or IO:InquireVariable<T>.
      * Can be used with STL containers.
      */
-    Variable<T>() = default;
+    Variable() = default;
 
     /** Default, using RAII STL containers */
-    ~Variable<T>() = default;
+    ~Variable() = default;
 
     /** Checks if object is valid, e.g. if( variable ) { //..valid } */
     explicit operator bool() const noexcept;
@@ -389,7 +389,7 @@ public:
     using Span = adios2::detail::Span<T>;
 
 private:
-    Variable<T>(core::Variable<IOType> *variable);
+    Variable(core::Variable<IOType> *variable);
     core::Variable<IOType> *m_Variable = nullptr;
 
     std::vector<std::vector<typename Variable<T>::Info>> DoAllStepsBlocksInfo();


### PR DESCRIPTION
Building a C++20 library against ADIOS2 fails with GCC 11.2.0. This PR allows compilation without fatal errors. An explanation of what has been tightened in the C++ standard is at https://stackoverflow.com/questions/63513984/can-class-template-constructors-have-a-redundant-template-parameter-list-in-c2.

See also https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97202.