### PR TITLE
utils: Fix bpls linking in Windows

### DIFF
--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -11,7 +11,9 @@ configure_file(
 
 # BPLS
 add_executable(bpls ./bpls/bpls.cpp)
-target_link_libraries(bpls adios2_core adios2sys adios2::thirdparty::pugixml)
+target_link_libraries(bpls
+                      PUBLIC adios2_core adios2sys
+                      PRIVATE adios2::thirdparty::pugixml $<$<PLATFORM_ID:Windows>:shlwapi>)
 target_include_directories(bpls PRIVATE ${PROJECT_BINARY_DIR})
 set_property(TARGET bpls PROPERTY OUTPUT_NAME bpls${ADIOS2_EXECUTABLE_SUFFIX})
 install(TARGETS bpls EXPORT adios2

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -49,7 +49,6 @@
 #ifdef _WIN32
 #include "shlwapi.h"
 #include "windows.h"
-#pragma comment(lib, "shlwapi.lib")
 #pragma warning(disable : 4101) // unreferenced local variable
 #else
 #include <fnmatch.h>


### PR DESCRIPTION
This fixes the error:
```
ld.exe: source/utils/CMakeFiles/bpls.dir/bpls/bpls.cpp.obj:bpls.cpp:(.text+0x67994): undefined reference to '__imp_PathMatchSpecA'
```
