### PR TITLE
Handshake fix: rank 0 should receive msg from last rank, not from -1.

### DIFF
--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -243,6 +243,12 @@ template <typename T>
 void Comm::Send(const T *buf, size_t count, int dest, int tag,
                 const std::string &hint) const
 {
+    if (dest < 0 || dest > m_Impl->Size() - 1)
+    {
+        throw std::runtime_error(
+            "Invalid MPI dest rank in Send: " + std::to_string(dest) +
+            " for a communicator of size " + std::to_string(m_Impl->Size()));
+    }
     return m_Impl->Send(buf, count, CommImpl::GetDatatype<T>(), dest, tag,
                         hint);
 }
@@ -251,6 +257,12 @@ template <typename T>
 Comm::Status Comm::Recv(T *buf, size_t count, int source, int tag,
                         const std::string &hint) const
 {
+    if (source < 0 || source > m_Impl->Size() - 1)
+    {
+        throw std::runtime_error(
+            "Invalid MPI source rank in Recv: " + std::to_string(source) +
+            " for a communicator of size " + std::to_string(m_Impl->Size()));
+    }
     return m_Impl->Recv(buf, count, CommImpl::GetDatatype<T>(), source, tag,
                         hint);
 }
@@ -268,6 +280,12 @@ template <typename T>
 Comm::Req Comm::Isend(const T *buffer, const size_t count, int dest, int tag,
                       const std::string &hint) const
 {
+    if (dest < 0 || dest > m_Impl->Size() - 1)
+    {
+        throw std::runtime_error(
+            "Invalid MPI dest rank in Isend: " + std::to_string(dest) +
+            " for a communicator of size " + std::to_string(m_Impl->Size()));
+    }
     return m_Impl->Isend(buffer, count, CommImpl::GetDatatype<T>(), dest, tag,
                          hint);
 }
@@ -276,6 +294,12 @@ template <typename T>
 Comm::Req Comm::Irecv(T *buffer, const size_t count, int source, int tag,
                       const std::string &hint) const
 {
+    if (source < 0 || source > m_Impl->Size() - 1)
+    {
+        throw std::runtime_error(
+            "Invalid MPI source rank in Irecv: " + std::to_string(source) +
+            " for a communicator of size " + std::to_string(m_Impl->Size()));
+    }
     return m_Impl->Irecv(buffer, count, CommImpl::GetDatatype<T>(), source, tag,
                          hint);
 }

--- a/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
@@ -201,7 +201,7 @@ void MPIShmChain::HandshakeLinks_Start(helper::Comm &comm, HandshakeStruct &hs)
     else // rank 0 receives from last
     {
         hs.recvRequest = comm.Irecv(
-            &hs.recvToken, 1, comm.Size()-1, 0,
+            &hs.recvToken, 1, comm.Size() - 1, 0,
             "Irecv handshake with neighbor, MPIChain aggregator, at Open");
     }
 }

--- a/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
@@ -201,7 +201,7 @@ void MPIShmChain::HandshakeLinks_Start(helper::Comm &comm, HandshakeStruct &hs)
     else // rank 0 receives from last
     {
         hs.recvRequest = comm.Irecv(
-            &hs.recvToken, 1, rank - 1, 0,
+            &hs.recvToken, 1, comm.Size()-1, 0,
             "Irecv handshake with neighbor, MPIChain aggregator, at Open");
     }
 }


### PR DESCRIPTION
Added error checks in Comm send/recv functions to throw an error in case of bad source/dest.
fixes #3344 