### PR TITLE
Optimize processing attributes, by using a new AttributeBase.Equals()…

### DIFF
--- a/source/adios2/core/Attribute.h
+++ b/source/adios2/core/Attribute.h
@@ -67,6 +67,8 @@ public:
 
 private:
     std::string DoGetInfoValue() const noexcept override;
+    bool DoEqual(const void *values, const size_t elements) const
+        noexcept override;
 };
 
 } // end namespace core

--- a/source/adios2/core/Attribute.tcc
+++ b/source/adios2/core/Attribute.tcc
@@ -145,6 +145,35 @@ std::string Attribute<T>::DoGetInfoValue() const noexcept
     return value;
 }
 
+template <typename T>
+bool Attribute<T>::DoEqual(const void *values, const size_t elements) const
+    noexcept
+{
+    if (m_Elements != elements)
+    {
+        return false;
+    }
+
+    const T *data = reinterpret_cast<const T *>(values);
+
+    if (m_IsSingleValue)
+    {
+        return (*data == m_DataSingleValue);
+    }
+    else
+    {
+        for (size_t i = 0; i < elements; ++i)
+        {
+            if (data[i] != m_DataArray[i])
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
 } // end namespace core
 } // end namespace adios2
 

--- a/source/adios2/core/AttributeBase.cpp
+++ b/source/adios2/core/AttributeBase.cpp
@@ -40,5 +40,11 @@ Params AttributeBase::GetInfo() const noexcept
     return info;
 }
 
+bool AttributeBase::Equals(const void *values, const size_t elements) const
+    noexcept
+{
+    return this->DoEqual(values, elements);
+}
+
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/core/AttributeBase.h
+++ b/source/adios2/core/AttributeBase.h
@@ -54,8 +54,16 @@ public:
 
     Params GetInfo() const noexcept;
 
+    /**
+     * Compare Attribute's current value with input
+     * @return true if they equal, false otherwise
+     */
+    bool Equals(const void *values, const size_t elements) const noexcept;
+
 private:
     virtual std::string DoGetInfoValue() const noexcept = 0;
+    virtual bool DoEqual(const void *values, const size_t elements) const
+        noexcept = 0;
 };
 
 } // end namespace core

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -126,11 +126,12 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T &value,
     auto itExistingAttribute = m_Attributes.find(globalName);
     if (itExistingAttribute != m_Attributes.end())
     {
-        if (helper::ValueToString(value) !=
-            itExistingAttribute->second->GetInfo()["Value"])
+        if (itExistingAttribute->second->m_Type == helper::GetDataType<T>())
         {
-            if (itExistingAttribute->second->m_Type == helper::GetDataType<T>())
+            if (!itExistingAttribute->second->Equals(
+                    static_cast<const void *>(&value), 1))
             {
+
                 Attribute<T> &a =
                     static_cast<Attribute<T> &>(*itExistingAttribute->second);
                 a.Modify(value);
@@ -140,16 +141,16 @@ Attribute<T> &IO::DefineAttribute(const std::string &name, const T &value,
                         globalName, itExistingAttribute->second->m_Type);
                 }
             }
-            else
-            {
-                helper::Throw<std::invalid_argument>(
-                    "Core", "IO", "DefineAttribute",
-                    "modifiable attribute " + globalName +
-                        " has been defined with type " +
-                        ToString(itExistingAttribute->second->m_Type) +
-                        ". Type cannot be changed to " +
-                        ToString(helper::GetDataType<T>()));
-            }
+        }
+        else
+        {
+            helper::Throw<std::invalid_argument>(
+                "Core", "IO", "DefineAttribute",
+                "modifiable attribute " + globalName +
+                    " has been defined with type " +
+                    ToString(itExistingAttribute->second->m_Type) +
+                    ". Type cannot be changed to " +
+                    ToString(helper::GetDataType<T>()));
         }
         return static_cast<Attribute<T> &>(*itExistingAttribute->second);
     }
@@ -190,15 +191,12 @@ IO::DefineAttribute(const std::string &name, const T *array,
     auto itExistingAttribute = m_Attributes.find(globalName);
     if (itExistingAttribute != m_Attributes.end())
     {
-        const std::string arrayValues(
-            "{ " +
-            helper::VectorToCSV(std::vector<T>(array, array + elements)) +
-            " }");
-
-        if (itExistingAttribute->second->GetInfo()["Value"] != arrayValues)
+        if (itExistingAttribute->second->m_Type == helper::GetDataType<T>())
         {
-            if (itExistingAttribute->second->m_Type == helper::GetDataType<T>())
+            if (!itExistingAttribute->second->Equals(
+                    static_cast<const void *>(array), elements))
             {
+
                 Attribute<T> &a =
                     static_cast<Attribute<T> &>(*itExistingAttribute->second);
                 a.Modify(array, elements);
@@ -208,16 +206,16 @@ IO::DefineAttribute(const std::string &name, const T *array,
                         globalName, itExistingAttribute->second->m_Type);
                 }
             }
-            else
-            {
-                helper::Throw<std::invalid_argument>(
-                    "Core", "IO", "DefineAttribute",
-                    "modifiable attribute " + globalName +
-                        " has been defined with type " +
-                        ToString(itExistingAttribute->second->m_Type) +
-                        ". Type cannot be changed to " +
-                        ToString(helper::GetDataType<T>()));
-            }
+        }
+        else
+        {
+            helper::Throw<std::invalid_argument>(
+                "Core", "IO", "DefineAttribute",
+                "modifiable attribute " + globalName +
+                    " has been defined with type " +
+                    ToString(itExistingAttribute->second->m_Type) +
+                    ". Type cannot be changed to " +
+                    ToString(helper::GetDataType<T>()));
         }
         return static_cast<Attribute<T> &>(*itExistingAttribute->second);
     }

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -158,17 +158,22 @@ DataType BP5Deserializer::TranslateFFSType2ADIOS(const char *Type, int size)
     return DataType::None;
 }
 
