### PR TITLE
added freeze function to StructDefinition

### DIFF
--- a/bindings/CXX11/adios2/cxx11/VariableNT.cpp
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.cpp
@@ -29,6 +29,13 @@ void StructDefinition::AddItem(const std::string &name, const size_t offset,
     m_StructDefinition->AddItem(name, offset, type, size);
 }
 
+void StructDefinition::Freeze() noexcept
+{
+    helper::CheckForNullptr(m_StructDefinition,
+                            "in call to StructDefinition::Freeze");
+    m_StructDefinition->Freeze();
+}
+
 size_t StructDefinition::StructSize() const noexcept
 {
     helper::CheckForNullptr(m_StructDefinition,

--- a/bindings/CXX11/adios2/cxx11/VariableNT.h
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.h
@@ -30,6 +30,7 @@ class StructDefinition
 public:
     void AddItem(const std::string &name, const size_t offset,
                  const DataType type, const size_t size = 1);
+    void Freeze() noexcept;
     size_t StructSize() const noexcept;
     size_t Items() const noexcept;
     std::string Name(const size_t index) const;

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -851,7 +851,7 @@ void IO::CheckTransportType(const std::string type) const
 }
 
 VariableStruct &IO::DefineStructVariable(const std::string &name,
-                                         const StructDefinition &def,
+                                         StructDefinition &def,
                                          const Dims &shape, const Dims &start,
                                          const Dims &count,
                                          const bool constantDims)
@@ -886,6 +886,8 @@ VariableStruct &IO::DefineStructVariable(const std::string &name,
             variable.AddOperation(operation.first, operation.second);
         }
     }
+
+    def.Freeze();
 
     return variable;
 }

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -183,7 +183,7 @@ public:
                    const bool constantDims = false);
 
     VariableStruct &DefineStructVariable(const std::string &name,
-                                         const StructDefinition &def,
+                                         StructDefinition &def,
                                          const Dims &shape = Dims(),
                                          const Dims &start = Dims(),
                                          const Dims &count = Dims(),

--- a/source/adios2/core/VariableStruct.cpp
+++ b/source/adios2/core/VariableStruct.cpp
@@ -22,6 +22,12 @@ StructDefinition::StructDefinition(const size_t size) : m_StructSize(size) {}
 void StructDefinition::AddItem(const std::string &name, const size_t offset,
                                const DataType type, const size_t size)
 {
+    if (m_Frozen)
+    {
+        helper::Throw<std::runtime_error>(
+            "core", "VariableStruct::StructDefinition", "AddItem",
+            "struct definition already frozen");
+    }
     if (type == DataType::None || type == DataType::Struct)
     {
         helper::Throw<std::invalid_argument>("core",
@@ -30,9 +36,9 @@ void StructDefinition::AddItem(const std::string &name, const size_t offset,
     }
     if (offset + helper::GetDataTypeSize(type) * size > m_StructSize)
     {
-        helper::Throw<std::invalid_argument>("core",
-                                             "VariableStruct::StructDefinition",
-                                             "AddItem", "exceeded struct size");
+        helper::Throw<std::runtime_error>("core",
+                                          "VariableStruct::StructDefinition",
+                                          "AddItem", "exceeded struct size");
     }
     m_Definition.emplace_back();
     auto &d = m_Definition.back();
@@ -41,6 +47,8 @@ void StructDefinition::AddItem(const std::string &name, const size_t offset,
     d.Type = type;
     d.Size = size;
 }
+
+void StructDefinition::Freeze() noexcept { m_Frozen = true; }
 
 size_t StructDefinition::StructSize() const noexcept { return m_StructSize; }
 

--- a/source/adios2/core/VariableStruct.h
+++ b/source/adios2/core/VariableStruct.h
@@ -33,6 +33,7 @@ public:
     StructDefinition(const size_t size);
     void AddItem(const std::string &name, const size_t offset,
                  const DataType type, const size_t size = 1);
+    void Freeze() noexcept;
     size_t StructSize() const noexcept;
     size_t Items() const noexcept;
     std::string Name(const size_t index) const;
@@ -42,6 +43,7 @@ public:
 
 private:
     std::vector<StructItemDefinition> m_Definition;
+    bool m_Frozen = false;
     size_t m_StructSize;
 };
 

--- a/testing/adios2/engine/ssc/TestSscStruct.cpp
+++ b/testing/adios2/engine/ssc/TestSscStruct.cpp
@@ -73,6 +73,8 @@ void Writer(const Dims &shape, const Dims &start, const Dims &count,
     particleDef.AddItem("b", 4, adios2::DataType::Int32, 4);
     auto varStruct =
         io.DefineStructVariable("particles", particleDef, shape, start, count);
+    EXPECT_THROW(particleDef.AddItem("c", 4, adios2::DataType::Int32, 4),
+                 std::runtime_error);
     std::vector<particle> myParticles(datasize);
     for (size_t i = 0; i < datasize; ++i)
     {

--- a/testing/adios2/interface/TestADIOSDefineVariable.cpp
+++ b/testing/adios2/interface/TestADIOSDefineVariable.cpp
@@ -664,13 +664,16 @@ TEST_F(ADIOSDefineVariableTest, DefineStructVariable)
     auto def1 = adios.DefineStruct("def1", 24);
     def1.AddItem("a", 0, adios2::DataType::Int8, 1);
     def1.AddItem("b", 4, adios2::DataType::Int32, 5);
+    def1.Freeze();
+    EXPECT_THROW(def1.AddItem("c", 0, adios2::DataType::Int32),
+                 std::runtime_error);
 
     auto def2 = adios.DefineStruct("def2", 28);
     def2.AddItem("a", 0, adios2::DataType::Int8, 1);
     def2.AddItem("b", 4, adios2::DataType::Int32, 5);
     def2.AddItem("c", 24, adios2::DataType::Int32);
     EXPECT_THROW(def2.AddItem("c", 27, adios2::DataType::Int32),
-                 std::invalid_argument);
+                 std::runtime_error);
 
     auto structVar =
         io.DefineStructVariable("particle", def1, shape, start, count);


### PR DESCRIPTION
Since multiple struct variables can use one struct definition, there needs a freeze feature to finalize a struct definition, so that it ensures the struct definition is not changed in between defining different variables. 

This function can be called from the user code. Even if users don't call it, it will still automatically freeze when the first variable is being created using a struct definition.  