### PR TITLE
Rename some portions of Struct interface

### DIFF
--- a/bindings/CXX11/adios2/cxx11/VariableNT.cpp
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.cpp
@@ -21,12 +21,12 @@ StructDefinition::StructDefinition(core::StructDefinition *ptr)
 {
 }
 
-void StructDefinition::AddItem(const std::string &name, const size_t offset,
-                               const DataType type, const size_t size)
+void StructDefinition::AddField(const std::string &name, const size_t offset,
+                                const DataType type, const size_t size)
 {
     helper::CheckForNullptr(m_StructDefinition,
-                            "in call to StructDefinition::AddItem");
-    m_StructDefinition->AddItem(name, offset, type, size);
+                            "in call to StructDefinition::AddField");
+    m_StructDefinition->AddField(name, offset, type, size);
 }
 
 void StructDefinition::Freeze() noexcept
@@ -43,11 +43,11 @@ size_t StructDefinition::StructSize() const noexcept
     return m_StructDefinition->StructSize();
 }
 
-size_t StructDefinition::Items() const noexcept
+size_t StructDefinition::Fields() const noexcept
 {
     helper::CheckForNullptr(m_StructDefinition,
-                            "in call to StructDefinition::Items");
-    return m_StructDefinition->Items();
+                            "in call to StructDefinition::Fields");
+    return m_StructDefinition->Fields();
 }
 std::string StructDefinition::Name(const size_t index) const
 {
@@ -67,11 +67,11 @@ DataType StructDefinition::Type(const size_t index) const
                             "in call to StructDefinition::Type");
     return m_StructDefinition->Type(index);
 }
-size_t StructDefinition::Size(const size_t index) const
+size_t StructDefinition::ElementCount(const size_t index) const
 {
     helper::CheckForNullptr(m_StructDefinition,
-                            "in call to StructDefinition::Size");
-    return m_StructDefinition->Size(index);
+                            "in call to StructDefinition::ElementCount");
+    return m_StructDefinition->ElementCount(index);
 }
 
 VariableNT::VariableNT(core::VariableBase *variable) : m_Variable(variable) {}
@@ -253,74 +253,74 @@ void VariableNT::RemoveOperations()
     m_Variable->RemoveOperations();
 }
 
-size_t VariableNT::StructItems() const
+size_t VariableNT::StructFields() const
 {
-    helper::CheckForNullptr(m_Variable, "in call to VariableNT::StructItems");
+    helper::CheckForNullptr(m_Variable, "in call to VariableNT::StructFields");
     if (m_Variable->m_Type != DataType::Struct)
     {
         helper::Throw<std::runtime_error>(
-            "bindings::CXX11", "VariableNT", "StructItems",
+            "bindings::CXX11", "VariableNT", "StructFields",
             "invalid data type " + ToString(m_Variable->m_Type) +
                 ", only Struct type supports this API");
     }
     return reinterpret_cast<core::VariableStruct *>(m_Variable)
-        ->m_StructDefinition.Items();
+        ->m_StructDefinition.Fields();
 }
-std::string VariableNT::StructItemName(const size_t index) const
+std::string VariableNT::StructFieldName(const size_t index) const
 {
     helper::CheckForNullptr(m_Variable,
-                            "in call to VariableNT::StructItemName");
+                            "in call to VariableNT::StructFieldName");
     if (m_Variable->m_Type != DataType::Struct)
     {
         helper::Throw<std::runtime_error>(
-            "bindings::CXX11", "VariableNT", "StructItemName",
+            "bindings::CXX11", "VariableNT", "StructFieldName",
             "invalid data type " + ToString(m_Variable->m_Type) +
                 ", only Struct type supports this API");
     }
     return reinterpret_cast<core::VariableStruct *>(m_Variable)
         ->m_StructDefinition.Name(index);
 }
-size_t VariableNT::StructItemOffset(const size_t index) const
+size_t VariableNT::StructFieldOffset(const size_t index) const
 {
     helper::CheckForNullptr(m_Variable,
-                            "in call to VariableNT::StructItemOffset");
+                            "in call to VariableNT::StructFieldOffset");
     if (m_Variable->m_Type != DataType::Struct)
     {
         helper::Throw<std::runtime_error>(
-            "bindings::CXX11", "VariableNT", "StructItemOffset",
+            "bindings::CXX11", "VariableNT", "StructFieldOffset",
             "invalid data type " + ToString(m_Variable->m_Type) +
                 ", only Struct type supports this API");
     }
     return reinterpret_cast<core::VariableStruct *>(m_Variable)
         ->m_StructDefinition.Offset(index);
 }
