### PR TITLE
fix api for gcc11

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Attribute.h
+++ b/bindings/CXX11/adios2/cxx11/Attribute.h
@@ -43,8 +43,8 @@ public:
      * attributes from IO:DefineAttribute<T> or IO:InquireAttribute<T>.
      * Can be used with STL containers.
      */
-    Attribute<T>() = default;
-    ~Attribute<T>() = default;
+    Attribute() = default;
+    ~Attribute() = default;
 
     /** Checks if object is valid, e.g. if( attribute ) { //..valid } */
     explicit operator bool() const noexcept;
@@ -74,7 +74,7 @@ public:
     bool IsValue() const;
 
 private:
-    Attribute<T>(core::Attribute<IOType> *attribute);
+    Attribute(core::Attribute<IOType> *attribute);
     core::Attribute<IOType> *m_Attribute = nullptr;
 };
 

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -139,10 +139,10 @@ public:
      * variables from IO:DefineVariable<T> or IO:InquireVariable<T>.
      * Can be used with STL containers.
      */
-    Variable<T>() = default;
+    Variable() = default;
 
     /** Default, using RAII STL containers */
-    ~Variable<T>() = default;
+    ~Variable() = default;
 
     /** Checks if object is valid, e.g. if( variable ) { //..valid } */
     explicit operator bool() const noexcept;
@@ -389,7 +389,7 @@ private:
     std::vector<typename Variable<T>::Info>
     ToBlocksInfoMin(const MinVarInfo *coreVarInfo) const;
 
-    Variable<T>(core::Variable<IOType> *variable);
+    Variable(core::Variable<IOType> *variable);
 
     std::vector<std::vector<typename Variable<T>::Info>> DoAllStepsBlocksInfo();
     std::map<size_t, std::vector<typename Variable<T>::Info>>

--- a/source/adios2/core/Attribute.h
+++ b/source/adios2/core/Attribute.h
@@ -31,7 +31,7 @@ public:
      * Copy constructor (enforces zero-padding)
      * @param other
      */
-    Attribute<T>(const Attribute<T> &other);
+    Attribute(const Attribute<T> &other);
 
     /**
      * Data array constructor
@@ -40,7 +40,7 @@ public:
      * @param elements
      * @param allowModifications
      */
-    Attribute<T>(const std::string &name, const T *data, const size_t elements,
+    Attribute(const std::string &name, const T *data, const size_t elements,
                  const bool allowModification);
 
     /**
@@ -50,10 +50,10 @@ public:
      * @param elements
      * @param allowModifications
      */
-    Attribute<T>(const std::string &name, const T &data,
+    Attribute(const std::string &name, const T &data,
                  const bool allowModification);
 
-    ~Attribute<T>() = default;
+    ~Attribute() = default;
 
     /**
      * Modification of an existing attribute (array)


### PR DESCRIPTION
Instead of

```cpp
template <class T>
struct foo {
     foo<T>()=default;
}
```

do this

```cpp
template <class T>
struct foo {
     foo()=default;
}
```

`foo` doesn't need to be explicitly specialized with type T, and with GCC 11, the former doesn't even compile.


