### PR TITLE
bpls -l for a single scalar (not over time) for a BP5 file showed 0. …

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1812,7 +1812,10 @@ bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
                 writer_meta_base =
                     GetMetadataBase(VarRec, RelStep, WriterRank++);
             }
-            ApplyElementMinMax(MinMax, VarRec->Type, writer_meta_base);
+            if (writer_meta_base)
+            {
+                ApplyElementMinMax(MinMax, VarRec->Type, writer_meta_base);
+            }
         }
         else if (VarRec->OrigShapeID == ShapeID::LocalValue)
         {
@@ -1822,7 +1825,9 @@ bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
                 void *writer_meta_base =
                     GetMetadataBase(VarRec, RelStep, WriterRank);
                 if (writer_meta_base)
+                {
                     ApplyElementMinMax(MinMax, VarRec->Type, writer_meta_base);
+                }
             }
         }
     }

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1232,7 +1232,8 @@ int printVariableInfo(core::Engine *fp, core::IO *io,
         if (longopt && !timestep)
         {
             fprintf(outf, " = ");
-            print_data(&variable->m_Value, 0, adiosvartype, false);
+            auto mm = variable->MinMax();
+            print_data(&mm.second, 0, adiosvartype, false);
         }
         fprintf(outf, "\n");
 


### PR DESCRIPTION
…Fixed to use variable->MinMax() but also fixed in BP5Deserializer to not segfault if the scalar is not present in every step of the file.