### PR TITLE
Clean the GPU code to allow multiple backends

### DIFF
--- a/source/adios2/core/Variable.cpp
+++ b/source/adios2/core/Variable.cpp
@@ -49,7 +49,7 @@ namespace core
         info.StepsCount = stepsCount;                                          \
         info.Data = const_cast<T *>(data);                                     \
         info.Operations = m_Operations;                                        \
-        info.IsGPU = IsCUDAPointer((void *)data);                              \
+        info.MemSpace = DetectMemorySpace((void *)data);                       \
         m_BlocksInfo.push_back(info);                                          \
         return m_BlocksInfo.back();                                            \
     }                                                                          \

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -81,7 +81,7 @@ public:
         SelectionType Selection = SelectionType::BoundingBox;
         bool IsValue = false;
         bool IsReverseDims = false;
-        bool IsGPU = false;
+        MemorySpace MemSpace = MemorySpace::Host;
     };
 
     /** use for multiblock info */

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -43,30 +43,45 @@ VariableBase::VariableBase(const std::string &name, const DataType type,
     InitShapeType();
 }
 
-bool VariableBase::IsCUDAPointer(const void *ptr)
-{
-    if (m_MemorySpace == MemorySpace::CUDA)
-        return true;
-    if (m_MemorySpace == MemorySpace::Host)
-        return false;
-
-#ifdef ADIOS2_HAVE_CUDA
-    cudaPointerAttributes attr;
-    cudaPointerGetAttributes(&attr, ptr);
-    return attr.type == cudaMemoryTypeDevice;
-#else
-    return false;
-#endif
-}
-
 size_t VariableBase::TotalSize() const noexcept
 {
     return helper::GetTotalSize(m_Count);
 }
 
+MemorySpace VariableBase::DetectMemorySpace(const void *ptr)
+{
+    if (m_MemSpaceRequested != MemorySpace::Detect)
+    {
+        m_MemSpaceDetected = m_MemSpaceRequested;
+        return m_MemSpaceRequested;
+    }
+
+    // if the user requested MemorySpace::Detect
+#ifdef ADIOS2_HAVE_CUDA
+    cudaPointerAttributes attr;
+    cudaPointerGetAttributes(&attr, ptr);
+    if (attr.type == cudaMemoryTypeDevice)
+    {
+        m_MemSpaceDetected = MemorySpace::CUDA;
+        return MemorySpace::CUDA;
+    }
+#endif
+    m_MemSpaceDetected = MemorySpace::Host;
+    return MemorySpace::Host;
+}
+
+MemorySpace VariableBase::GetMemorySpace(const void *ptr)
+{
+    if (m_MemSpaceDetected == MemorySpace::Detect)
+        m_MemSpaceDetected = DetectMemorySpace(ptr);
+    return m_MemSpaceDetected;
+}
+
 void VariableBase::SetMemorySpace(const MemorySpace mem)
 {
-    m_MemorySpace = mem;
+    m_MemSpaceRequested = mem;
+    // reset the detected memory space
+    m_MemSpaceDetected = MemorySpace::Detect;
 }
 
 void VariableBase::SetShape(const adios2::Dims &shape)

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -50,11 +50,13 @@ public:
     /** Variable -> sizeof(T),
      *  VariableStruct -> from constructor sizeof(struct) */
     const size_t m_ElementSize;
+    /* User requested memory space and the detected memory space */
 #ifdef ADIOS2_HAVE_CUDA
-    MemorySpace m_MemorySpace = MemorySpace::Detect;
+    MemorySpace m_MemSpaceRequested = MemorySpace::Detect;
 #else
-    MemorySpace m_MemorySpace = MemorySpace::Host;
+    MemorySpace m_MemSpaceRequested = MemorySpace::Host;
 #endif
+    MemorySpace m_MemSpaceDetected = MemorySpace::Detect;
 
     ShapeID m_ShapeID = ShapeID::Unknown; ///< see shape types in ADIOSTypes.h
     size_t m_BlockID = 0; ///< current block ID for local variables, global = 0
@@ -121,13 +123,19 @@ public:
     size_t TotalSize() const noexcept;
 
     /**
-     * Check if buffer is allocated on CUDA space
+     * Detect the memory space where a buffer was allocated and return it
      * @param pointer to the user data
      */
