### PR TITLE
Adjust DefineStruct bindings

### DIFF
--- a/bindings/CXX11/adios2/cxx11/ADIOS.cpp
+++ b/bindings/CXX11/adios2/cxx11/ADIOS.cpp
@@ -82,20 +82,6 @@ Operator ADIOS::InquireOperator(const std::string name)
     }
 }
 
-StructDefinition ADIOS::DefineStruct(const std::string &name, const size_t size)
-{
-    CheckPointer("for struct name " + name +
-                 ", in call to ADIOS::DefineStruct");
-    return StructDefinition(&m_ADIOS->DefineStruct(name, size));
-}
-
-StructDefinition ADIOS::InquireStruct(const std::string &name)
-{
-    CheckPointer("for struct name " + name +
-                 ", in call to ADIOS::InquireStruct");
-    return StructDefinition(m_ADIOS->InquireStruct(name));
-}
-
 bool ADIOS::RemoveIO(const std::string name)
 {
     CheckPointer("for io name " + name + ", in call to ADIOS::RemoveIO");

--- a/bindings/CXX11/adios2/cxx11/ADIOS.h
+++ b/bindings/CXX11/adios2/cxx11/ADIOS.h
@@ -229,9 +229,6 @@ public:
      */
     Operator InquireOperator(const std::string name);
 
-    StructDefinition DefineStruct(const std::string &name, const size_t size);
-    StructDefinition InquireStruct(const std::string &name);
-
     /**
      * Flushes all engines in write mode in all IOs created with the current
      * ADIOS object. If no IO or Engine exist, it does nothing.

--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -182,6 +182,13 @@ VariableNT IO::DefineVariable(const DataType type, const std::string &name,
     else { return nullptr; }
 }
 
+StructDefinition IO::DefineStruct(const std::string &name, const size_t size)
+{
+    helper::CheckForNullptr(m_IO, "for struct name " + name +
+                                      ", in call to IO::DefineStruct");
+    return StructDefinition(&m_IO->DefineStruct(name, size));
+}
+
 VariableNT IO::DefineStructVariable(const std::string &name,
                                     const StructDefinition &def,
                                     const Dims &shape, const Dims &start,

--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -159,6 +159,8 @@ public:
                               const Dims &count = Dims(),
                               const bool constantDims = false);
 
+    StructDefinition DefineStruct(const std::string &name, const size_t size);
+
     VariableNT DefineStructVariable(const std::string &name,
                                     const StructDefinition &def,
                                     const Dims &shape = Dims(),

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -194,38 +194,6 @@ ADIOS::InquireOperator(const std::string &name) noexcept
     }
 }
 
-StructDefinition &ADIOS::DefineStruct(const std::string &name,
-                                      const size_t size)
-{
-    if (m_StructDefinitions.find(name) != m_StructDefinitions.end())
-    {
-        helper::Throw<std::invalid_argument>("Core", "ADIOS", "DefineStruct",
-                                             "Struct " + name +
-                                                 " defined twice");
-    }
-    return m_StructDefinitions.emplace(name, StructDefinition(name, size))
-        .first->second;
-}
-
-StructDefinition *ADIOS::InquireStruct(const std::string &name)
-{
-    auto it = m_StructDefinitions.find(name);
-    if (it == m_StructDefinitions.end())
-    {
-        return nullptr;
-    }
-    else
-    {
-        return &it->second;
-    }
-}
-
-const std::unordered_map<std::string, StructDefinition> &
-ADIOS::StructDefinitions() const
-{
-    return m_StructDefinitions;
-}
-
 bool ADIOS::RemoveIO(const std::string name)
 {
     if (m_IOs.erase(name) == 1)

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -132,10 +132,12 @@ public:
     std::pair<std::string, Params> *
     InquireOperator(const std::string &name) noexcept;
 
-    StructDefinition &DefineStruct(const std::string &name, const size_t size);
-    StructDefinition *InquireStruct(const std::string &name);
-    const std::unordered_map<std::string, StructDefinition> &
-    StructDefinitions() const;
+    /*
+     * StructDefinitions are defined using the operators in the IO,
+     * but they are emplaced into a set in the ADIOS to give them
+     * global scope
+     */
+    std::unordered_map<std::string, StructDefinition> m_StructDefinitions;
 
     /**
      * DANGER ZONE: removes a particular IO. This will effectively eliminate any
@@ -180,8 +182,6 @@ private:
 
     /** operators created with DefineOperator */
     std::unordered_map<std::string, std::pair<std::string, Params>> m_Operators;
-
-    std::unordered_map<std::string, StructDefinition> m_StructDefinitions;
 
     /** Flag for Enter/ExitComputationBlock */
     bool enteredComputationBlock = false;

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -850,6 +850,19 @@ void IO::CheckTransportType(const std::string type) const
     }
 }
 
