### PR TITLE
Add template-free C++ API 

### DIFF
--- a/bindings/CXX11/CMakeLists.txt
+++ b/bindings/CXX11/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(adios2_cxx11
   adios2/cxx11/Types.cpp
   adios2/cxx11/Types.tcc
   adios2/cxx11/Variable.cpp
+  adios2/cxx11/VariableNT.cpp
   adios2/cxx11/fstream/ADIOS2fstream.cpp
   adios2/cxx11/Group.cpp
   adios2/cxx11/Group.tcc
@@ -77,11 +78,12 @@ install(
 )
 
 install(
-  FILES adios2/cxx11/ADIOS.h 
+  FILES adios2/cxx11/ADIOS.h
         adios2/cxx11/ADIOS.inl
         adios2/cxx11/IO.h
         adios2/cxx11/Group.h
-        adios2/cxx11/Variable.h 
+        adios2/cxx11/Variable.h
+        adios2/cxx11/VariableNT.h
         adios2/cxx11/Attribute.h
         adios2/cxx11/Engine.h
         adios2/cxx11/Operator.h

--- a/bindings/CXX11/adios2/cxx11/Engine.cpp
+++ b/bindings/CXX11/adios2/cxx11/Engine.cpp
@@ -160,6 +160,51 @@ void Engine::Put(VariableNT &variable, const void *data, const Mode launch)
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
+void Engine::Get(VariableNT &variable, void *data, const Mode launch)
+{
+    adios2::helper::CheckForNullptr(m_Engine, "in call to Engine::Get");
+    adios2::helper::CheckForNullptr(variable.m_Variable,
+                                    "for variable in call to Engine::Get");
+    std::string type = ToString(variable.m_Variable->m_Type);
+#define declare_type(T)                                                        \
+    if (type == GetType<T>())                                                  \
+    {                                                                          \
+        m_Engine->Get(                                                         \
+            *reinterpret_cast<core::Variable<T> *>(variable.m_Variable),       \
+            reinterpret_cast<T *>(data), launch);                              \
+    }
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+    else {}
+}
+
+#define declare_type(T)                                                        \
+    void Engine::Get(VariableNT &variable, T &datum, const Mode launch)        \
+    {                                                                          \
+        adios2::helper::CheckForNullptr(m_Engine, "in call to Engine::Get");   \
+        adios2::helper::CheckForNullptr(                                       \
+            variable.m_Variable, "for variable in call to Engine::Get");       \
+        m_Engine->Get(                                                         \
+            *reinterpret_cast<core::Variable<T> *>(variable.m_Variable),       \
+            datum, launch);                                                    \
+    }
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+#define declare_type(T)                                                        \
+    void Engine::Get(VariableNT &variable, std::vector<T> &datum,              \
+                     const Mode launch)                                        \
+    {                                                                          \
+        adios2::helper::CheckForNullptr(m_Engine, "in call to Engine::Get");   \
+        adios2::helper::CheckForNullptr(                                       \
+            variable.m_Variable, "for variable in call to Engine::Get");       \
+        m_Engine->Get(                                                         \
+            *reinterpret_cast<core::Variable<T> *>(variable.m_Variable),       \
+            datum, launch);                                                    \
+    }
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
 #define declare_template_instantiation(T)                                      \
                                                                                \
     template typename Variable<T>::Span Engine::Put(Variable<T>, const bool,   \

--- a/bindings/CXX11/adios2/cxx11/Engine.cpp
+++ b/bindings/CXX11/adios2/cxx11/Engine.cpp
@@ -129,6 +129,24 @@ size_t Engine::Steps() const
 
 Engine::Engine(core::Engine *engine) : m_Engine(engine) {}
 
+void Engine::Put(VariableNT &variable, const void *data, const Mode launch)
+{
+    helper::CheckForNullptr(m_Engine, "in call to Engine::Put");
+    helper::CheckForNullptr(variable.m_Variable,
+                            "for variable in call to Engine::Put");
+    std::string type = ToString(variable.m_Variable->m_Type);
+#define declare_type(T)                                                        \
+    if (type == GetType<T>())                                                  \
+    {                                                                          \
+        m_Engine->Put(                                                         \
+            *reinterpret_cast<core::Variable<T> *>(variable.m_Variable),       \
+            reinterpret_cast<const T *>(data), launch);                        \
+    }
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+    else {}
+}
+
 #define declare_template_instantiation(T)                                      \
                                                                                \
     template typename Variable<T>::Span Engine::Put(Variable<T>, const bool,   \

--- a/bindings/CXX11/adios2/cxx11/Engine.cpp
+++ b/bindings/CXX11/adios2/cxx11/Engine.cpp
@@ -147,6 +147,19 @@ void Engine::Put(VariableNT &variable, const void *data, const Mode launch)
     else {}
 }
 
+#define declare_type(T)                                                        \
+    void Engine::Put(VariableNT &variable, const T &datum, const Mode launch)  \
+    {                                                                          \
+        helper::CheckForNullptr(m_Engine, "in call to Engine::Put");           \
+        helper::CheckForNullptr(variable.m_Variable,                           \
+                                "for variable in call to Engine::Put");        \
+        m_Engine->Put(                                                         \
+            *reinterpret_cast<core::Variable<T> *>(variable.m_Variable),       \
+            datum, launch);                                                    \
+    }
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
 #define declare_template_instantiation(T)                                      \
                                                                                \
     template typename Variable<T>::Span Engine::Put(Variable<T>, const bool,   \

--- a/bindings/CXX11/adios2/cxx11/Engine.h
+++ b/bindings/CXX11/adios2/cxx11/Engine.h
@@ -179,6 +179,12 @@ public:
     void Put(Variable<T> variable, const T &datum,
              const Mode launch = Mode::Deferred);
 
+#define declare_type(T)                                                        \
+    void Put(VariableNT &variable, const T &datum,                             \
+             const Mode launch = Mode::Deferred);
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
     /**
      * Put data associated with a Variable in the Engine
      * Overloaded version that accepts variables names, and r-values and single

--- a/bindings/CXX11/adios2/cxx11/Engine.h
+++ b/bindings/CXX11/adios2/cxx11/Engine.h
@@ -13,6 +13,7 @@
 
 #include "Types.h"
 #include "Variable.h"
+#include "VariableNT.h"
 
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/common/ADIOSTypes.h"
@@ -140,6 +141,9 @@ public:
      */
     template <class T>
     void Put(Variable<T> variable, const T *data,
+             const Mode launch = Mode::Deferred);
+
+    void Put(VariableNT &variable, const void *data,
              const Mode launch = Mode::Deferred);
 
     /**

--- a/bindings/CXX11/adios2/cxx11/Engine.h
+++ b/bindings/CXX11/adios2/cxx11/Engine.h
@@ -229,6 +229,9 @@ public:
     template <class T>
     void Get(Variable<T> variable, T *data, const Mode launch = Mode::Deferred);
 
+    void Get(VariableNT &variable, void *data,
+             const Mode launch = Mode::Deferred);
+
     /**
      * Get data associated with a Variable from the Engine. Overloaded version
      * to get variable by name.
@@ -264,6 +267,18 @@ public:
     template <class T>
     void Get(Variable<T> variable, T &datum,
              const Mode launch = Mode::Deferred);
+
+#define declare_type(T)                                                        \
+    void Get(VariableNT &variable, T &datum,                                   \
+             const Mode launch = Mode::Deferred);
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+
+#define declare_type(T)                                                        \
+    void Get(VariableNT &variable, std::vector<T> &datum,                      \
+             const Mode launch = Mode::Deferred);
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
 
     /**
      * Get single value data associated with a Variable from the Engine

--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -165,6 +165,23 @@ std::string IO::EngineType() const
     return m_IO->m_EngineType;
 }
 
+VariableNT IO::DefineVariable(const DataType type, const std::string &name,
+                              const Dims &shape, const Dims &start,
+                              const Dims &count, const bool constantDims)
+{
+    helper::CheckForNullptr(m_IO, "for variable name " + name +
+                                      ", in call to IO::DefineVariable");
+#define declare_type(T)                                                        \
+    if (ToString(type) == GetType<T>())                                        \
+    {                                                                          \
+        return VariableNT(&m_IO->DefineVariable<typename TypeInfo<T>::IOType>( \
+            name, shape, start, count, constantDims));                         \
+    }
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+    else { return nullptr; }
+}
+
 // PRIVATE
 IO::IO(core::IO *io) : m_IO(io) {}
 

--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -182,6 +182,22 @@ VariableNT IO::DefineVariable(const DataType type, const std::string &name,
     else { return nullptr; }
 }
 
+VariableNT IO::InquireVariable(const std::string &name)
+{
+    helper::CheckForNullptr(m_IO, "for variable name " + name +
+                                      ", in call to IO::InquireVariable");
+    auto type = m_IO->InquireVariableType(name);
+#define declare_type(T)                                                        \
+    if (ToString(type) == GetType<T>())                                        \
+    {                                                                          \
+        return VariableNT(                                                     \
+            m_IO->InquireVariable<typename TypeInfo<T>::IOType>(name));        \
+    }
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+    else { return nullptr; }
+}
+
 // PRIVATE
 IO::IO(core::IO *io) : m_IO(io) {}
 

--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -11,15 +11,16 @@
 #ifndef ADIOS2_BINDINGS_CXX11_CXX11_IO_H_
 #define ADIOS2_BINDINGS_CXX11_CXX11_IO_H_
 
+#if ADIOS2_USE_MPI
+#include <mpi.h>
+#endif
+
 #include "Attribute.h"
 #include "Engine.h"
 #include "Group.h"
 #include "Operator.h"
 #include "Variable.h"
-#if ADIOS2_USE_MPI
-#include <mpi.h>
-#endif
-
+#include "VariableNT.h"
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/common/ADIOSTypes.h"
 
@@ -151,6 +152,12 @@ public:
     DefineVariable(const std::string &name, const Dims &shape = Dims(),
                    const Dims &start = Dims(), const Dims &count = Dims(),
                    const bool constantDims = false);
+
+    VariableNT DefineVariable(const DataType type, const std::string &name,
+                              const Dims &shape = Dims(),
+                              const Dims &start = Dims(),
+                              const Dims &count = Dims(),
+                              const bool constantDims = false);
 
     /**
      * Retrieve a Variable object within current IO object

--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -168,6 +168,8 @@ public:
     template <class T>
     Variable<T> InquireVariable(const std::string &name);
 
+    VariableNT InquireVariable(const std::string &name);
+
     /**
      * @brief Define attribute inside io. Array input version
      * @param name unique attribute identifier IO object or for a Variable if

--- a/bindings/CXX11/adios2/cxx11/IO.tcc
+++ b/bindings/CXX11/adios2/cxx11/IO.tcc
@@ -80,4 +80,4 @@ Attribute<T> IO::InquireAttribute(const std::string &name,
 
 } // end namespace adios2
 
-#endif /* ADIOS2_BINDINGS_CXX11_CXX11_IO_TCC_ */
+#endif // ADIOS2_BINDINGS_CXX11_CXX11_IO_TCC_

--- a/bindings/CXX11/adios2/cxx11/Operator.h
+++ b/bindings/CXX11/adios2/cxx11/Operator.h
@@ -33,12 +33,6 @@ class Operator; // private implementation
 
 class Operator
 {
-    friend class ADIOS;
-    friend class IO;
-
-    template <class T>
-    friend class Variable;
-
 public:
     /**
      * Empty (default) constructor, use it as a placeholder for future
@@ -74,6 +68,13 @@ public:
     Params &Parameters() const;
 
 private:
+    friend class ADIOS;
+    friend class IO;
+
+    friend class VariableNT;
+    template <class T>
+    friend class Variable;
+
     Params *m_Parameters;
     std::string m_Type;
     Operator(const std::string &type, Params *params);

--- a/bindings/CXX11/adios2/cxx11/Variable.cpp
+++ b/bindings/CXX11/adios2/cxx11/Variable.cpp
@@ -162,11 +162,11 @@ namespace adios2
                                      const Params &parameters)                 \
     {                                                                          \
         helper::CheckForNullptr(m_Variable,                                    \
-                                "in call to Variable<T>::AddOperator");        \
+                                "in call to Variable<T>::AddOperation");       \
         if (!op)                                                               \
         {                                                                      \
             throw std::invalid_argument("ERROR: invalid operator, in call to " \
-                                        "Variable<T>::AddOperator");           \
+                                        "Variable<T>::AddOperation");          \
         }                                                                      \
         auto params = op.Parameters();                                         \
         for (const auto &p : parameters)                                       \
@@ -180,6 +180,8 @@ namespace adios2
     size_t Variable<T>::AddOperation(const std::string &type,                  \
                                      const Params &parameters)                 \
     {                                                                          \
+        helper::CheckForNullptr(m_Variable,                                    \
+                                "in call to Variable<T>::AddOperation");       \
         return m_Variable->AddOperation(type, parameters);                     \
     }                                                                          \
                                                                                \

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -400,4 +400,4 @@ std::string ToString(const Variable<T> &variable);
 
 } // end namespace adios2
 
-#endif /* ADIOS2_BINDINGS_CXX11_CXX11_VARIABLE_H_ */
+#endif // ADIOS2_BINDINGS_CXX11_CXX11_VARIABLE_H_

--- a/bindings/CXX11/adios2/cxx11/VariableNT.cpp
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.cpp
@@ -1,0 +1,17 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * Variable.cpp :
+ *
+ *  Created on: Apr 18, 2022
+ *      Author: Jason Wang jason.ruonan.wang@gmail.com
+ */
+#include "VariableNT.h"
+
+namespace adios2
+{
+
+VariableNT::VariableNT(core::VariableBase *variable) : m_Variable(variable) {}
+
+} // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/VariableNT.cpp
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.cpp
@@ -7,11 +7,172 @@
  *  Created on: Apr 18, 2022
  *      Author: Jason Wang jason.ruonan.wang@gmail.com
  */
+
 #include "VariableNT.h"
+#include "adios2/core/VariableBase.h"
+#include "adios2/helper/adiosFunctions.h"
 
 namespace adios2
 {
 
 VariableNT::VariableNT(core::VariableBase *variable) : m_Variable(variable) {}
+
+VariableNT::operator bool() const noexcept { return m_Variable != nullptr; }
+
+void VariableNT::SetMemorySpace(const MemorySpace mem)
+{
+    helper::CheckForNullptr(m_Variable,
+                            "in call to VariableNT::SetMemorySpace");
+    m_Variable->SetMemorySpace(mem);
+}
+
+void VariableNT::SetShape(const Dims &shape)
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::SetShape");
+    m_Variable->SetShape(shape);
+}
+
+void VariableNT::SetBlockSelection(const size_t blockID)
+{
+    helper::CheckForNullptr(m_Variable,
+                            "in call to VariableNT::SetBlockSelection");
+    m_Variable->SetBlockSelection(blockID);
+}
+
+void VariableNT::SetSelection(const Box<Dims> &selection)
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::SetSelection");
+    m_Variable->SetSelection(selection);
+}
+
+void VariableNT::SetMemorySelection(const Box<Dims> &memorySelection)
+{
+    helper::CheckForNullptr(m_Variable,
+                            "in call to VariableNT::SetMemorySelection");
+    m_Variable->SetMemorySelection(memorySelection);
+}
+
+void VariableNT::SetStepSelection(const Box<size_t> &stepSelection)
+{
+    helper::CheckForNullptr(m_Variable,
+                            "in call to VariableNT::SetStepSelection");
+    m_Variable->SetStepSelection(stepSelection);
+}
+
+/*
+size_t VariableNT::SelectionSize() const
+{
+    helper::CheckForNullptr(m_Variable,
+            "in call to VariableNT::SelectionSize");
+    return m_Variable->SelectionSize();
+}
+*/
+
+std::string VariableNT::Name() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::Name");
+    return m_Variable->m_Name;
+}
+
+std::string VariableNT::Type() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::Type");
+    return ToString(m_Variable->m_Type);
+}
+
+size_t VariableNT::Sizeof() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::Sizeof");
+    return m_Variable->m_ElementSize;
+}
+
+adios2::ShapeID VariableNT::ShapeID() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::ShapeID");
+    return m_Variable->m_ShapeID;
+}
+
+/*
+Dims VariableNT::Shape(const size_t step) const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::Shape");
+    return m_Variable->Shape(step);
+}
+*/
+
+Dims VariableNT::Start() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::Start");
+    return m_Variable->m_Start;
+}
+
+/*
+Dims VariableNT::Count() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::Count");
+    return m_Variable->Count();
+}
+*/
+
+size_t VariableNT::Steps() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::Steps");
+    return m_Variable->m_AvailableStepsCount;
+}
+
+size_t VariableNT::StepsStart() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::StepsStart");
+    return m_Variable->m_AvailableStepsStart;
+}
+
+size_t VariableNT::BlockID() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::BlockID");
+    return m_Variable->m_BlockID;
+}
+
+size_t VariableNT::AddOperation(const Operator op, const Params &parameters)
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::AddOperation");
+    if (!op)
+    {
+        helper::Throw<std::invalid_argument>("bindings::CXX11", "VariableNT",
+                                             "AddOperation",
+                                             "invalid operation");
+    }
+    auto params = op.Parameters();
+    for (const auto &p : parameters)
+    {
+        params[p.first] = p.second;
+    }
+    return m_Variable->AddOperation(op.m_Type, params);
+}
+
+size_t VariableNT::AddOperation(const std::string &type,
+                                const Params &parameters)
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::AddOperation");
+    return m_Variable->AddOperation(type, parameters);
+}
+
+std::vector<Operator> VariableNT::Operations() const
+{
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::Operations");
+    std::vector<Operator> operations;
+    operations.reserve(m_Variable->m_Operations.size());
+    for (const auto &op : m_Variable->m_Operations)
+    {
+        operations.push_back(Operator(op->m_TypeString, &op->GetParameters()));
+    }
+    return operations;
+}
+
+void VariableNT::RemoveOperations()
+{
+    helper::CheckForNullptr(m_Variable,
+                            "in call to VariableNT::RemoveOperations");
+    m_Variable->RemoveOperations();
+}
 
 } // end namespace adios2

