### PR TITLE
Revert "CI: Workaround for Windows builds 20221120.1"

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -282,8 +282,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: source
-      - name: (WORKAROUND for windows-2022=20221120.1)) Remove Perl Strawberry
-        run: rm -rf C:/Strawberry/
       - name: Setup
         shell: pwsh
         run: gha/scripts/ci/gh-actions/windows-setup.ps1


### PR DESCRIPTION
This reverts commit 3bd90769e05c66600710c0182d96a973f98c1561.

Revers #3394

The above commit was a workaround for a problem that has been resolved in the GitHub runner Windows images.

Upstream resolved issue: https://github.com/actions/runner-images/issues/6627