### PR TITLE
Change (at least) some sprintf() to snprintf()

### DIFF
--- a/bindings/C/adios2/c/adios2_c_io.cpp
+++ b/bindings/C/adios2/c/adios2_c_io.cpp
@@ -389,7 +389,7 @@ adios2_error adios2_inquire_subgroups(char ***results, const char *full_prefix,
         for (auto &m : subGrpNames)
         {
             (*results)[i] = (char *)malloc(m.size() + 1);
-            sprintf((*results)[i], "%s", m.c_str());
+            snprintf((*results)[i], m.size() + 1, "%s", m.c_str());
             (*results)[i][m.size()] = '\0';
             i++;
         }

--- a/source/adios2/engine/dataspaces/DataSpacesReader.cpp
+++ b/source/adios2/engine/dataspaces/DataSpacesReader.cpp
@@ -112,7 +112,7 @@ StepStatus DataSpacesReader::BeginStep(StepMode mode, const float timeout_sec)
             dspaces_client_t *client = get_client_handle();
             char meta_str[256];
             unsigned int metalen;
-            sprintf(meta_str, "VARMETA@%s", fstr);
+            snprintf(meta_str, sizeof(meta_str), "VARMETA@%s", fstr);
             int err = dspaces_get_meta(*client, meta_str, META_MODE_NEXT,
                                        m_CurrentStep, &bcast_array[1],
                                        (void **)&buffer, &metalen);
@@ -131,7 +131,7 @@ StepStatus DataSpacesReader::BeginStep(StepMode mode, const float timeout_sec)
             dspaces_client_t *client = get_client_handle();
             char meta_str[256];
             unsigned int metalen;
-            sprintf(meta_str, "VARMETA@%s", fstr);
+            snprintf(meta_str, sizeof(meta_str), "VARMETA@%s", fstr);
             int err = dspaces_get_meta(*client, meta_str, META_MODE_LAST,
                                        m_CurrentStep, &bcast_array[1],
                                        (void **)&buffer, &metalen);

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -239,7 +239,7 @@ char *BP5Serializer::BuildVarName(const char *base_name, const ShapeID Shape,
     }
     else
     {
-        sprintf(Ret, "%s_%d_%d_", Prefix, element_size, type);
+        snprintf(Ret, Len, "%s_%d_%d_", Prefix, element_size, type);
         strcat(Ret, base_name);
     }
     return Ret;
@@ -257,11 +257,11 @@ static char *BuildLongName(const char *base_name, const ShapeID Shape,
     char *Ret = (char *)malloc(Len);
     if (StructID)
     {
-        sprintf(Ret, "%s_%d_%d_%s", Prefix, element_size, type, StructID);
+        snprintf(Ret, Len, "%s_%d_%d_%s", Prefix, element_size, type, StructID);
     }
     else
     {
-        sprintf(Ret, "%s_%d_%d", Prefix, element_size, type);
+        snprintf(Ret, Len, "%s_%d_%d", Prefix, element_size, type);
     }
     strcat(Ret, "_");
     strcat(Ret, base_name);
@@ -286,7 +286,7 @@ char *BP5Serializer::BuildArrayDimsName(const char *base_name, const int type,
     const char *Prefix = NamePrefix(ShapeID::GlobalArray);
     int Len = strlen(base_name) + 3 + strlen(Prefix) + 16;
     char *Ret = (char *)malloc(Len);
-    sprintf(Ret, "%s%d_%d_", Prefix, element_size, type);
+    snprintf(Ret, Len, "%s%d_%d_", Prefix, element_size, type);
     strcat(Ret, base_name);
     strcat(Ret, "Dims");
     return Ret;
@@ -299,7 +299,7 @@ char *BP5Serializer::BuildArrayDBCountName(const char *base_name,
     const char *Prefix = NamePrefix(ShapeID::GlobalArray);
     int Len = strlen(base_name) + 3 + strlen(Prefix) + 16;
     char *Ret = (char *)malloc(Len);
-    sprintf(Ret, "%s%d_%d_", Prefix, element_size, type);
+    snprintf(Ret, Len, "%s%d_%d_", Prefix, element_size, type);
     strcat(Ret, base_name);
     strcat(Ret, "DBCount");
     return Ret;
@@ -312,7 +312,7 @@ char *BP5Serializer::BuildArrayBlockCountName(const char *base_name,
     const char *Prefix = NamePrefix(ShapeID::GlobalArray);
     int Len = strlen(base_name) + 3 + strlen(Prefix) + 24;
     char *Ret = (char *)malloc(Len);
-    sprintf(Ret, "%s%d_%d_", Prefix, element_size, type);
+    snprintf(Ret, Len, "%s%d_%d_", Prefix, element_size, type);
     strcat(Ret, base_name);
     strcat(Ret, "BlockCount");
     return Ret;
@@ -364,7 +364,8 @@ void BP5Serializer::AddFixedArrayField(FMFieldList *FieldP, int *CountP,
 {
     const char *TransType = TranslateADIOS2Type2FFS(Type);
     char *TypeWithArray = (char *)malloc(strlen(TransType) + 16);
-    sprintf(TypeWithArray, "*(%s[%d])", TransType, DimCount);
+    snprintf(TypeWithArray, strlen(TransType) + 16, "*(%s[%d])", TransType,
+             DimCount);
     free((void *)TransType);
     AddSimpleField(FieldP, CountP, Name, TypeWithArray, sizeof(void *));
     free(TypeWithArray);
@@ -378,7 +379,8 @@ void BP5Serializer::AddVarArrayField(FMFieldList *FieldP, int *CountP,
     char *TransType = TranslateADIOS2Type2FFS(Type);
     char *TypeWithArray =
         (char *)malloc(strlen(TransType) + strlen(SizeField) + 8);
-    sprintf(TypeWithArray, "%s[%s]", TransType, SizeField);
+    snprintf(TypeWithArray, strlen(TransType) + strlen(SizeField) + 8, "%s[%s]",
+             TransType, SizeField);
     free(TransType);
     AddSimpleField(FieldP, CountP, Name, TypeWithArray, sizeof(void *));
     free(TypeWithArray);
@@ -392,7 +394,8 @@ void BP5Serializer::AddDoubleArrayField(FMFieldList *FieldP, int *CountP,
     char *TransType = TranslateADIOS2Type2FFS(Type);
     char *TypeWithArray =
         (char *)malloc(strlen(TransType) + strlen(SizeField) + 8);
-    sprintf(TypeWithArray, "%s[2][%s]", TransType, SizeField);
+    snprintf(TypeWithArray, strlen(TransType) + strlen(SizeField) + 8,
+             "%s[2][%s]", TransType, SizeField);
     AddSimpleField(FieldP, CountP, Name, TypeWithArray, sizeof(void *));
     free(TransType);
     free(TypeWithArray);
@@ -447,8 +450,8 @@ BP5Serializer::CreateWriterRec(void *Variable, const char *Name, DataType Type,
         TextStructID = (char *)malloc(IDLength * 2 + 1);
         for (int i = 0; i < IDLength; i++)
         {
-            sprintf(&TextStructID[i * 2], "%02x",
-                    ((unsigned char *)ServerID)[i]);
+            snprintf(&TextStructID[i * 2], 3, "%02x",
+                     ((unsigned char *)ServerID)[i]);
         }
         NewStructFormats.push_back(Format);
     }

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -96,7 +96,7 @@ static char *buildContactInfo(SstStream Stream, attr_list DPAttrs)
 {
     char *Contact = CP_GetContactString(Stream, DPAttrs);
     char *FullInfo = malloc(strlen(Contact) + 20);
-    sprintf(FullInfo, "%p:%s", (void *)Stream, Contact);
+    snprintf(FullInfo, strlen(Contact) + 20, "%p:%s", (void *)Stream, Contact);
     free(Contact);
     return FullInfo;
 }
@@ -177,8 +177,9 @@ static int writeContactInfoFile(const char *Name, SstStream Stream,
      * write the contact information file with a temporary name before
      * renaming it to the final version to help prevent partial reads
      */
-    sprintf(TmpName, "%s.tmp", Name);
-    sprintf(FileName, "%s" SST_POSTFIX, Name);
+    snprintf(TmpName, strlen(Name) + strlen(".tmp") + 1, "%s.tmp", Name);
+    snprintf(FileName, strlen(Name) + strlen(SST_POSTFIX) + 1, "%s" SST_POSTFIX,
+             Name);
     WriterInfo = fopen(TmpName, "w");
     if (!WriterInfo)
     {
@@ -1656,7 +1657,7 @@ void SstWriterClose(SstStream Stream)
                                List->Timestep, List->Expired,
                                List->PreciousTimestep, List->ReferenceCount,
                                Stream->QueuedTimestepCount);
-                    sprintf(tmp, "%ld ", List->Timestep);
+                    snprintf(tmp, sizeof(tmp), "%ld ", List->Timestep);
                     StringList = realloc(StringList,
                                          strlen(StringList) + strlen(tmp) + 1);
                     strcat(StringList, tmp);

--- a/source/adios2/toolkit/sst/cp/ffs_marshal.c
+++ b/source/adios2/toolkit/sst/cp/ffs_marshal.c
@@ -53,7 +53,7 @@ static char *BuildVarName(const char *base_name, const int type,
 {
     int Len = strlen(base_name) + 2 + strlen("SST_") + 16;
     char *Ret = malloc(Len);
-    sprintf(Ret, "SST%d_%d_", element_size, type);
+    snprintf(Ret, Len, "SST%d_%d_", element_size, type);
     strcat(Ret, base_name);
     return Ret;
 }
@@ -75,7 +75,7 @@ static char *BuildArrayDimsName(const char *base_name, const int type,
 {
     int Len = strlen(base_name) + 3 + strlen("SST_") + 16;
     char *Ret = malloc(Len);
-    sprintf(Ret, "SST%d_%d_", element_size, type);
+    snprintf(Ret, Len, "SST%d_%d_", element_size, type);
     strcat(Ret, base_name);
     strcat(Ret, "Dims");
     return Ret;
@@ -86,7 +86,7 @@ static char *BuildArrayDBCountName(const char *base_name, const int type,
 {
     int Len = strlen(base_name) + 3 + strlen("SST_") + 16;
     char *Ret = malloc(Len);
-    sprintf(Ret, "SST%d_%d_", element_size, type);
+    snprintf(Ret, Len, "SST%d_%d_", element_size, type);
     strcat(Ret, base_name);
     strcat(Ret, "DBCount");
     return Ret;
@@ -300,7 +300,8 @@ static void AddFixedArrayField(FMFieldList *FieldP, int *CountP,
 {
     const char *TransType = TranslateADIOS2Type2FFS(Type);
     char *TypeWithArray = malloc(strlen(TransType) + 16);
-    sprintf(TypeWithArray, "*(%s[%d])", TransType, DimCount);
+    snprintf(TypeWithArray, strlen(TransType) + 16, "*(%s[%d])", TransType,
+             DimCount);
     free((void *)TransType);
     AddSimpleField(FieldP, CountP, Name, TypeWithArray, sizeof(void *));
     free(TypeWithArray);
@@ -311,7 +312,8 @@ static void AddVarArrayField(FMFieldList *FieldP, int *CountP, const char *Name,
 {
     char *TransType = TranslateADIOS2Type2FFS(Type);
     char *TypeWithArray = malloc(strlen(TransType) + strlen(SizeField) + 8);
-    sprintf(TypeWithArray, "%s[%s]", TransType, SizeField);
+    snprintf(TypeWithArray, strlen(TransType) + strlen(SizeField) + 8, "%s[%s]",
+             TransType, SizeField);
     free(TransType);
     AddSimpleField(FieldP, CountP, Name, TypeWithArray, sizeof(void *));
     free(TypeWithArray);
@@ -887,7 +889,8 @@ static void IssueReadRequests(SstStream Stream, FFSArrayRequest Reqs)
                 realloc(Info->WriterInfo[WriterRank].RawBuffer, DataSize);
 
             char tmpstr[256] = {0};
-            sprintf(tmpstr, "Request to rank %d, bytes", WriterRank);
+            snprintf(tmpstr, sizeof(tmpstr), "Request to rank %d, bytes",
+                     WriterRank);
             PERFSTUBS_SAMPLE_COUNTER(tmpstr, (double)DataSize);
             Info->WriterInfo[WriterRank].ReadHandle = SstReadRemoteMemory(
                 Stream, WriterRank, Stream->ReaderTimestep, 0, DataSize,

--- a/source/adios2/toolkit/sst/dp/daos_dp.c
+++ b/source/adios2/toolkit/sst/dp/daos_dp.c
@@ -620,7 +620,7 @@ static void *DaosReadRemoteMemory(CP_Services Svcs, DP_RS_Stream Stream_v,
     char *StringName = malloc(20);
     void *NVBlock;
     char *BaseAddr;
-    sprintf(StringName, "Timestep_%ld", Timestep);
+    snprintf(StringName, 20, "Timestep_%ld", Timestep);
     BaseAddr =
         NULL; // nvs_get_with_malloc(Stream->writer_nvs[Rank], StringName, 1);
 
@@ -714,7 +714,7 @@ static void DaosProvideTimestep(CP_Services Svcs, DP_WS_Stream Stream_v,
 
     char *StringName = malloc(20);
     void *NVBlock;
-    sprintf(StringName, "Timestep_%ld", Timestep);
+    snprintf(StringName, 20, "Timestep_%ld", Timestep);
     NVBlock = NULL; // nvs_alloc(Stream->nvs, &Data->DataSize, StringName);
     memcpy(NVBlock, Data->block, Data->DataSize);
     // nvs_snapshot_(Stream->nvs, &Stream->Rank);

--- a/source/adios2/toolkit/sst/dp/dummy_dp.c
+++ b/source/adios2/toolkit/sst/dp/dummy_dp.c
@@ -199,7 +199,8 @@ static DP_RS_Stream DummyInitReader(CP_Services Svcs, void *CP_Stream,
 
     SMPI_Comm_rank(comm, &Stream->Rank);
 
-    sprintf(DummyContactString, "Reader Rank %d, test contact", Stream->Rank);
+    snprintf(DummyContactString, 64, "Reader Rank %d, test contact",
+             Stream->Rank);
 
     /*
      * add a handler for read reply messages
@@ -377,7 +378,7 @@ static DP_WSR_Stream DummyInitWriterPerReader(CP_Services Svcs,
         (DummyReaderContactInfo *)providedReaderInfo_v;
 
     SMPI_Comm_rank(comm, &Rank);
-    sprintf(DummyContactString, "Writer Rank %d, test contact", Rank);
+    snprintf(DummyContactString, 64, "Writer Rank %d, test contact", Rank);
 
     WSR_Stream->WS_Stream = WS_Stream; /* pointer to writer struct */
     WSR_Stream->PeerCohort = PeerCohort;
@@ -580,8 +581,8 @@ static void DummyProvideTimestep(CP_Services Svcs, DP_WS_Stream Stream_v,
         malloc(sizeof(struct _DummyPerTimestepInfo));
 
     Info->CheckString = malloc(64);
-    sprintf(Info->CheckString, "Dummy info for timestep %ld from rank %d",
-            Timestep, Stream->Rank);
+    snprintf(Info->CheckString, 64, "Dummy info for timestep %ld from rank %d",
+             Timestep, Stream->Rank);
     Info->CheckInt = Stream->Rank * 1000 + Timestep;
     Entry->Data = Data;
     Entry->Timestep = Timestep;

--- a/source/adios2/toolkit/sst/dp/evpath_dp.c
+++ b/source/adios2/toolkit/sst/dp/evpath_dp.c
@@ -781,7 +781,7 @@ static DP_WSR_Stream EvpathInitWriterPerReader(CP_Services Svcs,
         (EvpathReaderContactInfo *)providedReaderInfo_v;
 
     SMPI_Comm_rank(comm, &Rank);
-    sprintf(EvpathContactString, "Writer Rank %d, test contact", Rank);
+    snprintf(EvpathContactString, 64, "Writer Rank %d, test contact", Rank);
 
     WSR_Stream->WS_Stream = WS_Stream; /* pointer to writer struct */
     WSR_Stream->PeerCohort = PeerCohort;

--- a/source/h5vol/H5Vol_attr.c
+++ b/source/h5vol/H5Vol_attr.c
@@ -42,7 +42,7 @@ void *H5VL_adios2_attr_open(void *obj, const H5VL_loc_params_t *loc_params,
         else
         {
             char withSlash[strlen(name) + 2];
-            sprintf(withSlash, "/%s", name);
+            snprintf(withSlash, sizeof(withSlash), "/%s", name);
             withSlash[strlen(name) + 1] = '\0';
             attr = gLocateAttrFrom(vol, withSlash);
             if (NULL == attr)

--- a/source/h5vol/H5Vol_dataset.c
+++ b/source/h5vol/H5Vol_dataset.c
@@ -30,10 +30,10 @@ void *H5VL_adios2_dataset_create(void *obj, const H5VL_loc_params_t *loc_params,
         if (vol->m_Path[strlen(vol->m_Path) - 1] == '/')
         {
             pathSize = pathSize - 1;
-            sprintf(fullPath, "%s%s", vol->m_Path, name);
+            snprintf(fullPath, sizeof(fullPath), "%s%s", vol->m_Path, name);
         }
         else
-            sprintf(fullPath, "%s/%s", vol->m_Path, name);
+            snprintf(fullPath, sizeof(fullPath), "%s/%s", vol->m_Path, name);
 
         fullPath[pathSize] = '\0';
 

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1544,7 +1544,7 @@ int doList(const char *path)
         adios_verbose = 3; // print info lines
     if (verbose > 2)
         adios_verbose = 4; // print debug lines
-    sprintf(init_params, "verbose=%d", adios_verbose);
+    snprintf(init_params, sizeof(init_params), "verbose=%d", adios_verbose);
     if (hidden_attrs)
         strcat(init_params, ";show_hidden_attrs");
 
@@ -2967,10 +2967,12 @@ int print_dataset(const void *data, const DataType vartype, uint64_t *s,
         {
             if (!noindex && tdims > 0)
             {
-                sprintf(idxstr, "    (%*" PRIu64, ndigits[0], ids[0]);
+                snprintf(idxstr, sizeof(idxstr), "    (%*" PRIu64, ndigits[0],
+                         ids[0]);
                 for (i = 1; i < tdims; i++)
                 {
-                    sprintf(buf, ",%*" PRIu64, ndigits[i], ids[i]);
+                    snprintf(buf, sizeof(buf), ",%*" PRIu64, ndigits[i],
+                             ids[i]);
                     strcat(idxstr, buf);
                 }
                 strcat(idxstr, ")    ");

--- a/testing/adios2/engine/bp/TestBPWriteReadCuda.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadCuda.cpp
@@ -143,8 +143,8 @@ void RateCUDA(const std::string mode)
             for (size_t i = 0; i < NxTotal; i++)
             {
                 char msg[1 << 8] = {0};
-                sprintf(msg, "t=%d i=%zu rank=%d r32o=%f r32s=%f", t, i,
-                        mpiRank, r32o[i], r32s[i]);
+                snprintf(msg, sizeof(msg), "t=%d i=%zu rank=%d r32o=%f r32s=%f",
+                         t, i, mpiRank, r32o[i], r32s[i]);
                 ASSERT_LT(std::abs(r32o[i] - r32s[i]), EPSILON) << msg;
             }
         }

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
@@ -128,8 +128,8 @@ void ZFPRateCUDA(const std::string rate)
             for (size_t i = 0; i < NxTotal; i++)
             {
                 char msg[1 << 8] = {0};
-                sprintf(msg, "t=%d i=%zu rank=%d r32o=%f r32s=%f", t, i,
-                        mpiRank, r32o[i], r32s[i]);
+                snprintf(msg, sizeof(msg), "t=%d i=%zu rank=%d r32o=%f r32s=%f",
+                         t, i, mpiRank, r32o[i], r32s[i]);
                 ASSERT_LT(std::abs(r32o[i] - r32s[i]), EPSILON) << msg;
             }
         }

--- a/testing/adios2/performance/manyvars/PerfManyVars.c
+++ b/testing/adios2/performance/manyvars/PerfManyVars.c
@@ -91,12 +91,12 @@ void alloc_vars()
     }
 
     char fmt[16];
-    sprintf(fmt, "v%%%d.%dd", digit, digit);
+    snprintf(fmt, sizeof(fmt), "v%%%d.%dd", digit, digit);
     printf("fmt=[%s]\n", fmt);
     for (i = 0; i < NVARS; i++)
     {
         // sprintf(varnames[i], "v%-*d", digit, i);
-        sprintf(varnames[i], fmt, i);
+        snprintf(varnames[i], 16, fmt, i);
     }
     printf("varname[0]=%s\n", varnames[0]);
     printf("varname[%d]=%s\n", NVARS - 1, varnames[NVARS - 1]);

--- a/testing/adios2/performance/manyvars/TestManyVars.cpp
+++ b/testing/adios2/performance/manyvars/TestManyVars.cpp
@@ -188,10 +188,10 @@ public:
         }
 
         char fmt[32];
-        sprintf(fmt, "v%%%d.%dd", digit, digit);
+        snprintf(fmt, sizeof(fmt), "v%%%d.%dd", digit, digit);
         for (size_t i = 0; i < NVARS; i++)
         {
-            sprintf(varnames[i], fmt, i);
+            snprintf(varnames[i], 16, fmt, i);
         }
     }
 


### PR DESCRIPTION
sprintf() is deprecated and the new XCode compiler is throwing warnings on use.  This PR fixes changes at least some of the uses of sprintf() to snprintf() with appropriate length values.  Some uses remain and some of them demand more than the trivial mods performed in this PR.  There are additional uses of sprintf() in the thirdparty codes, but the way we're compiling those seems to keep us from getting warnings there.  I don't think I can count on the test suite exercising all of these code paths, so more eyes on this PR are welcome.