### PR TITLE
CopyBuffer: Skip Zero Elements

### DIFF
--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -146,6 +146,11 @@ template <class T>
 void CopyToBuffer(std::vector<char> &buffer, size_t &position, const T *source,
                   const size_t elements) noexcept
 {
+    if (elements == 0)
+    {
+        return;
+    }
+
     const char *src = reinterpret_cast<const char *>(source);
     std::copy(src, src + elements * sizeof(T), buffer.begin() + position);
     position += elements * sizeof(T);


### PR DESCRIPTION
Avoid operating on invalid memory in `CopyBuffer` if the operation is zero elements.

Related to #3460

- [ ] testing on Summit: does not seem to change the underlying issue in `void adios2::core::engine::BP4Writer::PutSyncCommon<unsigned long>(adios2::core::Variable<unsigned long>&, adios2::core::Variable<unsigned long>::BPInfo const&, bool)+0x130`