### PR TITLE
ci: fix macos install test missing deps

### DIFF
--- a/scripts/ci/gh-actions/macos-setup.sh
+++ b/scripts/ci/gh-actions/macos-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "Setting up default XCode version"
 if [ -z "${GH_YML_MATRIX_COMPILER}" ]
 then
@@ -15,7 +17,19 @@ fi
 sudo xcode-select --switch /Applications/Xcode_${XCODE_VER}.app
 
 echo "Installing CMake"
-brew install cmake
+
+{
+  readonly version="3.23.3"
+  readonly checksum="45cda7b87cad41ac407fc150e4682b85c3eb45b1977d8e89319cb3a9a6f341f3"
+  readonly pkg="cmake-${version}-macos-universal.tar.gz"
+  echo "${checksum}  ${pkg}" > cmake.sha256sum
+
+  curl -OL "https://github.com/Kitware/CMake/releases/download/v${version}/${pkg}"
+  shasum -a 256 --check cmake.sha256sum
+
+  sudo tar -xvzf ${pkg} --strip-components 1 -C /Applications/
+}
+
 
 echo "Installing Ninja"
 brew install ninja


### PR DESCRIPTION
Cmake 3.24 deprecated some features that are used in our install test. This MR fix the CMake used for MacOS build to 3.23.3.

This is a temporary fix, final fix is being tracked here: https://github.com/ornladios/ADIOS2/issues/3309