### PR TITLE
SST with MPI dataplane: only print MPI initialization warning on rank 0

### DIFF
--- a/source/adios2/toolkit/sst/dp/mpi_dp.c
+++ b/source/adios2/toolkit/sst/dp/mpi_dp.c
@@ -271,10 +271,15 @@ static void MpiInitialize()
 
     if (provided != MPI_THREAD_MULTIPLE)
     {
-        fprintf(stderr,
-                "MPI init without MPI_THREAD_MULTIPLE (Externally "
-                "initialized:%s)\n",
-                IsInitialized ? "true" : "false");
+        int rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        if (!rank)
+        {
+            fprintf(stderr,
+                    "MPI init without MPI_THREAD_MULTIPLE (Externally "
+                    "initialized:%s)\n",
+                    IsInitialized ? "true" : "false");
+        }
     }
 }
 


### PR DESCRIPTION
This PR prints the MPI initialization warning on rank 0 of the world comm instead of all ranks.

@vicentebolea