--- a/bindings/CXX11/adios2/cxx11/VariableNT.cpp
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "VariableNT.h"
+#include "Types.h"
 #include "adios2/core/VariableBase.h"
 #include "adios2/helper/adiosFunctions.h"
 
@@ -59,14 +60,23 @@ void VariableNT::SetStepSelection(const Box<size_t> &stepSelection)
     m_Variable->SetStepSelection(stepSelection);
 }
 
-/*
 size_t VariableNT::SelectionSize() const
 {
-    helper::CheckForNullptr(m_Variable,
-            "in call to VariableNT::SelectionSize");
-    return m_Variable->SelectionSize();
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::SelectionSize");
+    auto type = ToString(m_Variable->m_Type);
+#define declare_type(T)                                                        \
+    if (type == GetType<T>())                                                  \
+    {                                                                          \
+        return reinterpret_cast<core::Variable<T> *>(m_Variable)               \
+            ->SelectionSize();                                                 \
+    }
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+    helper::Throw<std::runtime_error>("bindings::CXX11", "VariableNT",
+                                      "SelectionSize",
+                                      "invalid data type " + type);
+    return 0;
 }
-*/
 
 std::string VariableNT::Name() const
 {
@@ -92,13 +102,21 @@ adios2::ShapeID VariableNT::ShapeID() const
     return m_Variable->m_ShapeID;
 }
 
