### PR TITLE
added BlocksInfo API for VariableNT, and implementation for VariableStruct in SSC

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Engine.cpp
+++ b/bindings/CXX11/adios2/cxx11/Engine.cpp
@@ -223,6 +223,81 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
+std::vector<VariableNT::Info> Engine::BlocksInfo(const VariableNT &variable,
+                                                 const size_t step) const
+{
+    std::vector<VariableNT::Info> ret;
+    if (variable.m_Variable->m_Type == DataType::Struct)
+    {
+    }
+#define declare_type(T)                                                        \
+    else if (variable.m_Variable->m_Type == helper::GetDataType<T>())          \
+    {                                                                          \
+        auto blocksInfoT =                                                     \
+            BlocksInfo(Variable<T>(reinterpret_cast<core::Variable<T> *>(      \
+                           variable.m_Variable)),                              \
+                       step);                                                  \
+        for (const auto &b : blocksInfoT)                                      \
+        {                                                                      \
+            ret.emplace_back();                                                \
+            auto &br = ret.back();                                             \
+            br.Start = b.Start;                                                \
+            br.Count = b.Count;                                                \
+            br.WriterID = b.WriterID;                                          \
+            br.Step = b.Step;                                                  \
+            br.IsReverseDims = b.IsReverseDims;                                \
+            br.IsValue = b.IsValue;                                            \
+        }                                                                      \
+    }
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+    else
+    {
+        helper::Throw<std::runtime_error>("bindings::CXX11", "Engine",
+                                          "BlocksInfo", "invalid data type");
+    }
+    return ret;
+}
+
+std::map<size_t, std::vector<VariableNT::Info>>
+Engine::AllStepsBlocksInfo(const VariableNT &variable) const
+{
+    std::map<size_t, std::vector<VariableNT::Info>> ret;
+    if (variable.m_Variable->m_Type == DataType::Struct)
+    {
+    }
+#define declare_type(T)                                                        \
+    else if (variable.m_Variable->m_Type == helper::GetDataType<T>())          \
+    {                                                                          \
+        auto blocksInfoT = AllStepsBlocksInfo(Variable<T>(                     \
+            reinterpret_cast<core::Variable<T> *>(variable.m_Variable)));      \
+        for (const auto &bv : blocksInfoT)                                     \
+        {                                                                      \
+            auto &bvr = ret[bv.first];                                         \
+            for (const auto &b : bv.second)                                    \
+            {                                                                  \
+                bvr.emplace_back();                                            \
+                auto &br = bvr.back();                                         \
+                br.Start = b.Start;                                            \
+                br.Count = b.Count;                                            \
+                br.WriterID = b.WriterID;                                      \
+                br.Step = b.Step;                                              \
+                br.IsReverseDims = b.IsReverseDims;                            \
+                br.IsValue = b.IsValue;                                        \
+            }                                                                  \
+        }                                                                      \
+    }
+    ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
+#undef declare_type
+    else
+    {
+        helper::Throw<std::runtime_error>("bindings::CXX11", "Engine",
+                                          "AllStepsBlocksInfo",
+                                          "invalid data type");
+    }
+    return ret;
+}
+
 #define declare_template_instantiation(T)                                      \
     template void Engine::Put<T>(Variable<T>, const T *, const Mode);          \
     template void Engine::Put<T>(const std::string &, const T *, const Mode);  \