-DataType VariableNT::StructItemType(const size_t index) const
+DataType VariableNT::StructFieldType(const size_t index) const
 {
     helper::CheckForNullptr(m_Variable,
-                            "in call to VariableNT::StructItemType");
+                            "in call to VariableNT::StructFieldType");
     if (m_Variable->m_Type != DataType::Struct)
     {
         helper::Throw<std::runtime_error>(
-            "bindings::CXX11", "VariableNT", "StructItemType",
+            "bindings::CXX11", "VariableNT", "StructFieldType",
             "invalid data type " + ToString(m_Variable->m_Type) +
                 ", only Struct type supports this API");
     }
     return reinterpret_cast<core::VariableStruct *>(m_Variable)
         ->m_StructDefinition.Type(index);
 }
-size_t VariableNT::StructItemSize(const size_t index) const
+size_t VariableNT::StructFieldElementCount(const size_t index) const
 {
     helper::CheckForNullptr(m_Variable,
-                            "in call to VariableNT::StructItemSize");
+                            "in call to VariableNT::StructFieldElementCount");
     if (m_Variable->m_Type != DataType::Struct)
     {
         helper::Throw<std::runtime_error>(
-            "bindings::CXX11", "VariableNT", "StructItemSize",
+            "bindings::CXX11", "VariableNT", "StructFieldElementCount",
             "invalid data type " + ToString(m_Variable->m_Type) +
                 ", only Struct type supports this API");
     }
     return reinterpret_cast<core::VariableStruct *>(m_Variable)
-        ->m_StructDefinition.Size(index);
+        ->m_StructDefinition.ElementCount(index);
 }
 
 std::pair<VariableNT::T, VariableNT::T>

--- a/bindings/CXX11/adios2/cxx11/VariableNT.h
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.h
@@ -28,15 +28,15 @@ class StructDefinition
 {
 
 public:
-    void AddItem(const std::string &name, const size_t offset,
-                 const DataType type, const size_t size = 1);
+    void AddField(const std::string &name, const size_t offset,
+                  const DataType type, const size_t size = 1);
     void Freeze() noexcept;
     size_t StructSize() const noexcept;
-    size_t Items() const noexcept;
+    size_t Fields() const noexcept;
     std::string Name(const size_t index) const;
     size_t Offset(const size_t index) const;
     DataType Type(const size_t index) const;
-    size_t Size(const size_t index) const;
+    size_t ElementCount(const size_t index) const;
 
 private:
     friend class ADIOS;
@@ -209,11 +209,11 @@ public:
      */
     void RemoveOperations();
 
-    size_t StructItems() const;
-    std::string StructItemName(const size_t index) const;
-    size_t StructItemOffset(const size_t index) const;
-    DataType StructItemType(const size_t index) const;
-    size_t StructItemSize(const size_t index) const;
+    size_t StructFields() const;
+    std::string StructFieldName(const size_t index) const;
+    size_t StructFieldOffset(const size_t index) const;
+    DataType StructFieldType(const size_t index) const;
+    size_t StructFieldElementCount(const size_t index) const;
 
     union T
     {

--- a/source/adios2/common/ADIOSTypes.cpp
+++ b/source/adios2/common/ADIOSTypes.cpp
@@ -367,4 +367,42 @@ void MinMaxStruct::Dump(DataType Type)
         break;
     }
 }
