### PR TITLE
moved Variable<T>::Shape() to VariableBase

### DIFF
--- a/source/adios2/core/Variable.cpp
+++ b/source/adios2/core/Variable.cpp
@@ -67,12 +67,6 @@ namespace core
     }                                                                          \
                                                                                \
     template <>                                                                \
-    Dims Variable<T>::Shape(const size_t step) const                           \
-    {                                                                          \
-        return DoShape(step);                                                  \
-    }                                                                          \
-                                                                               \
-    template <>                                                                \
     Dims Variable<T>::Count() const                                            \
     {                                                                          \
         return DoCount();                                                      \

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -107,8 +107,6 @@ public:
 
     size_t SubStreamsInfoSize();
 
-    Dims Shape(const size_t step = adios2::EngineCurrentStep) const;
-
     Dims Count() const;
 
     size_t SelectionSize() const;
@@ -123,8 +121,6 @@ public:
     AllStepsBlocksInfo() const;
 
 private:
-    Dims DoShape(const size_t step) const;
-
     Dims DoCount() const;
 
     size_t DoSelectionSize() const;
@@ -133,8 +129,6 @@ private:
 
     std::vector<std::vector<typename Variable<T>::BPInfo>>
     DoAllStepsBlocksInfo() const;
-
-    void CheckRandomAccess(const size_t step, const std::string hint) const;
 
     size_t WriterIndex;
 };

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -22,39 +22,6 @@ namespace core
 {
 
 template <class T>
-Dims Variable<T>::DoShape(const size_t step) const
-{
-    CheckRandomAccess(step, "Shape");
-
-    if (m_Engine)
-    {
-        // see if the engine implements Variable Shape inquiry
-        auto ShapePtr = m_Engine->VarShape(*this, step);
-        if (ShapePtr)
-        {
-            return *ShapePtr;
-        }
-    }
-    if (m_FirstStreamingStep && step == adios2::EngineCurrentStep)
-    {
-        return m_Shape;
-    }
-
-    if (m_Engine != nullptr && m_ShapeID == ShapeID::GlobalArray)
-    {
-        const size_t stepInput =
-            !m_FirstStreamingStep ? m_Engine->CurrentStep() : step;
-
-        const auto it = m_AvailableShapes.find(stepInput + 1);
-        if (it != m_AvailableShapes.end())
-        {
-            return it->second;
-        }
-    }
-    return m_Shape;
-}
-
-template <class T>
 Dims Variable<T>::DoCount() const
 {
     auto lf_Step = [&]() -> size_t {
@@ -240,21 +207,6 @@ Variable<T>::DoAllStepsBlocksInfo() const
     }
 
     return m_Engine->AllRelativeStepsBlocksInfo(*this);
-}
-
-template <class T>
-void Variable<T>::CheckRandomAccess(const size_t step,
-                                    const std::string hint) const
-{
-    if (!m_FirstStreamingStep && step != DefaultSizeT)
-    {
-        helper::Throw<std::invalid_argument>(
-            "Core", "Variable", "CheckRandomAccess",
-            "can't pass a step input in "
-            "streaming (BeginStep/EndStep)"
-            "mode for variable " +
-                m_Name + ", in call to Variable<T>::" + hint);
-    }
 }
 
 } // end namespace core

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -215,7 +215,8 @@ public:
      */
     void CheckRandomAccessConflict(const std::string hint) const;
 
-    Dims GetShape(const size_t step = adios2::EngineCurrentStep);
+    Dims Shape(const size_t step = adios2::EngineCurrentStep) const;
+    Dims GetShape(const size_t step = adios2::EngineCurrentStep) const;
 
     /**
      * Get info for attributes associated with this variable. Attribute name
@@ -239,6 +240,8 @@ protected:
      *  SetSelection.
      * @param hint extra debugging info for the exception */
     void CheckDimensionsCommon(const std::string hint) const;
+
+    void CheckRandomAccess(const size_t step, const std::string hint) const;
 };
 
 } // end namespace core


### PR DESCRIPTION
Variable<T>::Shape() does not use any templated types so there is no point to make it templated