### PR TITLE
Fig bug in the IME file transport

### DIFF
--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -122,13 +122,13 @@ void FileIME::Open(const std::string &name, const Mode openMode,
     m_IsOpen = true;
 }
 
-void FileIME::SetParameters(const Params &parameters)
+void FileIME::SetParameters(const Params &params)
 {
     auto param = params.find("synctopfs");
     if (param != params.end())
     {
-        m_SyncToPFS =
-            helper::StringTo<bool>(value, " in Parameter key=SyncToPFS");
+        m_SyncToPFS = helper::StringTo<bool>(param->second,
+                                             " in Parameter key=SyncToPFS");
     }
 }
 


### PR DESCRIPTION
This bug was introduced in PR #3388 
here:
[https://github.com/ornladios/ADIOS2/commit/f31d2cb05ff4dd375d431d8043d2e16aee798b64](https://github.com/ornladios/ADIOS2/commit/f31d2cb05ff4dd375d431d8043d2e16aee798b64#diff-4cb33e244ce899f10daacb5669a29eed59c1227475c9825e81ae68990a8de984)

I do not understand how the CI did not catch this nor did any of my previous runs. 

@pnorbert please make sure my fix is correct. Should we include checking this in the CI?