### PR TITLE
Allowing the option of CUDA memory space only if CUDA is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,7 @@ endif()
 
 
 set(ADIOS2_CONFIG_OPTS
-    BP5 DataMan DataSpaces HDF5 HDF5_VOL MHS SST CUDA Fortran MPI Python Blosc Blosc2 BZip2 LIBPRESSIO MGARD PNG SZ ZFP DAOS IME O_DIRECT Sodium Catalyst SysVShMem ZeroMQ Profiling Endian_Reverse
+    BP5 DataMan DataSpaces HDF5 HDF5_VOL MHS SST CUDA Fortran MPI Python Blosc Blosc2 BZip2 LIBPRESSIO MGARD PNG SZ ZFP DAOS IME O_DIRECT Sodium Catalyst SysVShMem ZeroMQ Profiling Endian_Reverse GPU_Support
 )
 
 GenerateADIOSHeaderConfig(${ADIOS2_CONFIG_OPTS})

--- a/bindings/CXX11/adios2/cxx11/Engine.cpp
+++ b/bindings/CXX11/adios2/cxx11/Engine.cpp
@@ -12,11 +12,19 @@
 #include "Engine.tcc"
 
 #include "adios2/core/Engine.h"
-
 #include "adios2/helper/adiosFunctions.h"
 
 namespace adios2
 {
+
+#ifdef ADIOS2_HAVE_GPU_SUPPORT
+void Engine::CheckMemorySpace(MemorySpace variableMem, MemorySpace bufferMem)
+{
+    if (variableMem != MemorySpace::Detect && variableMem != bufferMem)
+        helper::Throw<std::runtime_error>("CXX-Bindings", "Engine", "Put",
+                                          "Memory space mismatch");
+}
+#endif
 
 Engine::operator bool() const noexcept
 {

--- a/bindings/CXX11/adios2/cxx11/KokkosView.h
+++ b/bindings/CXX11/adios2/cxx11/KokkosView.h
@@ -17,10 +17,22 @@ struct memspace_kokkos_to_adios2<Kokkos::HostSpace>
     static constexpr adios2::MemorySpace value = adios2::MemorySpace::Host;
 };
 
-#ifdef KOKKOS_ENABLE_CUDA
+#if defined(KOKKOS_ENABLE_CUDA) && defined(ADIOS2_HAVE_CUDA)
 
 template <>
 struct memspace_kokkos_to_adios2<Kokkos::CudaSpace>
+{
+    static constexpr adios2::MemorySpace value = adios2::MemorySpace::CUDA;
+};
+
+template <>
+struct memspace_kokkos_to_adios2<Kokkos::CudaUVMSpace>
+{
+    static constexpr adios2::MemorySpace value = adios2::MemorySpace::CUDA;
+};
+
+template <>
+struct memspace_kokkos_to_adios2<Kokkos::CudaHostPinnedSpace>
 {
     static constexpr adios2::MemorySpace value = adios2::MemorySpace::CUDA;
 };

--- a/bindings/CXX11/adios2/cxx11/Variable.cpp
+++ b/bindings/CXX11/adios2/cxx11/Variable.cpp
@@ -38,6 +38,12 @@ namespace adios2
     }                                                                          \
                                                                                \
     template <>                                                                \