-    bool IsCUDAPointer(const void *ptr);
+    MemorySpace DetectMemorySpace(const void *ptr);
 
     /**
-     * Set the memory space
+     * Get the memory space where a given buffers was allocated
+     * @param pointer to the user data
+     */
+    MemorySpace GetMemorySpace(const void *ptr);
+
+    /**
+     * Set the memory space where user buffers will be allocated
      * @param the memory space where the expected buffers were allocated
      */
     void SetMemorySpace(const MemorySpace mem);

--- a/source/adios2/core/VariableStruct.h
+++ b/source/adios2/core/VariableStruct.h
@@ -73,7 +73,7 @@ public:
         SelectionType Selection = SelectionType::BoundingBox;
         bool IsValue = false;
         bool IsReverseDims = false;
-        bool IsGPU = false;
+        MemorySpace MemSpace = MemorySpace::Host;
     };
 
     std::vector<BPInfo> m_BlocksInfo;

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -1737,7 +1737,7 @@ void BP5Writer::PutCommon(VariableBase &variable, const void *values, bool sync)
     }
 
     // if the user buffer is allocated on the GPU always use sync mode
-    if (variable.GetMemorySpace(values) != MemorySpace::Host)
+    if (variable.DetectMemorySpace(values) != MemorySpace::Host)
         sync = true;
 
     size_t *Shape = NULL;

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -1737,7 +1737,7 @@ void BP5Writer::PutCommon(VariableBase &variable, const void *values, bool sync)
     }
 
     // if the user buffer is allocated on the GPU always use sync mode
-    if (variable.IsCUDAPointer(values))
+    if (variable.GetMemorySpace(values) != MemorySpace::Host)
         sync = true;
 
     size_t *Shape = NULL;

--- a/source/adios2/helper/adiosCUDA.cu
+++ b/source/adios2/helper/adiosCUDA.cu
@@ -1,21 +1,29 @@
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
- *
- * adiosCUDA.cpp
- *
- *  Created on: May 9, 2021
- *      Author: Ana Gainaru gainarua@ornl.gov
  */
 
 #ifndef ADIOS2_HELPER_ADIOSCUDA_CU_
 #define ADIOS2_HELPER_ADIOSCUDA_CU_
 
 #include "adios2/common/ADIOSMacros.h"
+#include <cuda_runtime.h>
 #include <thrust/device_ptr.h>
 #include <thrust/extrema.h>
 
 #include "adiosCUDA.h"
+
+void adios2::helper::CUDAMemcpyGPUToBuffer(void *dst, const char *GPUbuffer,
+                                           size_t byteCount)
+{
+    cudaMemcpy(dst, GPUbuffer, byteCount, cudaMemcpyDeviceToHost);
+}
+
+void adios2::helper::CUDAMemcpyBufferToGPU(char *GPUbuffer, const char *src,
+                                           size_t byteCount)
+{
+    cudaMemcpy(GPUbuffer, src, byteCount, cudaMemcpyHostToDevice);
+}
 
 namespace
 {

--- a/source/adios2/helper/adiosCUDA.h
+++ b/source/adios2/helper/adiosCUDA.h
@@ -1,15 +1,12 @@
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
- *
- * adiosCUDA.h CUDA functions used in the ADIOS framework
- *
- *  Created on: May 9, 2021
- *      Author: Ana Gainaru gainarua@ornl.gov
  */
 
 #ifndef ADIOS2_HELPER_ADIOSCUDA_H_
 #define ADIOS2_HELPER_ADIOSCUDA_H_
+
+#include <cstddef>
 
 namespace adios2
 {
@@ -23,12 +20,19 @@ namespace helper
 #endif
 
 /*
- * CUDA kernel for computing the min and max from a
- * GPU buffer
+ * CUDA kernel for computing the min and max from a GPU buffer
  */
 template <class T>
 ADIOS2_EXPORT void CUDAMinMax(const T *values, const size_t size, T &min,
                               T &max);
+
+/**
+ * Wrapper around cudaMemcpy needed for isolating CUDA interface dependency
+ */
+ADIOS2_EXPORT void CUDAMemcpyGPUToBuffer(void *dst, const char *GPUbuffer,
+                                         size_t byteCount);
+ADIOS2_EXPORT void CUDAMemcpyBufferToGPU(char *GPUbuffer, const char *src,
+                                         size_t byteCount);
 
 } // helper
 } // adios2

