### PR TITLE
CMAKE: Check usability of MPI_Port_open

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -385,7 +385,24 @@ if(ADIOS2_USE_SST AND NOT WIN32)
     endif()
   endif()
   if(ADIOS2_HAVE_MPI)
-    set(ADIOS2_SST_HAVE_MPI TRUE)
+    set(CMAKE_REQUIRED_LIBRARIES MPI::MPI_C)
+    include(CheckCSourceRuns)
+    check_c_source_runs([=[
+        #include <mpi.h>
+        #include <stdlib.h>
+
+        #if !defined(MPICH)
+        #error "MPICH is the only supported library"
+        #endif
+
+        int main()
+        {
+          MPI_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, NULL);
+          MPI_Open_port(MPI_INFO_NULL, malloc(sizeof(char) * MPI_MAX_PORT_NAME));
+          MPI_Finalize();
+        }]=]
+    ADIOS2_HAVE_MPI_CLIENT_SERVER)
+    unset(CMAKE_REQUIRED_LIBRARIES)
   endif()
 endif()
 

--- a/source/adios2/toolkit/sst/CMakeLists.txt
+++ b/source/adios2/toolkit/sst/CMakeLists.txt
@@ -39,7 +39,7 @@ if(ADIOS2_HAVE_ZFP)
   target_link_libraries(sst PRIVATE zfp::zfp)
 endif()
 
-if(ADIOS2_HAVE_MPI)
+if(ADIOS2_HAVE_MPI_CLIENT_SERVER)
   target_sources(sst PRIVATE dp/mpi_dp.c)
   target_link_libraries(sst PRIVATE MPI::MPI_C)
 endif()


### PR DESCRIPTION
This will disable the SST MPI if the MPI_Port_open function is not working or if MPICH is not defined.

Related #3377 