### PR TITLE
Necessary revision to get VOL work HDF5 1.13 & BP4

### DIFF
--- a/source/h5vol/H5VolReadWrite.c
+++ b/source/h5vol/H5VolReadWrite.c
@@ -143,7 +143,8 @@ void gInitADIOS2(hid_t acc_tpl)
     MPI_Initialized(&flag);
     if (!flag)
     {
-        SHOW_ERROR_MSG("H5VL_ADIOS2: Error: MPI is not initialized");
+      RANK_ZERO_MSG("H5VL_ADIOS2 WARNING: MPI is not initialized, will use Serial ADIOS\n");
+      m_ADIOS2=adios2_init_serial();
     }
     else
     {
@@ -879,6 +880,10 @@ herr_t gADIOS2ReadVar(H5VL_VarDef_t *varDef)
 
         adios2_set_selection(varDef->m_Variable, varDef->m_DimCount, start,
                              count);
+
+	if (varDef->m_MemSpaceID > 0) {
+	  RANK_ZERO_MSG("\n## No memory space is supported. Expect limited support when VOL supports BP5. \n");
+	}
     }
     adios2_get(varDef->m_Engine, varDef->m_Variable, varDef->m_Data,
                adios2_mode_sync);

--- a/source/h5vol/H5VolReadWrite.c
+++ b/source/h5vol/H5VolReadWrite.c
@@ -143,8 +143,9 @@ void gInitADIOS2(hid_t acc_tpl)
     MPI_Initialized(&flag);
     if (!flag)
     {
-      RANK_ZERO_MSG("H5VL_ADIOS2 WARNING: MPI is not initialized, will use Serial ADIOS\n");
-      m_ADIOS2=adios2_init_serial();
+        RANK_ZERO_MSG("H5VL_ADIOS2 WARNING: MPI is not initialized, will use "
+                      "Serial ADIOS\n");
+        m_ADIOS2 = adios2_init_serial();
     }
     else
     {
@@ -881,9 +882,11 @@ herr_t gADIOS2ReadVar(H5VL_VarDef_t *varDef)
         adios2_set_selection(varDef->m_Variable, varDef->m_DimCount, start,
                              count);
 
-	if (varDef->m_MemSpaceID > 0) {
-	  RANK_ZERO_MSG("\n## No memory space is supported. Expect limited support when VOL supports BP5. \n");
-	}
+        if (varDef->m_MemSpaceID > 0)
+        {
+            RANK_ZERO_MSG("\n## No memory space is supported. Expect limited "
+                          "support when VOL supports BP5. \n");
+        }
     }
     adios2_get(varDef->m_Engine, varDef->m_Variable, varDef->m_Data,
                adios2_mode_sync);

--- a/source/h5vol/H5VolReadWrite.h
+++ b/source/h5vol/H5VolReadWrite.h
@@ -51,13 +51,13 @@ static herr_t H5VL_adios2_datatype_close(void *dt, hid_t H5_ATTR_UNUSED dxpl_id,
 // Define H5VOL functions
 //
 static const H5VL_class_t H5VL_adios2_def = {
-    H5VL_ADIOS2_VERSION,
+    H5VL_VERSION, /* Version # of connector, needed for v1.13 */
     (H5VL_class_value_t)H5VL_ADIOS2_VALUE,
-    H5VL_ADIOS2_NAME,   /* name */
-    0,                  /* Version # of connector */
-    H5VL_CAP_FLAG_NONE, /* Capability flags for connector */
-    H5VL_adios2_init,   /* initialize */
-    H5VL_adios2_term,   /* terminate */
+    H5VL_ADIOS2_NAME,    /* name */
+    H5VL_ADIOS2_VERSION, /* version of this vol, not as important  */
+    H5VL_CAP_FLAG_NONE,  /* Capability flags for connector */
+    H5VL_adios2_init,    /* initialize */
+    H5VL_adios2_term,    /* terminate */
     {
         /* info_cls */
         (size_t)0, /* info size    */

--- a/source/h5vol/H5Vol_dataset.c
+++ b/source/h5vol/H5Vol_dataset.c
@@ -113,13 +113,13 @@ herr_t H5VL_adios2_dataset_get(void *dset, H5VL_dataset_get_args_t *args,
     case H5VL_DATASET_GET_SPACE:
     {
         REQUIRE_SUCC_MSG((varDef->m_ShapeID >= 0), -1,
-			  "H5VOL-ADIOS2: Unable to get space id.");
+                         "H5VOL-ADIOS2: Unable to get space id.");
         args->args.get_space.space_id = H5Scopy(varDef->m_ShapeID);
         break;
     }
     case H5VL_DATASET_GET_TYPE:
     {
-        args->args.get_type.type_id  = H5Tcopy(varDef->m_TypeID);
+        args->args.get_type.type_id = H5Tcopy(varDef->m_TypeID);
         break;
     }
     default:
@@ -142,14 +142,14 @@ herr_t H5VL_adios2_dataset_write(void *dset, hid_t mem_type_id,
     varDef->m_Data = (void *)buf;
 
     if (file_space_id > 0)
-      varDef->m_HyperSlabID = file_space_id;
+        varDef->m_HyperSlabID = file_space_id;
     else
-      varDef->m_HyperSlabID = varDef->m_ShapeID;
+        varDef->m_HyperSlabID = varDef->m_ShapeID;
 
     if (mem_space_id > 0)
-      varDef->m_MemSpaceID = mem_space_id;
+        varDef->m_MemSpaceID = mem_space_id;
     else
-      varDef->m_MemSpaceID = varDef->m_ShapeID;
+        varDef->m_MemSpaceID = varDef->m_ShapeID;
 
     varDef->m_PropertyID = plist_id;
 

--- a/testing/h5vol/TestH5VolWriteReadBPFile.cpp
+++ b/testing/h5vol/TestH5VolWriteReadBPFile.cpp
@@ -467,7 +467,7 @@ void HDF5NativeReader::ReadVar(const std::string varName, void *dataArray,
         dimsm[0] = memspaceSize;
         hid_t memspace = H5Screate_simple(1, dimsm, NULL);
         */
-        memspace = H5S_ALL;
+        hid_t memspace = H5S_ALL;
 
         hid_t ret = H5Dread(dataSetId, h5type, memspace, dataspace, H5P_DEFAULT,
                             dataArray);

--- a/testing/h5vol/TestH5VolWriteReadBPFile.cpp
+++ b/testing/h5vol/TestH5VolWriteReadBPFile.cpp
@@ -462,9 +462,12 @@ void HDF5NativeReader::ReadVar(const std::string varName, void *dataArray,
                 "Unable to create a selection for dataset" + varName);
         }
 
+        /*
         hsize_t dimsm[1];
         dimsm[0] = memspaceSize;
         hid_t memspace = H5Screate_simple(1, dimsm, NULL);
+        */
+        memspace = H5S_ALL;
 
         hid_t ret = H5Dread(dataSetId, h5type, memspace, dataspace, H5P_DEFAULT,
                             dataArray);


### PR DESCRIPTION
There are some signature changes in 1.13 and the VOL was written around hdf5 1.12.   A few changes needs to make in order for tests to succeed. 

Notice the current VOL is using BP4, and the memory selection is handled only in BP5.  It requires memory selection to have the same dimension as the global dimension. While HDF5 does not have such limitation. 