### PR TITLE
Reader-side struct API changes

### DIFF
--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -238,10 +238,6 @@ VariableNT IO::InquireStructVariable(const std::string &name,
         m_IO->InquireStructVariable(name, *def.m_StructDefinition));
 }
 
-StructDefinition *GetWriteStructDef(VariableNT var) noexcept;
-StructDefinition *GetReadStructDef(VariableNT var) noexcept;
-void SetReadStructDef(VariableNT var, const StructDefinition &def);
-
 // PRIVATE
 IO::IO(core::IO *io) : m_IO(io) {}
 

--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -238,6 +238,10 @@ VariableNT IO::InquireStructVariable(const std::string &name,
         m_IO->InquireStructVariable(name, *def.m_StructDefinition));
 }
 
+StructDefinition *GetWriteStructDef(VariableNT var) noexcept;
+StructDefinition *GetReadStructDef(VariableNT var) noexcept;
+void SetReadStructDef(VariableNT var, const StructDefinition &def);
+
 // PRIVATE
 IO::IO(core::IO *io) : m_IO(io) {}
 

--- a/bindings/CXX11/adios2/cxx11/VariableNT.cpp
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.cpp
@@ -19,7 +19,6 @@ namespace adios2
 StructDefinition::StructDefinition(core::StructDefinition *ptr)
 : m_StructDefinition(ptr)
 {
-    ptr->BindingsStructDefinition = this;
 }
 
 void StructDefinition::AddField(const std::string &name, const size_t offset,
@@ -42,6 +41,13 @@ size_t StructDefinition::StructSize() const noexcept
     helper::CheckForNullptr(m_StructDefinition,
                             "in call to StructDefinition::StructSize");
     return m_StructDefinition->StructSize();
+}
+
+std::string StructDefinition::StructName() const noexcept
+{
+    helper::CheckForNullptr(m_StructDefinition,
+                            "in call to StructDefinition::StructName");
+    return m_StructDefinition->StructName();
 }
 
 size_t StructDefinition::Fields() const noexcept
@@ -648,7 +654,7 @@ std::pair<double, double> VariableNT::MinMaxDouble(const size_t step) const
     return {MinDouble(step), MaxDouble(step)};
 }
 
-StructDefinition *VariableNT::GetWriteStructDef() noexcept
+StructDefinition VariableNT::GetWriteStructDef() noexcept
 {
     helper::CheckForNullptr(m_Variable,
                             "in call to VariableNT::StructFieldElementCount");
@@ -662,12 +668,10 @@ StructDefinition *VariableNT::GetWriteStructDef() noexcept
     core::StructDefinition *CoreSD =
         reinterpret_cast<core::VariableStruct *>(m_Variable)
             ->GetWriteStructDef();
-    if (CoreSD->BindingsStructDefinition)
-        return (StructDefinition *)CoreSD->BindingsStructDefinition;
-    return new StructDefinition(CoreSD);
+    return StructDefinition(CoreSD);
 }
 
-StructDefinition *VariableNT::GetReadStructDef() noexcept
+StructDefinition VariableNT::GetReadStructDef() noexcept
 {
     helper::CheckForNullptr(m_Variable,
                             "in call to VariableNT::StructFieldElementCount");
@@ -680,11 +684,7 @@ StructDefinition *VariableNT::GetReadStructDef() noexcept
     }
     auto CoreSD = reinterpret_cast<core::VariableStruct *>(m_Variable)
                       ->GetReadStructDef();
-    if (!CoreSD)
-        return nullptr;
-    if (CoreSD->BindingsStructDefinition)
-        return (StructDefinition *)CoreSD->BindingsStructDefinition;
-    return new StructDefinition(CoreSD);
+    return StructDefinition(CoreSD);
 }
 
 void VariableNT::SetReadStructDef(const StructDefinition &def)

--- a/bindings/CXX11/adios2/cxx11/VariableNT.h
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.h
@@ -32,18 +32,20 @@ public:
                   const DataType type, const size_t size = 1);
     void Freeze() noexcept;
     size_t StructSize() const noexcept;
+    std::string StructName() const noexcept;
     size_t Fields() const noexcept;
     std::string Name(const size_t index) const;
     size_t Offset(const size_t index) const;
     DataType Type(const size_t index) const;
     size_t ElementCount(const size_t index) const;