--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -449,15 +449,13 @@ int NdCopy(const char *in, const CoreDims &inStart, const CoreDims &inCount,
         // algorithm used.
         if (inIsLittleEndian == outIsLittleEndian)
         {
-#ifdef ADIOS2_HAVE_CUDA
-            if (MemSpace == MemorySpace::CUDA)
+            if (MemSpace != MemorySpace::Host)
             {
-                helper::NdCopyCUDA(inOvlpBase, outOvlpBase, inOvlpGapSize,
-                                   outOvlpGapSize, ovlpCount, minContDim,
-                                   blockSize);
+                helper::NdCopyGPU(inOvlpBase, outOvlpBase, inOvlpGapSize,
+                                  outOvlpGapSize, ovlpCount, minContDim,
+                                  blockSize, MemSpace);
                 return 0;
             }
-#endif
             // most efficient algm
             // warning: number of function stacks used is number of dimensions
             // of data.
@@ -480,14 +478,12 @@ int NdCopy(const char *in, const CoreDims &inStart, const CoreDims &inCount,
         // different endianess mode
         else
         {
-#ifdef ADIOS2_HAVE_CUDA
-            if (MemSpace == MemorySpace::CUDA)
+            if (MemSpace != MemorySpace::Host)
             {
                 helper::Throw<std::invalid_argument>(
                     "Helper", "Memory", "CopyContiguousMemory",
                     "Direct byte order reversal not supported for GPU buffers");
             }
-#endif
             if (!safeMode)
             {
                 NdCopyRecurDFSeqPaddingRevEndian(
@@ -511,14 +507,12 @@ int NdCopy(const char *in, const CoreDims &inStart, const CoreDims &inCount,
     // padding
     else
     {
-#ifdef ADIOS2_HAVE_CUDA
-        if (MemSpace == MemorySpace::CUDA)
+        if (MemSpace != MemorySpace::Host)
         {
             helper::Throw<std::invalid_argument>(
                 "Helper", "Memory", "CopyContiguousMemory",
                 "Direct byte order reversal not supported for GPU buffers");
         }
-#endif
         //        CoreDims revInCount(inCount);
         //        CoreDims revOutCount(outCount);
         //

--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -15,10 +15,6 @@
 
 #include "adios2/helper/adiosType.h"
 
-#ifdef ADIOS2_HAVE_CUDA
-#include <cuda_runtime.h>
-#endif
-
 namespace adios2
 {
 namespace helper
@@ -719,18 +715,5 @@ uint64_t PaddingToAlignOffset(uint64_t offset, uint64_t alignment_size)
     }
     return padSize;
 }
-
-#ifdef ADIOS2_HAVE_CUDA
-void MemcpyGPUToBuffer(void *dst, const char *GPUbuffer, size_t byteCount)
-{
-    cudaMemcpy(dst, GPUbuffer, byteCount, cudaMemcpyDeviceToHost);
-}
-
-void MemcpyBufferToGPU(char *GPUbuffer, const char *src, size_t byteCount)
-{
-    cudaMemcpy(GPUbuffer, src, byteCount, cudaMemcpyHostToDevice);
-}
-#endif
-
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -57,12 +57,6 @@ void CudaMemCopyToBuffer(char *dest, size_t position, const T *GPUbuffer,
 template <class T>
 void CudaMemCopyFromBuffer(T *GPUbuffer, size_t position, const char *source,
                            const size_t size) noexcept;
-
-/**
- * Wrapper around cudaMemcpy needed for isolating CUDA interface dependency
- */
-void MemcpyGPUToBuffer(void *dst, const char *GPUbuffer, size_t byteCount);
-void MemcpyBufferToGPU(char *GPUbuffer, const char *src, size_t byteCount);
 #endif
 
 /**

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -186,7 +186,7 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
                           const bool isRowMajor = true,
                           const bool reverseDimensions = false,
                           const bool endianReverse = false,
-                          const bool isGPU = false);
+                          const MemorySpace memSpace = MemorySpace::Host);
 
 template <class T>
 void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
@@ -196,12 +196,12 @@ void ClipContiguousMemory(T *dest, const Dims &destStart, const Dims &destCount,
                           const bool isRowMajor = true,
                           const bool reverseDimensions = false,
                           const bool endianReverse = false,
-                          const bool isGPU = false);
+                          const MemorySpace memSpace = MemorySpace::Host);
 
 template <class T>
 void CopyContiguousMemory(const char *src, const size_t stride, T *dest,
                           const bool endianReverse = false,
-                          const bool isGPU = false);
+                          const MemorySpace memSpace = MemorySpace::Host);
 
 /**
  * Clips a vector returning the sub-vector between start and end (end is

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -40,24 +40,23 @@ template <class T>
 void InsertToBuffer(std::vector<char> &buffer, const T *source,
                     const size_t elements = 1) noexcept;
 
-#ifdef ADIOS2_HAVE_CUDA
 /*
  * Copies data from a GPU buffer to a specific location in the adios buffer
  */
 template <class T>
 void CopyFromGPUToBuffer(std::vector<char> &dest, size_t &position,
-                         const T *source, const size_t elements = 1) noexcept;
+                         const T *source, MemorySpace memSpace,
+                         const size_t elements = 1) noexcept;
 template <class T>
-void CudaMemCopyToBuffer(char *dest, size_t position, const T *GPUbuffer,
-                         const size_t size) noexcept;
+void CopyFromGPUToBuffer(char *dest, size_t position, const T *GPUbuffer,
+                         MemorySpace memSpace, const size_t size) noexcept;
 
 /*
  * Copies data from a specific location in the adios buffer to a GPU buffer
  */
 template <class T>
-void CudaMemCopyFromBuffer(T *GPUbuffer, size_t position, const char *source,
-                           const size_t size) noexcept;
-#endif
+void CopyFromBufferToGPU(T *GPUbuffer, size_t position, const char *source,
+                         MemorySpace memSpace, const size_t size) noexcept;
 
 /**
  * Copies data to a specific location in the buffer updating position

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -21,6 +21,7 @@
 #include <thread>
 /// \endcond
 
+#include "adios2/helper/adiosCUDA.h"
 #include "adios2/helper/adiosMath.h"
 #include "adios2/helper/adiosSystem.h"
 #include "adios2/helper/adiosType.h"
@@ -88,7 +89,7 @@ void CudaMemCopyToBuffer(char *dest, size_t position, const T *GPUbuffer,
                          const size_t size) noexcept
 {
     const char *buffer = reinterpret_cast<const char *>(GPUbuffer);
-    MemcpyGPUToBuffer(dest + position, buffer, size);
+    helper::CUDAMemcpyGPUToBuffer(dest + position, buffer, size);
 }
 
 template <class T>
@@ -96,7 +97,7 @@ void CudaMemCopyFromBuffer(T *GPUbuffer, size_t position, const char *source,
                            const size_t size) noexcept
 {
     char *dest = reinterpret_cast<char *>(GPUbuffer);
-    MemcpyBufferToGPU(dest, source + position, size);
+    helper::CUDAMemcpyBufferToGPU(dest, source + position, size);
 }
 
 static inline void NdCopyCUDA(const char *&inOvlpBase, char *&outOvlpBase,

--- a/source/adios2/toolkit/format/bp/BPSerializer.tcc
+++ b/source/adios2/toolkit/format/bp/BPSerializer.tcc
@@ -73,16 +73,17 @@ inline void BPSerializer::PutPayloadInBuffer(
     const size_t blockSize = helper::GetTotalSize(blockInfo.Count);
     m_Profiler.Start("memcpy");
 
-#ifdef ADIOS2_HAVE_CUDA
-    if (blockInfo.MemSpace == MemorySpace::CUDA)
+    if (blockInfo.MemSpace != MemorySpace::Host)
     {
+#ifdef ADIOS2_HAVE_CUDA
         helper::CopyFromGPUToBuffer(m_Data.m_Buffer, m_Data.m_Position,
-                                    blockInfo.Data, blockSize);
+                                    blockInfo.Data, blockInfo.MemSpace,
+                                    blockSize);
         m_Profiler.Stop("memcpy");
         m_Data.m_AbsolutePosition += blockSize * sizeof(T);
+#endif
         return;
     }
-#endif
 
     if (!blockInfo.MemoryStart.empty())
     {

--- a/source/adios2/toolkit/format/bp/BPSerializer.tcc
+++ b/source/adios2/toolkit/format/bp/BPSerializer.tcc
@@ -74,7 +74,7 @@ inline void BPSerializer::PutPayloadInBuffer(
     m_Profiler.Start("memcpy");
 
 #ifdef ADIOS2_HAVE_CUDA
-    if (blockInfo.IsGPU)
+    if (blockInfo.MemSpace == MemorySpace::CUDA)
     {
         helper::CopyFromGPUToBuffer(m_Data.m_Buffer, m_Data.m_Position,
                                     blockInfo.Data, blockSize);

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -598,7 +598,7 @@ void BP4Deserializer::PostDataRead(
         blockInfo.Data, blockInfoStart, blockInfo.Count,
         m_ThreadBuffers[threadID][0].data(), subStreamBoxInfo.BlockBox,
         subStreamBoxInfo.IntersectionBox, m_IsRowMajor, m_ReverseDimensions,
-        endianReverse, blockInfo.IsGPU);
+        endianReverse, blockInfo.MemSpace);
 }
 
 void BP4Deserializer::BackCompatDecompress(

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
@@ -336,7 +336,7 @@ BP4Serializer::GetBPStats(const bool singleValue,
     stats.FileIndex = GetFileIndex();
 
 #ifdef ADIOS2_HAVE_CUDA
-    if (blockInfo.IsGPU)
+    if (blockInfo.MemSpace == MemorySpace::CUDA)
     {
         const size_t size = helper::GetTotalSize(blockInfo.Count);
         helper::CUDAMinMax(blockInfo.Data, size, stats.Min, stats.Max);

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1203,9 +1203,7 @@ bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable,
         }
         return false;
     }
-    MemorySpace MemSpace = MemorySpace::Host;
-    if (variable.IsCUDAPointer(DestData))
-        MemSpace = MemorySpace::CUDA;
+    MemorySpace MemSpace = variable.GetMemorySpace(DestData);
     if ((variable.m_SelectionType == adios2::SelectionType::BoundingBox) &&
         (variable.m_ShapeID == ShapeID::GlobalArray))
     {

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -694,9 +694,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name,
     }
     else
     {
-        MemorySpace MemSpace = MemorySpace::Host;
-        if (VB->IsCUDAPointer(Data))
-            MemSpace = MemorySpace::CUDA;
+        MemorySpace MemSpace = VB->GetMemorySpace(Data);
         MetaArrayRec *MetaEntry =
             (MetaArrayRec *)((char *)(MetadataBuf) + Rec->MetaOffset);
         size_t ElemCount = CalcSize(DimCount, Count);

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
@@ -155,13 +155,13 @@ size_t ChunkV::AddToVec(const size_t size, const void *buf, size_t align,
 void ChunkV::CopyDataToBuffer(const size_t size, const void *buf, size_t pos,
                               MemorySpace MemSpace)
 {
-#ifdef ADIOS2_HAVE_CUDA
-    if (MemSpace == MemorySpace::CUDA)
+    if (MemSpace != MemorySpace::Host)
     {
-        helper::CudaMemCopyToBuffer(m_TailChunk->Ptr, pos, buf, size);
+#ifdef ADIOS2_HAVE_CUDA
+        helper::CopyFromGPUToBuffer(m_TailChunk->Ptr, pos, buf, MemSpace, size);
+#endif
         return;
     }
-#endif
     memcpy(m_TailChunk->Ptr + pos, buf, size);
 }
 


### PR DESCRIPTION
Currently the `isGPU` member is true if the CUDA backend is enabled. When multiple backends will exist, the flag will be confusing. The PR prepares the code for adding Kokkos as an option for memory management:
1. Codes for each backend will have a separate helper file. I moved all the CUDA function to the `helper::adiosCUDA` files. 
2. All backends will share the same logic and will only diverge when the copy needs to take place (or the minmax computation)