### PR TITLE
BP5 read direct to application memory (1 dimensional case)

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -47,7 +47,7 @@ public:
         size_t StartOffset;
         size_t ReadLength;
         char *DestinationAddr;
-        void *Internal;
+        bool DirectToAppMemory;
         size_t ReqIndex;
         size_t OffsetInBlock;
         size_t BlockID;
@@ -230,6 +230,9 @@ private:
     std::vector<BP5ArrayRequest> PendingRequests;
     void *GetMetadataBase(BP5VarRec *VarRec, size_t Step,
                           size_t WriterRank) const;
+    bool IsContiguousTransfer(BP5ArrayRequest *Req, size_t *offsets,
+                              size_t *count);
+
     size_t CurTimestep = 0;
 
     /* We assume operators are not thread-safe, call Decompress() one at a time


### PR DESCRIPTION
In general in ADIOS, writers populate portions of a virtual multidimensional variables logically decomposed across writer ranks and readers request multidimensional slices out of that space.  Each block of each writer's contribution was contiguous (or made contiguous) when it was written, and each readers completed request will end up being contiguous in reader memory, but because a reader request might pull data from multiple writer blocks or involve only a subset of a block, filling a read request often involves non-contiguous transfers.  That is, sections of a writer block that were contiguous in that block end up being non-contiguous in the reader destination, and vice versa.  Because of this BP5 was conservative, always reading data into a temporary buffer and then slicing it into the appropriate place in application memory.  It would be more efficient to read directly into application memory when we have a contiguous-to-contiguous transfer, but the general case of determining if a transfer is really contiguous-to-contiguous for multidimensional data is somewhat tricky.  However, the 1D case is easier to reason about and is addressed in this PR.  Modifications are contained entirely in BP5Serializer::GenerateReadRequests and FinalizeGets.  @anagainaru I've excluded cases where our destination is not in the Host MemorySpace (and corrected one spot where the destination memory space was not initialized in the ReadRequest. 