-/*
 Dims VariableNT::Shape(const size_t step) const
 {
     helper::CheckForNullptr(m_Variable, "in call to VariableNT::Shape");
-    return m_Variable->Shape(step);
+    auto type = ToString(m_Variable->m_Type);
+#define declare_type(T)                                                        \
+    if (type == GetType<T>())                                                  \
+    {                                                                          \
+        return reinterpret_cast<core::Variable<T> *>(m_Variable)->Shape(step); \
+    }
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+    helper::Throw<std::runtime_error>("bindings::CXX11", "VariableNT", "Shape",
+                                      "invalid data type " + type);
+    return Dims();
 }
-*/
 
 Dims VariableNT::Start() const
 {
@@ -106,13 +124,21 @@ Dims VariableNT::Start() const
     return m_Variable->m_Start;
 }
 
-/*
 Dims VariableNT::Count() const
 {
     helper::CheckForNullptr(m_Variable, "in call to VariableNT::Count");
-    return m_Variable->Count();
+    auto type = ToString(m_Variable->m_Type);
+#define declare_type(T)                                                        \
+    if (type == GetType<T>())                                                  \
+    {                                                                          \
+        return reinterpret_cast<core::Variable<T> *>(m_Variable)->Count();     \
+    }
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+    helper::Throw<std::runtime_error>("bindings::CXX11", "VariableNT", "Count",
+                                      "invalid data type " + type);
+    return Dims();
 }
-*/
 
 size_t VariableNT::Steps() const
 {

--- a/bindings/CXX11/adios2/cxx11/VariableNT.h
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.h
@@ -1,0 +1,200 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * VariableNT.h :
+ *
+ *  Created on: Apr 18, 2022
+ *      Author: Jason Wang jason.ruonan.wang@gmail.com
+ */
+
+#ifndef ADIOS2_BINDINGS_CXX11_CXX11_VARIABLENT_H_
+#define ADIOS2_BINDINGS_CXX11_CXX11_VARIABLENT_H_
+
+#include "Operator.h"
+#include "adios2/common/ADIOSTypes.h"
+#include <string>
+
+namespace adios2
+{
+namespace core
+{
+class VariableBase;
+}
+
+class VariableNT
+{
+
+public:
+    VariableNT() = default;
+
+    ~VariableNT() = default;
+
+    /** Checks if object is valid, e.g. if( variable ) { //..valid } */
+    explicit operator bool() const noexcept;
+
+    /**
+     * Sets the memory space for all following Puts
+     * to either host (default) or device (currently only CUDA supported)
+     * @param mem memory space where Put buffers are allocated
+     */
+    void SetMemorySpace(const MemorySpace mem);
+
+    /**
+     * Set new shape, care must be taken when reading back the variable for
+     * different steps. Only applies to Global arrays.
+     * @param shape new shape dimensions array
+     */
+    void SetShape(const adios2::Dims &shape);
+
+    /**
+     * Read mode only. Required for reading local variables, ShapeID() =
+     * ShapeID::LocalArray or ShapeID::LocalValue. For Global Arrays it will Set
+     * the appropriate Start and Count Selection for the global array
+     * coordinates.
+     * @param blockID: variable block index defined at write time. Blocks can be
+     * inspected with bpls -D variableName
+     */
+    void SetBlockSelection(const size_t blockID);
+
+    /**
+     * Sets a variable selection modifying current {start, count}
+     * Count is the dimension from Start point
+     * @param selection input {start, count}
+     */
+    void SetSelection(const adios2::Box<adios2::Dims> &selection);
+
+    /**
+     * Set the local start (offset) point to the memory pointer passed at Put
+     * and the memory local dimensions (count). Used for non-contiguous memory
+     * writes and reads (e.g. multidimensional ghost-cells).
+     * Currently Get only works for formats based on BP3.
+     * @param memorySelection {memoryStart, memoryCount}
+     * <pre>
+     * 		memoryStart: relative local offset of variable.start to the
+     * contiguous memory pointer passed at Put from which data starts. e.g. if
+     * variable.Start() = {rank*Ny,0} and there is 1 ghost cell per dimension,
+     * then memoryStart = {1,1}
+     * 		memoryCount: local dimensions for the contiguous memory pointer
+     * passed at Put, e.g. if there is 1 ghost cell per dimension and
+     * variable.Count() = {Ny,Nx}, then memoryCount = {Ny+2,Nx+2}
+     * </pre>
+     */
+    void SetMemorySelection(const adios2::Box<adios2::Dims> &memorySelection);
+
+    /**
+     * Sets a step selection modifying current startStep, countStep
+     * countStep is the number of steps from startStep point
+     * @param stepSelection input {startStep, countStep}
+     */
+    void SetStepSelection(const adios2::Box<size_t> &stepSelection);
+
+    /**
+     * Returns the number of elements required for pre-allocation based on
+     * current count and stepsCount
+     * @return elements of type T required for pre-allocation
+     */
+    size_t SelectionSize() const;
+
+    /**
+     * Inspects Variable name
+     * @return name
+     */
+    std::string Name() const;
+
+    /**
+     * Inspects Variable type
+     * @return type string literal containing the type: double, float, unsigned
+     * int, etc.
+     */
+    std::string Type() const;
+
+    /**
+     * Inspects size of the current element type, sizeof(T)
+     * @return sizeof(T) for current system
+     */
+    size_t Sizeof() const;
+
+    /**
+     * Inspects shape id for current variable
+     * @return from enum adios2::ShapeID
+     */
+    adios2::ShapeID ShapeID() const;
+
+    /**
+     * Inspects shape in global variables
+     * @param step input for a particular Shape if changing over time. If
+     * default, either return absolute or in streaming mode it returns the shape
+     * for the current engine step
+     * @return shape vector
+     */
+    adios2::Dims Shape(const size_t step = adios2::EngineCurrentStep) const;
+
+    /**
+     * Inspects current start point
+     * @return start vector
+     */
+    adios2::Dims Start() const;
+
+    /**
+     * Inspects current count from start
+     * @return count vector
+     */
+    adios2::Dims Count() const;
+
+    /**
+     * For read mode, inspect the number of available steps
+     * @return available steps
+     */
+    size_t Steps() const;
+
+    /**
+     * For read mode, inspect the start step for available steps
+     * @return available start step
+     */
+    size_t StepsStart() const;
+
+    /**
+     * For read mode, retrieve current BlockID, default = 0 if not set with
+     * SetBlockID
+     * @return current block id
+     */
+    size_t BlockID() const;
+
+    /**
+     *Adds operation and parameters to current Variable object
+     * @param op operator to be added
+     * @param parameters key/value settings particular to the Variable, not to
+     * be confused by op own parameters
+     * @return operation index handler in Operations()
+     */
+    size_t AddOperation(const Operator op,
+                        const adios2::Params &parameters = adios2::Params());
+
+    size_t AddOperation(const std::string &type,
+                        const adios2::Params &parameters = adios2::Params());
+
+    /**
+     * Inspects current operators added with AddOperator
+     * @return vector of Variable<T>::OperatorInfo
+     */
+    std::vector<Operator> Operations() const;
+
+    /**
+     * Removes all current Operations associated with AddOperation.
+     * Provides the posibility to apply or not operators on a block basis.
+     */
+    void RemoveOperations();
+
+private:
+    friend class IO;
+    friend class Engine;
+    VariableNT(core::VariableBase *variable);
+    core::VariableBase *m_Variable = nullptr;
+};
+
+std::string ToString(const VariableNT &variable);
+
+} // end namespace adios2
+
+#endif // ADIOS2_BINDINGS_CXX11_CXX11_VARIABLE_H_

--- a/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
@@ -509,7 +509,7 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead1D8NT)
         adios2::Engine bpReader =
             io.Open(fname, adios2::Mode::ReadRandomAccess);
 
