### PR TITLE
GPU buffers will never bypass the ADIOS internal buffers

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -2,7 +2,7 @@
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *
- * BP5Serializer.h
+ * BP5Deserializer.h
  *
  */
 
@@ -1357,10 +1357,12 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers,
                     RR.WriterRank = WriterRank;
                     RR.StartOffset =
                         writer_meta_base->DataBlockLocation[NeededBlock];
-
-                    RR.DirectToAppMemory = IsContiguousTransfer(
-                        Req, &writer_meta_base->Offsets[StartDim],
-                        &writer_meta_base->Count[StartDim]);
+                    if (Req->MemSpace != MemorySpace::Host)
+                        RR.DirectToAppMemory = false;
+                    else
+                        RR.DirectToAppMemory = IsContiguousTransfer(
+                            Req, &writer_meta_base->Offsets[StartDim],
+                            &writer_meta_base->Count[StartDim]);
                     RR.ReadLength =
                         helper::GetDataTypeSize(Req->VarRec->Type) *
                         CalcBlockLength(Req->VarRec->DimCount,
@@ -1490,9 +1492,12 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers,
                                 StartOffsetInBlock;
                             RR.ReadLength =
                                 EndOffsetInBlock - StartOffsetInBlock;
-                            RR.DirectToAppMemory = IsContiguousTransfer(
-                                Req, &writer_meta_base->Offsets[StartDim],
-                                &writer_meta_base->Count[StartDim]);
+                            if (Req->MemSpace != MemorySpace::Host)
+                                RR.DirectToAppMemory = false;
+                            else
+                                RR.DirectToAppMemory = IsContiguousTransfer(
+                                    Req, &writer_meta_base->Offsets[StartDim],
+                                    &writer_meta_base->Count[StartDim]);
                             if (RR.DirectToAppMemory)
                             {
                                 /*


### PR DESCRIPTION
The BP5 tests do not pass for contiguous buffers because the `IsContiguousTransfer` function returns true regardless of the buffer memory space. The bug appears after PR #3387.
 @eisenhauer you mention that you made sure to avoid the case of GPU buffers but I cannot find any code for this. Maybe it was removed later, but in the current form, all the GPU tests with BP5 are failing.