### PR TITLE
Allow an inline writer to be created and used without an inline reader

### DIFF
--- a/source/adios2/engine/inline/InlineWriter.cpp
+++ b/source/adios2/engine/inline/InlineWriter.cpp
@@ -41,12 +41,19 @@ InlineWriter::InlineWriter(IO &io, const std::string &name, const Mode mode,
 const InlineReader *InlineWriter::GetReader() const
 {
     const auto &engine_map = m_IO.GetEngines();
-    if (engine_map.size() != 2)
+    if (engine_map.size() == 1)
+    {
+        // it should be fine for a writer to be created and start running,
+        // without the reader having been created. This is necessary to run
+        // correctly with ParaView Catalyst Live.
+        return nullptr;
+    }
+    else if (engine_map.size() > 2)
     {
         helper::Throw<std::runtime_error>(
             "Engine", "InlineWriter", "GetReader",
-            "There must be exactly one reader and one "
-            "writer for the inline engine.");
+            "There must be only one inline writer and at most "
+            "one inline reader.");
     }
 
     std::shared_ptr<Engine> e = engine_map.begin()->second;
@@ -77,7 +84,7 @@ StepStatus InlineWriter::BeginStep(StepMode mode, const float timeoutSeconds)
     }
 
     auto reader = GetReader();
-    if (reader->IsInsideStep())
+    if (reader && reader->IsInsideStep())
     {
         m_InsideStep = false;
         return StepStatus::NotReady;


### PR DESCRIPTION
Previously we were requiring that when an inline writer is created and inline reader must be created before the writer can start BeginStep. I was able to work around that when getting ADIOS/Fides to work with Catalyst for batch in situ processing, but for Catalyst Live (interactive in situ) I can't work around it. I need to be able to create the reader a bit later than is currently possible. 

With this and a small fix in VTK, Catalyst Live is working! Still needs more testing of some different situations, but overall it ended up being a lot easier to get working than I expected. @pnorbert I can demo it with gray scott at Tuesday's meeting if you'd like to see it. 

@chuckatkins Is it good to merge this into release and do another patch release? 