-        auto var_iString = io.InquireVariable<std::string>("iString");
+        auto var_iString = io.InquireVariable("iString");
         EXPECT_TRUE(var_iString);
         ASSERT_EQ(var_iString.Shape().size(), 0);
         ASSERT_EQ(var_iString.Steps(), NSteps);
@@ -520,7 +520,7 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead1D8NT)
         ASSERT_EQ(var_i8.Steps(), NSteps);
         ASSERT_EQ(var_i8.Shape()[0], mpiSize * Nx);
 
-        auto var_i16 = io.InquireVariable<int16_t>("i16");
+        auto var_i16 = io.InquireVariable("i16");
         EXPECT_TRUE(var_i16);
         ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
         ASSERT_EQ(var_i16.Steps(), NSteps);
@@ -532,7 +532,7 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead1D8NT)
         ASSERT_EQ(var_i32.Steps(), NSteps);
         ASSERT_EQ(var_i32.Shape()[0], mpiSize * Nx);
 
-        auto var_i64 = io.InquireVariable<int64_t>("i64");
+        auto var_i64 = io.InquireVariable("i64");
         EXPECT_TRUE(var_i64);
         ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
         ASSERT_EQ(var_i64.Steps(), NSteps);
@@ -544,7 +544,7 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead1D8NT)
         ASSERT_EQ(var_u8.Steps(), NSteps);
         ASSERT_EQ(var_u8.Shape()[0], mpiSize * Nx);
 
