### PR TITLE
moved ToBlocksInfoMin to private

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -381,14 +381,15 @@ public:
     std::map<size_t, std::vector<typename Variable<T>::Info>>
     AllStepsBlocksInfoMap() const;
 
-    std::vector<typename Variable<T>::Info>
-    ToBlocksInfoMin(const MinVarInfo *coreVarInfo) const;
-
     using Span = adios2::detail::Span<T>;
 
 private:
-    Variable<T>(core::Variable<IOType> *variable);
     core::Variable<IOType> *m_Variable = nullptr;
+
+    std::vector<typename Variable<T>::Info>
+    ToBlocksInfoMin(const MinVarInfo *coreVarInfo) const;
+
+    Variable<T>(core::Variable<IOType> *variable);
 
     std::vector<std::vector<typename Variable<T>::Info>> DoAllStepsBlocksInfo();
     std::map<size_t, std::vector<typename Variable<T>::Info>>

--- a/bindings/CXX11/adios2/cxx11/VariableNT.cpp
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.cpp
@@ -10,6 +10,7 @@
 
 #include "VariableNT.h"
 #include "Types.h"
+#include "Variable.h"
 #include "adios2/core/VariableBase.h"
 #include "adios2/helper/adiosFunctions.h"
 

--- a/bindings/CXX11/adios2/cxx11/VariableNT.cpp
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.cpp
@@ -10,7 +10,6 @@
 
 #include "VariableNT.h"
 #include "Types.h"
-#include "Variable.h"
 #include "adios2/core/VariableBase.h"
 #include "adios2/helper/adiosFunctions.h"
 


### PR DESCRIPTION
This function in the Variable API class seems like it should be a private function, instead of public. It accepts a pointer parameter defined in adios2::core, which is not supposed to be exposed to users in any situation. From the API logic and the context, I only see cases in which it is called from inside the API classes, not from users. 