+    MemorySpace Variable<T>::GetMemorySpace()                                  \
+    {                                                                          \
+        return m_Variable->m_MemSpace;                                         \
+    }                                                                          \
+                                                                               \
+    template <>                                                                \
     void Variable<T>::SetShape(const Dims &shape)                              \
     {                                                                          \
         helper::CheckForNullptr(m_Variable,                                    \

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -155,6 +155,12 @@ public:
     void SetMemorySpace(const MemorySpace mem);
 
     /**
+     * Get the memory space that was set by the application
+     * @return the memory space stored in the Variable object
+     */
+    MemorySpace GetMemorySpace();
+
+    /**
      * Set new shape, care must be taken when reading back the variable for
      * different steps. Only applies to Global arrays.
      * @param shape new shape dimensions array

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -193,6 +193,7 @@ endif()
 if(CMAKE_CUDA_COMPILER AND CUDAToolkit_FOUND)
   enable_language(CUDA)
   set(ADIOS2_HAVE_CUDA TRUE)
+  set(ADIOS2_HAVE_GPU_Support TRUE)
 endif()
 
 # Fortran

--- a/examples/kokkos/kokkosWriteRead.cpp
+++ b/examples/kokkos/kokkosWriteRead.cpp
@@ -23,7 +23,7 @@
         }                                                                      \
     } while (false)
 
-int BPWrite(const std::string fname, const size_t N, int nSteps,
+int BPWrite(const std::string fname, const size_t N, size_t nSteps,
             const std::string engine)
 {
     int rank, size;
@@ -86,18 +86,16 @@ int BPWrite(const std::string fname, const size_t N, int nSteps,
     return 0;
 }
 
-int BPRead(const std::string fname, const size_t N, int nSteps,
+int BPRead(const std::string fname, const size_t N, size_t nSteps,
            std::string engine)
 {
-    int rank, size;
+    int rank;
 #if ADIOS2_USE_MPI
     int provided;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
 #else
     rank = 0;
-    size = 1;
 #endif
     // Create ADIOS structures
 #if ADIOS2_USE_MPI
@@ -148,7 +146,8 @@ int main(int argc, char **argv)
 {
     const std::vector<std::string> list_of_engines = {"BPFile", "BP5"};
     const size_t N = 6000;
-    int nSteps = 10, ret = 0, rank = 0;
+    size_t nSteps = 10;
+    int ret = 0, rank = 0;
 #if ADIOS2_USE_MPI
     int provided;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -35,10 +35,12 @@ namespace adios2
 /** Memory space for the user provided buffers */
 enum class MemorySpace
 {
+#ifdef ADIOS2_HAVE_GPU_SUPPORT
     Detect, ///< Detect the memory space automatically
-    Host,   ///< Host memory space (default)
+#endif
+    Host, ///< Host memory space
 #ifdef ADIOS2_HAVE_CUDA
-    CUDA    ///< CUDA memory spaces
+    CUDA ///< CUDA memory spaces
 #endif
 };
 

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -37,7 +37,9 @@ enum class MemorySpace
 {
     Detect, ///< Detect the memory space automatically
     Host,   ///< Host memory space (default)
+#ifdef ADIOS2_HAVE_CUDA
     CUDA    ///< CUDA memory spaces
+#endif
 };
 
 /** Variable shape type identifier, assigned automatically from the signature of

--- a/source/adios2/core/Variable.cpp
+++ b/source/adios2/core/Variable.cpp
@@ -49,7 +49,7 @@ namespace core
         info.StepsCount = stepsCount;                                          \
         info.Data = const_cast<T *>(data);                                     \
         info.Operations = m_Operations;                                        \
-        info.MemSpace = DetectMemorySpace((void *)data);                       \
+        info.MemSpace = GetMemorySpace((void *)data);                          \
         m_BlocksInfo.push_back(info);                                          \
         return m_BlocksInfo.back();                                            \
     }                                                                          \

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -50,13 +50,14 @@ size_t VariableBase::TotalSize() const noexcept
 
 MemorySpace VariableBase::DetectMemorySpace(const void *ptr)
 {
+#ifdef ADIOS2_HAVE_GPU_SUPPORT
     if (m_MemSpaceRequested != MemorySpace::Detect)
     {
         m_MemSpaceDetected = m_MemSpaceRequested;
         return m_MemSpaceRequested;
     }
+#endif
 
-    // if the user requested MemorySpace::Detect
 #ifdef ADIOS2_HAVE_CUDA
     cudaPointerAttributes attr;
     cudaPointerGetAttributes(&attr, ptr);
@@ -72,16 +73,21 @@ MemorySpace VariableBase::DetectMemorySpace(const void *ptr)
 
 MemorySpace VariableBase::GetMemorySpace(const void *ptr)
 {
+#ifdef ADIOS2_HAVE_GPU_SUPPORT
     if (m_MemSpaceDetected == MemorySpace::Detect)
         m_MemSpaceDetected = DetectMemorySpace(ptr);
     return m_MemSpaceDetected;
+#endif
+    return MemorySpace::Host;
 }
 
 void VariableBase::SetMemorySpace(const MemorySpace mem)
 {
     m_MemSpaceRequested = mem;
     // reset the detected memory space
+#ifdef ADIOS2_HAVE_GPU_SUPPORT
     m_MemSpaceDetected = MemorySpace::Detect;
+#endif
 }
 
 void VariableBase::SetShape(const adios2::Dims &shape)

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -48,13 +48,12 @@ size_t VariableBase::TotalSize() const noexcept
     return helper::GetTotalSize(m_Count);
 }
 
-MemorySpace VariableBase::DetectMemorySpace(const void *ptr)
+MemorySpace VariableBase::GetMemorySpace(const void *ptr)
 {
 #ifdef ADIOS2_HAVE_GPU_SUPPORT
-    if (m_MemSpaceRequested != MemorySpace::Detect)
+    if (m_MemSpace != MemorySpace::Detect)
     {
-        m_MemSpaceDetected = m_MemSpaceRequested;
-        return m_MemSpaceRequested;
+        return m_MemSpace;
     }
 #endif
 
@@ -63,32 +62,13 @@ MemorySpace VariableBase::DetectMemorySpace(const void *ptr)
     cudaPointerGetAttributes(&attr, ptr);
     if (attr.type == cudaMemoryTypeDevice)
     {
-        m_MemSpaceDetected = MemorySpace::CUDA;
         return MemorySpace::CUDA;
     }
 #endif
-    m_MemSpaceDetected = MemorySpace::Host;
     return MemorySpace::Host;
 }
 
-MemorySpace VariableBase::GetMemorySpace(const void *ptr)
-{
-#ifdef ADIOS2_HAVE_GPU_SUPPORT
-    if (m_MemSpaceDetected == MemorySpace::Detect)
-        m_MemSpaceDetected = DetectMemorySpace(ptr);
-    return m_MemSpaceDetected;
-#endif
-    return MemorySpace::Host;
-}
-
-void VariableBase::SetMemorySpace(const MemorySpace mem)
-{
-    m_MemSpaceRequested = mem;
-    // reset the detected memory space
-#ifdef ADIOS2_HAVE_GPU_SUPPORT
-    m_MemSpaceDetected = MemorySpace::Detect;
-#endif
-}
+void VariableBase::SetMemorySpace(const MemorySpace mem) { m_MemSpace = mem; }
 
 void VariableBase::SetShape(const adios2::Dims &shape)
 {

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -51,12 +51,13 @@ public:
      *  VariableStruct -> from constructor sizeof(struct) */
     const size_t m_ElementSize;
     /* User requested memory space and the detected memory space */
-#ifdef ADIOS2_HAVE_CUDA
+#ifdef ADIOS2_HAVE_GPU_SUPPORT
     MemorySpace m_MemSpaceRequested = MemorySpace::Detect;
+    MemorySpace m_MemSpaceDetected = MemorySpace::Detect;
 #else
     MemorySpace m_MemSpaceRequested = MemorySpace::Host;
+    MemorySpace m_MemSpaceDetected = MemorySpace::Host;
 #endif
-    MemorySpace m_MemSpaceDetected = MemorySpace::Detect;
 
     ShapeID m_ShapeID = ShapeID::Unknown; ///< see shape types in ADIOSTypes.h
     size_t m_BlockID = 0; ///< current block ID for local variables, global = 0

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -50,13 +50,12 @@ public:
     /** Variable -> sizeof(T),
      *  VariableStruct -> from constructor sizeof(struct) */
     const size_t m_ElementSize;
-    /* User requested memory space and the detected memory space */
+
+    /* User requested memory space */
 #ifdef ADIOS2_HAVE_GPU_SUPPORT
-    MemorySpace m_MemSpaceRequested = MemorySpace::Detect;
-    MemorySpace m_MemSpaceDetected = MemorySpace::Detect;
+    MemorySpace m_MemSpace = MemorySpace::Detect;
 #else
-    MemorySpace m_MemSpaceRequested = MemorySpace::Host;
-    MemorySpace m_MemSpaceDetected = MemorySpace::Host;
+    MemorySpace m_MemSpace = MemorySpace::Host;
 #endif
 
     ShapeID m_ShapeID = ShapeID::Unknown; ///< see shape types in ADIOSTypes.h
@@ -122,12 +121,6 @@ public:
      * @return number of elements
      */
     size_t TotalSize() const noexcept;
-
-    /**
-     * Detect the memory space where a buffer was allocated and return it
-     * @param pointer to the user data
-     */
-    MemorySpace DetectMemorySpace(const void *ptr);
 
     /**
      * Get the memory space where a given buffers was allocated

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -1737,7 +1737,7 @@ void BP5Writer::PutCommon(VariableBase &variable, const void *values, bool sync)
     }
 
     // if the user buffer is allocated on the GPU always use sync mode
-    if (variable.DetectMemorySpace(values) != MemorySpace::Host)
+    if (variable.GetMemorySpace(values) != MemorySpace::Host)
         sync = true;
 
     size_t *Shape = NULL;


### PR DESCRIPTION
This PR attempts to give compile time errors if a GPU application is trying to use ADIOS2 without any GPU support (I added the `ADIOS2_HAVE_GPU_SUPPORT` macro set to TRUE if there is any GPU backend: CUDA, Kokkos, HIP, etc.) 

Before this PR if an application mistakingly set the ADIOS2 memory space to CUDA or Detect when ADIOS2 was not build with CUDA enabled it would get a segmentation fault. After this PR a code like this:

```c++
        data.SetMemorySpace(adios2::MemorySpace::CUDA);
        bpReader.Get(data, gpuSimData);
```
is now giving
```
example.cpp: In function 'int BPWrite(std::string, size_t, int)':
/gpfs/alpine/csc143/proj-shared/againaru/adios/code_example_cuda/cudaADIOS2example.cpp:63:45: error: 'CUDA' is not a member of 'adios2::MemorySpace'
   63 |    data.SetMemorySpace(adios2::MemorySpace::CUDA);
      |                                             ^~~~
make[2]: *** [CMakeFiles/adiosCUDAex.dir/build.make:76: CMakeFiles/adiosCUDAex.dir/cudaADIOS2example.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/adiosCUDAex.dir/all] Error 2
```

If the memory space it set to `MemorySpace::Detect` it will also throw a compile time error.

If the user does not choose a memory space, it defaults to `MemorySpace::Host` and the code gives a segmentation fault.