### PR TITLE
WIP:  Fix untyped conversion in PNG operator test

### DIFF
--- a/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
@@ -19,7 +19,7 @@ std::string engineName; // comes from command line
 template <class T>
 static T Random100()
 {
-    return std::rand() % 100;
+    return static_cast<T>(std::rand() % 100);
 }
 
 void PNGAccuracy2D(const std::string compressionLevel)


### PR DESCRIPTION
This error doesn't always seem to pop up in CI, but trying a fix regardless.