+    explicit operator bool() const { return (m_StructDefinition != nullptr); }
 
 private:
     friend class ADIOS;
     friend class IO;
     friend class VariableNT;
-    StructDefinition(core::StructDefinition *ptr);
-    core::StructDefinition *m_StructDefinition;
+    StructDefinition(core::StructDefinition *ptr = nullptr);
+    core::StructDefinition *m_StructDefinition = nullptr;
 };
 
 class VariableNT
@@ -252,8 +254,8 @@ public:
     std::pair<double, double>
     MinMaxDouble(const size_t step = adios2::DefaultSizeT) const;
 
-    StructDefinition *GetWriteStructDef() noexcept;
-    StructDefinition *GetReadStructDef() noexcept;
+    StructDefinition GetWriteStructDef() noexcept;
+    StructDefinition GetReadStructDef() noexcept;
     void SetReadStructDef(const StructDefinition &def);
 
 private:

--- a/bindings/CXX11/adios2/cxx11/VariableNT.h
+++ b/bindings/CXX11/adios2/cxx11/VariableNT.h
@@ -41,6 +41,7 @@ public:
 private:
     friend class ADIOS;
     friend class IO;
+    friend class VariableNT;
     StructDefinition(core::StructDefinition *ptr);
     core::StructDefinition *m_StructDefinition;
 };
@@ -250,6 +251,10 @@ public:
     double MaxDouble(const size_t step = adios2::DefaultSizeT) const;
     std::pair<double, double>
     MinMaxDouble(const size_t step = adios2::DefaultSizeT) const;
+
+    StructDefinition *GetWriteStructDef() noexcept;
+    StructDefinition *GetReadStructDef() noexcept;
+    void SetReadStructDef(const StructDefinition &def);
 
 private:
     friend class IO;

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -137,7 +137,7 @@ public:
      * but they are emplaced into a set in the ADIOS to give them
      * global scope
      */