--- a/bindings/CXX11/adios2/cxx11/Engine.cpp
+++ b/bindings/CXX11/adios2/cxx11/Engine.cpp
@@ -229,6 +229,24 @@ std::vector<VariableNT::Info> Engine::BlocksInfo(const VariableNT &variable,
     std::vector<VariableNT::Info> ret;
     if (variable.m_Variable->m_Type == DataType::Struct)
     {
+        adios2::helper::CheckForNullptr(
+            m_Engine, "for Engine in call to Engine::BlocksInfo");
+        adios2::helper::CheckForNullptr(
+            variable.m_Variable, "for variable in call to Engine::BlocksInfo");
+        auto blocksInfo = m_Engine->BlocksInfo(
+            *reinterpret_cast<core::VariableStruct *>(variable.m_Variable),
+            step);
+        for (const auto &b : blocksInfo)
+        {
+            ret.emplace_back();
+            auto &br = ret.back();
+            br.Start = b.Start;
+            br.Count = b.Count;
+            br.WriterID = b.WriterID;
+            br.Step = b.Step;
+            br.IsReverseDims = b.IsReverseDims;
+            br.IsValue = b.IsValue;
+        }
     }
 #define declare_type(T)                                                        \
     else if (variable.m_Variable->m_Type == helper::GetDataType<T>())          \
@@ -265,6 +283,28 @@ Engine::AllStepsBlocksInfo(const VariableNT &variable) const
     std::map<size_t, std::vector<VariableNT::Info>> ret;
     if (variable.m_Variable->m_Type == DataType::Struct)
     {
+        adios2::helper::CheckForNullptr(
+            m_Engine, "for Engine in call to Engine::AllStepsBlocksInfo");
+        adios2::helper::CheckForNullptr(
+            variable.m_Variable,
+            "for variable in call to Engine::AllStepsBlocksInfo");
+        auto blocksInfo = m_Engine->AllStepsBlocksInfo(
+            *reinterpret_cast<core::VariableStruct *>(variable.m_Variable));
+        for (const auto &bv : blocksInfo)
+        {
+            auto &bvr = ret[bv.first];
+            for (const auto &b : bv.second)
+            {
+                bvr.emplace_back();
+                auto &br = bvr.back();
+                br.Start = b.Start;
+                br.Count = b.Count;
+                br.WriterID = b.WriterID;
+                br.Step = b.Step;
+                br.IsReverseDims = b.IsReverseDims;
+                br.IsValue = b.IsValue;
+            }
+        }
     }
 #define declare_type(T)                                                        \
     else if (variable.m_Variable->m_Type == helper::GetDataType<T>())          \

--- a/bindings/CXX11/adios2/cxx11/Engine.cpp
+++ b/bindings/CXX11/adios2/cxx11/Engine.cpp
@@ -233,7 +233,7 @@ std::vector<VariableNT::Info> Engine::BlocksInfo(const VariableNT &variable,
             m_Engine, "for Engine in call to Engine::BlocksInfo");
         adios2::helper::CheckForNullptr(
             variable.m_Variable, "for variable in call to Engine::BlocksInfo");
-        auto blocksInfo = m_Engine->BlocksInfo(
+        auto blocksInfo = m_Engine->BlocksInfoStruct(
             *reinterpret_cast<core::VariableStruct *>(variable.m_Variable),
             step);
         for (const auto &b : blocksInfo)
@@ -288,7 +288,7 @@ Engine::AllStepsBlocksInfo(const VariableNT &variable) const
         adios2::helper::CheckForNullptr(
             variable.m_Variable,
             "for variable in call to Engine::AllStepsBlocksInfo");
-        auto blocksInfo = m_Engine->AllStepsBlocksInfo(
+        auto blocksInfo = m_Engine->AllStepsBlocksInfoStruct(
             *reinterpret_cast<core::VariableStruct *>(variable.m_Variable));
         for (const auto &bv : blocksInfo)
         {

--- a/bindings/CXX11/adios2/cxx11/Engine.h
+++ b/bindings/CXX11/adios2/cxx11/Engine.h
@@ -430,6 +430,9 @@ public:
     std::map<size_t, std::vector<typename Variable<T>::Info>>
     AllStepsBlocksInfo(const Variable<T> variable) const;
 
+    std::map<size_t, std::vector<VariableNT::Info>>
+    AllStepsBlocksInfo(const VariableNT &variable) const;
+
     /**
      * Extracts all available blocks information for a particular
      * variable and step.
@@ -442,6 +445,9 @@ public:
     template <class T>
     std::vector<typename Variable<T>::Info>
     BlocksInfo(const Variable<T> variable, const size_t step) const;
+
+    std::vector<VariableNT::Info> BlocksInfo(const VariableNT &variable,
+                                             const size_t step) const;
 
     /**
      * Get the absolute steps of a variable in a file. This is for

--- a/bindings/CXX11/adios2/cxx11/VariableNT.h
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.h
@@ -230,6 +230,17 @@ public:
         std::complex<double> DComplex;
     };
 
+    struct Info
+    {
+        adios2::Dims Start;
+        adios2::Dims Count;
+        int WriterID = 0;
+        size_t BlockID = 0;
+        size_t Step = 0;
+        bool IsReverseDims = false;
+        bool IsValue = false;
+    };
+
     T Min(const size_t step = adios2::DefaultSizeT) const;
     T Max(const size_t step = adios2::DefaultSizeT) const;
     std::pair<T, T> MinMax(const size_t step = adios2::DefaultSizeT) const;

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -238,21 +238,22 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 std::map<size_t, std::vector<VariableStruct::BPInfo>>
-Engine::DoAllStepsBlocksInfo(const VariableStruct &variable) const
+Engine::DoAllStepsBlocksInfoStruct(const VariableStruct &variable) const
 {
     ThrowUp("DoAllStepsBlocksInfo");
     return std::map<size_t, std::vector<VariableStruct::BPInfo>>();
 }
 
 std::vector<std::vector<VariableStruct::BPInfo>>
-Engine::DoAllRelativeStepsBlocksInfo(const VariableStruct &variable) const
+Engine::DoAllRelativeStepsBlocksInfoStruct(const VariableStruct &variable) const
 {
     ThrowUp("DoAllRelativeStepsBlocksInfo");
     return std::vector<std::vector<VariableStruct::BPInfo>>();
 }
 
 std::vector<VariableStruct::BPInfo>
-Engine::DoBlocksInfo(const VariableStruct &variable, const size_t step) const
+Engine::DoBlocksInfoStruct(const VariableStruct &variable,
+                           const size_t step) const
 {
     ThrowUp("DoBlocksInfo");
     return std::vector<VariableStruct::BPInfo>();
@@ -312,21 +313,22 @@ void Engine::CommonChecks(VariableBase &variable, const void *data,
 }
 
 std::map<size_t, std::vector<VariableStruct::BPInfo>>
-Engine::AllStepsBlocksInfo(const VariableStruct &variable) const
+Engine::AllStepsBlocksInfoStruct(const VariableStruct &variable) const
 {
-    return DoAllStepsBlocksInfo(variable);
+    return DoAllStepsBlocksInfoStruct(variable);
 }
 
 std::vector<std::vector<VariableStruct::BPInfo>>
-Engine::AllRelativeStepsBlocksInfo(const VariableStruct &variable) const
+Engine::AllRelativeStepsBlocksInfoStruct(const VariableStruct &variable) const
 {
-    return DoAllRelativeStepsBlocksInfo(variable);
+    return DoAllRelativeStepsBlocksInfoStruct(variable);
 }
 
 std::vector<VariableStruct::BPInfo>
-Engine::BlocksInfo(const VariableStruct &variable, const size_t step) const
+Engine::BlocksInfoStruct(const VariableStruct &variable,
+                         const size_t step) const
 {
-    return DoBlocksInfo(variable, step);
+    return DoBlocksInfoStruct(variable, step);
 }
 
 // PUBLIC TEMPLATE FUNCTIONS EXPANSION WITH SCOPED TYPES

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -237,6 +237,27 @@ void Engine::DoGetStructDeferred(VariableStruct &, void *)
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
+std::map<size_t, std::vector<VariableStruct::BPInfo>>
+Engine::DoAllStepsBlocksInfo(const VariableStruct &variable) const
+{
+    ThrowUp("DoAllStepsBlocksInfo");
+    return std::map<size_t, std::vector<VariableStruct::BPInfo>>();
+}
+
+std::vector<std::vector<VariableStruct::BPInfo>>
+Engine::DoAllRelativeStepsBlocksInfo(const VariableStruct &variable) const
+{
+    ThrowUp("DoAllRelativeStepsBlocksInfo");
+    return std::vector<std::vector<VariableStruct::BPInfo>>();
+}
+
+std::vector<VariableStruct::BPInfo>
+Engine::DoBlocksInfo(const VariableStruct &variable, const size_t step) const
+{
+    ThrowUp("DoBlocksInfo");
+    return std::vector<VariableStruct::BPInfo>();
+}
+
 #define declare_type(T, L)                                                     \
     T *Engine::DoBufferData_##L(const int bufferIdx,                           \
                                 const size_t payloadPosition,                  \
@@ -288,6 +309,24 @@ void Engine::CommonChecks(VariableBase &variable, const void *data,
         helper::CheckForNullptr(
             data, "for data argument in non-zero count block, " + hint);
     }
+}
+
+std::map<size_t, std::vector<VariableStruct::BPInfo>>
+Engine::AllStepsBlocksInfo(const VariableStruct &variable) const
+{
+    return DoAllStepsBlocksInfo(variable);
+}
+
+std::vector<std::vector<VariableStruct::BPInfo>>
+Engine::AllRelativeStepsBlocksInfo(const VariableStruct &variable) const
+{
+    return DoAllRelativeStepsBlocksInfo(variable);
+}
+
+std::vector<VariableStruct::BPInfo>
+Engine::BlocksInfo(const VariableStruct &variable, const size_t step) const
+{
+    return DoBlocksInfo(variable, step);
 }
 
 // PUBLIC TEMPLATE FUNCTIONS EXPANSION WITH SCOPED TYPES

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -406,7 +406,7 @@ public:
     AllStepsBlocksInfo(const Variable<T> &variable) const;
 
     std::map<size_t, std::vector<VariableStruct::BPInfo>>
-    AllStepsBlocksInfo(const VariableStruct &variable) const;
+    AllStepsBlocksInfoStruct(const VariableStruct &variable) const;
 
     /**
      * This function is internal, for public interface use
@@ -419,7 +419,7 @@ public:
     AllRelativeStepsBlocksInfo(const Variable<T> &variable) const;
 
     std::vector<std::vector<VariableStruct::BPInfo>>
-    AllRelativeStepsBlocksInfo(const VariableStruct &variable) const;
+    AllRelativeStepsBlocksInfoStruct(const VariableStruct &variable) const;
 
     /**
      * Extracts all available blocks information for a particular
@@ -435,7 +435,7 @@ public:
     BlocksInfo(const Variable<T> &variable, const size_t step) const;
 
     std::vector<VariableStruct::BPInfo>
-    BlocksInfo(const VariableStruct &variable, const size_t step) const;
+    BlocksInfoStruct(const VariableStruct &variable, const size_t step) const;
 
     /**
      * Get the absolute steps of a variable in a file. This is for
@@ -583,13 +583,13 @@ protected:
 #undef declare_type
 
     virtual std::map<size_t, std::vector<VariableStruct::BPInfo>>
-    DoAllStepsBlocksInfo(const VariableStruct &variable) const;
+    DoAllStepsBlocksInfoStruct(const VariableStruct &variable) const;
 
     virtual std::vector<std::vector<VariableStruct::BPInfo>>
-    DoAllRelativeStepsBlocksInfo(const VariableStruct &variable) const;
+    DoAllRelativeStepsBlocksInfoStruct(const VariableStruct &variable) const;
 
     virtual std::vector<VariableStruct::BPInfo>
-    DoBlocksInfo(const VariableStruct &variable, const size_t step) const;
+    DoBlocksInfoStruct(const VariableStruct &variable, const size_t step) const;
 
 #define declare_type(T, L)                                                     \
     virtual T *DoBufferData_##L(const int bufferIdx,                           \

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -30,6 +30,7 @@
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/core/IO.h"
 #include "adios2/core/Variable.h"
+#include "adios2/core/VariableStruct.h"
 #include "adios2/helper/adiosComm.h"
 
 namespace adios2
@@ -404,6 +405,9 @@ public:
     std::map<size_t, std::vector<typename Variable<T>::BPInfo>>
     AllStepsBlocksInfo(const Variable<T> &variable) const;
 
+    std::map<size_t, std::vector<VariableStruct::BPInfo>>
+    AllStepsBlocksInfo(const VariableStruct &variable) const;
+
     /**
      * This function is internal, for public interface use
      * Variable<T>::AllStepsBlocksInfo
@@ -413,6 +417,9 @@ public:
     template <class T>
     std::vector<std::vector<typename Variable<T>::BPInfo>>
     AllRelativeStepsBlocksInfo(const Variable<T> &variable) const;
+
+    std::vector<std::vector<VariableStruct::BPInfo>>
+    AllRelativeStepsBlocksInfo(const VariableStruct &variable) const;
 
     /**
      * Extracts all available blocks information for a particular
@@ -426,6 +433,9 @@ public:
     template <class T>
     std::vector<typename Variable<T>::BPInfo>
     BlocksInfo(const Variable<T> &variable, const size_t step) const;
+
+    std::vector<VariableStruct::BPInfo>
+    BlocksInfo(const VariableStruct &variable, const size_t step) const;
 
     /**
      * Get the absolute steps of a variable in a file. This is for
@@ -571,6 +581,15 @@ protected:
 
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
+
+    virtual std::map<size_t, std::vector<VariableStruct::BPInfo>>
+    DoAllStepsBlocksInfo(const VariableStruct &variable) const;
+
+    virtual std::vector<std::vector<VariableStruct::BPInfo>>
+    DoAllRelativeStepsBlocksInfo(const VariableStruct &variable) const;
+
+    virtual std::vector<VariableStruct::BPInfo>
+    DoBlocksInfo(const VariableStruct &variable, const size_t step) const;
 
 #define declare_type(T, L)                                                     \
     virtual T *DoBufferData_##L(const int bufferIdx,                           \

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -122,7 +122,8 @@ ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
 std::vector<VariableStruct::BPInfo>
-SscReader::DoBlocksInfo(const VariableStruct &variable, const size_t step) const
+SscReader::DoBlocksInfoStruct(const VariableStruct &variable,
+                              const size_t step) const
 {
     return m_EngineInstance->BlocksInfo(variable, step);
 }

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -121,6 +121,12 @@ void SscReader::DoClose(const int transportIndex)
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
+std::vector<VariableStruct::BPInfo>
+SscReader::DoBlocksInfo(const VariableStruct &variable, const size_t step) const
+{
+    return m_EngineInstance->BlocksInfo(variable, step);
+}
+
 void SscReader::DoGetStructSync(VariableStruct &variable, void *data)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();

--- a/source/adios2/engine/ssc/SscReader.h
+++ b/source/adios2/engine/ssc/SscReader.h
@@ -45,6 +45,8 @@ private:
 
     void DoGetStructSync(VariableStruct &, void *) final;
     void DoGetStructDeferred(VariableStruct &, void *) final;
+    std::vector<VariableStruct::BPInfo>
+    DoBlocksInfo(const VariableStruct &variable, const size_t step) const final;
 
     void DoClose(const int transportIndex = -1) final;
 

--- a/source/adios2/engine/ssc/SscReader.h
+++ b/source/adios2/engine/ssc/SscReader.h
@@ -46,7 +46,8 @@ private:
     void DoGetStructSync(VariableStruct &, void *) final;
     void DoGetStructDeferred(VariableStruct &, void *) final;
     std::vector<VariableStruct::BPInfo>
-    DoBlocksInfo(const VariableStruct &variable, const size_t step) const final;
+    DoBlocksInfoStruct(const VariableStruct &variable,
+                       const size_t step) const final;
 
     void DoClose(const int transportIndex = -1) final;
 

--- a/source/adios2/engine/ssc/SscReaderBase.h
+++ b/source/adios2/engine/ssc/SscReaderBase.h
@@ -46,6 +46,9 @@ public:
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
+    virtual std::vector<VariableStruct::BPInfo>
+    BlocksInfo(const VariableStruct &variable, const size_t step) const = 0;
+
     virtual void GetDeferred(VariableBase &, void *) = 0;
 
 protected:

--- a/source/adios2/engine/ssc/SscReaderGeneric.cpp
+++ b/source/adios2/engine/ssc/SscReaderGeneric.cpp
@@ -575,10 +575,10 @@ SscReaderGeneric::BlocksInfo(const VariableStruct &variable,
                              const size_t step) const
 {
     std::vector<VariableStruct::BPInfo> ret;
-
-    for (const auto &r : m_GlobalWritePattern)
+    size_t blockID = 0;
+    for (size_t i = 0; i < m_GlobalWritePattern.size(); ++i)
     {
-        for (auto &v : r)
+        for (auto &v : m_GlobalWritePattern[i])
         {
             if (v.name == variable.m_Name)
             {
@@ -590,10 +590,13 @@ SscReaderGeneric::BlocksInfo(const VariableStruct &variable,
                 b.Step = m_CurrentStep;
                 b.StepsStart = m_CurrentStep;
                 b.StepsCount = 1;
+                b.WriterID = i;
+                b.BlockID = blockID;
                 if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
                 {
                     b.IsReverseDims = true;
                 }
+                ++blockID;
             }
         }
     }

--- a/source/adios2/engine/ssc/SscReaderGeneric.cpp
+++ b/source/adios2/engine/ssc/SscReaderGeneric.cpp
@@ -576,7 +576,7 @@ SscReaderGeneric::BlocksInfo(const VariableStruct &variable,
 {
     std::vector<VariableStruct::BPInfo> ret;
     size_t blockID = 0;
-    for (int i = 0; i < m_GlobalWritePattern.size(); ++i)
+    for (int i = 0; i < static_cast<int>(m_GlobalWritePattern.size()); ++i)
     {
         for (auto &v : m_GlobalWritePattern[i])
         {

--- a/source/adios2/engine/ssc/SscReaderGeneric.cpp
+++ b/source/adios2/engine/ssc/SscReaderGeneric.cpp
@@ -570,6 +570,35 @@ void SscReaderGeneric::GetDeferred(VariableBase &variable, void *data)
     }
 }
 
+std::vector<VariableStruct::BPInfo>
+SscReaderGeneric::BlocksInfo(const VariableStruct &variable,
+                             const size_t step) const
+{
+    std::vector<VariableStruct::BPInfo> ret;
+
+    for (const auto &r : m_GlobalWritePattern)
+    {
+        for (auto &v : r)
+        {
+            if (v.name == variable.m_Name)
+            {
+                ret.emplace_back();
+                auto &b = ret.back();
+                b.Start = v.start;
+                b.Count = v.count;
+                b.Shape = v.shape;
+                b.Step = m_CurrentStep;
+                b.StepsStart = m_CurrentStep;
+                b.StepsCount = 1;
+                if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
+                {
+                    b.IsReverseDims = true;
+                }
+            }
+        }
+    }
+    return ret;
+}
 }
 }
 }

--- a/source/adios2/engine/ssc/SscReaderGeneric.cpp
+++ b/source/adios2/engine/ssc/SscReaderGeneric.cpp
@@ -576,7 +576,7 @@ SscReaderGeneric::BlocksInfo(const VariableStruct &variable,
 {
     std::vector<VariableStruct::BPInfo> ret;
     size_t blockID = 0;
-    for (size_t i = 0; i < m_GlobalWritePattern.size(); ++i)
+    for (int i = 0; i < m_GlobalWritePattern.size(); ++i)
     {
         for (auto &v : m_GlobalWritePattern[i])
         {

--- a/source/adios2/engine/ssc/SscReaderGeneric.h
+++ b/source/adios2/engine/ssc/SscReaderGeneric.h
@@ -45,6 +45,9 @@ public:
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
+    std::vector<VariableStruct::BPInfo>
+    BlocksInfo(const VariableStruct &variable, const size_t step) const final;
+
     void GetDeferred(VariableBase &, void *) final;
 
 private:

--- a/source/adios2/engine/ssc/SscReaderGeneric.tcc
+++ b/source/adios2/engine/ssc/SscReaderGeneric.tcc
@@ -30,7 +30,7 @@ SscReaderGeneric::BlocksInfoCommon(const Variable<T> &variable,
 {
     std::vector<typename Variable<T>::BPInfo> ret;
     size_t blockID = 0;
-    for (int i = 0; i < m_GlobalWritePattern.size(); ++i)
+    for (int i = 0; i < static_cast<int>(m_GlobalWritePattern.size()); ++i)
     {
         for (auto &v : m_GlobalWritePattern[i])
         {

--- a/source/adios2/engine/ssc/SscReaderGeneric.tcc
+++ b/source/adios2/engine/ssc/SscReaderGeneric.tcc
@@ -46,9 +46,7 @@ SscReaderGeneric::BlocksInfoCommon(const Variable<T> &variable,
                 b.StepsCount = 1;
                 if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
                 {
-                    std::reverse(b.Start.begin(), b.Start.end());
-                    std::reverse(b.Count.begin(), b.Count.end());
-                    std::reverse(b.Shape.begin(), b.Shape.end());
+                    b.IsReverseDims = true;
                 }
                 if (v.shapeId == ShapeID::GlobalValue ||
                     v.shapeId == ShapeID::LocalValue)

--- a/source/adios2/engine/ssc/SscReaderGeneric.tcc
+++ b/source/adios2/engine/ssc/SscReaderGeneric.tcc
@@ -29,10 +29,10 @@ SscReaderGeneric::BlocksInfoCommon(const Variable<T> &variable,
                                    const size_t step) const
 {
     std::vector<typename Variable<T>::BPInfo> ret;
-
-    for (const auto &r : m_GlobalWritePattern)
+    size_t blockID = 0;
+    for (size_t i = 0; i < m_GlobalWritePattern.size(); ++i)
     {
-        for (auto &v : r)
+        for (auto &v : m_GlobalWritePattern[i])
         {
             if (v.name == variable.m_Name)
             {
@@ -44,6 +44,8 @@ SscReaderGeneric::BlocksInfoCommon(const Variable<T> &variable,
                 b.Step = m_CurrentStep;
                 b.StepsStart = m_CurrentStep;
                 b.StepsCount = 1;
+                b.WriterID = i;
+                b.BlockID = blockID;
                 if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
                 {
                     b.IsReverseDims = true;
@@ -66,6 +68,7 @@ SscReaderGeneric::BlocksInfoCommon(const Variable<T> &variable,
                                     v.bufferCount);
                     }
                 }
+                ++blockID;
             }
         }
     }

--- a/source/adios2/engine/ssc/SscReaderGeneric.tcc
+++ b/source/adios2/engine/ssc/SscReaderGeneric.tcc
@@ -30,7 +30,7 @@ SscReaderGeneric::BlocksInfoCommon(const Variable<T> &variable,
 {
     std::vector<typename Variable<T>::BPInfo> ret;
     size_t blockID = 0;
-    for (size_t i = 0; i < m_GlobalWritePattern.size(); ++i)
+    for (int i = 0; i < m_GlobalWritePattern.size(); ++i)
     {
         for (auto &v : m_GlobalWritePattern[i])
         {

--- a/source/adios2/engine/ssc/SscReaderNaive.cpp
+++ b/source/adios2/engine/ssc/SscReaderNaive.cpp
@@ -205,6 +205,33 @@ void SscReaderNaive::GetDeferred(VariableBase &variable, void *data)
     }
 }
 
+std::vector<VariableStruct::BPInfo>
+SscReaderNaive::BlocksInfo(const VariableStruct &variable,
+                           const size_t step) const
+{
+    std::vector<VariableStruct::BPInfo> ret;
+    auto it = m_BlockMap.find(variable.m_Name);
+    if (it != m_BlockMap.end())
+    {
+        for (const auto &v : it->second)
+        {
+            ret.emplace_back();
+            auto &b = ret.back();
+            b.Start = v.start;
+            b.Count = v.count;
+            b.Shape = v.shape;
+            b.Step = m_CurrentStep;
+            b.StepsStart = m_CurrentStep;
+            b.StepsCount = 1;
+            if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
+            {
+                b.IsReverseDims = true;
+            }
+        }
+    }
+    return ret;
+}
+
 }
 }
 }

--- a/source/adios2/engine/ssc/SscReaderNaive.cpp
+++ b/source/adios2/engine/ssc/SscReaderNaive.cpp
@@ -210,6 +210,7 @@ SscReaderNaive::BlocksInfo(const VariableStruct &variable,
                            const size_t step) const
 {
     std::vector<VariableStruct::BPInfo> ret;
+    size_t blockID = 0;
     auto it = m_BlockMap.find(variable.m_Name);
     if (it != m_BlockMap.end())
     {
@@ -223,10 +224,12 @@ SscReaderNaive::BlocksInfo(const VariableStruct &variable,
             b.Step = m_CurrentStep;
             b.StepsStart = m_CurrentStep;
             b.StepsCount = 1;
+            b.BlockID = blockID;
             if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
             {
                 b.IsReverseDims = true;
             }
+            ++blockID;
         }
     }
     return ret;

--- a/source/adios2/engine/ssc/SscReaderNaive.h
+++ b/source/adios2/engine/ssc/SscReaderNaive.h
@@ -45,6 +45,9 @@ public:
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
+    std::vector<VariableStruct::BPInfo>
+    BlocksInfo(const VariableStruct &variable, const size_t step) const final;
+
     void GetDeferred(VariableBase &, void *) final;
 
 private:

--- a/source/adios2/engine/ssc/SscReaderNaive.tcc
+++ b/source/adios2/engine/ssc/SscReaderNaive.tcc
@@ -44,9 +44,7 @@ SscReaderNaive::BlocksInfoCommon(const Variable<T> &variable,
             b.StepsCount = 1;
             if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
             {
-                std::reverse(b.Start.begin(), b.Start.end());
-                std::reverse(b.Count.begin(), b.Count.end());
-                std::reverse(b.Shape.begin(), b.Shape.end());
+                b.IsReverseDims = true;
             }
             if (v.shapeId == ShapeID::GlobalValue ||
                 v.shapeId == ShapeID::LocalValue)

--- a/source/adios2/engine/ssc/SscReaderNaive.tcc
+++ b/source/adios2/engine/ssc/SscReaderNaive.tcc
@@ -29,6 +29,7 @@ SscReaderNaive::BlocksInfoCommon(const Variable<T> &variable,
                                  const size_t step) const
 {
     std::vector<typename Variable<T>::BPInfo> ret;
+    size_t blockID = 0;
     auto it = m_BlockMap.find(variable.m_Name);
     if (it != m_BlockMap.end())
     {
@@ -42,6 +43,7 @@ SscReaderNaive::BlocksInfoCommon(const Variable<T> &variable,
             b.Step = m_CurrentStep;
             b.StepsStart = m_CurrentStep;
             b.StepsCount = 1;
+            b.BlockID = blockID;
             if (m_IO.m_ArrayOrder != ArrayOrdering::RowMajor)
             {
                 b.IsReverseDims = true;
@@ -53,6 +55,7 @@ SscReaderNaive::BlocksInfoCommon(const Variable<T> &variable,
                 std::memcpy(reinterpret_cast<char *>(&b.Value), v.value.data(),
                             v.value.size());
             }
+            ++blockID;
         }
     }
     return ret;


### PR DESCRIPTION
This is still based on the templated API, for apps that need to use in near future. But in the long run, we should aim to implement a non-template BlocksInfo from the API layer down to adios2::core. The current API layer is extremely inefficient in the sense that it needs to traverse every single BlockInfo element for a deep copy from adios2::core to the API objects. This causes ridiculous performance loss for apps that have a large number of blocks and need to call BlocksInfo frequently. It REALLY should be implemented so that we can use a single memcpy() to copy an entire block. Even if it means that we always need to reserve memory space for the largest possible data type, it will still be much more efficient in block intensive workflows. 