-void BP5Deserializer::BreakdownVarName(const char *Name, char **base_name_p,
-                                       DataType *type_p, int *element_size_p)
+const char *BP5Deserializer::BreakdownVarName(const char *Name,
+                                              DataType *type_p,
+                                              int *element_size_p)
 {
-    int Type;
-    int ElementSize;
-    const char *NameStart = strchr(strchr(Name + 4, '_') + 1, '_') + 1;
-    // + 4 to skip BP5_ or bp5_ prefix
-    sscanf(Name + 4, "%d_%d_", &ElementSize, &Type);
-    *element_size_p = ElementSize;
+    // const char *NameStart = strchr(strchr(Name + 4, '_') + 1, '_') + 1;
+    // sscanf(Name + 4, "%d_%d", &ElementSize, &Type);
+    /* string formatted as bp5_%d_%d_actualname */
+    char *p;
+    // + 3 to skip BP5_ or bp5_ prefix
+    long n = strtol(Name + 4, &p, 10);
+    *element_size_p = static_cast<int>(n);
+    ++p; // skip '_'
+    long Type = strtol(p, &p, 10);
     *type_p = (DataType)Type;
-    *base_name_p = strdup(NameStart);
+    ++p; // skip '_'
+    return p;
 }
 
 void BP5Deserializer::BreakdownFieldType(const char *FieldType, bool &Operator,
@@ -232,14 +237,16 @@ void BP5Deserializer::BreakdownV1ArrayName(const char *Name, char **base_name_p,
 void BP5Deserializer::BreakdownArrayName(const char *Name, char **base_name_p,
                                          DataType *type_p, int *element_size_p)
 {
-    int Type;
-    int ElementSize;
-    const char *NameStart = strchr(strchr(Name + 4, '_') + 1, '_') + 1;
+    /* string formatted as bp5_%d_%d_actualname */
+    char *p;
     // + 3 to skip BP5_ or bp5_ prefix
-    sscanf(Name + 4, "%d_%d", &ElementSize, &Type);
-    *element_size_p = ElementSize;
+    long n = strtol(Name + 4, &p, 10);
+    *element_size_p = static_cast<int>(n);
+    ++p; // skip '_'
+    long Type = strtol(p, &p, 10);
     *type_p = (DataType)Type;
-    *base_name_p = strdup(NameStart);
+    ++p; // skip '_'
+    *base_name_p = strdup(p);
 }
 
 BP5Deserializer::BP5VarRec *BP5Deserializer::LookupVarByKey(void *Key) const
@@ -826,15 +833,15 @@ void BP5Deserializer::InstallAttributeData(void *AttributeBlock,
     int i = 0;
     while (FieldList[i].field_name)
     {
-        char *FieldName;
+
         void *field_data = (char *)BaseData + FieldList[i].field_offset;
 
         if (!NameIndicatesAttrArray(FieldList[i].field_name))
         {
             DataType Type;
             int ElemSize;
-            BreakdownVarName(FieldList[i].field_name, &FieldName, &Type,
-                             &ElemSize);
+            const char *FieldName =
+                BreakdownVarName(FieldList[i].field_name, &Type, &ElemSize);
             if (Type == adios2::DataType::Struct)
             {
                 return;
@@ -858,7 +865,6 @@ void BP5Deserializer::InstallAttributeData(void *AttributeBlock,
                 std::cout << "Loading attribute matched no type "
                           << ToString(Type) << std::endl;
             }
-            free(FieldName);
             i++;
         }
         else

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -180,8 +180,8 @@ private:
     BP5VarRec *LookupVarByName(const char *Name);
     BP5VarRec *CreateVarRec(const char *ArrayName);
     void ReverseDimensions(size_t *Dimensions, int count, int times);
-    void BreakdownVarName(const char *Name, char **base_name_p,
-                          DataType *type_p, int *element_size_p);
+    const char *BreakdownVarName(const char *Name, DataType *type_p,
+                                 int *element_size_p);
     void BreakdownFieldType(const char *FieldType, bool &Operator,
                             bool &MinMax);
     void BreakdownArrayName(const char *Name, char **base_name_p,


### PR DESCRIPTION
… function instead of building a small string map. Also speed up BP5Deserializer.BreakDownVarName, and BreakDownArrayName by using strtol() calls instead of sscanf.