+StructDefinition &IO::DefineStruct(const std::string &name, const size_t size)
+{
+    if (m_ADIOS.m_StructDefinitions.find(name) !=
+        m_ADIOS.m_StructDefinitions.end())
+    {
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "DefineStruct", "Struct " + name + " defined twice");
+    }
+    return m_ADIOS.m_StructDefinitions
+        .emplace(name, StructDefinition(name, size))
+        .first->second;
+}
+
 VariableStruct &IO::DefineStructVariable(const std::string &name,
                                          StructDefinition &def,
                                          const Dims &shape, const Dims &start,

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -286,6 +286,8 @@ public:
     InquireStructVariable(const std::string &name, const StructDefinition &def,
                           const bool allowReorganize = false) noexcept;
 
+    StructDefinition &DefineStruct(const std::string &name, const size_t size);
+
     /**
      * @brief Returns the type of an existing variable as an string
      * @param name input variable name

--- a/source/adios2/engine/ssc/SscWriterGeneric.cpp
+++ b/source/adios2/engine/ssc/SscWriterGeneric.cpp
@@ -307,7 +307,7 @@ void SscWriterGeneric::SyncWritePattern(bool finalStep)
 
     if (m_WriterRank == 0)
     {
-        ssc::SerializeStructDefinitions(m_IO.m_ADIOS.StructDefinitions(),
+        ssc::SerializeStructDefinitions(m_IO.m_ADIOS.m_StructDefinitions,
                                         localBuffer);
     }
 

--- a/source/adios2/engine/ssc/SscWriterNaive.cpp
+++ b/source/adios2/engine/ssc/SscWriterNaive.cpp
@@ -49,7 +49,7 @@ void SscWriterNaive::EndStep(const bool writerLocked)
 
     if (m_WriterRank == 0)
     {
-        ssc::SerializeStructDefinitions(m_IO.m_ADIOS.StructDefinitions(),
+        ssc::SerializeStructDefinitions(m_IO.m_ADIOS.m_StructDefinitions,
                                         m_Buffer);
     }
 

--- a/testing/adios2/engine/ssc/TestSscStruct.cpp
+++ b/testing/adios2/engine/ssc/TestSscStruct.cpp
@@ -68,7 +68,7 @@ void Writer(const Dims &shape, const Dims &start, const Dims &count,
         int8_t a;
         int b[4];
     };
-    auto particleDef = adios.DefineStruct("particle", sizeof(particle));
+    auto particleDef = io.DefineStruct("particle", sizeof(particle));
     particleDef.AddField("a", offsetof(struct particle, a),
                          adios2::DataType::Int8); // simple field
     particleDef.AddField("b", offsetof(struct particle, b),
@@ -154,13 +154,13 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count,
 
     engine.LockReaderSelections();
 
-    auto particleDef1 = adios.DefineStruct("particle1", sizeof(particle));
+    auto particleDef1 = io.DefineStruct("particle1", sizeof(particle));
     particleDef1.AddField("a", offsetof(struct particle, a),
                           adios2::DataType::Int8);
     particleDef1.AddField("b", offsetof(struct particle, b),
                           adios2::DataType::Int32, 4);
 
-    auto particleDef2 = adios.DefineStruct("particle2", sizeof(particle) + 4);
+    auto particleDef2 = io.DefineStruct("particle2", sizeof(particle) + 4);
     particleDef2.AddField("a", offsetof(struct particle, a),
                           adios2::DataType::Int8, 1);
     particleDef2.AddField("b", offsetof(struct particle, b),

--- a/testing/adios2/engine/staging-common/TestStructRead.cpp
+++ b/testing/adios2/engine/staging-common/TestStructRead.cpp
@@ -77,12 +77,12 @@ TEST_F(StructReadTest, ADIOS2StructRead)
 
     engine.LockReaderSelections();
 
-    auto particleDef1 = adios.DefineStruct("particle1", sizeof(particle));
+    auto particleDef1 = io.DefineStruct("particle1", sizeof(particle));
     particleDef1.AddField("a", offsetof(particle, a), adios2::DataType::Int8);
     particleDef1.AddField("b", offsetof(particle, b), adios2::DataType::Int32,
                           4);
 
-    auto particleDef2 = adios.DefineStruct("particle2", sizeof(particle) + 4);
+    auto particleDef2 = io.DefineStruct("particle2", sizeof(particle) + 4);
     particleDef2.AddField("a", offsetof(particle, a), adios2::DataType::Int8);
     particleDef2.AddField("b", offsetof(particle, b), adios2::DataType::Int32,
                           4);

--- a/testing/adios2/engine/staging-common/TestStructWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestStructWrite.cpp
@@ -92,7 +92,7 @@ TEST_F(StructWriteTest, ADIOS2CommonWrite)
         int8_t a;
         int b[4];
     };
-    auto particleDef = adios.DefineStruct("particle", sizeof(particle));
+    auto particleDef = io.DefineStruct("particle", sizeof(particle));
     particleDef.AddField("a", offsetof(struct particle, a),
                          adios2::DataType::Int8);
     particleDef.AddField("b", offsetof(struct particle, b),

--- a/testing/adios2/interface/TestADIOSDefineVariable.cpp
+++ b/testing/adios2/interface/TestADIOSDefineVariable.cpp
@@ -666,7 +666,7 @@ TEST_F(ADIOSDefineVariableTest, DefineStructVariable)
         int8_t a;
         int32_t b[5];
     } def1;
-    auto struct1 = adios.DefineStruct("def1", sizeof(def1));
+    auto struct1 = io.DefineStruct("def1", sizeof(def1));
     struct1.AddField("a", offsetof(def1, a), adios2::DataType::Int8);
     struct1.AddField("b", offsetof(def1, b), adios2::DataType::Int32, 5);
     struct1.Freeze();
@@ -679,7 +679,7 @@ TEST_F(ADIOSDefineVariableTest, DefineStructVariable)
         int32_t b[5];
         int32_t c;
     } def2;
-    auto struct2 = adios.DefineStruct("def2", sizeof(def2));
+    auto struct2 = io.DefineStruct("def2", sizeof(def2));
     struct2.AddField("a", offsetof(def2, a), adios2::DataType::Int8);
     struct2.AddField("b", offsetof(def2, b), adios2::DataType::Int32, 5);
     struct2.AddField("c", 24, adios2::DataType::Int32);


### PR DESCRIPTION
Essentially this PR:

1. Moves DefineStruct from the ADIOS to the IO class in the bindings, but maintains the ADIOS as the owner of the object (to facilitate using StructDefinitions in multiple IOs.)
2. Eliminates InquireStruct (lookup struct definition by name) from the external bindings as unnecessary.  (Still in core, at least for now.)
3. Eliminates the StructDefinitions() method in favor of direct internal access to the map m_StructDefinitions().

What is _not_ done here is to change anything other than the C++ bindings.  When the Struct bindings are finalized in C++, C bindings at least should follow.  We also need to see if we can support Fortran derived types and numpy structured arrays.

Having DefineStruct in the ADIOS was likely motivated by the idea that a struct definition is like a `typedef`, something that is hardcoded into an application, known to be fixed at compile-time, maybe has a simple name that's unique across the entire source code, etc.  Assumptions like these easily accommodate simple producer/consumer situations where all parties have full _a priori_ knowledge of the data being exchanged, but they are insufficient to support ADIOS' goals of discovery and introspection.  This is a step towards those goals for the struct interface.