### PR TITLE
Fix race condition in OnDemand delivery

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -128,6 +128,7 @@ typedef struct _CPTimestepEntry
     struct _TimestepMetadataMsg *Msg;
     int MetaDataSendCount;
     int ReferenceCount;
+    int InProgressFlag;
     int Expired;
     int PreciousTimestep;
     void **DP_TimestepInfo;

--- a/testing/adios2/engine/staging-common/TestDistributionRead.cpp
+++ b/testing/adios2/engine/staging-common/TestDistributionRead.cpp
@@ -66,8 +66,6 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
 
     adios2::Engine engine1 = io1.Open(fname, adios2::Mode::Read);
 
-    time_point<Clock> startTime = Clock::now();
-
     std::string varname1 = "r64";
 
     size_t first_step = SIZE_MAX;
@@ -76,13 +74,6 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
     {
         size_t writerSize;
         size_t step;
-        if (OnDemand && (total_steps > 0))
-        {
-            time_point<Clock> end = Clock::now();
-            milliseconds diff = duration_cast<milliseconds>(end - startTime);
-            std::cout << "Reader " << first_step << "Got an step at time "
-                      << diff.count() << "ms" << std::endl;
-        }
         auto var1 = io1.InquireVariable<double>(varname1);
 
         EXPECT_TRUE(var1);
@@ -122,7 +113,6 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
                                                myLength, writerSize * Nx);
         if (first_step == SIZE_MAX)
         {
-            std::cout << "My first step was step " << step << std::endl;
             first_step = step;
         }
         if (result != 0)
@@ -131,66 +121,6 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
                       << " timestep " << step << std::endl;
         }
         EXPECT_EQ(result, 0);
-        if (OnDemand)
-        {
-            std::cout << "Reader " << first_step << " Got Step " << step
-                      << std::endl;
-            switch (first_step)
-            {
-            case 0:
-            {
-                double StepDelay[] = {1, 3, 5, 0, 0, 20};
-                int ExpectedStep[] = {0, 4, 7, 10, 12, 15};
-                EXPECT_EQ(ExpectedStep[total_steps], step);
-                std::cout << "Reader " << first_step << " Sleeping for "
-                          << StepDelay[total_steps] << std::endl;
-                std::this_thread::sleep_for(std::chrono::milliseconds(
-                    (long)(StepDelay[total_steps] * 1000.0)));
-                time_point<Clock> end = Clock::now();
-                milliseconds diff =
-                    duration_cast<milliseconds>(end - startTime);
-                std::cout << "Reader " << first_step
-                          << "Doing begin step at time " << diff.count() << "ms"
-                          << std::endl;
-
-                break;
-            }
-            case 1:
-            {
-                double StepDelay[] = {0, 0, 1.5, 5, 0, 0, 1, 10};
-                int ExpectedStep[] = {1, 3, 5, 8, 11, 14, 17, 19};
-                EXPECT_EQ(ExpectedStep[total_steps], step);
-                std::cout << "Reader " << first_step << " Sleeping for "
-                          << StepDelay[total_steps] << std::endl;
-                std::this_thread::sleep_for(std::chrono::milliseconds(
-                    (long)(StepDelay[total_steps] * 1000.0)));
-                time_point<Clock> end = Clock::now();
-                milliseconds diff =
-                    duration_cast<milliseconds>(end - startTime);
-                std::cout << "Reader " << first_step
-                          << "Doing begin step at time " << diff.count() << "ms"
-                          << std::endl;
-                break;
-            }
-            case 2:
-            {
-                double StepDelay[] = {3, 2, 4, 0, 0, 0, 0};
-                int ExpectedStep[] = {2, 6, 9, 13, 16, 18};
-                EXPECT_EQ(ExpectedStep[total_steps], step);
-                std::cout << "Reader " << first_step << " Sleeping for "
-                          << StepDelay[total_steps] << std::endl;
-                std::this_thread::sleep_for(std::chrono::milliseconds(
-                    (long)(StepDelay[total_steps] * 1000.0)));
-                time_point<Clock> end = Clock::now();
-                milliseconds diff =
-                    duration_cast<milliseconds>(end - startTime);
-                std::cout << "Reader " << first_step
-                          << "Doing begin step at time " << diff.count() << "ms"
-                          << std::endl;
-                break;
-            }
-            }
-        }
         total_steps++;
     }
     if (RoundRobin)
@@ -206,18 +136,7 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
     }
     else if (OnDemand)
     {
-        switch (first_step)
-        {
-        case 0:
-            EXPECT_EQ(total_steps, 6);
-            break;
-        case 1:
-            EXPECT_EQ(total_steps, 8);
-            break;
-        case 2:
-            EXPECT_EQ(total_steps, 6);
-            break;
-        }
+        std::cout << " Total steps received is " << total_steps << std::endl;
     }
     else
     {

--- a/testing/adios2/engine/staging-common/TestDistributionWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestDistributionWrite.cpp
@@ -121,17 +121,6 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         }
         engine1.Put(step_var, step);
         engine1.EndStep();
-        if (OnDemand)
-        {
-            if (step >= 2)
-            {
-                // send out first three quickly, so those (assume 3) guys find
-                // out who they are, then one every 2 sec
-                std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-            }
-            if (step == 8)
-                std::this_thread::sleep_for(std::chrono::milliseconds(10000));
-        }
     }
     // Close the file
     engine1.Close();


### PR DESCRIPTION
This mod excludes the timestep that is currently being processed in ProvideTimestep() from consideration for transmission in the RequestTimestep handler.  This resolves a race condition where the "in-the-queue-but-not-quite-complete" timestep might be sent out OnDemand before it's ready because it looks to the handler like it's the next one to be requested OnDemand.  Instead, the handler will queue its request and let ProvideTimestep() proceed as normal.  This obviates the need for the prior race condition patch because ProvideTimestep() will never find that the step it is working on has been sent out before it's done.

This patch also includes changes to the TestDistributionRead/Write in their OnDemand sections which were previously unused.  Those tests are now suitable for running on the command line like:  
bin/TestDistributionWrite --on_demand --num_steps 1000 SST tmp & bin/TestDistributionRead --on_demand SST tmp & bin/TestDistributionRead --on_demand SST tmp & bin/TestDistributionRead --on_demand SST tmp
And one can manually add the "Total steps received is" numbers to see if they sum to 1000.  This test is still not suitable for CI, but handy for manual testing.