### PR TITLE
removed VariableBase::GetShape

### DIFF
--- a/bindings/CXX11/adios2/cxx11/VariableNT.cpp
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.cpp
@@ -156,21 +156,7 @@ adios2::ShapeID VariableNT::ShapeID() const
 Dims VariableNT::Shape(const size_t step) const
 {
     helper::CheckForNullptr(m_Variable, "in call to VariableNT::Shape");
-    auto type = m_Variable->m_Type;
-#define declare_type(T)                                                        \
-    if (type == helper::GetDataType<T>())                                      \
-    {                                                                          \
-        return reinterpret_cast<core::Variable<T> *>(m_Variable)->Shape(step); \
-    }
-    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
-#undef declare_type
-    else if (type == DataType::Struct)
-    {
-        return reinterpret_cast<core::VariableStruct *>(m_Variable)->m_Shape;
-    }
-    helper::Throw<std::runtime_error>("bindings::CXX11", "VariableNT", "Shape",
-                                      "invalid data type " + ToString(type));
-    return Dims();
+    return m_Variable->Shape(step);
 }
 
 Dims VariableNT::Start() const

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -621,8 +621,6 @@ void VariableBase::CheckRandomAccess(const size_t step,
     }
 }
 
-Dims VariableBase::GetShape(const size_t step) const { return Shape(step); }
-
 Dims VariableBase::Shape(const size_t step) const
 {
     CheckRandomAccess(step, "Shape");

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -216,7 +216,6 @@ public:
     void CheckRandomAccessConflict(const std::string hint) const;
 
     Dims Shape(const size_t step = adios2::EngineCurrentStep) const;
-    Dims GetShape(const size_t step = adios2::EngineCurrentStep) const;
 
     /**
      * Get info for attributes associated with this variable. Attribute name

--- a/source/utils/adios_reorganize/Reorganize.cpp
+++ b/source/utils/adios_reorganize/Reorganize.cpp
@@ -388,7 +388,7 @@ Reorganize::Decompose(int numproc, int rank, VarInfo &vi,
         return writesize;
     }
 
-    size_t ndim = vi.v->GetShape().size();
+    size_t ndim = vi.v->Shape().size();
 
     /* Scalars */
     if (ndim == 0)
@@ -462,12 +462,12 @@ Reorganize::Decompose(int numproc, int rank, VarInfo &vi,
         }
         else
         {
-            count = vi.v->GetShape()[i] / np[i];
+            count = vi.v->Shape()[i] / np[i];
             start = count * pos[i];
             if (pos[i] == np[i] - 1)
             {
                 // last one in the dimension may need to read more than the rest
-                count = vi.v->GetShape()[i] - count * (np[i] - 1);
+                count = vi.v->Shape()[i] - count * (np[i] - 1);
             }
         }
         vi.start.push_back(start);
@@ -532,15 +532,15 @@ int Reorganize::ProcessMetadata(core::Engine &rStream, core::IO &io,
             {
                 std::cout << "    " << ToString(type) << " " << name;
             }
-            // if (variable->GetShape().size() > 0)
+            // if (variable->Shape().size() > 0)
             if (variable->m_ShapeID == adios2::ShapeID::GlobalArray)
             {
                 if (!m_Rank)
                 {
-                    std::cout << "[" << variable->GetShape()[0];
-                    for (size_t j = 1; j < variable->GetShape().size(); j++)
+                    std::cout << "[" << variable->Shape()[0];
+                    for (size_t j = 1; j < variable->Shape().size(); j++)
                     {
-                        std::cout << ", " << variable->GetShape()[j];
+                        std::cout << ", " << variable->Shape()[j];
                     }
                     std::cout << "]" << std::endl;
                 }


### PR DESCRIPTION
The implementation of Variable::Shape() was so extremely complicated. There were
Variable<T>::Shape()
Variable<T>::DoShape()
Variable<T>::GetShape()

These functions basically do a very simple thing in a crazy incomprehensible way, resulting in tens of functions in the virtual table, whereas the functionality itself can be easily implemented in one single non-templated function. 

This PR, together with the previous PR, removes such a weird implementation, as part of our effort to fully remove templates in adios2::core. 