-    std::unordered_map<std::string, StructDefinition> m_StructDefinitions;
+    std::unordered_multimap<std::string, StructDefinition> m_StructDefinitions;
 
     /**
      * DANGER ZONE: removes a particular IO. This will effectively eliminate any

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -853,15 +853,9 @@ void IO::CheckTransportType(const std::string type) const
 
 StructDefinition &IO::DefineStruct(const std::string &name, const size_t size)
 {
-    if (m_ADIOS.m_StructDefinitions.find(name) !=
-        m_ADIOS.m_StructDefinitions.end())
-    {
-        helper::Throw<std::invalid_argument>(
-            "Core", "IO", "DefineStruct", "Struct " + name + " defined twice");
-    }
     return m_ADIOS.m_StructDefinitions
         .emplace(name, StructDefinition(name, size))
-        .first->second;
+        ->second;
 }
 
 VariableStruct &IO::DefineStructVariable(const std::string &name,

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -953,27 +953,28 @@ VariableStruct *IO::InquireStructVariable(const std::string &name,
         return nullptr;
     }
 
-    if (ret->m_StructDefinition.Fields() != def.Fields())
+    if (ret->m_WriteStructDefinition->Fields() != def.Fields())
     {
         return nullptr;
     }
 
     for (size_t i = 0; i < def.Fields(); ++i)
     {
-        if (ret->m_StructDefinition.Name(i) != def.Name(i))
+        if (ret->m_WriteStructDefinition->Name(i) != def.Name(i))
         {
             return nullptr;
         }
-        if (ret->m_StructDefinition.Offset(i) != def.Offset(i) &&
+        if (ret->m_WriteStructDefinition->Offset(i) != def.Offset(i) &&
             !allowReorganize)
         {
             return nullptr;
         }
-        if (ret->m_StructDefinition.Type(i) != def.Type(i))
+        if (ret->m_WriteStructDefinition->Type(i) != def.Type(i))
         {
             return nullptr;
         }
-        if (ret->m_StructDefinition.ElementCount(i) != def.ElementCount(i))
+        if (ret->m_WriteStructDefinition->ElementCount(i) !=
+            def.ElementCount(i))
         {
             return nullptr;
         }

--- a/source/adios2/core/VariableStruct.cpp
+++ b/source/adios2/core/VariableStruct.cpp
@@ -111,6 +111,7 @@ VariableStruct::VariableStruct(const std::string &name,
                constantDims)
 {
     m_WriteStructDefinition = const_cast<StructDefinition *>(&def);
+    m_ReadStructDefinition = nullptr;
 }
 
 void VariableStruct::SetData(const void *data) noexcept

--- a/source/adios2/core/VariableStruct.cpp
+++ b/source/adios2/core/VariableStruct.cpp
@@ -108,9 +108,9 @@ VariableStruct::VariableStruct(const std::string &name,
                                const Dims &start, const Dims &count,
                                const bool constantDims)
 : VariableBase(name, DataType::Struct, def.StructSize(), shape, start, count,
-               constantDims),
-  m_StructDefinition(def)
+               constantDims)
 {
+    m_WriteStructDefinition = const_cast<StructDefinition *>(&def);
 }
 
 void VariableStruct::SetData(const void *data) noexcept
@@ -119,6 +119,21 @@ void VariableStruct::SetData(const void *data) noexcept
 }
 
 void *VariableStruct::GetData() const noexcept { return m_Data; }
+
+StructDefinition *VariableStruct::GetWriteStructDef() noexcept
+{
+    return m_WriteStructDefinition;
+}
+
+StructDefinition *VariableStruct::GetReadStructDef() noexcept
+{
+    return m_ReadStructDefinition;
+}
+
+void VariableStruct::SetReadStructDef(const StructDefinition *def)
+{
+    m_ReadStructDefinition = (StructDefinition *)def;
+}
 
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/core/VariableStruct.h
+++ b/source/adios2/core/VariableStruct.h
@@ -41,7 +41,6 @@ public:
     size_t Offset(const size_t index) const;
     DataType Type(const size_t index) const;
     size_t ElementCount(const size_t index) const;
-    void *BindingsStructDefinition = nullptr;
 
 private:
     std::vector<StructFieldDefinition> m_Definition;

--- a/source/adios2/core/VariableStruct.h
+++ b/source/adios2/core/VariableStruct.h
@@ -41,6 +41,7 @@ public:
     size_t Offset(const size_t index) const;
     DataType Type(const size_t index) const;
     size_t ElementCount(const size_t index) const;
+    void *BindingsStructDefinition = nullptr;
 
 private:
     std::vector<StructFieldDefinition> m_Definition;
@@ -88,7 +89,12 @@ public:
 
     void *GetData() const noexcept;
 
-    const StructDefinition &m_StructDefinition;
+    StructDefinition *m_WriteStructDefinition;
+    StructDefinition *m_ReadStructDefinition;
+
+    StructDefinition *GetWriteStructDef() noexcept;
+    StructDefinition *GetReadStructDef() noexcept;
+    void SetReadStructDef(const StructDefinition *def);
 };
 
 } // end namespace core

--- a/source/adios2/engine/ssc/SscHelper.cpp
+++ b/source/adios2/engine/ssc/SscHelper.cpp
@@ -432,7 +432,7 @@ void DeserializeAttribute(const Buffer &input, uint64_t &pos, IO &io,
 }
 
 void SerializeStructDefinitions(
-    const std::unordered_map<std::string, StructDefinition> &definitions,
+    const std::unordered_multimap<std::string, StructDefinition> &definitions,
     Buffer &output)
 {
     if (definitions.empty())

--- a/source/adios2/engine/ssc/SscHelper.h
+++ b/source/adios2/engine/ssc/SscHelper.h
@@ -152,7 +152,7 @@ RankPosMap CalculateOverlap(BlockVecVec &globalPattern,
 void SerializeVariables(const BlockVec &input, Buffer &output, const int rank);
 void SerializeAttributes(IO &input, Buffer &output);
 void SerializeStructDefinitions(
-    const std::unordered_map<std::string, StructDefinition> &definitions,
+    const std::unordered_multimap<std::string, StructDefinition> &definitions,
     Buffer &output);
 void DeserializeVariable(
     const Buffer &input, const ShapeID shapeId, uint64_t &pos, BlockInfo &b,

--- a/source/adios2/engine/ssc/SscWriterGeneric.cpp
+++ b/source/adios2/engine/ssc/SscWriterGeneric.cpp
@@ -257,7 +257,7 @@ void SscWriterGeneric::PutDeferred(VariableBase &variable, const void *data)
             if (variable.m_Type == DataType::Struct)
             {
                 b.structDef = reinterpret_cast<VariableStruct *>(&variable)
-                                  ->m_StructDefinition.StructName();
+                                  ->m_WriteStructDefinition->StructName();
             }
         }
         else

--- a/source/adios2/engine/ssc/SscWriterNaive.cpp
+++ b/source/adios2/engine/ssc/SscWriterNaive.cpp
@@ -178,7 +178,7 @@ void SscWriterNaive::PutDeferred(VariableBase &variable, const void *data)
         if (variable.m_Type == DataType::Struct)
         {
             b.structDef = reinterpret_cast<VariableStruct *>(&variable)
-                              ->m_StructDefinition.StructName();
+                              ->m_WriteStructDefinition->StructName();
         }
     }
 }

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -211,6 +211,8 @@ private:
     bool GetSingleValueFromMetadata(core::VariableBase &variable,
                                     BP5VarRec *VarRec, void *DestData,
                                     size_t Step, size_t WriterRank);
+    void StructQueueReadChecks(core::VariableStruct *variable,
+                               BP5VarRec *VarRec);
 
     enum RequestTypeEnum
     {

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -104,6 +104,7 @@ private:
         size_t DimCount = 0;
         ShapeID OrigShapeID;
         core::StructDefinition *Def = nullptr;
+        core::StructDefinition *ReaderDef = nullptr;
         char *Operator = NULL;
         DataType Type;
         int ElementSize = 0;
@@ -201,7 +202,8 @@ private:
     void *ArrayVarSetup(core::Engine *engine, const char *variableName,
                         const DataType type, int DimCount, size_t *Shape,
                         size_t *Start, size_t *Count,
-                        core::StructDefinition *Def);
+                        core::StructDefinition *Def,
+                        core::StructDefinition *ReaderDef);
     void MapGlobalToLocalIndex(size_t Dims, const size_t *GlobalIndex,
                                const size_t *LocalOffsets, size_t *LocalIndex);
     size_t RelativeToAbsoluteStep(const BP5VarRec *VarRec, size_t RelStep);

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -422,7 +422,9 @@ BP5Serializer::CreateWriterRec(void *Variable, const char *Name, DataType Type,
     {
         core::VariableStruct *VS =
             static_cast<core::VariableStruct *>(Variable);
-        const core::StructDefinition *SD = &VS->m_StructDefinition;
+        core::StructDefinition *SD = VS->m_WriteStructDefinition;
+        if (VS->m_ReadStructDefinition)
+            SD = VS->m_ReadStructDefinition; // Data has been converted to this
         FMField *List = (FMField *)malloc((SD->Fields() + 1) * sizeof(List[0]));
         for (size_t i = 0; i < SD->Fields(); i++)
         {


### PR DESCRIPTION
Proposed API changes to the reader side for struct variables.

The idea is this:  Rather than the prior API where you had to do this:
`                auto varStruct = io.InquireStructVariable("particles", particleDef);`
(That is, you had to know the details of the structure definition _a priori_ in order to find the variable.)
We're going to do something like this:
```
                auto varStruct = io.InquireStructVariable("particles");
                if (varStruct && (varStruct.GetReadStructDef() == nullptr))
                {
                    auto WriteStruct = varStruct.GetWriteStructDef();
                    (void)WriteStruct; // unused here, but available if needed
                    auto particleDef =
                        io.DefineStruct("particle1", sizeof(particle));
                    particleDef.AddField("a", offsetof(particle, a),
                                          adios2::DataType::Int8);
                    particleDef.AddField("b", offsetof(particle, b),
                                          adios2::DataType::Int32, 4);
                    varStruct.SetReadStructDef(particleDef);
                }
```
That is, we're going to allow introspection of incoming types, allow a structure definition to be associated with a specific incoming variable (rather than being pulled by name from a global map), and eventually we may allow the reader side structures to not exactly match writer-side structures (to an extent to be determined later).