+
+int TypeElementSize(DataType adiosvartype)
+{
+    switch (adiosvartype)
+    {
+    case DataType::UInt8:
+        return 1;
+    case DataType::Int8:
+        return 1;
+    case DataType::String:
+        return -1;
+    case DataType::UInt16:
+        return 2;
+    case DataType::Int16:
+        return 2;
+    case DataType::UInt32:
+        return 4;
+    case DataType::Int32:
+        return 4;
+    case DataType::UInt64:
+        return 8;
+    case DataType::Int64:
+        return 8;
+    case DataType::Float:
+        return 4;
+    case DataType::Double:
+        return 8;
+    case DataType::FloatComplex:
+        return 8;
+    case DataType::DoubleComplex:
+        return 16;
+    case DataType::LongDouble:
+        return 16;
+    default:
+        return -1;
+    }
+}
+
 } // end namespace adios2

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -296,6 +296,12 @@ template <typename T, typename Enable = void>
 struct TypeInfo;
 
 /**
+ *  Return the actual size in bytes of elements of the given type.  Returns -1
+ * for strings.
+ */
+int TypeElementSize(DataType adiosvartype);
+
+/**
  * ToString
  * makes a string from an enum class like ShapeID etc, for debugging etc
  * It is also overloaded elsewhere to allow for a readable representation of

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -939,12 +939,12 @@ VariableStruct *IO::InquireStructVariable(const std::string &name,
         return nullptr;
     }
 
-    if (ret->m_StructDefinition.Items() != def.Items())
+    if (ret->m_StructDefinition.Fields() != def.Fields())
     {
         return nullptr;
     }
 
-    for (size_t i = 0; i < def.Items(); ++i)
+    for (size_t i = 0; i < def.Fields(); ++i)
     {
         if (ret->m_StructDefinition.Name(i) != def.Name(i))
         {
@@ -959,7 +959,7 @@ VariableStruct *IO::InquireStructVariable(const std::string &name,
         {
             return nullptr;
         }
-        if (ret->m_StructDefinition.Size(i) != def.Size(i))
+        if (ret->m_StructDefinition.ElementCount(i) != def.ElementCount(i))
         {
             return nullptr;
         }

--- a/source/adios2/core/VariableStruct.cpp
+++ b/source/adios2/core/VariableStruct.cpp
@@ -22,42 +22,42 @@ StructDefinition::StructDefinition(const std::string &name, const size_t size)
 {
 }
 
-void StructDefinition::AddItem(const std::string &name, const size_t offset,
-                               const DataType type, const size_t size)
+void StructDefinition::AddField(const std::string &name, const size_t offset,
+                                const DataType type, const size_t elementcount)
 {
     if (m_Frozen)
     {
         helper::Throw<std::runtime_error>(
-            "core", "VariableStruct::StructDefinition", "AddItem",
+            "core", "VariableStruct::StructDefinition", "AddField",
             "struct definition already frozen");
     }
     if (type == DataType::None || type == DataType::Struct)
     {
         helper::Throw<std::invalid_argument>("core",
                                              "VariableStruct::StructDefinition",
-                                             "AddItem", "invalid data type");
+                                             "AddField", "invalid data type");
     }
-    if (offset + helper::GetDataTypeSize(type) * size > m_StructSize)
+    if (offset + helper::GetDataTypeSize(type) * elementcount > m_StructSize)
     {
         helper::Throw<std::runtime_error>("core",
                                           "VariableStruct::StructDefinition",
-                                          "AddItem", "exceeded struct size");
+                                          "AddField", "exceeded struct size");
     }
     m_Definition.emplace_back();
     auto &d = m_Definition.back();
     d.Name = name;
     d.Offset = offset;
     d.Type = type;
-    d.Size = size;
+    d.ElementCount = elementcount;
 }
 
 void StructDefinition::Freeze() noexcept { m_Frozen = true; }
 
 size_t StructDefinition::StructSize() const noexcept { return m_StructSize; }
 
-size_t StructDefinition::Items() const noexcept { return m_Definition.size(); }
+size_t StructDefinition::Fields() const noexcept { return m_Definition.size(); }
 
-std::string StructDefinition::Name() const noexcept { return m_Name; }
+std::string StructDefinition::StructName() const noexcept { return m_Name; }
 
 std::string StructDefinition::Name(const size_t index) const
 {
@@ -92,15 +92,15 @@ DataType StructDefinition::Type(const size_t index) const
     return m_Definition[index].Type;
 }
 
-size_t StructDefinition::Size(const size_t index) const
+size_t StructDefinition::ElementCount(const size_t index) const
 {
     if (index >= m_Definition.size())
     {
         helper::Throw<std::invalid_argument>("core",
                                              "VariableStruct::StructDefinition",
-                                             "Size", "invalid index");
+                                             "ElementCount", "invalid index");
     }
-    return m_Definition[index].Size;
+    return m_Definition[index].ElementCount;
 }
 
 VariableStruct::VariableStruct(const std::string &name,

--- a/source/adios2/core/VariableStruct.h
+++ b/source/adios2/core/VariableStruct.h
@@ -22,28 +22,28 @@ namespace core
 class StructDefinition
 {
 public:
-    struct StructItemDefinition
+    struct StructFieldDefinition
     {
         std::string Name;
         size_t Offset;
         DataType Type;
-        size_t Size;
+        size_t ElementCount;
     };
 
     StructDefinition(const std::string &name, const size_t size);
-    void AddItem(const std::string &name, const size_t offset,
-                 const DataType type, const size_t size = 1);
+    void AddField(const std::string &name, const size_t offset,
+                  const DataType type, const size_t size = 1);
     void Freeze() noexcept;
     size_t StructSize() const noexcept;
-    size_t Items() const noexcept;
+    std::string StructName() const noexcept;
+    size_t Fields() const noexcept;
     std::string Name(const size_t index) const;
-    std::string Name() const noexcept;
     size_t Offset(const size_t index) const;
     DataType Type(const size_t index) const;
-    size_t Size(const size_t index) const;
+    size_t ElementCount(const size_t index) const;
 
 private:
-    std::vector<StructItemDefinition> m_Definition;
+    std::vector<StructFieldDefinition> m_Definition;
     bool m_Frozen = false;
     std::string m_Name;
     size_t m_StructSize;

--- a/source/adios2/engine/ssc/SscHelper.cpp
+++ b/source/adios2/engine/ssc/SscHelper.cpp
@@ -453,9 +453,9 @@ void SerializeStructDefinitions(
         pos += p.first.size();
         output.value<uint64_t>(pos) = p.second.StructSize();
         pos += 8;
-        output[pos] = static_cast<uint8_t>(p.second.Items());
+        output[pos] = static_cast<uint8_t>(p.second.Fields());
         ++pos;
-        for (size_t i = 0; i < p.second.Items(); ++i)
+        for (size_t i = 0; i < p.second.Fields(); ++i)
         {
             output[pos] = static_cast<uint8_t>(p.second.Name(i).size());
             ++pos;
@@ -466,7 +466,7 @@ void SerializeStructDefinitions(
             pos += 8;
             output.value<DataType>(pos) = p.second.Type(i);
             pos += sizeof(DataType);
-            output.value<uint64_t>(pos) = p.second.Size(i);
+            output.value<uint64_t>(pos) = p.second.ElementCount(i);
             pos += 8;
         }
     }
@@ -517,8 +517,8 @@ void DeserializeStructDefinitions(
             pos += 8;
             if (structDefinition != nullptr)
             {
-                structDefinition->AddItem(itemName, itemOffset, itemType,
-                                          itemSize);
+                structDefinition->AddField(itemName, itemOffset, itemType,
+                                           itemSize);
             }
         }
     }

--- a/source/adios2/engine/ssc/SscWriterGeneric.cpp
+++ b/source/adios2/engine/ssc/SscWriterGeneric.cpp
@@ -257,7 +257,7 @@ void SscWriterGeneric::PutDeferred(VariableBase &variable, const void *data)
             if (variable.m_Type == DataType::Struct)
             {
                 b.structDef = reinterpret_cast<VariableStruct *>(&variable)
-                                  ->m_StructDefinition.Name();
+                                  ->m_StructDefinition.StructName();
             }
         }
         else

--- a/source/adios2/engine/ssc/SscWriterNaive.cpp
+++ b/source/adios2/engine/ssc/SscWriterNaive.cpp
@@ -178,7 +178,7 @@ void SscWriterNaive::PutDeferred(VariableBase &variable, const void *data)
         if (variable.m_Type == DataType::Struct)
         {
             b.structDef = reinterpret_cast<VariableStruct *>(&variable)
-                              ->m_StructDefinition.Name();
+                              ->m_StructDefinition.StructName();
         }
     }
 }

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -386,10 +386,24 @@ BP5Deserializer::ControlInfo *BP5Deserializer::BuildControl(FMFormat Format)
                     FMFieldList List = StructList[0].field_list;
                     while (List->field_name != NULL)
                     {
-                        DataType Type = TranslateFFSType2ADIOS(
-                            List->field_type, List->field_size);
-                        Def->AddItem(List->field_name, List->field_offset, Type,
-                                     List->field_size);
+                        char *ind = (char *)index(List->field_type, '[');
+                        if (!ind)
+                        {
+                            DataType Type = TranslateFFSType2ADIOS(
+                                List->field_type, List->field_size);
+                            Def->AddField(List->field_name, List->field_offset,
+                                          Type);
+                        }
+                        else
+                        {
+                            *ind = 0; // terminate string temporarily
+                            DataType Type = TranslateFFSType2ADIOS(
+                                List->field_type, List->field_size);
+                            size_t Count = strtol(ind + 1, NULL, 10);
+                            Def->AddField(List->field_name, List->field_offset,
+                                          Type, Count);
+                            *ind = '['; // restore string
+                        }
                         List++;
                     }
                     VarRec->Def = Def;

--- a/testing/adios2/engine/staging-common/TestStructRead.cpp
+++ b/testing/adios2/engine/staging-common/TestStructRead.cpp
@@ -78,13 +78,15 @@ TEST_F(StructReadTest, ADIOS2StructRead)
     engine.LockReaderSelections();
 
     auto particleDef1 = adios.DefineStruct("particle1", sizeof(particle));
-    particleDef1.AddItem("a", 0, adios2::DataType::Int8, 1);
-    particleDef1.AddItem("b", 4, adios2::DataType::Int32, 4);
+    particleDef1.AddField("a", offsetof(particle, a), adios2::DataType::Int8);
+    particleDef1.AddField("b", offsetof(particle, b), adios2::DataType::Int32,
+                          4);
 
     auto particleDef2 = adios.DefineStruct("particle2", sizeof(particle) + 4);
-    particleDef2.AddItem("a", 0, adios2::DataType::Int8, 1);
-    particleDef2.AddItem("b", 4, adios2::DataType::Int32, 4);
-    particleDef2.AddItem("c", 20, adios2::DataType::Int32, 1);
+    particleDef2.AddField("a", offsetof(particle, a), adios2::DataType::Int8);
+    particleDef2.AddField("b", offsetof(particle, b), adios2::DataType::Int32,
+                          4);
+    particleDef2.AddField("c", 20, adios2::DataType::Int32); // arbitrary offset
 
     while (true)
     {

--- a/testing/adios2/engine/staging-common/TestStructWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestStructWrite.cpp
@@ -93,11 +93,13 @@ TEST_F(StructWriteTest, ADIOS2CommonWrite)
         int b[4];
     };
     auto particleDef = adios.DefineStruct("particle", sizeof(particle));
-    particleDef.AddItem("a", 0, adios2::DataType::Int8, 1);
-    particleDef.AddItem("b", 4, adios2::DataType::Int32, 4);
+    particleDef.AddField("a", offsetof(struct particle, a),
+                         adios2::DataType::Int8);
+    particleDef.AddField("b", offsetof(struct particle, b),
+                         adios2::DataType::Int32, 4);
     auto varStruct =
         io.DefineStructVariable("particles", particleDef, shape, start, count);
-    EXPECT_THROW(particleDef.AddItem("c", 4, adios2::DataType::Int32, 4),
+    EXPECT_THROW(particleDef.AddField("c", 4, adios2::DataType::Int32),
                  std::runtime_error);
     std::vector<particle> myParticles(datasize);
     for (size_t i = 0; i < datasize; ++i)


### PR DESCRIPTION
More clean up of pending PRs.  This is largely cosmetic.  Where the prior struct interface called the components of a user-defined structure "items" (and had methods named appropriately), this PR now calls them "fields".  Also, it changes the name of a property of a field that I had initially misinterpreted.   The "Size" parameter to "AddItem" was used to define statically sized array fields (not to give the overall size of the field).  This has been changed to "ElementCount", and the BP5 implementation of structs changed to match this interpretation of that parameter.  Tests have also been changed to use the "offsetof()" macro rather than assuming _a priori_ knowledge of compiler-assigned field offsets.

The details of this are open to change.  Maybe "Member" instead of "Field"?  Maybe rather than a single AddField method that adds both single-element fields and static-array fields, that can be split into two methods with more explicit names?  But we should settle before the next release...