### PR TITLE
CI: Workaround for Windows builds 20221120.1

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -282,6 +282,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: source
+      - name: (WORKAROUND for windows-2022=20221120.1)) Remove Perl Strawberry
+        run: rm -rf C:/Strawberry/
       - name: Setup
         shell: pwsh
         run: gha/scripts/ci/gh-actions/windows-setup.ps1


### PR DESCRIPTION
CI: Workaround for Windows builds 20221120.1

- Observed in windows-2022 and windows 2019 version 20221120.1
- It is a known issue on how CMake 3.25 discovers static libraries.
- It consists in CMake wrongly picking static libraries from the Perl
  Strawberry distribution.

Upstream issue:
- https://github.com/actions/runner-images/issues/6627

This will be resolved in the incoming CMake 3.25.1 which will be eventually included in one of the next windows Github-hosted images 