### PR TITLE
CMAKE: Support cmake 3.24

### DIFF
--- a/cmake/install/post/generate-adios2-config.sh.in
+++ b/cmake/install/post/generate-adios2-config.sh.in
@@ -58,8 +58,16 @@ function prefixify() {
   echo "$@" | sed "s|${PREFIX}|\${ADIOS2_PREFIX}|g"
 }
 
-PREFIX="${DESTDIR}$1"
+PREFIX="$1"
+
+if [ "${1:0:1}" != "/" ]
+then
+  # Convert relative paths to absolute based on DESTDIR
+  PREFIX="${DESTDIR:-$(pwd)}/$1"
+fi
+
 shift
+
 CMAKE="@CMAKE_COMMAND@"
 SOURCE_DIR="@ADIOS2_SOURCE_DIR@/cmake/install/post/adios2-config-dummy"
 BUILD_DIR=$(mktemp -d)
@@ -78,10 +86,10 @@ then
   export FC="@MPI_Fortran_COMPILER@"
 fi
 
-EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -Dadios2_DIR=${PREFIX}/@CMAKE_INSTALL_CMAKEDIR@"
+export adios2_DIR="${PREFIX}/@CMAKE_INSTALL_CMAKEDIR@"
 if [ -n "@CMAKE_PREFIX_PATH@" ]
 then
-  EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DCMAKE_PREFIX_PATH=@CMAKE_PREFIX_PATH@"
+  export CMAKE_PREFIX_PATH="@CMAKE_PREFIX_PATH@:${CMAKE_PREFIX_PATH}"
 fi
 
 echo "Configuring adios2-config@ADIOS2_EXECUTABLE_SUFFIX@ dummy CMake project"

--- a/scripts/ci/gh-actions/macos-setup.sh
+++ b/scripts/ci/gh-actions/macos-setup.sh
@@ -19,8 +19,8 @@ sudo xcode-select --switch /Applications/Xcode_${XCODE_VER}.app
 echo "Installing CMake"
 
 {
-  readonly version="3.23.3"
-  readonly checksum="45cda7b87cad41ac407fc150e4682b85c3eb45b1977d8e89319cb3a9a6f341f3"
+  readonly version="3.24.2"
+  readonly checksum="efb11a78c064dd7c54a50b8da247254d252112c402c6e48cb7db3f9c84a4e5ad"
   readonly pkg="cmake-${version}-macos-universal.tar.gz"
   echo "${checksum}  ${pkg}" > cmake.sha256sum
 

--- a/scripts/ci/images-v2/packages.yaml.in
+++ b/scripts/ci/images-v2/packages.yaml.in
@@ -6,7 +6,7 @@ packages:
   adios2:
     variants: $(MPI_VARIANT)+blosc+bzip2+zfp+sz+png+sst+dataman+ssc+hdf5+python+fortran
   cmake:
-    version: [3.22.4]
+    version: [3.24]
   mpich:
     version: [3.3.2]
     variants: device=ch3 netmod=tcp

--- a/testing/install/Fortran/CMakeLists.txt
+++ b/testing/install/Fortran/CMakeLists.txt
@@ -4,10 +4,10 @@
 #------------------------------------------------------------------------------#
 
 cmake_minimum_required(VERSION 3.6)
-project(adios_fortran_test Fortran)
+project(adios_fortran_test Fortran C)
 enable_testing()
 
-find_package(adios2 REQUIRED)
+find_package(adios2 COMPONENTS Fortran REQUIRED)
 
 # Test using serial Fortran bindings through adios2::fortran target.
 add_executable(adios_fortran_test main_nompi_check.F90)


### PR DESCRIPTION
- [x] Update el8-gcc10|11 CI docker images to use CMake 3.24
- [x] #3348 ADIOS2 CMAKE dummy error
- [x] #3335
- [x] #3309

fixes #3348 
fixes #3335
fixes #3309 