### PR TITLE
Added default_init_allocator from http://stackoverflow.com/a/21028912…

### DIFF
--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -302,7 +302,7 @@ void BP3Writer::WriteProfilingJSONFile()
                                    transportTypes, transportProfilers) +
                                ",\n");
 
-    const std::vector<char> profilingJSON(
+    const helper::adiosvec<char> profilingJSON(
         m_BP3Serializer.AggregateProfilingJSON(lineJSON));
 
     if (m_BP3Serializer.m_RankMPI == 0)

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -559,7 +559,7 @@ size_t BP4Reader::UpdateBuffer(const TimePoint &timeoutInstant,
         {
             const size_t maxIdxSize =
                 idxFileSize - m_MDIndexFileAlreadyReadSize;
-            std::vector<char> idxbuf(maxIdxSize);
+            helper::adiosvec<char> idxbuf(maxIdxSize);
             m_MDIndexFileManager.ReadFile(idxbuf.data(), maxIdxSize,
                                           m_MDIndexFileAlreadyReadSize);
             size_t newIdxSize;
@@ -685,7 +685,8 @@ bool BP4Reader::CheckWriterActive()
     size_t flag = 0;
     if (m_BP4Deserializer.m_RankMPI == 0)
     {
-        std::vector<char> header(m_BP4Deserializer.m_IndexHeaderSize, '\0');
+        helper::adiosvec<char> header(m_BP4Deserializer.m_IndexHeaderSize,
+                                      '\0');
         m_MDIndexFileManager.ReadFile(
             header.data(), m_BP4Deserializer.m_IndexHeaderSize, 0, 0);
         bool active = m_BP4Deserializer.ReadActiveFlag(header);

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -550,7 +550,7 @@ void BP4Writer::WriteProfilingJSONFile()
                                    transportTypes, transportProfilers) +
                                ",\n");
 
-    const std::vector<char> profilingJSON(
+    const helper::adiosvec<char> profilingJSON(
         m_BP4Serializer.AggregateProfilingJSON(lineJSON));
 
     if (m_BP4Serializer.m_RankMPI == 0)

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -302,7 +302,7 @@ void BP5Reader::PerformGets()
         double readTotal = 0.0;
         double subfileTotal = 0.0;
         size_t nReads = 0;
-        std::vector<char> buf(maxReadSize);
+        helper::adiosvec<char> buf(maxReadSize);
 
         while (true)
         {
@@ -393,7 +393,7 @@ void BP5Reader::PerformGets()
     {
         size_t maxOpenFiles = helper::SetWithinLimit(
             (size_t)m_Parameters.MaxOpenFilesAtOnce, (size_t)1, MaxSizeT);
-        std::vector<char> buf(maxReadSize);
+        helper::adiosvec<char> buf(maxReadSize);
         for (auto &Req : ReadRequests)
         {
             if (!Req.DestinationAddr)
@@ -1070,7 +1070,7 @@ size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL,
     return position;
 }
 
-bool BP5Reader::ReadActiveFlag(std::vector<char> &buffer)
+bool BP5Reader::ReadActiveFlag(helper::adiosvec<char> &buffer)
 {
     if (buffer.size() < m_ActiveFlagPosition)
     {
@@ -1094,7 +1094,7 @@ bool BP5Reader::CheckWriterActive()
         auto fsize = m_MDIndexFileManager.GetFileSize(0);
         if (fsize >= m_IndexHeaderSize)
         {
-            std::vector<char> header(m_IndexHeaderSize, '\0');
+            helper::adiosvec<char> header(m_IndexHeaderSize, '\0');
             m_MDIndexFileManager.ReadFile(header.data(), m_IndexHeaderSize, 0,
                                           0);
             bool active = ReadActiveFlag(header);

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -150,7 +150,7 @@ private:
                       const Seconds &pollSeconds,
                       const Seconds &timeoutSeconds);
 
-    bool ReadActiveFlag(std::vector<char> &buffer);
+    bool ReadActiveFlag(helper::adiosvec<char> &buffer);
 
     /* Parse metadata.
      *

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -227,7 +227,7 @@ private:
 
     std::vector<std::vector<size_t>> FlushPosSizeInfo;
 
-    void MakeHeader(std::vector<char> &buffer, size_t &position,
+    void MakeHeader(helper::adiosvec<char> &buffer, size_t &position,
                     const std::string fileType, const bool isActive);
 
     std::vector<uint64_t> m_WriterSubfileMap; // rank => subfile index

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -682,7 +682,7 @@ void SstReader::PerformGets()
     else if (m_WriterMarshalMethod == SstMarshalBP)
     {
         std::vector<void *> sstReadHandlers;
-        std::vector<std::vector<char>> buffers;
+        std::vector<helper::adiosvec<char>> buffers;
         size_t iter = 0;
 
         if (m_BP3Deserializer->m_DeferredVariables.empty())

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -54,13 +54,14 @@ public:
 
 private:
     template <class T>
-    void ReadVariableBlocksRequests(Variable<T> &variable,
-                                    std::vector<void *> &sstReadHandlers,
-                                    std::vector<std::vector<char>> &buffers);
+    void
+    ReadVariableBlocksRequests(Variable<T> &variable,
+                               std::vector<void *> &sstReadHandlers,
+                               std::vector<helper::adiosvec<char>> &buffers);
 
     template <class T>
     void ReadVariableBlocksFill(Variable<T> &variable,
-                                std::vector<std::vector<char>> &buffers,
+                                std::vector<helper::adiosvec<char>> &buffers,
                                 size_t &iter);
 
     template <class T>

--- a/source/adios2/engine/sst/SstReader.tcc
+++ b/source/adios2/engine/sst/SstReader.tcc
@@ -26,7 +26,7 @@ namespace engine
 template <class T>
 void SstReader::ReadVariableBlocksRequests(
     Variable<T> &variable, std::vector<void *> &sstReadHandlers,
-    std::vector<std::vector<char>> &buffers)
+    std::vector<helper::adiosvec<char>> &buffers)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
 
@@ -122,9 +122,9 @@ void SstReader::ReadVariableBlocksRequests(
 }
 
 template <class T>
-void SstReader::ReadVariableBlocksFill(Variable<T> &variable,
-                                       std::vector<std::vector<char>> &buffers,
-                                       size_t &iter)
+void SstReader::ReadVariableBlocksFill(
+    Variable<T> &variable, std::vector<helper::adiosvec<char>> &buffers,
+    size_t &iter)
 {
     PERFSTUBS_SCOPED_TIMER_FUNC();
 

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -8,6 +8,7 @@
 #ifndef ADIOS2_HELPER_ADIOSCOMM_H_
 #define ADIOS2_HELPER_ADIOSCOMM_H_
 
+#include <adios2/helper/adiosType.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -184,6 +185,10 @@ public:
     template <class T>
     void GathervVectors(const std::vector<T> &in, std::vector<T> &out,
                         size_t &position, int rankDestination = 0) const;
+
+    template <class T>
+    void GathervVectors(const helper::adiosvec<T> &in, helper::adiosvec<T> &out,
+                        size_t &position, int rankDestination = 0) const;
     /**
      * Perform AllGather for source value
      * @param source input
@@ -202,6 +207,10 @@ public:
 
     template <class T>
     void BroadcastVector(std::vector<T> &vector,
+                         const int rankSource = 0) const;
+
+    template <class T>
+    void BroadcastVector(helper::adiosvec<T> &vector,
                          const int rankSource = 0) const;
 
     std::string BroadcastFile(const std::string &fileName,

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -37,7 +37,7 @@ void CopyEndianReverse(const char *src, const size_t payloadStride, T *dest);
  * @param elements number of elements of source type
  */
 template <class T>
-void InsertToBuffer(std::vector<char> &buffer, const T *source,
+void InsertToBuffer(helper::adiosvec<char> &buffer, const T *source,
                     const size_t elements = 1) noexcept;
 
 #ifdef ADIOS2_HAVE_CUDA
@@ -45,7 +45,7 @@ void InsertToBuffer(std::vector<char> &buffer, const T *source,
  * Copies data from a GPU buffer to a specific location in the adios buffer
  */
 template <class T>
-void CopyFromGPUToBuffer(std::vector<char> &dest, size_t &position,
+void CopyFromGPUToBuffer(helper::adiosvec<char> &dest, size_t &position,
                          const T *source, const size_t elements = 1) noexcept;
 template <class T>
 void CudaMemCopyToBuffer(char *dest, size_t position, const T *GPUbuffer,
@@ -74,8 +74,8 @@ void MemcpyBufferToGPU(char *GPUbuffer, const char *src, size_t byteCount);
  * @param elements number of elements of source type
  */
 template <class T>
-void CopyToBuffer(std::vector<char> &buffer, size_t &position, const T *source,
-                  const size_t elements = 1) noexcept;
+void CopyToBuffer(helper::adiosvec<char> &buffer, size_t &position,
+                  const T *source, const size_t elements = 1) noexcept;
 
 /**
  * Copies data to a specific location in the buffer updating position using
@@ -88,13 +88,14 @@ void CopyToBuffer(std::vector<char> &buffer, size_t &position, const T *source,
  * @param threads number of threads sharing the copy load
  */
 template <class T>
-void CopyToBufferThreads(std::vector<char> &buffer, size_t &position,
+void CopyToBufferThreads(helper::adiosvec<char> &buffer, size_t &position,
                          const T *source, const size_t elements = 1,
                          const unsigned int threads = 1) noexcept;
 
 template <class T>
-void ReverseCopyFromBuffer(const std::vector<char> &buffer, size_t &position,
-                           T *destination, const size_t elements = 1) noexcept;
+void ReverseCopyFromBuffer(const helper::adiosvec<char> &buffer,
+                           size_t &position, T *destination,
+                           const size_t elements = 1) noexcept;
 
 /**
  * Copy memory from a buffer at a certain input position
@@ -105,7 +106,7 @@ void ReverseCopyFromBuffer(const std::vector<char> &buffer, size_t &position,
  * @param elements  number of elements of destination type
  */
 template <class T>
-void CopyFromBuffer(const std::vector<char> &buffer, size_t &position,
+void CopyFromBuffer(const helper::adiosvec<char> &buffer, size_t &position,
                     T *destination, const size_t elements = 1) noexcept;
 
 /**
@@ -114,18 +115,19 @@ void CopyFromBuffer(const std::vector<char> &buffer, size_t &position,
  * @param element to be added to buffer
  */
 template <class T>
-void InsertU64(std::vector<char> &buffer, const T element) noexcept;
+void InsertU64(helper::adiosvec<char> &buffer, const T element) noexcept;
 
 template <class T>
-T ReadValue(const std::vector<char> &buffer, size_t &position,
+T ReadValue(const helper::adiosvec<char> &buffer, size_t &position,
             const bool isLittleEndian = true) noexcept;
 
 /** Read in 'nElems' elements from buffer into output array
  * output must be pre-allocated.
  */
 template <class T>
-void ReadArray(const std::vector<char> &buffer, size_t &position, T *output,
-               const size_t nElems, const bool isLittleEndian = true) noexcept;
+void ReadArray(const helper::adiosvec<char> &buffer, size_t &position,
+               T *output, const size_t nElems,
+               const bool isLittleEndian = true) noexcept;
 
 /**
  * General function to copy memory between blocks of different type and start
@@ -190,7 +192,7 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
 
 template <class T>
 void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
-                          const std::vector<char> &contiguousMemory,
+                          const helper::adiosvec<char> &contiguousMemory,
                           const Box<Dims> &blockBox,
                           const Box<Dims> &intersectionBox,
                           const bool isRowMajor = true,
@@ -211,8 +213,12 @@ void CopyContiguousMemory(const char *src, const size_t stride, T *dest,
  * @param end
  */
 template <class T>
-void ClipVector(std::vector<T> &vec, const size_t start,
+void ClipVector(helper::adiosvec<T> &vec, const size_t start,
                 const size_t end) noexcept;
+
+template <class T>
+void Resize(helper::adiosvec<T> &vec, const size_t dataSize,
+            const std::string hint, T value = T());
 
 template <class T>
 void Resize(std::vector<T> &vec, const size_t dataSize, const std::string hint,

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -67,7 +67,7 @@ inline void CopyEndianReverse<std::complex<double>>(const char *src,
 #endif
 
 template <class T>
-void InsertToBuffer(std::vector<char> &buffer, const T *source,
+void InsertToBuffer(helper::adiosvec<char> &buffer, const T *source,
                     const size_t elements) noexcept
 {
     const char *src = reinterpret_cast<const char *>(source);
@@ -76,7 +76,7 @@ void InsertToBuffer(std::vector<char> &buffer, const T *source,
 
 #ifdef ADIOS2_HAVE_CUDA
 template <class T>
-void CopyFromGPUToBuffer(std::vector<char> &dest, size_t &position,
+void CopyFromGPUToBuffer(helper::adiosvec<char> &dest, size_t &position,
                          const T *GPUbuffer, const size_t elements) noexcept
 {
     CudaMemCopyToBuffer(dest.data(), position, GPUbuffer, elements * sizeof(T));
@@ -132,8 +132,8 @@ static inline void NdCopyCUDA(const char *&inOvlpBase, char *&outOvlpBase,
 #endif
 
 template <class T>
-void CopyToBuffer(std::vector<char> &buffer, size_t &position, const T *source,
-                  const size_t elements) noexcept
+void CopyToBuffer(helper::adiosvec<char> &buffer, size_t &position,
+                  const T *source, const size_t elements) noexcept
 {
     const char *src = reinterpret_cast<const char *>(source);
     std::copy(src, src + elements * sizeof(T), buffer.begin() + position);
@@ -141,7 +141,7 @@ void CopyToBuffer(std::vector<char> &buffer, size_t &position, const T *source,
 }
 
 template <class T>
-void CopyToBufferThreads(std::vector<char> &buffer, size_t &position,
+void CopyToBufferThreads(helper::adiosvec<char> &buffer, size_t &position,
                          const T *source, const size_t elements,
                          const unsigned int threads) noexcept
 {
@@ -204,7 +204,7 @@ void CopyToBufferThreads(std::vector<char> &buffer, size_t &position,
 }
 
 template <class T>
-inline void ReverseCopyFromBuffer(const std::vector<char> &buffer,
+inline void ReverseCopyFromBuffer(const helper::adiosvec<char> &buffer,
                                   size_t &position, T *destination,
                                   const size_t elements) noexcept
 {
@@ -215,7 +215,7 @@ inline void ReverseCopyFromBuffer(const std::vector<char> &buffer,
 }
 
 template <class T>
-void CopyFromBuffer(const std::vector<char> &buffer, size_t &position,
+void CopyFromBuffer(const helper::adiosvec<char> &buffer, size_t &position,
                     T *destination, size_t elements) noexcept
 {
     std::copy(buffer.begin() + position,
@@ -225,14 +225,14 @@ void CopyFromBuffer(const std::vector<char> &buffer, size_t &position,
 }
 
 template <class T>
-void InsertU64(std::vector<char> &buffer, const T element) noexcept
+void InsertU64(helper::adiosvec<char> &buffer, const T element) noexcept
 {
     const uint64_t element64 = static_cast<uint64_t>(element);
     InsertToBuffer(buffer, &element64, 1);
 }
 
 template <class T>
-inline T ReadValue(const std::vector<char> &buffer, size_t &position,
+inline T ReadValue(const helper::adiosvec<char> &buffer, size_t &position,
                    const bool isLittleEndian) noexcept
 {
     T value;
@@ -254,7 +254,7 @@ inline T ReadValue(const std::vector<char> &buffer, size_t &position,
 
 template <>
 inline std::complex<float>
-ReadValue<std::complex<float>>(const std::vector<char> &buffer,
+ReadValue<std::complex<float>>(const helper::adiosvec<char> &buffer,
                                size_t &position,
                                const bool isLittleEndian) noexcept
 {
@@ -278,7 +278,7 @@ ReadValue<std::complex<float>>(const std::vector<char> &buffer,
 
 template <>
 inline std::complex<double>
-ReadValue<std::complex<double>>(const std::vector<char> &buffer,
+ReadValue<std::complex<double>>(const helper::adiosvec<char> &buffer,
                                 size_t &position,
                                 const bool isLittleEndian) noexcept
 {
@@ -301,7 +301,7 @@ ReadValue<std::complex<double>>(const std::vector<char> &buffer,
 }
 
 template <class T>
-inline void ReadArray(const std::vector<char> &buffer, size_t &position,
+inline void ReadArray(const helper::adiosvec<char> &buffer, size_t &position,
                       T *output, const size_t nElems,
                       const bool isLittleEndian) noexcept
 {
@@ -320,7 +320,7 @@ inline void ReadArray(const std::vector<char> &buffer, size_t &position,
 }
 
 template <>
-inline void ReadArray<std::complex<float>>(const std::vector<char> &buffer,
+inline void ReadArray<std::complex<float>>(const helper::adiosvec<char> &buffer,
                                            size_t &position,
                                            std::complex<float> *output,
                                            const size_t nElems,
@@ -341,11 +341,11 @@ inline void ReadArray<std::complex<float>>(const std::vector<char> &buffer,
 }
 
 template <>
-inline void ReadArray<std::complex<double>>(const std::vector<char> &buffer,
-                                            size_t &position,
-                                            std::complex<double> *output,
-                                            const size_t nElems,
-                                            const bool isLittleEndian) noexcept
+inline void
+ReadArray<std::complex<double>>(const helper::adiosvec<char> &buffer,
+                                size_t &position, std::complex<double> *output,
+                                const size_t nElems,
+                                const bool isLittleEndian) noexcept
 {
 #ifdef ADIOS2_HAVE_ENDIAN_REVERSE
     if (IsLittleEndian() != isLittleEndian)
@@ -362,7 +362,7 @@ inline void ReadArray<std::complex<double>>(const std::vector<char> &buffer,
 }
 
 template <class T>
-void ClipVector(std::vector<T> &vec, const size_t start,
+void ClipVector(helper::adiosvec<T> &vec, const size_t start,
                 const size_t end) noexcept
 {
     vec.resize(end);
@@ -623,7 +623,7 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
 
 template <class T>
 void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
-                          const std::vector<char> &contiguousMemory,
+                          const helper::adiosvec<char> &contiguousMemory,
                           const Box<Dims> &blockBox,
                           const Box<Dims> &intersectionBox,
                           const bool isRowMajor, const bool reverseDimensions,
@@ -662,6 +662,25 @@ void CopyContiguousMemory(const char *src, const size_t payloadStride, T *dest,
 #else
     std::copy(src, src + payloadStride, reinterpret_cast<char *>(dest));
 #endif
+}
+
+template <class T>
+void Resize(helper::adiosvec<T> &vec, const size_t dataSize,
+            const std::string hint, T value)
+{
+    try
+    {
+        // avoid power of 2 capacity growth
+        vec.reserve(dataSize);
+        vec.resize(dataSize, value);
+    }
+    catch (...)
+    {
+        helper::ThrowNested<std::runtime_error>(
+            "Helper", "adiosMemory", "Resize",
+            "buffer overflow when resizing to " + std::to_string(dataSize) +
+                " bytes, " + hint);
+    }
 }
 
 template <class T>
@@ -910,9 +929,9 @@ static inline void NdCopyIterDFDynamic(const char *inBase, char *outBase,
 {
     size_t curDim = 0;
     DimsArray pos(ovlpCount.size() + 1, (size_t)0);
-    std::vector<const char *> inAddr(ovlpCount.size() + 1);
+    helper::adiosvec<const char *> inAddr(ovlpCount.size() + 1);
     inAddr[0] = inBase;
-    std::vector<char *> outAddr(ovlpCount.size() + 1);
+    helper::adiosvec<char *> outAddr(ovlpCount.size() + 1);
     outAddr[0] = outBase;
     while (true)
     {
@@ -947,9 +966,9 @@ static inline void NdCopyIterDFDynamicRevEndian(
 {
     size_t curDim = 0;
     DimsArray pos(ovlpCount.size() + 1, (size_t)0);
-    std::vector<const char *> inAddr(ovlpCount.size() + 1);
+    helper::adiosvec<const char *> inAddr(ovlpCount.size() + 1);
     inAddr[0] = inBase;
-    std::vector<char *> outAddr(ovlpCount.size() + 1);
+    helper::adiosvec<char *> outAddr(ovlpCount.size() + 1);
     outAddr[0] = outBase;
     while (true)
     {

--- a/source/adios2/helper/adiosType.h
+++ b/source/adios2/helper/adiosType.h
@@ -321,6 +321,42 @@ std::set<T> VectorToSet(const std::vector<T> &input) noexcept;
 template <class T, class U>
 U EraseKey(const T &key, std::map<T, U> &map);
 
+// Allocator adaptor that interposes construct() calls to
+// convert value initialization into default initialization.
+// From: http://stackoverflow.com/a/21028912/273767
+template <typename T, typename A = std::allocator<T>>
+class default_init_allocator : public A
+{
+    typedef std::allocator_traits<A> a_t;
+
+public:
+    template <typename U>
+    struct rebind
+    {
+        using other =
+            default_init_allocator<U, typename a_t::template rebind_alloc<U>>;
+    };
+
+    using A::A;
+
+    template <typename U>
+    void
+    construct(U *ptr) noexcept(std::is_nothrow_default_constructible<U>::value)
+    {
+        ::new (static_cast<void *>(ptr)) U;
+    }
+    template <typename U, typename... Args>
+    void construct(U *ptr, Args &&... args)
+    {
+        a_t::construct(static_cast<A &>(*this), ptr,
+                       std::forward<Args>(args)...);
+    }
+};
+
+// Vector<T> with uninitialized allocation
+template <typename T>
+using adiosvec = std::vector<T, default_init_allocator<T>>;
+
 } // end namespace helper
 } // end namespace adios2
 

--- a/source/adios2/toolkit/format/bp/BPBase.cpp
+++ b/source/adios2/toolkit/format/bp/BPBase.cpp
@@ -405,7 +405,7 @@ size_t BPBase::GetProcessGroupIndexSize(const std::string name,
 }
 
 BPBase::ProcessGroupIndex
-BPBase::ReadProcessGroupIndexHeader(const std::vector<char> &buffer,
+BPBase::ReadProcessGroupIndexHeader(const helper::adiosvec<char> &buffer,
                                     size_t &position,
                                     const bool isLittleEndian) const noexcept
 {
@@ -424,7 +424,7 @@ BPBase::ReadProcessGroupIndexHeader(const std::vector<char> &buffer,
     return index;
 }
 
-std::string BPBase::ReadBPString(const std::vector<char> &buffer,
+std::string BPBase::ReadBPString(const helper::adiosvec<char> &buffer,
                                  size_t &position,
                                  const bool isLittleEndian) const noexcept
 {
@@ -478,7 +478,7 @@ BPBase::TransformTypeEnum(const std::string transformType) const noexcept
 
 #define declare_template_instantiation(T)                                      \
     template BPBase::Characteristics<T>                                        \
-    BPBase::ReadElementIndexCharacteristics(const std::vector<char> &,         \
+    BPBase::ReadElementIndexCharacteristics(const helper::adiosvec<char> &,    \
                                             size_t &, const BPBase::DataTypes, \
                                             const bool, const bool) const;
 

--- a/source/adios2/toolkit/format/bp/BPBase.h
+++ b/source/adios2/toolkit/format/bp/BPBase.h
@@ -20,6 +20,7 @@
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2/helper/adiosType.h"
 #include "adios2/toolkit/aggregator/mpi/MPIChain.h"
 #include "adios2/toolkit/format/buffer/Buffer.h"
 #include "adios2/toolkit/format/buffer/heap/BufferSTL.h"
@@ -42,7 +43,7 @@ public:
     struct SerialElementIndex
     {
         /** buffer containing the metadata index, start with 500bytes */
-        std::vector<char> Buffer;
+        helper::adiosvec<char> Buffer;
 
         /** number of characteristics sets (time and spatial aggregation) */
         uint64_t Count = 0;
@@ -290,7 +291,7 @@ public:
      * Indices:
      * [threadID][bufferID]
      */
-    std::map<size_t, std::map<size_t, std::vector<char>>> m_ThreadBuffers;
+    std::map<size_t, std::map<size_t, helper::adiosvec<char>>> m_ThreadBuffers;
 
     /**
      * Default constructor
@@ -486,7 +487,7 @@ protected:
     /** holds extra metadata for operations in BP buffer */
     struct BPOpInfo
     {
-        std::vector<char> Metadata;
+        helper::adiosvec<char> Metadata;
         // pre-operator dimensions
         Dims PreShape;
         Dims PreCount;
@@ -580,7 +581,7 @@ protected:
      * @return populated PGIndex struct
      */
     ProcessGroupIndex ReadProcessGroupIndexHeader(
-        const std::vector<char> &buffer, size_t &position,
+        const helper::adiosvec<char> &buffer, size_t &position,
         const bool isLittleEndian = true) const noexcept;
 
     /**
@@ -592,7 +593,8 @@ protected:
      * @return populated PGIndex struct
      */
     virtual ElementIndexHeader
-    ReadElementIndexHeader(const std::vector<char> &buffer, size_t &position,
+    ReadElementIndexHeader(const helper::adiosvec<char> &buffer,
+                           size_t &position,
                            const bool isLittleEndian = true) const noexcept = 0;
 
     /**
@@ -606,7 +608,7 @@ protected:
      */
     template <class T>
     Characteristics<T>
-    ReadElementIndexCharacteristics(const std::vector<char> &buffer,
+    ReadElementIndexCharacteristics(const helper::adiosvec<char> &buffer,
                                     size_t &position, const DataTypes dataType,
                                     const bool untilTimeStep = false,
                                     const bool isLittleEndian = true) const;
@@ -618,7 +620,8 @@ protected:
      * @param position input start position, output as end element
      * @return populated string
      */
-    std::string ReadBPString(const std::vector<char> &buffer, size_t &position,
+    std::string ReadBPString(const helper::adiosvec<char> &buffer,
+                             size_t &position,
                              const bool isLittleEndian = true) const noexcept;
 
 private:
@@ -627,8 +630,8 @@ private:
      * struct for a variable block
      */
     template <class T>
-    void ParseCharacteristics(const std::vector<char> &buffer, size_t &position,
-                              const DataTypes dataType,
+    void ParseCharacteristics(const helper::adiosvec<char> &buffer,
+                              size_t &position, const DataTypes dataType,
                               const bool untilTimeStep,
                               Characteristics<T> &characteristics,
                               const bool isLittleEndian = true) const;

--- a/source/adios2/toolkit/format/bp/BPBase.tcc
+++ b/source/adios2/toolkit/format/bp/BPBase.tcc
@@ -24,8 +24,9 @@ namespace format
 
 template <class T>
 BPBase::Characteristics<T> BPBase::ReadElementIndexCharacteristics(
-    const std::vector<char> &buffer, size_t &position, const DataTypes dataType,
-    const bool untilTimeStep, const bool isLittleEndian) const
+    const helper::adiosvec<char> &buffer, size_t &position,
+    const DataTypes dataType, const bool untilTimeStep,
+    const bool isLittleEndian) const
 {
     Characteristics<T> characteristics;
     characteristics.EntryCount =
@@ -42,8 +43,9 @@ BPBase::Characteristics<T> BPBase::ReadElementIndexCharacteristics(
 // String specialization
 template <>
 inline void
-BPBase::ParseCharacteristics(const std::vector<char> &buffer, size_t &position,
-                             const DataTypes dataType, const bool untilTimeStep,
+BPBase::ParseCharacteristics(const helper::adiosvec<char> &buffer,
+                             size_t &position, const DataTypes dataType,
+                             const bool untilTimeStep,
                              Characteristics<std::string> &characteristics,
                              const bool isLittleEndian) const
 {
@@ -190,7 +192,7 @@ BPBase::ParseCharacteristics(const std::vector<char> &buffer, size_t &position,
 }
 
 template <class T>
-inline void BPBase::ParseCharacteristics(const std::vector<char> &buffer,
+inline void BPBase::ParseCharacteristics(const helper::adiosvec<char> &buffer,
                                          size_t &position,
                                          const DataTypes /*dataType*/,
                                          const bool untilTimeStep,
@@ -519,9 +521,9 @@ inline void BPBase::ParseCharacteristics(const std::vector<char> &buffer,
             const size_t metadataLength = static_cast<size_t>(
                 helper::ReadValue<uint16_t>(buffer, position, isLittleEndian));
 
-            characteristics.Statistics.Op.Metadata =
-                std::vector<char>(buffer.begin() + position,
-                                  buffer.begin() + position + metadataLength);
+            characteristics.Statistics.Op.Metadata = helper::adiosvec<char>(
+                buffer.begin() + position,
+                buffer.begin() + position + metadataLength);
             position += metadataLength;
 
             characteristics.Statistics.Op.IsActive = true;

--- a/source/adios2/toolkit/format/bp/BPSerializer.cpp
+++ b/source/adios2/toolkit/format/bp/BPSerializer.cpp
@@ -91,7 +91,7 @@ std::string BPSerializer::GetRankProfilingJSON(
     return rankLog;
 }
 
-std::vector<char>
+helper::adiosvec<char>
 BPSerializer::AggregateProfilingJSON(const std::string &rankLog) const
 {
     // Gather sizes
@@ -99,7 +99,7 @@ BPSerializer::AggregateProfilingJSON(const std::string &rankLog) const
     std::vector<size_t> rankLogsSizes = m_Comm.GatherValues(rankLogSize);
 
     // Gatherv JSON per rank
-    std::vector<char> profilingJSON(3);
+    helper::adiosvec<char> profilingJSON(3);
     const std::string header("[\n");
     const std::string footer("\n]\n");
     size_t gatheredSize = 0;
@@ -129,7 +129,7 @@ BPSerializer::AggregateProfilingJSON(const std::string &rankLog) const
 }
 
 void BPSerializer::PutNameRecord(const std::string name,
-                                 std::vector<char> &buffer) noexcept
+                                 helper::adiosvec<char> &buffer) noexcept
 {
     const uint16_t length = static_cast<uint16_t>(name.size());
     helper::InsertToBuffer(buffer, &length);
@@ -137,7 +137,7 @@ void BPSerializer::PutNameRecord(const std::string name,
 }
 
 void BPSerializer::PutNameRecord(const std::string name,
-                                 std::vector<char> &buffer,
+                                 helper::adiosvec<char> &buffer,
                                  size_t &position) noexcept
 {
     const uint16_t length = static_cast<uint16_t>(name.length());
@@ -148,7 +148,7 @@ void BPSerializer::PutNameRecord(const std::string name,
 void BPSerializer::PutDimensionsRecord(const Dims &localDimensions,
                                        const Dims &globalDimensions,
                                        const Dims &offsets,
-                                       std::vector<char> &buffer) noexcept
+                                       helper::adiosvec<char> &buffer) noexcept
 {
     if (offsets.empty())
     {
@@ -172,11 +172,11 @@ void BPSerializer::PutDimensionsRecord(const Dims &localDimensions,
 void BPSerializer::PutDimensionsRecord(const Dims &localDimensions,
                                        const Dims &globalDimensions,
                                        const Dims &offsets,
-                                       std::vector<char> &buffer,
+                                       helper::adiosvec<char> &buffer,
                                        size_t &position,
                                        const bool isCharacteristic) noexcept
 {
-    auto lf_CopyDimension = [](std::vector<char> &buffer, size_t &position,
+    auto lf_CopyDimension = [](helper::adiosvec<char> &buffer, size_t &position,
                                const size_t dimension,
                                const bool isCharacteristic) {
         if (!isCharacteristic)
@@ -222,11 +222,12 @@ void BPSerializer::PutDimensionsRecord(const Dims &localDimensions,
 void BPSerializer::PutMinifooter(const uint64_t pgIndexStart,
                                  const uint64_t variablesIndexStart,
                                  const uint64_t attributesIndexStart,
-                                 std::vector<char> &buffer, size_t &position,
-                                 const bool addSubfiles)
+                                 helper::adiosvec<char> &buffer,
+                                 size_t &position, const bool addSubfiles)
 {
     auto lf_CopyVersionChar = [](const std::string version,
-                                 std::vector<char> &buffer, size_t &position) {
+                                 helper::adiosvec<char> &buffer,
+                                 size_t &position) {
         helper::CopyToBuffer(buffer, position, version.c_str());
     };
 
@@ -361,7 +362,7 @@ void BPSerializer::MergeSerializeIndices(
         &nameRankIndices,
     helper::Comm const &comm, BufferSTL &bufferSTL)
 {
-    auto lf_GetCharacteristics = [&](const std::vector<char> &buffer,
+    auto lf_GetCharacteristics = [&](const helper::adiosvec<char> &buffer,
                                      size_t &position, const uint8_t dataType,
                                      uint8_t &count, uint32_t &length,
                                      uint32_t &timeStep)
@@ -581,7 +582,7 @@ void BPSerializer::MergeSerializeIndices(
         uint64_t setsCount = 0;
         unsigned int currentTimeStep = 1;
         bool marching = true;
-        std::vector<char> sorted;
+        helper::adiosvec<char> sorted;
 
         while (marching)
         {
@@ -848,7 +849,8 @@ BPSerializer::SerialElementIndex &BPSerializer::GetSerialElementIndex(
 
 #define declare_template_instantiation(T)                                      \
     template void BPSerializer::PutAttributeCharacteristicValueInIndex(        \
-        uint8_t &, const core::Attribute<T> &, std::vector<char> &) noexcept;  \
+        uint8_t &, const core::Attribute<T> &,                                 \
+        helper::adiosvec<char> &) noexcept;                                    \
                                                                                \
     template size_t BPSerializer::GetAttributeSizeInData(                      \
         const core::Attribute<T> &) const noexcept;                            \
@@ -864,15 +866,16 @@ ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #define declare_template_instantiation(T)                                      \
                                                                                \
     template void BPSerializer::PutCharacteristicRecord(                       \
-        const uint8_t, uint8_t &, const T &, std::vector<char> &) noexcept;    \
+        const uint8_t, uint8_t &, const T &,                                   \
+        helper::adiosvec<char> &) noexcept;                                    \
                                                                                \
     template void BPSerializer::PutCharacteristicRecord(                       \
-        const uint8_t, uint8_t &, const T &, std::vector<char> &,              \
+        const uint8_t, uint8_t &, const T &, helper::adiosvec<char> &,         \
         size_t &) noexcept;                                                    \
                                                                                \
     template void BPSerializer::PutCharacteristicOperation(                    \
         const core::Variable<T> &, const typename core::Variable<T>::BPInfo &, \
-        std::vector<char> &) noexcept;                                         \
+        helper::adiosvec<char> &) noexcept;                                    \
                                                                                \
     template void BPSerializer::PutOperationPayloadInBuffer(                   \
         const core::Variable<T> &,                                             \

--- a/source/adios2/toolkit/format/bp/BPSerializer.h
+++ b/source/adios2/toolkit/format/bp/BPSerializer.h
@@ -49,7 +49,8 @@ public:
      * @param rankProfilingJSON
      * @return profiling.json
      */
-    std::vector<char> AggregateProfilingJSON(const std::string &rankLog) const;
+    helper::adiosvec<char>
+    AggregateProfilingJSON(const std::string &rankLog) const;
 
     void UpdateOffsetsInMetadata();
 
@@ -62,21 +63,20 @@ protected:
     virtual void SerializeDataBuffer(core::IO &io) noexcept = 0;
 
     template <class T>
-    void
-    PutAttributeCharacteristicValueInIndex(uint8_t &characteristicsCounter,
-                                           const core::Attribute<T> &attribute,
-                                           std::vector<char> &buffer) noexcept;
+    void PutAttributeCharacteristicValueInIndex(
+        uint8_t &characteristicsCounter, const core::Attribute<T> &attribute,
+        helper::adiosvec<char> &buffer) noexcept;
 
     template <class T>
     void PutCharacteristicRecord(const uint8_t characteristicID,
                                  uint8_t &characteristicsCounter,
                                  const T &value,
-                                 std::vector<char> &buffer) noexcept;
+                                 helper::adiosvec<char> &buffer) noexcept;
 
     template <class T>
     void PutCharacteristicRecord(const uint8_t characteristicID,
                                  uint8_t &characteristicsCounter,
-                                 const T &value, std::vector<char> &buffer,
+                                 const T &value, helper::adiosvec<char> &buffer,
                                  size_t &position) noexcept;
 
     template <class T>
@@ -85,24 +85,24 @@ protected:
                             const bool sourceRowMajor) noexcept;
 
     void PutNameRecord(const std::string name,
-                       std::vector<char> &buffer) noexcept;
+                       helper::adiosvec<char> &buffer) noexcept;
 
-    void PutNameRecord(const std::string name, std::vector<char> &buffer,
+    void PutNameRecord(const std::string name, helper::adiosvec<char> &buffer,
                        size_t &position) noexcept;
 
     void PutDimensionsRecord(const Dims &localDimensions,
                              const Dims &globalDimensions, const Dims &offsets,
-                             std::vector<char> &buffer) noexcept;
+                             helper::adiosvec<char> &buffer) noexcept;
 
     void PutDimensionsRecord(const Dims &localDimensions,
                              const Dims &globalDimensions, const Dims &offsets,
-                             std::vector<char> &buffer, size_t &position,
+                             helper::adiosvec<char> &buffer, size_t &position,
                              const bool isCharacteristic = false) noexcept;
 
     void PutMinifooter(const uint64_t pgIndexStart,
                        const uint64_t variablesIndexStart,
                        const uint64_t attributesIndexStart,
-                       std::vector<char> &buffer, size_t &position,
+                       helper::adiosvec<char> &buffer, size_t &position,
                        const bool addSubfiles = false);
 
     void MergeSerializeIndices(
@@ -113,7 +113,7 @@ protected:
     template <class T>
     void UpdateIndexOffsetsCharacteristics(size_t &currentPosition,
                                            const DataTypes dataType,
-                                           std::vector<char> &buffer);
+                                           helper::adiosvec<char> &buffer);
 
     uint32_t GetFileIndex() const noexcept;
 
@@ -149,7 +149,7 @@ protected:
     void PutCharacteristicOperation(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::BPInfo &blockInfo,
-        std::vector<char> &buffer) noexcept;
+        helper::adiosvec<char> &buffer) noexcept;
 
     template <class T>
     void PutOperationPayloadInBuffer(

--- a/source/adios2/toolkit/format/bp/BPSerializer.inl
+++ b/source/adios2/toolkit/format/bp/BPSerializer.inl
@@ -23,7 +23,7 @@ template <>
 inline void BPSerializer::PutAttributeCharacteristicValueInIndex(
     uint8_t &characteristicsCounter,
     const core::Attribute<std::string> &attribute,
-    std::vector<char> &buffer) noexcept
+    helper::adiosvec<char> &buffer) noexcept
 {
     const uint8_t characteristicID =
         static_cast<uint8_t>(CharacteristicID::characteristic_value);

--- a/source/adios2/toolkit/format/bp/BPSerializer.tcc
+++ b/source/adios2/toolkit/format/bp/BPSerializer.tcc
@@ -21,7 +21,7 @@ namespace format
 template <class T>
 inline void BPSerializer::PutAttributeCharacteristicValueInIndex(
     uint8_t &characteristicsCounter, const core::Attribute<T> &attribute,
-    std::vector<char> &buffer) noexcept
+    helper::adiosvec<char> &buffer) noexcept
 {
     const uint8_t characteristicID = CharacteristicID::characteristic_value;
 
@@ -40,10 +40,9 @@ inline void BPSerializer::PutAttributeCharacteristicValueInIndex(
 }
 
 template <class T>
-void BPSerializer::PutCharacteristicRecord(const uint8_t characteristicID,
-                                           uint8_t &characteristicsCounter,
-                                           const T &value,
-                                           std::vector<char> &buffer) noexcept
+void BPSerializer::PutCharacteristicRecord(
+    const uint8_t characteristicID, uint8_t &characteristicsCounter,
+    const T &value, helper::adiosvec<char> &buffer) noexcept
 {
     const uint8_t id = characteristicID;
     helper::InsertToBuffer(buffer, &id);
@@ -55,7 +54,7 @@ template <class T>
 void BPSerializer::PutCharacteristicRecord(const uint8_t characteristicID,
                                            uint8_t &characteristicsCounter,
                                            const T &value,
-                                           std::vector<char> &buffer,
+                                           helper::adiosvec<char> &buffer,
                                            size_t &position) noexcept
 {
     const uint8_t id = characteristicID;
@@ -105,9 +104,9 @@ inline void BPSerializer::PutPayloadInBuffer(
 
 // PRIVATE
 template <class T>
-void BPSerializer::UpdateIndexOffsetsCharacteristics(size_t &currentPosition,
-                                                     const DataTypes dataType,
-                                                     std::vector<char> &buffer)
+void BPSerializer::UpdateIndexOffsetsCharacteristics(
+    size_t &currentPosition, const DataTypes dataType,
+    helper::adiosvec<char> &buffer)
 {
     const bool isLittleEndian = helper::IsLittleEndian();
 
@@ -366,7 +365,7 @@ template <class T>
 void BPSerializer::PutCharacteristicOperation(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::BPInfo &blockInfo,
-    std::vector<char> &buffer) noexcept
+    helper::adiosvec<char> &buffer) noexcept
 {
     const std::string type = blockInfo.Operations[0]->m_TypeString;
     const uint8_t typeLength = static_cast<uint8_t>(type.size());

--- a/source/adios2/toolkit/format/bp/bp3/BP3Base.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Base.cpp
@@ -118,7 +118,7 @@ size_t BP3Base::GetBPIndexSizeInData(const std::string &variableName,
 
 // PROTECTED
 BP3Base::ElementIndexHeader
-BP3Base::ReadElementIndexHeader(const std::vector<char> &buffer,
+BP3Base::ReadElementIndexHeader(const helper::adiosvec<char> &buffer,
                                 size_t &position,
                                 const bool isLittleEndian) const noexcept
 {

--- a/source/adios2/toolkit/format/bp/bp3/BP3Base.h
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Base.h
@@ -94,10 +94,9 @@ public:
                                 const Dims &count) const noexcept;
 
 protected:
-    ElementIndexHeader
-    ReadElementIndexHeader(const std::vector<char> &buffer, size_t &position,
-                           const bool isLittleEndian = true) const
-        noexcept final;
+    ElementIndexHeader ReadElementIndexHeader(
+        const helper::adiosvec<char> &buffer, size_t &position,
+        const bool isLittleEndian = true) const noexcept final;
 
 private:
     std::string GetBPSubStreamName(const std::string &name, const size_t id,

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
@@ -190,7 +190,7 @@ void BP3Deserializer::ParseVariablesIndex(const BufferSTL &bufferSTL,
                                           core::Engine &engine)
 {
     auto lf_ReadElementIndex = [&](core::Engine &engine,
-                                   const std::vector<char> &buffer,
+                                   const helper::adiosvec<char> &buffer,
                                    size_t position) {
         const ElementIndexHeader header = ReadElementIndexHeader(
             buffer, position, m_Minifooter.IsLittleEndian);
@@ -290,7 +290,7 @@ void BP3Deserializer::ParseAttributesIndex(const BufferSTL &bufferSTL,
                                            core::Engine &engine)
 {
     auto lf_ReadElementIndex = [&](core::Engine &engine,
-                                   const std::vector<char> &buffer,
+                                   const helper::adiosvec<char> &buffer,
                                    size_t position) {
         const ElementIndexHeader header = ReadElementIndexHeader(
             buffer, position, m_Minifooter.IsLittleEndian);
@@ -377,7 +377,7 @@ BP3Deserializer::PerformGetsVariablesSubFileInfo(core::IO &io)
 }
 
 void BP3Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
-                                 const std::vector<char> &contiguousMemory,
+                                 const helper::adiosvec<char> &contiguousMemory,
                                  const Box<Dims> &blockBox,
                                  const Box<Dims> &intersectionBox) const
 {
@@ -413,7 +413,7 @@ void BP3Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
         core::Variable<T> &, typename core::Variable<T>::BPInfo &) const;      \
                                                                                \
     template void BP3Deserializer::ClipContiguousMemory<T>(                    \
-        typename core::Variable<T>::BPInfo &, const std::vector<char> &,       \
+        typename core::Variable<T>::BPInfo &, const helper::adiosvec<char> &,  \
         const Box<Dims> &, const Box<Dims> &) const;                           \
                                                                                \
     template void BP3Deserializer::GetValueFromMetadata(                       \

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.h
@@ -114,7 +114,7 @@ public:
      */
     template <class T>
     void ClipContiguousMemory(typename core::Variable<T>::BPInfo &blockInfo,
-                              const std::vector<char> &contiguousMemory,
+                              const helper::adiosvec<char> &contiguousMemory,
                               const Box<Dims> &blockBox,
                               const Box<Dims> &intersectionBox) const;
 
@@ -158,7 +158,7 @@ public:
 
     // TODO : will deprecate
     void ClipMemory(const std::string &variableName, core::IO &io,
-                    const std::vector<char> &contiguousMemory,
+                    const helper::adiosvec<char> &contiguousMemory,
                     const Box<Dims> &blockBox,
                     const Box<Dims> &intersectionBox) const;
 
@@ -195,13 +195,13 @@ private:
     template <class T>
     void DefineVariableInEngineIO(const ElementIndexHeader &header,
                                   core::Engine &engine,
-                                  const std::vector<char> &buffer,
+                                  const helper::adiosvec<char> &buffer,
                                   size_t position) const;
 
     template <class T>
     void DefineAttributeInEngineIO(const ElementIndexHeader &header,
                                    core::Engine &engine,
-                                   const std::vector<char> &buffer,
+                                   const helper::adiosvec<char> &buffer,
                                    size_t position) const;
 
     template <class T>

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
@@ -168,7 +168,7 @@ void BP3Deserializer::SetVariableBlockInfo(
             const bool isRowMajor)
 
     {
-        const std::vector<char> &buffer = bufferSTL.m_Buffer;
+        const helper::adiosvec<char> &buffer = bufferSTL.m_Buffer;
 
         size_t position = blockIndexOffset;
 
@@ -286,7 +286,7 @@ void BP3Deserializer::SetVariableBlockInfo(
             const bool isRowMajor)
 
     {
-        const std::vector<char> &buffer = bufferSTL.m_Buffer;
+        const helper::adiosvec<char> &buffer = bufferSTL.m_Buffer;
 
         size_t position = blockIndexOffset;
 
@@ -665,7 +665,7 @@ BP3Deserializer::BlocksInfo(const core::Variable<T> &variable,
 template <class T>
 void BP3Deserializer::ClipContiguousMemory(
     typename core::Variable<T>::BPInfo &blockInfo,
-    const std::vector<char> &contiguousMemory, const Box<Dims> &blockBox,
+    const helper::adiosvec<char> &contiguousMemory, const Box<Dims> &blockBox,
     const Box<Dims> &intersectionBox) const
 {
     helper::ClipContiguousMemory(
@@ -677,7 +677,7 @@ void BP3Deserializer::ClipContiguousMemory(
 template <>
 inline void BP3Deserializer::DefineVariableInEngineIO<std::string>(
     const ElementIndexHeader &header, core::Engine &engine,
-    const std::vector<char> &buffer, size_t position) const
+    const helper::adiosvec<char> &buffer, size_t position) const
 {
     const size_t initialPosition = position;
 
@@ -782,10 +782,9 @@ inline void BP3Deserializer::DefineVariableInEngineIO<std::string>(
 }
 
 template <class T>
-void BP3Deserializer::DefineVariableInEngineIO(const ElementIndexHeader &header,
-                                               core::Engine &engine,
-                                               const std::vector<char> &buffer,
-                                               size_t position) const
+void BP3Deserializer::DefineVariableInEngineIO(
+    const ElementIndexHeader &header, core::Engine &engine,
+    const helper::adiosvec<char> &buffer, size_t position) const
 {
     const size_t initialPosition = position;
 
@@ -960,7 +959,7 @@ void BP3Deserializer::DefineVariableInEngineIO(const ElementIndexHeader &header,
 template <class T>
 void BP3Deserializer::DefineAttributeInEngineIO(
     const ElementIndexHeader &header, core::Engine &engine,
-    const std::vector<char> &buffer, size_t position) const
+    const helper::adiosvec<char> &buffer, size_t position) const
 {
     const Characteristics<T> characteristics =
         ReadElementIndexCharacteristics<T>(

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.cpp
@@ -38,9 +38,9 @@ void BP3Serializer::PutProcessGroupIndex(
     const std::vector<std::string> &transportsTypes) noexcept
 {
     m_Profiler.Start("buffering");
-    std::vector<char> &metadataBuffer = m_MetadataSet.PGIndex.Buffer;
+    helper::adiosvec<char> &metadataBuffer = m_MetadataSet.PGIndex.Buffer;
 
-    std::vector<char> &dataBuffer = m_Data.m_Buffer;
+    helper::adiosvec<char> &dataBuffer = m_Data.m_Buffer;
     size_t &dataPosition = m_Data.m_Position;
 
     m_MetadataSet.DataPGLengthPosition = dataPosition;
@@ -293,7 +293,7 @@ void BP3Serializer::SerializeMetadataInData(const bool updateAbsolutePosition,
     auto lf_FlattenIndices =
         [](const uint32_t count, const uint64_t length,
            const std::unordered_map<std::string, SerialElementIndex> &indices,
-           std::vector<char> &buffer, size_t &position) {
+           helper::adiosvec<char> &buffer, size_t &position) {
             helper::CopyToBuffer(buffer, position, &count);
             helper::CopyToBuffer(buffer, position, &length);
 
@@ -470,7 +470,7 @@ BP3Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
     auto lf_DeserializeIndices =
         [&](std::unordered_map<std::string, std::vector<SerialElementIndex>>
                 &deserialized,
-            const int rankSource, const std::vector<char> &serialized,
+            const int rankSource, const helper::adiosvec<char> &serialized,
             const size_t position, const size_t endPosition,
             const bool isRankConstant)
 
@@ -526,7 +526,7 @@ BP3Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
 
     auto lf_DeserializeAllIndices =
         [&](const int rankSource, const std::vector<size_t> headerInfo,
-            const std::vector<char> &serialized, const size_t position)
+            const helper::adiosvec<char> &serialized, const size_t position)
 
     {
         PERFSTUBS_SCOPED_TIMER_FUNC();
@@ -616,7 +616,7 @@ BP3Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
     {
         PERFSTUBS_SCOPED_TIMER_FUNC();
         const size_t serializedSize = bufferSTL.m_Position;
-        const std::vector<char> &serialized = bufferSTL.m_Buffer;
+        const helper::adiosvec<char> &serialized = bufferSTL.m_Buffer;
         size_t serializedPosition = 0;
         std::vector<size_t> headerInfo(4);
         const bool isLittleEndian = helper::IsLittleEndian();

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.h
@@ -118,11 +118,11 @@ public:
                                      const bool inMetadataBuffer);
 
 private:
-    std::vector<char> m_SerializedIndices;
-    std::vector<char> m_GatheredSerializedIndices;
+    helper::adiosvec<char> m_SerializedIndices;
+    helper::adiosvec<char> m_GatheredSerializedIndices;
 
     /** aggregate pg rank indices */
-    std::vector<char> m_PGRankIndices;
+    helper::adiosvec<char> m_PGRankIndices;
     /** deserialized variable indices per rank (vector index) */
     std::unordered_map<std::string, std::vector<BPBase::SerialElementIndex>>
         m_VariableRankIndices;
@@ -193,27 +193,28 @@ private:
     void PutVariableCharacteristics(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::BPInfo &blockInfo,
-        const Stats<T> &stats, std::vector<char> &buffer,
+        const Stats<T> &stats, helper::adiosvec<char> &buffer,
         typename core::Variable<T>::Span *span) noexcept;
 
     template <class T>
     void PutVariableCharacteristics(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::BPInfo &blockInfo,
-        const Stats<T> &stats, std::vector<char> &buffer,
+        const Stats<T> &stats, helper::adiosvec<char> &buffer,
         size_t &position) noexcept;
 
     /** Writes min max */
     template <class T>
     void PutBoundsRecord(const bool singleValue, const Stats<T> &stats,
                          uint8_t &characteristicsCounter,
-                         std::vector<char> &buffer) noexcept;
+                         helper::adiosvec<char> &buffer) noexcept;
 
     /** Overloaded version for data buffer */
     template <class T>
     void PutBoundsRecord(const bool singleValue, const Stats<T> &stats,
                          uint8_t &characteristicsCounter,
-                         std::vector<char> &buffer, size_t &position) noexcept;
+                         helper::adiosvec<char> &buffer,
+                         size_t &position) noexcept;
 
     /**
      * Wraps up the data buffer serialization in m_HeapBuffer and fills the pg

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.tcc
@@ -492,7 +492,7 @@ template <class T>
 void BP3Serializer::PutBoundsRecord(const bool singleValue,
                                     const Stats<T> &stats,
                                     uint8_t &characteristicsCounter,
-                                    std::vector<char> &buffer) noexcept
+                                    helper::adiosvec<char> &buffer) noexcept
 {
     if (singleValue)
     {
@@ -515,7 +515,7 @@ template <class T>
 void BP3Serializer::PutBoundsRecord(const bool singleValue,
                                     const Stats<T> &stats,
                                     uint8_t &characteristicsCounter,
-                                    std::vector<char> &buffer,
+                                    helper::adiosvec<char> &buffer,
                                     size_t &position) noexcept
 {
     if (singleValue)
@@ -545,7 +545,7 @@ template <>
 inline void BP3Serializer::PutVariableCharacteristics(
     const core::Variable<std::string> &variable,
     const core::Variable<std::string>::BPInfo &blockInfo,
-    const Stats<std::string> &stats, std::vector<char> &buffer,
+    const Stats<std::string> &stats, helper::adiosvec<char> &buffer,
     typename core::Variable<std::string>::Span * /*span*/) noexcept
 {
     const size_t characteristicsCountPosition = buffer.size();
@@ -600,7 +600,8 @@ template <class T>
 void BP3Serializer::PutVariableCharacteristics(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::BPInfo &blockInfo, const Stats<T> &stats,
-    std::vector<char> &buffer, typename core::Variable<T>::Span *span) noexcept
+    helper::adiosvec<char> &buffer,
+    typename core::Variable<T>::Span *span) noexcept
 {
     // going back at the end
     const size_t characteristicsCountPosition = buffer.size();
@@ -680,7 +681,7 @@ template <class T>
 void BP3Serializer::PutVariableCharacteristics(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::BPInfo &blockInfo, const Stats<T> &stats,
-    std::vector<char> &buffer, size_t &position) noexcept
+    helper::adiosvec<char> &buffer, size_t &position) noexcept
 {
     // going back at the end
     const size_t characteristicsCountPosition = position;

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
@@ -194,7 +194,7 @@ size_t BP4Base::GetBPIndexSizeInData(const std::string &variableName,
 
 // PROTECTED
 BP4Base::ElementIndexHeader
-BP4Base::ReadElementIndexHeader(const std::vector<char> &buffer,
+BP4Base::ReadElementIndexHeader(const helper::adiosvec<char> &buffer,
                                 size_t &position,
                                 const bool isLittleEndian) const noexcept
 {

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.h
@@ -138,10 +138,9 @@ protected:
      */
     size_t m_LastVarLengthPosInBuffer = 0;
 
-    ElementIndexHeader
-    ReadElementIndexHeader(const std::vector<char> &buffer, size_t &position,
-                           const bool isLittleEndian = true) const
-        noexcept final;
+    ElementIndexHeader ReadElementIndexHeader(
+        const helper::adiosvec<char> &buffer, size_t &position,
+        const bool isLittleEndian = true) const noexcept final;
 
 private:
     std::string GetBPSubStreamName(const std::string &name, const size_t id,

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
@@ -317,7 +317,7 @@ void BP4Deserializer::ParseVariablesIndexPerStep(const BufferSTL &bufferSTL,
                                                  size_t step)
 {
     auto lf_ReadElementIndexPerStep = [&](core::Engine &engine,
-                                          const std::vector<char> &buffer,
+                                          const helper::adiosvec<char> &buffer,
                                           size_t position, size_t step) {
         const ElementIndexHeader header = ReadElementIndexHeader(
             buffer, position, m_Minifooter.IsLittleEndian);
@@ -504,7 +504,7 @@ void BP4Deserializer::ParseAttributesIndexPerStep(const BufferSTL &bufferSTL,
                                                   size_t step)
 {
     auto lf_ReadElementIndex = [&](core::Engine &engine,
-                                   const std::vector<char> &buffer,
+                                   const helper::adiosvec<char> &buffer,
                                    size_t position) {
         const ElementIndexHeader header = ReadElementIndexHeader(
             buffer, position, m_Minifooter.IsLittleEndian);
@@ -630,7 +630,7 @@ BP4Deserializer::PerformGetsVariablesSubFileInfo(core::IO &io)
 }
 
 void BP4Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
-                                 const std::vector<char> &contiguousMemory,
+                                 const helper::adiosvec<char> &contiguousMemory,
                                  const Box<Dims> &blockBox,
                                  const Box<Dims> &intersectionBox) const
 {
@@ -655,7 +655,7 @@ void BP4Deserializer::ClipMemory(const std::string &variableName, core::IO &io,
 #undef declare_type
 }
 
-bool BP4Deserializer::ReadActiveFlag(std::vector<char> &buffer)
+bool BP4Deserializer::ReadActiveFlag(helper::adiosvec<char> &buffer)
 {
     if (buffer.size() < m_ActiveFlagPosition)
     {
@@ -682,7 +682,7 @@ bool BP4Deserializer::ReadActiveFlag(std::vector<char> &buffer)
         core::Variable<T> &, typename core::Variable<T>::BPInfo &) const;      \
                                                                                \
     template void BP4Deserializer::ClipContiguousMemory<T>(                    \
-        typename core::Variable<T>::BPInfo &, const std::vector<char> &,       \
+        typename core::Variable<T>::BPInfo &, const helper::adiosvec<char> &,  \
         const Box<Dims> &, const Box<Dims> &) const;                           \
                                                                                \
     template void BP4Deserializer::GetValueFromMetadata(                       \

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
@@ -129,7 +129,7 @@ public:
      */
     template <class T>
     void ClipContiguousMemory(typename core::Variable<T>::BPInfo &blockInfo,
-                              const std::vector<char> &contiguousMemory,
+                              const helper::adiosvec<char> &contiguousMemory,
                               const Box<Dims> &blockBox,
                               const Box<Dims> &intersectionBox) const;
 
@@ -173,11 +173,11 @@ public:
 
     // TODO : will deprecate
     void ClipMemory(const std::string &variableName, core::IO &io,
-                    const std::vector<char> &contiguousMemory,
+                    const helper::adiosvec<char> &contiguousMemory,
                     const Box<Dims> &blockBox,
                     const Box<Dims> &intersectionBox) const;
 
-    bool ReadActiveFlag(std::vector<char> &buffer);
+    bool ReadActiveFlag(helper::adiosvec<char> &buffer);
 
     // TODO: will deprecate
     bool m_PerformedGets = false;
@@ -216,13 +216,13 @@ private:
     template <class T>
     void DefineVariableInEngineIOPerStep(const ElementIndexHeader &header,
                                          core::Engine &engine,
-                                         const std::vector<char> &buffer,
+                                         const helper::adiosvec<char> &buffer,
                                          size_t position, size_t step) const;
 
     template <class T>
     void DefineAttributeInEngineIO(const ElementIndexHeader &header,
                                    core::Engine &engine,
-                                   const std::vector<char> &buffer,
+                                   const helper::adiosvec<char> &buffer,
                                    size_t position) const;
 
     template <class T>

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -171,7 +171,7 @@ void BP4Deserializer::SetVariableBlockInfo(
             const bool isRowMajor)
 
     {
-        const std::vector<char> &buffer = bufferSTL.m_Buffer;
+        const helper::adiosvec<char> &buffer = bufferSTL.m_Buffer;
 
         size_t position = blockIndexOffset;
 
@@ -289,7 +289,7 @@ void BP4Deserializer::SetVariableBlockInfo(
             const bool isRowMajor)
 
     {
-        const std::vector<char> &buffer = bufferSTL.m_Buffer;
+        const helper::adiosvec<char> &buffer = bufferSTL.m_Buffer;
 
         size_t position = blockIndexOffset;
 
@@ -625,7 +625,7 @@ BP4Deserializer::BlocksInfo(const core::Variable<T> &variable,
 template <class T>
 void BP4Deserializer::ClipContiguousMemory(
     typename core::Variable<T>::BPInfo &blockInfo,
-    const std::vector<char> &contiguousMemory, const Box<Dims> &blockBox,
+    const helper::adiosvec<char> &contiguousMemory, const Box<Dims> &blockBox,
     const Box<Dims> &intersectionBox) const
 {
     helper::ClipContiguousMemory(
@@ -638,7 +638,7 @@ void BP4Deserializer::ClipContiguousMemory(
 template <>
 inline void BP4Deserializer::DefineVariableInEngineIOPerStep<std::string>(
     const ElementIndexHeader &header, core::Engine &engine,
-    const std::vector<char> &buffer, size_t position, size_t step) const
+    const helper::adiosvec<char> &buffer, size_t position, size_t step) const
 {
     const size_t initialPosition = position;
 
@@ -790,7 +790,7 @@ inline void BP4Deserializer::DefineVariableInEngineIOPerStep<std::string>(
 template <class T>
 void BP4Deserializer::DefineVariableInEngineIOPerStep(
     const ElementIndexHeader &header, core::Engine &engine,
-    const std::vector<char> &buffer, size_t position, size_t step) const
+    const helper::adiosvec<char> &buffer, size_t position, size_t step) const
 {
     const size_t initialPosition = position;
 
@@ -1043,7 +1043,7 @@ void BP4Deserializer::DefineVariableInEngineIOPerStep(
 template <class T>
 void BP4Deserializer::DefineAttributeInEngineIO(
     const ElementIndexHeader &header, core::Engine &engine,
-    const std::vector<char> &buffer, size_t position) const
+    const helper::adiosvec<char> &buffer, size_t position) const
 {
     const Characteristics<T> characteristics =
         ReadElementIndexCharacteristics<T>(

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
@@ -40,7 +40,8 @@ void BP4Serializer::MakeHeader(BufferSTL &b, const std::string fileType,
                                const bool isActive)
 {
     auto lf_CopyVersionChar = [](const std::string version,
-                                 std::vector<char> &buffer, size_t &position) {
+                                 helper::adiosvec<char> &buffer,
+                                 size_t &position) {
         helper::CopyToBuffer(buffer, position, version.c_str());
     };
 
@@ -154,9 +155,9 @@ void BP4Serializer::PutProcessGroupIndex(
     const std::vector<std::string> &transportsTypes) noexcept
 {
     m_Profiler.Start("buffering");
-    std::vector<char> &metadataBuffer = m_MetadataSet.PGIndex.Buffer;
+    helper::adiosvec<char> &metadataBuffer = m_MetadataSet.PGIndex.Buffer;
 
-    std::vector<char> &dataBuffer = m_Data.m_Buffer;
+    helper::adiosvec<char> &dataBuffer = m_Data.m_Buffer;
     size_t &dataPosition = m_Data.m_Position;
     const size_t pgBeginPosition = dataPosition;
 
@@ -439,7 +440,7 @@ void BP4Serializer::SerializeMetadataInData(const bool updateAbsolutePosition,
     auto lf_FlattenIndices =
         [](const uint32_t count, const uint64_t length,
            const std::unordered_map<std::string, SerialElementIndex> &indices,
-           std::vector<char> &buffer, size_t &position) {
+           helper::adiosvec<char> &buffer, size_t &position) {
             helper::CopyToBuffer(buffer, position, &count);
             helper::CopyToBuffer(buffer, position, &length);
 
@@ -611,7 +612,7 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
         [&](std::unordered_map<size_t,
                                std::vector<std::tuple<size_t, size_t, size_t>>>
                 &pgIndicesInfo,
-            const int rankSource, const std::vector<char> &serialized,
+            const int rankSource, const helper::adiosvec<char> &serialized,
             const size_t position, const size_t endPosition) {
             size_t stepStartPosition = position;
             size_t stepBuffersize = 0;
@@ -694,7 +695,7 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
             }
         };
 
-    auto lf_GetCharacteristics = [&](const std::vector<char> &buffer,
+    auto lf_GetCharacteristics = [&](const helper::adiosvec<char> &buffer,
                                      size_t &position, const uint8_t dataType,
                                      uint8_t &count, uint32_t &length,
                                      uint32_t &timeStep)
@@ -746,7 +747,7 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
                 std::unordered_map<std::string,
                                    std::vector<std::tuple<size_t, size_t>>>>
                 &indicesInfo,
-            const int rankSource, const std::vector<char> &serialized,
+            const int rankSource, const helper::adiosvec<char> &serialized,
             const size_t position, const size_t endPosition)
 
     {
@@ -820,7 +821,7 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
                 std::unordered_map<std::string,
                                    std::vector<std::tuple<size_t, size_t>>>>
                 &indicesInfo,
-            const int rankSource, const std::vector<char> &serialized,
+            const int rankSource, const helper::adiosvec<char> &serialized,
             const size_t position, const size_t endPosition)
 
     {
@@ -889,7 +890,7 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
 
     auto lf_LocateAllIndices =
         [&](const int rankSource, const std::vector<size_t> headerInfo,
-            const std::vector<char> &serialized, const size_t position)
+            const helper::adiosvec<char> &serialized, const size_t position)
 
     {
         const size_t rankIndicesSize = headerInfo[0];
@@ -931,7 +932,7 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
                 std::unordered_map<std::string,
                                    std::vector<std::tuple<size_t, size_t>>>>
                 &attrIndicesInfo,
-            const std::vector<char> &serialized) {
+            const helper::adiosvec<char> &serialized) {
             auto &position = outBufferSTL.m_Position;
             auto &buffer = outBufferSTL.m_Buffer;
 
@@ -1098,7 +1099,7 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
     if (rank == 0)
     {
         const size_t serializedSize = inBufferSTL.m_Position;
-        const std::vector<char> &serialized = inBufferSTL.m_Buffer;
+        const helper::adiosvec<char> &serialized = inBufferSTL.m_Buffer;
         size_t serializedPosition = 0;
         std::vector<size_t> headerInfo(4);
         const bool isLittleEndian = helper::IsLittleEndian();
@@ -1126,7 +1127,7 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
     if (rank == 0)
     {
         auto &buffer = outBufferSTL.m_Buffer;
-        const std::vector<char> &serialized = inBufferSTL.m_Buffer;
+        const helper::adiosvec<char> &serialized = inBufferSTL.m_Buffer;
 
         size_t totalStep = m_PGIndicesInfo.size();
         size_t perStepExtraSize = 16 + 12 + 12;

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.h
@@ -137,8 +137,8 @@ public:
                                      const bool inMetadataBuffer);
 
 private:
-    std::vector<char> m_SerializedIndices;
-    std::vector<char> m_GatheredSerializedIndices;
+    helper::adiosvec<char> m_SerializedIndices;
+    helper::adiosvec<char> m_GatheredSerializedIndices;
 
     /** aggregate pg rank indices */
     std::unordered_map<size_t, std::vector<std::tuple<size_t, size_t, size_t>>>
@@ -222,27 +222,28 @@ private:
     void PutVariableCharacteristics(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::BPInfo &blockInfo,
-        const Stats<T> &stats, std::vector<char> &buffer,
+        const Stats<T> &stats, helper::adiosvec<char> &buffer,
         typename core::Variable<T>::Span *span) noexcept;
 
     template <class T>
     void PutVariableCharacteristicsInData(
         const core::Variable<T> &variable,
         const typename core::Variable<T>::BPInfo &blockInfo,
-        const Stats<T> &stats, std::vector<char> &buffer,
+        const Stats<T> &stats, helper::adiosvec<char> &buffer,
         size_t &position) noexcept;
 
     /** Writes min max */
     template <class T>
     void PutBoundsRecord(const bool singleValue, const Stats<T> &stats,
                          uint8_t &characteristicsCounter,
-                         std::vector<char> &buffer) noexcept;
+                         helper::adiosvec<char> &buffer) noexcept;
 
     /** Overloaded version for data buffer */
     template <class T>
     void PutBoundsRecord(const bool singleValue, const Stats<T> &stats,
                          uint8_t &characteristicsCounter,
-                         std::vector<char> &buffer, size_t &position) noexcept;
+                         helper::adiosvec<char> &buffer,
+                         size_t &position) noexcept;
 
     /**
      * Wraps up the data buffer serialization in m_HeapBuffer and fills the pg

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
@@ -602,7 +602,7 @@ template <class T>
 void BP4Serializer::PutBoundsRecord(const bool singleValue,
                                     const Stats<T> &stats,
                                     uint8_t &characteristicsCounter,
-                                    std::vector<char> &buffer) noexcept
+                                    helper::adiosvec<char> &buffer) noexcept
 {
     if (singleValue)
     {
@@ -653,7 +653,7 @@ template <class T>
 void BP4Serializer::PutBoundsRecord(const bool singleValue,
                                     const Stats<T> &stats,
                                     uint8_t &characteristicsCounter,
-                                    std::vector<char> &buffer,
+                                    helper::adiosvec<char> &buffer,
                                     size_t &position) noexcept
 {
     if (singleValue)
@@ -705,7 +705,7 @@ template <>
 inline void BP4Serializer::PutVariableCharacteristics(
     const core::Variable<std::string> &variable,
     const core::Variable<std::string>::BPInfo &blockInfo,
-    const Stats<std::string> &stats, std::vector<char> &buffer,
+    const Stats<std::string> &stats, helper::adiosvec<char> &buffer,
     typename core::Variable<std::string>::Span * /*span*/) noexcept
 {
     const size_t characteristicsCountPosition = buffer.size();
@@ -760,7 +760,8 @@ template <class T>
 void BP4Serializer::PutVariableCharacteristics(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::BPInfo &blockInfo, const Stats<T> &stats,
-    std::vector<char> &buffer, typename core::Variable<T>::Span *span) noexcept
+    helper::adiosvec<char> &buffer,
+    typename core::Variable<T>::Span *span) noexcept
 {
     // going back at the end
     const size_t characteristicsCountPosition = buffer.size();
@@ -844,7 +845,7 @@ template <class T>
 void BP4Serializer::PutVariableCharacteristicsInData(
     const core::Variable<T> &variable,
     const typename core::Variable<T>::BPInfo &blockInfo, const Stats<T> &stats,
-    std::vector<char> &buffer, size_t &position) noexcept
+    helper::adiosvec<char> &buffer, size_t &position) noexcept
 {
     // going back at the end
     const size_t characteristicsCountPosition = position;

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -1021,13 +1021,13 @@ BP5Serializer::TimestepInfo BP5Serializer::CloseTimestep(int timestep,
     return Ret;
 }
 
-std::vector<char> BP5Serializer::CopyMetadataToContiguous(
+helper::adiosvec<char> BP5Serializer::CopyMetadataToContiguous(
     const std::vector<BP5Base::MetaMetaInfoBlock> NewMetaMetaBlocks,
     const format::Buffer *MetaEncodeBuffer,
     const format::Buffer *AttributeEncodeBuffer, uint64_t DataSize,
     uint64_t WriterDataPos) const
 {
-    std::vector<char> Ret;
+    helper::adiosvec<char> Ret;
     uint64_t RetSize = 0;
     size_t Position = 0;
     size_t MetadataEncodeBufferAlignedSize =
@@ -1100,7 +1100,7 @@ std::vector<char> BP5Serializer::CopyMetadataToContiguous(
 }
 
 std::vector<core::iovec> BP5Serializer::BreakoutContiguousMetadata(
-    std::vector<char> *Aggregate, const std::vector<size_t> Counts,
+    helper::adiosvec<char> *Aggregate, const std::vector<size_t> Counts,
     std::vector<MetaMetaInfoBlock> &UniqueMetaMetaBlocks,
     std::vector<core::iovec> &AttributeBlocks, std::vector<uint64_t> &DataSizes,
     std::vector<uint64_t> &WriterDataPositions) const

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.h
@@ -89,14 +89,14 @@ public:
 
     core::Engine *m_Engine = NULL;
 
-    std::vector<char> CopyMetadataToContiguous(
+    helper::adiosvec<char> CopyMetadataToContiguous(
         const std::vector<MetaMetaInfoBlock> NewmetaMetaBlocks,
         const format::Buffer *MetaEncodeBuffer,
         const format::Buffer *AttributeEncodeBuffer, uint64_t DataSize,
         uint64_t WriterDataPos) const;
 
     std::vector<core::iovec> BreakoutContiguousMetadata(
-        std::vector<char> *Aggregate, const std::vector<size_t> Counts,
+        helper::adiosvec<char> *Aggregate, const std::vector<size_t> Counts,
         std::vector<MetaMetaInfoBlock> &UniqueMetaMetaBlocks,
         std::vector<core::iovec> &AttributeBlocks,
         std::vector<uint64_t> &DataSizes,

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.cpp
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.cpp
@@ -32,8 +32,7 @@ void BufferSTL::Resize(const size_t size, const std::string hint)
         // doing this will effectively replace the STL GNU default power of 2
         // reallocation.
         m_Buffer.reserve(size);
-        // must initialize memory (secure)
-        m_Buffer.resize(size, '\0');
+        m_Buffer.resize(size);
     }
     catch (...)
     {
@@ -87,7 +86,7 @@ size_t BufferSTL::GetAvailableSize() const
 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
 
-void BufferSTL::Delete() { std::vector<char>().swap(m_Buffer); }
+void BufferSTL::Delete() { helper::adiosvec<char>().swap(m_Buffer); }
 
 size_t BufferSTL::DebugGetSize() const { return m_Buffer.size(); };
 

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.h
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.h
@@ -14,6 +14,7 @@
 #include "adios2/toolkit/format/buffer/Buffer.h"
 
 #include "adios2/common/ADIOSMacros.h"
+#include "adios2/helper/adiosType.h"
 
 namespace adios2
 {
@@ -23,7 +24,7 @@ namespace format
 class BufferSTL : public Buffer
 {
 public:
-    std::vector<char> m_Buffer;
+    helper::adiosvec<char> m_Buffer;
 
     BufferSTL();
     ~BufferSTL() = default;

--- a/source/adios2/toolkit/profiling/iochrono/IOChrono.cpp
+++ b/source/adios2/toolkit/profiling/iochrono/IOChrono.cpp
@@ -109,7 +109,7 @@ std::string JSONProfiler::GetRankProfilingJSON(
     return rankLog;
 }
 
-std::vector<char>
+helper::adiosvec<char>
 JSONProfiler::AggregateProfilingJSON(const std::string &rankLog) const
 {
     // Gather sizes
@@ -117,7 +117,7 @@ JSONProfiler::AggregateProfilingJSON(const std::string &rankLog) const
     std::vector<size_t> rankLogsSizes = m_Comm.GatherValues(rankLogSize);
 
     // Gatherv JSON per rank
-    std::vector<char> profilingJSON(3);
+    helper::adiosvec<char> profilingJSON(3);
     const std::string header("[\n");
     const std::string footer("\n]\n");
     size_t gatheredSize = 0;

--- a/source/adios2/toolkit/profiling/iochrono/IOChrono.h
+++ b/source/adios2/toolkit/profiling/iochrono/IOChrono.h
@@ -74,7 +74,8 @@ public:
                          const std::vector<adios2::profiling::IOChrono *>
                              &transportsProfilers) noexcept;
 
-    std::vector<char> AggregateProfilingJSON(const std::string &rankLog) const;
+    helper::adiosvec<char>
+    AggregateProfilingJSON(const std::string &rankLog) const;
 
 private:
     IOChrono m_Profiler;

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -31,6 +31,7 @@
 #include <errno.h>
 
 #include "adios2/helper/adiosLog.h"
+#include "adios2/helper/adiosType.h"
 
 #if defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
@@ -268,7 +269,7 @@ bool introspectAsHDF5File(std::ifstream &f, const std::string &name) noexcept
 bool introspectAsBPFile(std::ifstream &f, const std::string &name) noexcept
 {
     const int MFOOTERSIZE = 56;
-    std::vector<char> buffer(MFOOTERSIZE, 0);
+    helper::adiosvec<char> buffer(MFOOTERSIZE);
     f.seekg(0, f.end);
     auto flength = f.tellg();
     if (flength < MFOOTERSIZE)

--- a/testing/adios2/performance/CMakeLists.txt
+++ b/testing/adios2/performance/CMakeLists.txt
@@ -6,3 +6,7 @@
 add_subdirectory(manyvars)
 add_subdirectory(query)
 add_subdirectory(metadata)
+
+# just for executing manually for performance studies
+add_executable(PerfVector PerfVector.cpp)
+target_link_libraries(PerfVector adios2_core)

--- a/testing/adios2/performance/PerfVector.cpp
+++ b/testing/adios2/performance/PerfVector.cpp
@@ -1,0 +1,106 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2/helper/adiosType.h>
+
+#ifndef _WIN32
+#include "strings.h"
+#else
+#define strcasecmp _stricmp
+#endif
+
+size_t MB = 1024 * 1024ULL;
+size_t N_MB = 1;
+
+static void Usage()
+{
+    std::cout << "PerfVector N " << std::endl;
+    std::cout << "  N is size of vector in MiB" << std::endl;
+}
+
+static bool ParseArgs(int argc, char **argv)
+{
+    if (argc > 1)
+    {
+        std::istringstream ss(argv[1]);
+        if (!(ss >> N_MB))
+            std::cerr << "Invalid number for size " << argv[1] << '\n';
+    }
+    else
+    {
+        Usage();
+        return false;
+    }
+    return true;
+}
+
+using TP = std::chrono::high_resolution_clock::time_point;
+#define NOW() std::chrono::high_resolution_clock::now();
+#define DURATION(T1, T2) static_cast<double>((T2 - T1).count()) / 1000000000.0;
+
+int main(int argc, char **argv)
+{
+    if (!ParseArgs(argc, argv))
+    {
+        return 1;
+    }
+
+    double timeInitialized, timeUninitialized, timeMalloc;
+    size_t N = N_MB * MB;
+
+    {
+        TP startInitialized = NOW();
+        std::vector<char> vecInitialized(N);
+        // vecInitialized.resize(N);
+        // char *ptr = vecInitialized.data();
+        // for (size_t i = 0; i < N; ++i)
+        //{
+        //    vecInitialized[i] = i % 256;
+        //}
+        TP endInitialized = NOW();
+        timeInitialized = DURATION(startInitialized, endInitialized);
+    }
+
+    {
+        TP startUninitialized = NOW();
+        // std::vector<char, default_init_allocator<char>> vecUninitialized(N);
+        adios2::helper::adiosvec<char> vecUninitialized(N);
+        // vecUninitialized.resize(N);
+        // char *ptr = vecUninitialized.data();
+        // for (size_t i = 0; i < N; ++i)
+        //{
+        //    vecUninitialized[i] = i % 256;
+        //}
+        TP endUninitialized = NOW();
+        timeUninitialized = DURATION(startUninitialized, endUninitialized);
+    }
+
+    {
+        TP startMalloc = NOW();
+        char *vecMalloc = (char *)malloc(N);
+        // char *ptr = vecMalloc;
+        /*for (size_t i = 0; i < N; ++i)
+        {
+            *ptr = i % 256;
+            ++ptr;
+        }*/
+        // for (size_t i = 0; i < N; ++i)
+        //{
+        //    vecMalloc[i] = i % 256;
+        //}
+        TP endMalloc = NOW();
+        timeMalloc = DURATION(startMalloc, endMalloc);
+        free(vecMalloc);
+    }
+
+    std::cout << "Size = " << N << " std::vector = " << timeInitialized
+              << " helper::adiosvec = " << timeUninitialized
+              << " Malloc = " << timeMalloc << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
…/273767 and adiosvec<T> type in helper::adiosType.h to be able to resize a vector without initialization. Changed BufferSTL and BP3/BP4/SST using adiosvec as well as in BP5 where vector<char> was used. It is much faster than vector<char> with Release build, but it is much slower with Debug build.

Release build:
  $ ./bin/PerfVector 1024
  Size = 1073741824 std::vector = 0.145024 helper::adiosvec = 5.73e-06 Malloc = 2e-08
Debug Build:
  $ ./bin/PerfVector 1024
  Size = 1073741824 std::vector = 0.145616 helper::adiosvec = 5.48551 Malloc = 9.16e-06