### PR TITLE
Fix SelectSteps: it always read the very first step's metadata no mat…

### DIFF
--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -841,7 +841,7 @@ size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL,
                     m_FilteredMetadataInfo.push_back(
                         std::make_pair(minfo_pos, minfo_size));
                 }
-                minfo_pos = MetadataPos;
+                minfo_pos = MetadataPos + MetadataSize;
                 minfo_size = 0;
             }
 
@@ -872,6 +872,7 @@ size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL,
     {
         m_FilteredMetadataInfo.push_back(std::make_pair(minfo_pos, minfo_size));
     }
+
     return position;
 }
 


### PR DESCRIPTION
…ter the selection. Test are now more complicated to check for a scalar's value as well as a newly created attribute in each (selected step) to catch potential mismatch in the future.