### PR TITLE
Fix a template instantiation issue with GCC 10 in dataman serializer

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -255,13 +255,15 @@ elseif(ADIOS2_USE_MHS)
 endif()
 
 # DataSpaces
-if(ADIOS2_USE_DataSpaces STREQUAL AUTO)
-  find_package(DataSpaces 2.1.1)
-elseif(ADIOS2_USE_DataSpaces)
-  find_package(DataSpaces 2.1.1 REQUIRED)
-endif()
-if(DATASPACES_FOUND)
-  set(ADIOS2_HAVE_DataSpaces TRUE)
+if(MPI_FOUND)
+    if(ADIOS2_USE_DataSpaces STREQUAL AUTO)
+        find_package(DataSpaces 2.1.1)
+    elseif(ADIOS2_USE_DataSpaces)
+        find_package(DataSpaces 2.1.1 REQUIRED)
+    endif()
+    if(DATASPACES_FOUND)
+        set(ADIOS2_HAVE_DataSpaces TRUE)
+    endif()
 endif()
 
 # HDF5

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -622,7 +622,6 @@ void DataManSerializer::Log(const int level, const std::string &message,
     }
 }
 
-template <>
 void DataManSerializer::PutData(
     const std::string *inputData, const std::string &varName,
     const Dims &varShape, const Dims &varStart, const Dims &varCount,

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -93,6 +93,14 @@ public:
     void PutAttributes(core::IO &io);
 
     // put a variable for writer
+    void PutData(const std::string *inputData, const std::string &varName,
+                 const Dims &varShape, const Dims &varStart,
+                 const Dims &varCount, const Dims &varMemStart,
+                 const Dims &varMemCount, const std::string &doid,
+                 const size_t step, const int rank, const std::string &address,
+                 const std::vector<std::shared_ptr<core::Operator>> &ops,
+                 VecPtr localBuffer = nullptr, JsonPtr metadataJson = nullptr);
+
     template <class T>
     void PutData(const T *inputData, const std::string &varName,
                  const Dims &varShape, const Dims &varStart,


### PR DESCRIPTION
Fixes #3151

It seems that GCC 10 handles template instantiation differently from previous GCC versions, and as a result, some template instantiation in DataMan serializer failed to pick up the correct template instantiation. This PR changed the affected template instantiation to simple function overloading. 