### PR TITLE
Fix:  BP5 LocalValue (shown at read as GlobalArray)  MinBlocksInfo ca…

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1485,6 +1485,7 @@ MinVarInfo *BP5Deserializer::MinBlocksInfo(const VariableBase &Var, size_t Step)
             if (writer_meta_base)
             {
                 MinBlockInfo Blk;
+                Blk.MinMax.Init(VarRec->Type);
                 Blk.WriterID = WriterRank;
                 Blk.BlockID = Id++;
                 Blk.BufferP = writer_meta_base;
@@ -1492,6 +1493,11 @@ MinVarInfo *BP5Deserializer::MinBlocksInfo(const VariableBase &Var, size_t Step)
                 {
                     Blk.Count = (size_t *)1;
                     Blk.Start = (size_t *)WriterRank;
+                }
+                if (writer_meta_base)
+                {
+                    ApplyElementMinMax(Blk.MinMax, VarRec->Type,
+                                       writer_meta_base);
                 }
                 MV->BlocksInfo.push_back(Blk);
             }


### PR DESCRIPTION
…rries values instead of allocated pointers in Shape, Start and Count. Added branches to bpls to handle such variables. Also added to BP5Deserialzer::MinBlocksInfo() to add the value to min/max. This fixes the bpls of examples/basics/values output (-l, -d, -D variants)