-        auto var_u16 = io.InquireVariable<uint16_t>("u16");
+        auto var_u16 = io.InquireVariable("u16");
         EXPECT_TRUE(var_u16);
         ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
         ASSERT_EQ(var_u16.Steps(), NSteps);
@@ -556,7 +556,7 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead1D8NT)
         ASSERT_EQ(var_u32.Steps(), NSteps);
         ASSERT_EQ(var_u32.Shape()[0], mpiSize * Nx);
 
-        auto var_u64 = io.InquireVariable<uint64_t>("u64");
+        auto var_u64 = io.InquireVariable("u64");
         EXPECT_TRUE(var_u64);
         ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
         ASSERT_EQ(var_u64.Steps(), NSteps);
@@ -568,7 +568,7 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead1D8NT)
         ASSERT_EQ(var_r32.Steps(), NSteps);
         ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
 
-        auto var_r64 = io.InquireVariable<double>("r64");
+        auto var_r64 = io.InquireVariable("r64");
         EXPECT_TRUE(var_r64);
         ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
         ASSERT_EQ(var_r64.Steps(), NSteps);

--- a/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
@@ -344,6 +344,329 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead1D8)
 }
 
 //******************************************************************************
+// 1D 1x8 test data non-template
+//******************************************************************************
+
+TEST_F(BPWriteReadVector, ADIOS2BPWriteRead1D8NT)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    const std::string fname("ADIOS2BPWriteReadVector1D8NT.bp");
+
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 8;
+
+    // Number of steps
+    const size_t NSteps = 3;
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+#endif
+
+    // Write test data using BP
+
+#if ADIOS2_USE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+    adios2::ADIOS adios;
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        // Declare 1D variables (NumOfProcesses * Nx)
+        // The local process' part (start, count) can be defined now or later
+        // before Write().
+        {
+            const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize)};
+            const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
+            const adios2::Dims count{Nx};
+
+            auto var_iString =
+                io.DefineVariable(adios2::DataType::String, "iString");
+            EXPECT_TRUE(var_iString);
+            auto var_i8 = io.DefineVariable(adios2::DataType::Int8, "i8", shape,
+                                            start, count);
+            EXPECT_TRUE(var_i8);
+            auto var_i16 = io.DefineVariable(adios2::DataType::Int16, "i16",
+                                             shape, start, count);
+            EXPECT_TRUE(var_i16);
+            auto var_i32 = io.DefineVariable(adios2::DataType::Int32, "i32",
+                                             shape, start, count);
+            EXPECT_TRUE(var_i32);
+            auto var_i64 = io.DefineVariable(adios2::DataType::Int64, "i64",
+                                             shape, start, count);
+            EXPECT_TRUE(var_i64);
+            auto var_u8 = io.DefineVariable(adios2::DataType::UInt8, "u8",
+                                            shape, start, count);
+            EXPECT_TRUE(var_u8);
+            auto var_u16 =
+                io.DefineVariable<uint16_t>("u16", shape, start, count);
+            EXPECT_TRUE(var_u16);
+            auto var_u32 =
+                io.DefineVariable<uint32_t>("u32", shape, start, count);
+            EXPECT_TRUE(var_u32);
+            auto var_u64 =
+                io.DefineVariable<uint64_t>("u64", shape, start, count);
+            EXPECT_TRUE(var_u64);
+            auto var_r32 = io.DefineVariable(adios2::DataType::Float, "r32",
+                                             shape, start, count);
+            EXPECT_TRUE(var_r32);
+            auto var_r64 = io.DefineVariable(adios2::DataType::Double, "r64",
+                                             shape, start, count);
+            EXPECT_TRUE(var_r64);
+        }
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        io.AddTransport("file");
+
+        // QUESTION: It seems that BPFilterWriter cannot overwrite existing
+        // files
+        // Ex. if you tune Nx and NSteps, the test would fail. But if you clear
+        // the cache in
+        // ${adios2Build}/testing/adios2/engine/bp/ADIOS2BPWriteRead1D8.bp.dir,
+        // then it works
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), mpiRank, mpiSize);
+
+            // Retrieve the variables that previously went out of scope
+            auto var_iString = io.InquireVariable("iString");
+            auto var_i8 = io.InquireVariable<int8_t>("i8");
+            auto var_i16 = io.InquireVariable("i16");
+            auto var_i32 = io.InquireVariable("i32");
+            auto var_i64 = io.InquireVariable("i64");
+            auto var_u8 = io.InquireVariable<uint8_t>("u8");
+            auto var_u16 = io.InquireVariable("u16");
+            auto var_u32 = io.InquireVariable("u32");
+            auto var_u64 = io.InquireVariable("u64");
+            auto var_r32 = io.InquireVariable("r32");
+            auto var_r64 = io.InquireVariable("r64");
+
+            // Make a 1D selection to describe the local dimensions of the
+            // variable we write and its offsets in the global spaces
+            adios2::Box<adios2::Dims> sel({mpiRank * Nx}, {Nx});
+
+            EXPECT_THROW(var_iString.SetSelection(sel), std::invalid_argument);
+            var_i8.SetSelection(sel);
+            var_i16.SetSelection(sel);
+            var_i32.SetSelection(sel);
+            var_i64.SetSelection(sel);
+            var_u8.SetSelection(sel);
+            var_u16.SetSelection(sel);
+            var_u32.SetSelection(sel);
+            var_u64.SetSelection(sel);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
+            // Write each one
+            // fill in the variable with values from starting index to
+            // starting index + count
+            bpWriter.BeginStep();
+
+            bpWriter.Put(var_iString, currentTestData.S1);
+            bpWriter.Put(var_i8, currentTestData.I8.data());
+            bpWriter.Put(var_i16, currentTestData.I16.data());
+            bpWriter.Put(var_i32, currentTestData.I32.data());
+            bpWriter.Put(var_i64, currentTestData.I64.data());
+            bpWriter.Put(var_u8, currentTestData.U8.data());
+            bpWriter.Put(var_u16, currentTestData.U16.data());
+            bpWriter.Put(var_u32, currentTestData.U32.data());
+            bpWriter.Put(var_u64, currentTestData.U64.data());
+            bpWriter.Put(var_r32, currentTestData.R32.data());
+            bpWriter.Put(var_r64, currentTestData.R64.data());
+            bpWriter.PerformPuts();
+
+            bpWriter.EndStep();
+        }
+
+        // Close the file
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        auto var_iString = io.InquireVariable<std::string>("iString");
+        EXPECT_TRUE(var_iString);
+        ASSERT_EQ(var_iString.Shape().size(), 0);
+        ASSERT_EQ(var_iString.Steps(), NSteps);
+
+        auto var_i8 = io.InquireVariable<int8_t>("i8");
+        EXPECT_TRUE(var_i8);
+        ASSERT_EQ(var_i8.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i8.Steps(), NSteps);
+        ASSERT_EQ(var_i8.Shape()[0], mpiSize * Nx);
+
+        auto var_i16 = io.InquireVariable<int16_t>("i16");
+        EXPECT_TRUE(var_i16);
+        ASSERT_EQ(var_i16.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i16.Steps(), NSteps);
+        ASSERT_EQ(var_i16.Shape()[0], mpiSize * Nx);
+
+        auto var_i32 = io.InquireVariable<int32_t>("i32");
+        EXPECT_TRUE(var_i32);
+        ASSERT_EQ(var_i32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i32.Steps(), NSteps);
+        ASSERT_EQ(var_i32.Shape()[0], mpiSize * Nx);
+
+        auto var_i64 = io.InquireVariable<int64_t>("i64");
+        EXPECT_TRUE(var_i64);
+        ASSERT_EQ(var_i64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_i64.Steps(), NSteps);
+        ASSERT_EQ(var_i64.Shape()[0], mpiSize * Nx);
+
+        auto var_u8 = io.InquireVariable<uint8_t>("u8");
+        EXPECT_TRUE(var_u8);
+        ASSERT_EQ(var_u8.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u8.Steps(), NSteps);
+        ASSERT_EQ(var_u8.Shape()[0], mpiSize * Nx);
+
+        auto var_u16 = io.InquireVariable<uint16_t>("u16");
+        EXPECT_TRUE(var_u16);
+        ASSERT_EQ(var_u16.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u16.Steps(), NSteps);
+        ASSERT_EQ(var_u16.Shape()[0], mpiSize * Nx);
+
+        auto var_u32 = io.InquireVariable<uint32_t>("u32");
+        EXPECT_TRUE(var_u32);
+        ASSERT_EQ(var_u32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u32.Steps(), NSteps);
+        ASSERT_EQ(var_u32.Shape()[0], mpiSize * Nx);
+
+        auto var_u64 = io.InquireVariable<uint64_t>("u64");
+        EXPECT_TRUE(var_u64);
+        ASSERT_EQ(var_u64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_u64.Steps(), NSteps);
+        ASSERT_EQ(var_u64.Shape()[0], mpiSize * Nx);
+
+        auto var_r32 = io.InquireVariable<float>("r32");
+        EXPECT_TRUE(var_r32);
+        ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r32.Steps(), NSteps);
+        ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Steps(), NSteps);
+        ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+
+        SmallTestData testData;
+
+        std::string IString;
+        std::vector<int8_t> I8;
+        std::vector<int16_t> I16;
+        std::vector<int32_t> I32;
+        std::vector<int64_t> I64;
+        std::vector<uint8_t> U8;
+        std::vector<uint16_t> U16;
+        std::vector<uint32_t> U32;
+        std::vector<uint64_t> U64;
+        std::vector<float> R32;
+        std::vector<double> R64;
+
+        const adios2::Dims start{mpiRank * Nx};
+        const adios2::Dims count{Nx};
+
+        const adios2::Box<adios2::Dims> sel(start, count);
+
+        var_i8.SetSelection(sel);
+        var_i16.SetSelection(sel);
+        var_i32.SetSelection(sel);
+        var_i64.SetSelection(sel);
+
+        var_u8.SetSelection(sel);
+        var_u16.SetSelection(sel);
+        var_u32.SetSelection(sel);
+        var_u64.SetSelection(sel);
+
+        var_r32.SetSelection(sel);
+        var_r64.SetSelection(sel);
+
+        for (size_t t = 0; t < NSteps; ++t)
+        {
+            var_i8.SetStepSelection({t, 1});
+            var_i16.SetStepSelection({t, 1});
+            var_i32.SetStepSelection({t, 1});
+            var_i64.SetStepSelection({t, 1});
+
+            var_u8.SetStepSelection({t, 1});
+            var_u16.SetStepSelection({t, 1});
+            var_u32.SetStepSelection({t, 1});
+            var_u64.SetStepSelection({t, 1});
+
+            var_r32.SetStepSelection({t, 1});
+            var_r64.SetStepSelection({t, 1});
+
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(t), mpiRank, mpiSize);
+
+            bpReader.Get(var_iString, IString);
+
+            bpReader.Get(var_i8, I8, adios2::Mode::Sync);
+            bpReader.Get(var_i16, I16, adios2::Mode::Sync);
+            bpReader.Get(var_i32, I32);
+            bpReader.Get(var_i64, I64);
+
+            bpReader.Get(var_u8, U8);
+            bpReader.Get(var_u16, U16);
+            bpReader.Get(var_u32, U32);
+            bpReader.Get(var_u64, U64);
+
+            bpReader.Get(var_r32, R32);
+            bpReader.Get(var_r64, R64);
+
+            bpReader.PerformGets();
+
+            EXPECT_EQ(IString, currentTestData.S1);
+
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                EXPECT_EQ(I8[i], currentTestData.I8[i]) << msg;
+                EXPECT_EQ(I16[i], currentTestData.I16[i]) << msg;
+                EXPECT_EQ(I32[i], currentTestData.I32[i]) << msg;
+                EXPECT_EQ(I64[i], currentTestData.I64[i]) << msg;
+                EXPECT_EQ(U8[i], currentTestData.U8[i]) << msg;
+                EXPECT_EQ(U16[i], currentTestData.U16[i]) << msg;
+                EXPECT_EQ(U32[i], currentTestData.U32[i]) << msg;
+                EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
+                EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+            }
+        }
+        bpReader.Close();
+    }
+}
+
+//******************************************************************************
 // 2D 2x4 test data
 //******************************************************************************
 


### PR DESCRIPTION
Since long time, users have been struggling with the templated C++ API of ADIOS2. It makes things unnecessarily hard for users to define and use ADIOS2 variables with data types that are only determined at runtime. It makes things even harder for users who want to put variable objects of different data types into a single container. 

It's time to correct this harmful C++ fundamentalism. A C++ code does not have to use templates. Whether to use templates should be determined in a case by case manner. 

This PR adds a template-free C++ API, which should be recommended for most use cases instead of the templated API. Some parts of it is currently still built on top of the templated API, but we should aim to remove most of the templated implementations in ADIOS2 core so we will save a huge lot of type conversions and macros that cut off the debugger processes. 

This is also inline with the user defined data type work. 