### PR TITLE
Minor fixes mpi tests

### DIFF
--- a/examples/basics/globalArray/globalArray_write.cpp
+++ b/examples/basics/globalArray/globalArray_write.cpp
@@ -43,6 +43,8 @@ int main(int argc, char *argv[])
     int rank = 0, nproc = 1;
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);

--- a/examples/basics/joinedArray/joinedArray_write.cpp
+++ b/examples/basics/joinedArray/joinedArray_write.cpp
@@ -43,6 +43,8 @@ int main(int argc, char *argv[])
 #if ADIOS2_USE_MPI
     int nproc = 1;
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);

--- a/examples/basics/localArray/localArray_write.cpp
+++ b/examples/basics/localArray/localArray_write.cpp
@@ -48,6 +48,8 @@ int main(int argc, char *argv[])
 #if ADIOS2_USE_MPI
     int nproc = 1;
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);

--- a/examples/basics/values/values_write.cpp
+++ b/examples/basics/values/values_write.cpp
@@ -31,6 +31,8 @@ int main(int argc, char *argv[])
     int rank = 0, nproc = 1;
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);

--- a/examples/experimental/runtimeconfig/hello/helloBPWriterXML.cpp
+++ b/examples/experimental/runtimeconfig/hello/helloBPWriterXML.cpp
@@ -28,6 +28,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/heatTransfer/read/heatRead.cpp
+++ b/examples/heatTransfer/read/heatRead.cpp
@@ -70,6 +70,7 @@ int main(int argc, char *argv[])
         threadSupportLevel = MPI_THREAD_MULTIPLE;
     }
 
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, threadSupportLevel, &provided);
 
     /* When writer and reader is launched together with a single mpirun command,

--- a/examples/heatTransfer/write/main.cpp
+++ b/examples/heatTransfer/write/main.cpp
@@ -47,6 +47,7 @@ int main(int argc, char *argv[])
         threadSupportLevel = MPI_THREAD_MULTIPLE;
     }
 
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, threadSupportLevel, &provided);
 
     /* When writer and reader is launched together with a single mpirun command,

--- a/examples/hello/bpAttributeWriter/helloBPAttributeWriter.cpp
+++ b/examples/hello/bpAttributeWriter/helloBPAttributeWriter.cpp
@@ -21,6 +21,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/bpFWriteCRead/CppReader.cpp
+++ b/examples/hello/bpFWriteCRead/CppReader.cpp
@@ -16,6 +16,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/bpFWriteCRead/CppWriter.cpp
+++ b/examples/hello/bpFWriteCRead/CppWriter.cpp
@@ -16,6 +16,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/bpFlushWriter/helloBPFlushWriter.cpp
+++ b/examples/hello/bpFlushWriter/helloBPFlushWriter.cpp
@@ -21,6 +21,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/bpReader/helloBPReader.cpp
+++ b/examples/hello/bpReader/helloBPReader.cpp
@@ -22,6 +22,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/bpReader/helloBPReaderHeatMap2D.cpp
+++ b/examples/hello/bpReader/helloBPReaderHeatMap2D.cpp
@@ -31,6 +31,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/bpReader/helloBPReaderHeatMap3D.cpp
+++ b/examples/hello/bpReader/helloBPReaderHeatMap3D.cpp
@@ -35,6 +35,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/bpTimeWriter/helloBPTimeWriter.cpp
+++ b/examples/hello/bpTimeWriter/helloBPTimeWriter.cpp
@@ -22,6 +22,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/bpWriter/helloBPPutDeferred.cpp
+++ b/examples/hello/bpWriter/helloBPPutDeferred.cpp
@@ -36,6 +36,8 @@ int main(int argc, char *argv[])
 
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/hello/bpWriter/helloBPSZ.cpp
+++ b/examples/hello/bpWriter/helloBPSZ.cpp
@@ -35,6 +35,8 @@ int main(int argc, char *argv[])
 
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/hello/bpWriter/helloBPSubStreams.cpp
+++ b/examples/hello/bpWriter/helloBPSubStreams.cpp
@@ -23,6 +23,8 @@ int main(int argc, char *argv[])
     int rank, size;
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/hello/bpWriter/helloBPWriter.c
+++ b/examples/hello/bpWriter/helloBPWriter.c
@@ -40,6 +40,8 @@ int main(int argc, char *argv[])
 
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/hello/bpWriter/helloBPWriter.cpp
+++ b/examples/hello/bpWriter/helloBPWriter.cpp
@@ -24,6 +24,8 @@ int main(int argc, char *argv[])
     int rank, size;
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/hello/datamanReader/helloDataManReader.cpp
+++ b/examples/hello/datamanReader/helloDataManReader.cpp
@@ -33,6 +33,8 @@ int main(int argc, char *argv[])
 {
     // initialize MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);

--- a/examples/hello/datamanWriter/helloDataManWriter.cpp
+++ b/examples/hello/datamanWriter/helloDataManWriter.cpp
@@ -52,6 +52,8 @@ int main(int argc, char *argv[])
 {
     // initialize MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);

--- a/examples/hello/dataspacesReader/helloDataSpacesReader.cpp
+++ b/examples/hello/dataspacesReader/helloDataSpacesReader.cpp
@@ -29,6 +29,8 @@ int main(int argc, char *argv[])
 
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/hello/dataspacesWriter/helloDataSpacesWriter.cpp
+++ b/examples/hello/dataspacesWriter/helloDataSpacesWriter.cpp
@@ -26,6 +26,8 @@ int main(int argc, char *argv[])
 
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/hello/hdf5Reader/helloHDF5Reader.cpp
+++ b/examples/hello/hdf5Reader/helloHDF5Reader.cpp
@@ -67,6 +67,8 @@ void ReadData(adios2::IO h5IO, adios2::Engine &h5Reader,
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/hdf5Writer/helloHDF5Writer.cpp
+++ b/examples/hello/hdf5Writer/helloHDF5Writer.cpp
@@ -20,6 +20,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/hello/inlineReaderWriter/helloInlineReaderWriter.cpp
+++ b/examples/hello/inlineReaderWriter/helloInlineReaderWriter.cpp
@@ -84,6 +84,8 @@ int main(int argc, char *argv[])
     int rank = 0, size = 1;
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/hello/skeleton/helloSkeletonReader.cpp
+++ b/examples/hello/skeleton/helloSkeletonReader.cpp
@@ -17,6 +17,8 @@ int main(int argc, char *argv[])
     int wrank = 0, wnproc = 1;
     MPI_Comm mpiReaderComm;
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
     MPI_Comm_size(MPI_COMM_WORLD, &wnproc);

--- a/examples/hello/skeleton/helloSkeletonWriter.cpp
+++ b/examples/hello/skeleton/helloSkeletonWriter.cpp
@@ -25,6 +25,8 @@ int main(int argc, char *argv[])
     int wrank = 0, wnproc = 1;
     MPI_Comm mpiWriterComm;
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
     MPI_Comm_size(MPI_COMM_WORLD, &wnproc);

--- a/examples/hello/sstReader/helloSstReader.cpp
+++ b/examples/hello/sstReader/helloSstReader.cpp
@@ -28,6 +28,8 @@ int main(int argc, char *argv[])
 
 #if ADIOS2_USE_MPI
     int provide;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provide);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/hello/sstWriter/helloSstWriter.cpp
+++ b/examples/hello/sstWriter/helloSstWriter.cpp
@@ -25,6 +25,8 @@ int main(int argc, char *argv[])
 
 #if ADIOS2_USE_MPI
     int provide;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provide);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/examples/query/test.cpp
+++ b/examples/query/test.cpp
@@ -15,6 +15,8 @@
 int main(int argc, char *argv[])
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
+++ b/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
@@ -215,6 +215,8 @@ int main(int argc, char *argv[])
     int rank = 0, nproc = 1;
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int wrank, wnproc;
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);

--- a/examples/useCases/insituGlobalArrays/insituGlobalArraysWriter.cpp
+++ b/examples/useCases/insituGlobalArrays/insituGlobalArraysWriter.cpp
@@ -90,6 +90,8 @@ int main(int argc, char *argv[])
     int rank = 0, nproc = 1;
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int wrank, wnproc;
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);

--- a/testing/adios2/bindings/C/TestBPAvailableVariablesAttribites.cpp
+++ b/testing/adios2/bindings/C/TestBPAvailableVariablesAttribites.cpp
@@ -269,6 +269,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/bindings/C/TestBPWriteAggregateReadLocal.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteAggregateReadLocal.cpp
@@ -369,6 +369,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/bindings/C/TestBPWriteReadMultiblock.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteReadMultiblock.cpp
@@ -298,6 +298,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -520,6 +520,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/bindings/C/TestNullWriteRead.cpp
+++ b/testing/adios2/bindings/C/TestNullWriteRead.cpp
@@ -116,6 +116,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/bindings/fortran/TestAdios2BindingsFortranIO.F90
+++ b/testing/adios2/bindings/fortran/TestAdios2BindingsFortranIO.F90
@@ -152,6 +152,8 @@ program main
   external testing_adios_io_engine_default
 
   INTEGER provided
+
+  ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
   call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
 
   call testing_adios_io_engine()

--- a/testing/adios2/bindings/fortran/TestBPReadGlobalsByName.F90
+++ b/testing/adios2/bindings/fortran/TestBPReadGlobalsByName.F90
@@ -15,6 +15,8 @@ program TestBPReadGlobalsByName
 
     ! Launch MPI
     INTEGER provided
+
+    ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
     call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
     call MPI_Comm_size(MPI_COMM_WORLD, isize, ierr)

--- a/testing/adios2/bindings/fortran/TestBPWriteReadAttributes.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteReadAttributes.F90
@@ -33,6 +33,8 @@ program TestBPWriteAttributes
 
     ! Launch MPI
     INTEGER provided
+
+    ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
 
     ! Create adios handler passing the communicator, debug mode and error flag

--- a/testing/adios2/bindings/fortran/TestBPWriteTypes.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypes.F90
@@ -32,6 +32,8 @@ program TestBPWriteTypes
 #if ADIOS2_USE_MPI
      ! Launch MPI
      INTEGER provided
+
+     ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
      call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
      call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
      call MPI_Comm_size(MPI_COMM_WORLD, isize, ierr)

--- a/testing/adios2/bindings/fortran/TestBPWriteTypesByName.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypesByName.F90
@@ -18,6 +18,8 @@
 
      ! Launch MPI
      INTEGER provided
+
+     ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
      call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
      call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
      call MPI_Comm_size(MPI_COMM_WORLD, isize, ierr)

--- a/testing/adios2/bindings/fortran/TestBPWriteTypesLocal.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypesLocal.F90
@@ -28,6 +28,8 @@
 
      ! Launch MPI
      INTEGER provided
+
+     ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
      call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
      call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
      call MPI_Comm_size(MPI_COMM_WORLD, isize, ierr)

--- a/testing/adios2/bindings/fortran/TestBPWriteVariableAttributes.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteVariableAttributes.F90
@@ -16,6 +16,8 @@ program TestBPWriteVariableAttributes
 
     ! Launch MPI
     INTEGER provided
+
+    ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
 
     ! Create adios handler passing the communicator, debug mode and error flag

--- a/testing/adios2/bindings/fortran/TestF2C_BPReadFBlocks.cpp
+++ b/testing/adios2/bindings/fortran/TestF2C_BPReadFBlocks.cpp
@@ -127,6 +127,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/bindings/fortran/TestNullEngine.F90
+++ b/testing/adios2/bindings/fortran/TestNullEngine.F90
@@ -18,6 +18,8 @@
 
      ! Launch MPI
      INTEGER provided
+
+     ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
      call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
      call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
      call MPI_Comm_size(MPI_COMM_WORLD, isize, ierr)

--- a/testing/adios2/bindings/fortran/TestRemove.F90
+++ b/testing/adios2/bindings/fortran/TestRemove.F90
@@ -18,6 +18,8 @@ program TestRemove
 #if ADIOS2_USE_MPI
     ! Launch MPI
     INTEGER provided
+
+    ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierr)
     call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
     call MPI_Comm_size(MPI_COMM_WORLD, isize, ierr)

--- a/testing/adios2/engine/bp/TestBPBufferSize.cpp
+++ b/testing/adios2/engine/bp/TestBPBufferSize.cpp
@@ -267,6 +267,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPChangingShape.cpp
+++ b/testing/adios2/engine/bp/TestBPChangingShape.cpp
@@ -365,6 +365,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPDirectIO.cpp
+++ b/testing/adios2/engine/bp/TestBPDirectIO.cpp
@@ -123,6 +123,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
     ::testing::InitGoogleTest(&argc, argv);

--- a/testing/adios2/engine/bp/TestBPFStreamWriteReadHighLevelAPI.cpp
+++ b/testing/adios2/engine/bp/TestBPFStreamWriteReadHighLevelAPI.cpp
@@ -723,6 +723,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPInquireDefine.cpp
+++ b/testing/adios2/engine/bp/TestBPInquireDefine.cpp
@@ -225,6 +225,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
     ::testing::InitGoogleTest(&argc, argv);

--- a/testing/adios2/engine/bp/TestBPInquireVariableException.cpp
+++ b/testing/adios2/engine/bp/TestBPInquireVariableException.cpp
@@ -76,6 +76,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
     ::testing::InitGoogleTest(&argc, argv);

--- a/testing/adios2/engine/bp/TestBPLargeMetadata.cpp
+++ b/testing/adios2/engine/bp/TestBPLargeMetadata.cpp
@@ -160,6 +160,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
+++ b/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
@@ -11,6 +11,8 @@ int main(int argc, char *argv[])
     int rank = 0;
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif

--- a/testing/adios2/engine/bp/TestBPParameterSelectSteps.cpp
+++ b/testing/adios2/engine/bp/TestBPParameterSelectSteps.cpp
@@ -301,6 +301,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPSelectSteps.cpp
+++ b/testing/adios2/engine/bp/TestBPSelectSteps.cpp
@@ -317,6 +317,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
     ::testing::InitGoogleTest(&argc, argv);

--- a/testing/adios2/engine/bp/TestBPStepsFileGlobalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsFileGlobalArray.cpp
@@ -960,6 +960,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPStepsFileLocalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsFileLocalArray.cpp
@@ -603,6 +603,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPStepsInSituGlobalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsInSituGlobalArray.cpp
@@ -687,6 +687,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPStepsInSituLocalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsInSituLocalArray.cpp
@@ -538,6 +538,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPTimeAggregation.cpp
+++ b/testing/adios2/engine/bp/TestBPTimeAggregation.cpp
@@ -715,6 +715,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteAggregateRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteAggregateRead.cpp
@@ -1003,6 +1003,8 @@ INSTANTIATE_TEST_SUITE_P(Substreams, BPWriteAggregateReadTest,
 int main(int argc, char **argv)
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 
     int result;

--- a/testing/adios2/engine/bp/TestBPWriteAppendReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteAppendReadADIOS2.cpp
@@ -913,6 +913,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
@@ -1442,6 +1442,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteMemorySelectionRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteMemorySelectionRead.cpp
@@ -951,6 +951,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteMultiblockRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteMultiblockRead.cpp
@@ -1414,6 +1414,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteNull.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteNull.cpp
@@ -619,6 +619,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
@@ -320,6 +320,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -2301,6 +2301,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2fstream.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2fstream.cpp
@@ -1652,6 +1652,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2stdio.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2stdio.cpp
@@ -1651,6 +1651,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
@@ -1020,6 +1020,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
@@ -1593,6 +1593,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
@@ -1234,6 +1234,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributesMultirank.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributesMultirank.cpp
@@ -123,6 +123,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
@@ -924,6 +924,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadCuda.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadCuda.cpp
@@ -171,6 +171,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariables.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariables.cpp
@@ -1917,6 +1917,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSel.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSel.cpp
@@ -1834,6 +1834,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSelHighLevel.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSelHighLevel.cpp
@@ -595,6 +595,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadMultiblock.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadMultiblock.cpp
@@ -2236,6 +2236,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -1597,6 +1597,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
@@ -1290,6 +1290,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadBZIP2.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadBZIP2.cpp
@@ -894,6 +894,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc.cpp
@@ -947,6 +947,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadLocalVariables.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadLocalVariables.cpp
@@ -1603,6 +1603,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadMGARD.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadMGARD.cpp
@@ -1007,6 +1007,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
@@ -450,6 +450,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadSZ.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadSZ.cpp
@@ -1044,6 +1044,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadSzComplex.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadSzComplex.cpp
@@ -367,6 +367,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
     int result;

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfp.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfp.cpp
@@ -976,6 +976,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpComplex.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpComplex.cpp
@@ -367,6 +367,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
     int result;

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpConfig.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpConfig.cpp
@@ -911,6 +911,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
@@ -157,6 +157,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpHighLevelAPI.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpHighLevelAPI.cpp
@@ -729,6 +729,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpRemoveOperations.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpRemoveOperations.cpp
@@ -498,6 +498,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/common/TestEngineCommon.cpp
+++ b/testing/adios2/engine/common/TestEngineCommon.cpp
@@ -301,6 +301,7 @@ int main(int argc, char **argv)
         threadSupportLevel = MPI_THREAD_MULTIPLE;
     }
 
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, threadSupportLevel, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
     MPI_Comm_size(MPI_COMM_WORLD, &numprocs);

--- a/testing/adios2/engine/dataman/TestDataManReaderSingleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManReaderSingleBuffer.cpp
@@ -295,6 +295,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int mpi_provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_provided);
     if (mpi_provided != MPI_THREAD_MULTIPLE)
     {

--- a/testing/adios2/engine/dataman/TestDataManWriterDoubleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManWriterDoubleBuffer.cpp
@@ -299,6 +299,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int mpi_provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mpi_provided);
     if (mpi_provided != MPI_THREAD_MULTIPLE)
     {

--- a/testing/adios2/engine/hdf5/TestHDF5Append.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5Append.cpp
@@ -383,6 +383,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/hdf5/TestHDF5StreamWriteReadHighLevelAPI.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5StreamWriteReadHighLevelAPI.cpp
@@ -521,6 +521,8 @@ int main(int argc, char **argv)
 {
 #ifdef TEST_HDF5_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/hdf5/TestHDF5WriteMemorySelectionRead.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteMemorySelectionRead.cpp
@@ -931,6 +931,8 @@ int main(int argc, char **argv)
 {
 #ifdef TEST_HDF5_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/hdf5/TestHDF5WriteReadAsStream.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteReadAsStream.cpp
@@ -1017,6 +1017,8 @@ int main(int argc, char **argv)
 {
 #ifdef TEST_HDF5_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/hdf5/TestHDF5WriteReadAttributesADIOS2.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteReadAttributesADIOS2.cpp
@@ -726,6 +726,8 @@ int main(int argc, char **argv)
 {
 #ifdef TEST_HDF5_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
+++ b/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
@@ -3213,6 +3213,8 @@ int main(int argc, char **argv)
 {
 #ifdef TEST_HDF5_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/inline/TestInlineWriteRead.cpp
+++ b/testing/adios2/engine/inline/TestInlineWriteRead.cpp
@@ -950,6 +950,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/mhs/TestMhsMultiRank.cpp
+++ b/testing/adios2/engine/mhs/TestMhsMultiRank.cpp
@@ -241,6 +241,8 @@ TEST_F(MhsEngineTest, TestMhsMultiRank)
 int main(int argc, char **argv)
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);

--- a/testing/adios2/engine/mhs/TestMhsMultiReader.cpp
+++ b/testing/adios2/engine/mhs/TestMhsMultiReader.cpp
@@ -235,6 +235,8 @@ TEST_F(MhsEngineTest, TestMhsMultiReader)
 int main(int argc, char **argv)
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);

--- a/testing/adios2/engine/mhs/TestMhsSingleRank.cpp
+++ b/testing/adios2/engine/mhs/TestMhsSingleRank.cpp
@@ -278,6 +278,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 #endif
     int result;

--- a/testing/adios2/engine/null/TestNullWriteRead.cpp
+++ b/testing/adios2/engine/null/TestNullWriteRead.cpp
@@ -182,6 +182,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/nullcore/TestNullCoreWrite.cpp
+++ b/testing/adios2/engine/nullcore/TestNullCoreWrite.cpp
@@ -161,6 +161,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/skeleton/TestSkeletonReader.cpp
+++ b/testing/adios2/engine/skeleton/TestSkeletonReader.cpp
@@ -63,6 +63,8 @@ int main(int argc, char *argv[])
     int wrank = 0, wnproc = 1;
     MPI_Comm mpiReaderComm;
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
     MPI_Comm_size(MPI_COMM_WORLD, &wnproc);

--- a/testing/adios2/engine/skeleton/TestSkeletonWriter.cpp
+++ b/testing/adios2/engine/skeleton/TestSkeletonWriter.cpp
@@ -35,6 +35,8 @@ int main(int argc, char *argv[])
     int wrank = 0, wnproc = 1;
     MPI_Comm mpiWriterComm;
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
     MPI_Comm_size(MPI_COMM_WORLD, &wnproc);

--- a/testing/adios2/engine/ssc/TestSscBaseThreading.cpp
+++ b/testing/adios2/engine/ssc/TestSscBaseThreading.cpp
@@ -260,6 +260,8 @@ TEST_F(SscEngineTest, TestSscBaseThreading)
 int main(int argc, char **argv)
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     int result = 0;
     if (provided == MPI_THREAD_MULTIPLE)

--- a/testing/adios2/engine/sst/TestSstParamFails.cpp
+++ b/testing/adios2/engine/sst/TestSstParamFails.cpp
@@ -226,6 +226,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/sst/TestSstWriterFails.cpp
+++ b/testing/adios2/engine/sst/TestSstWriterFails.cpp
@@ -127,6 +127,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/engine/staging-common/TestCommonClient.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonClient.cpp
@@ -397,6 +397,8 @@ int main(int argc, char **argv)
     int provided;
     int thread_support_level =
         (engine == "SST") ? MPI_THREAD_MULTIPLE : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 #endif
     result = RUN_ALL_TESTS();

--- a/testing/adios2/engine/staging-common/TestCommonRead.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonRead.cpp
@@ -485,6 +485,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
@@ -364,6 +364,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestCommonReadF.F90
+++ b/testing/adios2/engine/staging-common/TestCommonReadF.F90
@@ -73,6 +73,8 @@ program TestSstRead
   endif
 
   !Launch MPI
+
+  ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
   call MPI_Init_thread(threadSupportLevel, provided, ierr)
 
   call MPI_Comm_rank(MPI_COMM_WORLD, key, ierr);

--- a/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
@@ -178,6 +178,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestCommonReadR64.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadR64.cpp
@@ -151,6 +151,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
@@ -152,6 +152,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestCommonServer.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonServer.cpp
@@ -205,6 +205,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 #endif
 

--- a/testing/adios2/engine/staging-common/TestCommonWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWrite.cpp
@@ -257,6 +257,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestCommonWriteAttrs.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteAttrs.cpp
@@ -204,6 +204,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestCommonWriteF.F90
+++ b/testing/adios2/engine/staging-common/TestCommonWriteF.F90
@@ -67,6 +67,8 @@ program TestSstWrite
   endif
 
   !Launch MPI
+
+  ! MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
   call MPI_Init_thread(threadSupportLevel, provided, ierr)
 
   call MPI_Comm_rank(MPI_COMM_WORLD, key, ierr);

--- a/testing/adios2/engine/staging-common/TestCommonWriteLocal.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteLocal.cpp
@@ -121,6 +121,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestCommonWriteModes.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteModes.cpp
@@ -193,6 +193,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestCommonWriteShared.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteShared.cpp
@@ -172,6 +172,8 @@ int main(int argc, char **argv)
     int thread_support_level = (engine == "SST" || engine == "sst")
                                    ? MPI_THREAD_MULTIPLE
                                    : MPI_THREAD_SINGLE;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, thread_support_level, &provided);
 
     int key;

--- a/testing/adios2/engine/staging-common/TestStagingMPMD.cpp
+++ b/testing/adios2/engine/staging-common/TestStagingMPMD.cpp
@@ -375,6 +375,7 @@ int main(int argc, char **argv)
         threadSupportLevel = MPI_THREAD_MULTIPLE;
     }
 
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, threadSupportLevel, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
     MPI_Comm_size(MPI_COMM_WORLD, &numprocs);

--- a/testing/adios2/engine/staging-common/TestThreads.cpp
+++ b/testing/adios2/engine/staging-common/TestThreads.cpp
@@ -150,7 +150,6 @@ TEST_F(TestThreads, Basic)
     auto read_fut = std::async(std::launch::async, Read, BaseName, 0);
     auto write_fut = std::async(std::launch::async, Write, BaseName, 0);
     bool reader_success = read_fut.get();
-    sleep(1);
     bool writer_success = write_fut.get();
     EXPECT_TRUE(reader_success);
     EXPECT_TRUE(writer_success);

--- a/testing/adios2/interface/TestADIOSDefineAttribute.cpp
+++ b/testing/adios2/interface/TestADIOSDefineAttribute.cpp
@@ -801,6 +801,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/interface/TestADIOSDefineVariable.cpp
+++ b/testing/adios2/interface/TestADIOSDefineVariable.cpp
@@ -716,6 +716,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -504,6 +504,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/interface/TestADIOSInterfaceWrite.cpp
+++ b/testing/adios2/interface/TestADIOSInterfaceWrite.cpp
@@ -622,6 +622,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/performance/manyvars/PerfManyVars.c
+++ b/testing/adios2/performance/manyvars/PerfManyVars.c
@@ -157,6 +157,8 @@ int main(int argc, char **argv)
     int err, i;
 
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(comm, &rank);
     MPI_Comm_size(comm, &size);

--- a/testing/adios2/performance/manyvars/TestManyVars.cpp
+++ b/testing/adios2/performance/manyvars/TestManyVars.cpp
@@ -484,6 +484,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 #endif
     ::testing::InitGoogleTest(&argc, argv);

--- a/testing/adios2/performance/metadata/PerfMetaData.cpp
+++ b/testing/adios2/performance/metadata/PerfMetaData.cpp
@@ -523,6 +523,8 @@ int main(int argc, char **argv)
     if (UseMPI)
     {
         int provided;
+
+        // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
         MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 
         MPI_Comm_rank(MPI_COMM_WORLD, &key);

--- a/testing/adios2/performance/query/TestBPQuery.cpp
+++ b/testing/adios2/performance/query/TestBPQuery.cpp
@@ -295,6 +295,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/xml/TestXMLConfig.cpp
+++ b/testing/adios2/xml/TestXMLConfig.cpp
@@ -131,6 +131,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/adios2/yaml/TestYAMLConfig.cpp
+++ b/testing/adios2/yaml/TestYAMLConfig.cpp
@@ -101,6 +101,8 @@ int main(int argc, char **argv)
 {
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/h5vol/TestH5VolWriteReadBPFile.cpp
+++ b/testing/h5vol/TestH5VolWriteReadBPFile.cpp
@@ -1116,6 +1116,8 @@ int main(int argc, char **argv)
 {
 #ifdef TEST_HDF5_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
 

--- a/testing/install/C/main_mpi.c
+++ b/testing/install/C/main_mpi.c
@@ -16,6 +16,8 @@
 int main(int argc, char **argv)
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 
     adios2_adios *adios = adios2_init_mpi(MPI_COMM_WORLD);

--- a/testing/install/CXX11/main_mpi.cxx
+++ b/testing/install/CXX11/main_mpi.cxx
@@ -14,6 +14,8 @@
 int main(int argc, char **argv)
 {
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
 
     adios2::ADIOS adios(MPI_COMM_WORLD);

--- a/testing/utils/changingshape/TestUtilsChangingShape.cpp
+++ b/testing/utils/changingshape/TestUtilsChangingShape.cpp
@@ -32,6 +32,8 @@ int main(int argc, char **argv)
 
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);

--- a/testing/utils/cwriter/TestUtilsCWriter.c
+++ b/testing/utils/cwriter/TestUtilsCWriter.c
@@ -25,6 +25,8 @@ int main(int argc, char *argv[])
     int nproc = 1;
 #if ADIOS2_USE_MPI
     int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);


### PR DESCRIPTION
- ADD a comment explaining that multithread MPI is only needed for SST MPI_DP in every test and example.
- Removed rogue sleep(1) from priors pull-requests