### PR TITLE
Added support for Joined Arrays in the BP4 format and engine.

### DIFF
--- a/examples/basics/joinedArray/joinedArray_write.cpp
+++ b/examples/basics/joinedArray/joinedArray_write.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 #endif
-    const int NSTEPS = 5;
+    const int NSTEPS = 3;
 
     // generate different random numbers on each process,
     // but always the same sequence at each run
@@ -73,6 +73,7 @@ int main(int argc, char *argv[])
         // Get io settings from the config file or
         // create one with default settings here
         adios2::IO io = adios.DeclareIO("Output");
+        io.SetEngine("BP4");
 
         /*
          * Define joinable local array: type, name, global and local size
@@ -81,6 +82,9 @@ int main(int argc, char *argv[])
          */
         adios2::Variable<double> varTable = io.DefineVariable<double>(
             "table", {adios2::JoinedDim, Ncols}, {}, {Nrows, Ncols});
+
+        // adios2::Operator op = adios.DefineOperator("blosc", "blosc");
+        // varTable.AddOperation(op, {{"clevel", std::to_string(1)}});
 
         // Open file. "w" means we overwrite any existing file on disk,
         // but Advance() will append steps to the same file.
@@ -95,7 +99,7 @@ int main(int argc, char *argv[])
                 for (unsigned int col = 0; col < Ncols; col++)
                 {
                     mytable[row * Ncols + col] = static_cast<double>(
-                        rank * 1.0 + row * 0.1 + col * 0.01);
+                        step * 10.0 + rank * 1.0 + row * 0.1 + col * 0.01);
                 }
             }
 

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -91,6 +91,8 @@ public:
     size_t m_StepsStart = 0;
     size_t m_StepsCount = 1;
 
+    size_t m_JoinedDimPos = 0; // the joined dimension in a  JoinedArray
+
     /** Index Metadata Position in a serial metadata buffer */
     size_t m_IndexStart = 0;
 

--- a/source/adios2/toolkit/format/bp/BPBase.cpp
+++ b/source/adios2/toolkit/format/bp/BPBase.cpp
@@ -482,7 +482,8 @@ BPBase::TransformTypeEnum(const std::string transformType) const noexcept
     template BPBase::Characteristics<T>                                        \
     BPBase::ReadElementIndexCharacteristics(const std::vector<char> &,         \
                                             size_t &, const BPBase::DataTypes, \
-                                            const bool, const bool) const;
+                                            size_t &, const bool, const bool)  \
+        const;
 
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation

--- a/source/adios2/toolkit/format/bp/BPBase.h
+++ b/source/adios2/toolkit/format/bp/BPBase.h
@@ -621,6 +621,7 @@ protected:
     Characteristics<T>
     ReadElementIndexCharacteristics(const std::vector<char> &buffer,
                                     size_t &position, const DataTypes dataType,
+                                    size_t &joinedArrayShapePos,
                                     const bool untilTimeStep = false,
                                     const bool isLittleEndian = true) const;
 
@@ -644,6 +645,7 @@ private:
                               const DataTypes dataType,
                               const bool untilTimeStep,
                               Characteristics<T> &characteristics,
+                              size_t &joinedArrayShapePos,
                               const bool isLittleEndian = true) const;
 };
 

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
@@ -39,11 +39,12 @@ void BP3Deserializer::GetSyncVariableDataFromStream(core::Variable<T> &variable,
 
     auto &buffer = bufferSTL.m_Buffer;
     size_t position = itStep->second.front();
+    size_t irrelevant;
 
     const Characteristics<T> characteristics =
         ReadElementIndexCharacteristics<T>(buffer, position,
-                                           TypeTraits<T>::type_enum, false,
-                                           m_Minifooter.IsLittleEndian);
+                                           TypeTraits<T>::type_enum, irrelevant,
+                                           false, m_Minifooter.IsLittleEndian);
 
     const size_t payloadOffset = characteristics.Statistics.PayloadOffset;
     variable.m_Data = reinterpret_cast<T *>(&buffer[payloadOffset]);
@@ -193,11 +194,12 @@ void BP3Deserializer::SetVariableBlockInfo(
         const std::vector<char> &buffer = bufferSTL.m_Buffer;
 
         size_t position = blockIndexOffset;
+        size_t irrelevant;
 
         const Characteristics<T> blockCharacteristics =
-            ReadElementIndexCharacteristics<T>(buffer, position,
-                                               TypeTraits<T>::type_enum, false,
-                                               m_Minifooter.IsLittleEndian);
+            ReadElementIndexCharacteristics<T>(
+                buffer, position, TypeTraits<T>::type_enum, irrelevant, false,
+                m_Minifooter.IsLittleEndian);
         // check if they intersect
         helper::SubStreamBoxInfo subStreamInfo;
 
@@ -311,11 +313,12 @@ void BP3Deserializer::SetVariableBlockInfo(
         const std::vector<char> &buffer = bufferSTL.m_Buffer;
 
         size_t position = blockIndexOffset;
+        size_t irrelevant;
 
         const Characteristics<T> blockCharacteristics =
-            ReadElementIndexCharacteristics<T>(buffer, position,
-                                               TypeTraits<T>::type_enum, false,
-                                               m_Minifooter.IsLittleEndian);
+            ReadElementIndexCharacteristics<T>(
+                buffer, position, TypeTraits<T>::type_enum, irrelevant, false,
+                m_Minifooter.IsLittleEndian);
 
         // check if they intersect
         helper::SubStreamBoxInfo subStreamInfo;
@@ -486,10 +489,11 @@ void BP3Deserializer::GetValueFromMetadata(core::Variable<T> &variable,
         for (size_t b = blocksStart; b < blocksStart + blocksCount; ++b)
         {
             size_t localPosition = positions[b];
+            size_t irrelevant;
             const Characteristics<T> characteristics =
-                ReadElementIndexCharacteristics<T>(buffer, localPosition,
-                                                   type_string, false,
-                                                   m_Minifooter.IsLittleEndian);
+                ReadElementIndexCharacteristics<T>(
+                    buffer, localPosition, type_string, irrelevant, false,
+                    m_Minifooter.IsLittleEndian);
 
             data[dataCounter] = characteristics.Statistics.Value;
             ++dataCounter;
@@ -753,11 +757,12 @@ inline void BP3Deserializer::DefineVariableInEngineIO<std::string>(
     const std::vector<char> &buffer, size_t position) const
 {
     const size_t initialPosition = position;
+    size_t irrelevant;
 
     const Characteristics<std::string> characteristics =
         ReadElementIndexCharacteristics<std::string>(
-            buffer, position, static_cast<DataTypes>(header.DataType), false,
-            m_Minifooter.IsLittleEndian);
+            buffer, position, static_cast<DataTypes>(header.DataType),
+            irrelevant, false, m_Minifooter.IsLittleEndian);
 
     const std::string variableName =
         header.Path.empty() ? header.Name
@@ -807,12 +812,13 @@ inline void BP3Deserializer::DefineVariableInEngineIO<std::string>(
     while (position < endPosition)
     {
         const size_t subsetPosition = position;
+        size_t irrelevant;
 
         // read until step is found
         const Characteristics<std::string> subsetCharacteristics =
             ReadElementIndexCharacteristics<std::string>(
                 buffer, position, static_cast<DataTypes>(header.DataType),
-                false, m_Minifooter.IsLittleEndian);
+                irrelevant, false, m_Minifooter.IsLittleEndian);
 
         const bool isNextStep =
             stepsFound.insert(subsetCharacteristics.Statistics.Step).second;
@@ -862,11 +868,12 @@ void BP3Deserializer::DefineVariableInEngineIO(const ElementIndexHeader &header,
                                                size_t position) const
 {
     const size_t initialPosition = position;
+    size_t irrelevant;
 
     const Characteristics<T> characteristics =
         ReadElementIndexCharacteristics<T>(
-            buffer, position, static_cast<DataTypes>(header.DataType), false,
-            m_Minifooter.IsLittleEndian);
+            buffer, position, static_cast<DataTypes>(header.DataType),
+            irrelevant, false, m_Minifooter.IsLittleEndian);
 
     const std::string variableName =
         header.Path.empty() ? header.Name
@@ -951,12 +958,13 @@ void BP3Deserializer::DefineVariableInEngineIO(const ElementIndexHeader &header,
     while (position < endPosition)
     {
         const size_t subsetPosition = position;
+        size_t irrelevant;
 
         // read until step is found
         const Characteristics<T> subsetCharacteristics =
             ReadElementIndexCharacteristics<T>(
                 buffer, position, static_cast<DataTypes>(header.DataType),
-                false, m_Minifooter.IsLittleEndian);
+                irrelevant, false, m_Minifooter.IsLittleEndian);
 
         const T blockMin = characteristics.Statistics.IsValue
                                ? subsetCharacteristics.Statistics.Value
@@ -1038,10 +1046,11 @@ void BP3Deserializer::DefineAttributeInEngineIO(
     const ElementIndexHeader &header, core::Engine &engine,
     const std::vector<char> &buffer, size_t position) const
 {
+    size_t irrelevant;
     const Characteristics<T> characteristics =
         ReadElementIndexCharacteristics<T>(
-            buffer, position, static_cast<DataTypes>(header.DataType), false,
-            m_Minifooter.IsLittleEndian);
+            buffer, position, static_cast<DataTypes>(header.DataType),
+            irrelevant, false, m_Minifooter.IsLittleEndian);
 
     std::string attributeName(header.Name);
     if (!header.Path.empty())
@@ -1108,10 +1117,11 @@ BP3Deserializer::GetSubFileInfo(const core::Variable<T> &variable) const
         // blockPosition gets updated by Read, can't be const
         for (size_t blockPosition : blockStarts)
         {
+            size_t irrelevant;
             const Characteristics<T> blockCharacteristics =
                 ReadElementIndexCharacteristics<T>(
-                    buffer, blockPosition, TypeTraits<T>::type_enum, false,
-                    m_Minifooter.IsLittleEndian);
+                    buffer, blockPosition, TypeTraits<T>::type_enum, irrelevant,
+                    false, m_Minifooter.IsLittleEndian);
 
             // check if they intersect
             helper::SubFileInfo info;
@@ -1165,11 +1175,12 @@ BP3Deserializer::BlocksInfoCommon(
     for (const size_t blockIndexOffset : blocksIndexOffsets)
     {
         size_t position = blockIndexOffset;
+        size_t irrelevant;
 
         const Characteristics<T> blockCharacteristics =
-            ReadElementIndexCharacteristics<T>(m_Metadata.m_Buffer, position,
-                                               TypeTraits<T>::type_enum, false,
-                                               m_Minifooter.IsLittleEndian);
+            ReadElementIndexCharacteristics<T>(
+                m_Metadata.m_Buffer, position, TypeTraits<T>::type_enum,
+                irrelevant, false, m_Minifooter.IsLittleEndian);
 
         typename core::Variable<T>::BPInfo blockInfo;
         blockInfo.Shape = blockCharacteristics.Shape;

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
@@ -709,8 +709,10 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
 #define make_case(T)                                                           \
     case (TypeTraits<T>::type_enum):                                           \
     {                                                                          \
+        size_t irrelevant;                                                     \
         const auto characteristics = ReadElementIndexCharacteristics<T>(       \
-            buffer, position, TypeTraits<T>::type_enum, true, isLittleEndian); \
+            buffer, position, TypeTraits<T>::type_enum, irrelevant, true,      \
+            isLittleEndian);                                                   \
         count = characteristics.EntryCount;                                    \
         length = characteristics.EntryLength;                                  \
         timeStep = characteristics.Statistics.Step;                            \
@@ -721,9 +723,11 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
 
         case (type_string_array):
         {
+            size_t irrelevant;
             const auto characteristics =
                 ReadElementIndexCharacteristics<std::string>(
-                    buffer, position, type_string_array, true, isLittleEndian);
+                    buffer, position, type_string_array, irrelevant, true,
+                    isLittleEndian);
             count = characteristics.EntryCount;
             length = characteristics.EntryLength;
             timeStep = characteristics.Statistics.Step;

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -191,6 +191,9 @@ gtest_add_tests_helper(StepsInSituGlobalArray MPI_ALLOW BP Engine.BP. .BP4
 gtest_add_tests_helper(StepsInSituLocalArray MPI_ALLOW BP Engine.BP. .BP4
   WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4"
 )
+gtest_add_tests_helper(JoinedArray MPI_ALLOW BP Engine.BP. .BP4
+  WORKING_DIRECTORY ${BP4_DIR} EXTRA_ARGS "BP4"
+)
 
 gtest_add_tests_helper(InquireVariableException MPI_ALLOW BP Engine.BP. .BP4
   WORKING_DIRECTORY ${BP4_DIR}

--- a/testing/adios2/engine/bp/TestBPJoinedArray.cpp
+++ b/testing/adios2/engine/bp/TestBPJoinedArray.cpp
@@ -1,0 +1,226 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * TestBPJoinedArray.cpp :
+ *
+ *  Created on: Dec 17, 2018
+ *      Author: Norbert Podhorszki, Keichi Takahashi
+ */
+
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#include "../SmallTestData.h"
+
+std::string engineName; // comes from command line
+
+class BPJoinedArray : public ::testing::Test
+{
+public:
+    BPJoinedArray() = default;
+
+    SmallTestData m_TestData;
+};
+
+TEST_F(BPJoinedArray, MultiBlock)
+{
+    // Write multiple blocks per process
+    // Change number of rows per block and per process
+    // Change total number of rows in each step
+    // Write two variables to ensure both will end up with the same order of
+    // rows in reading
+
+    const int nsteps = 3;
+    const size_t Ncols = 4;
+    const std::vector<int> nblocksPerProcess = {2, 3, 2, 1, 3, 2};
+
+    int rank = 0, nproc = 1;
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+    const int nblocks = (rank < static_cast<int>(nblocksPerProcess.size())
+                             ? nblocksPerProcess[rank]
+                             : 1);
+#else
+    adios2::ADIOS adios;
+    const int nblocks = nblocksPerProcess[0];
+#endif
+
+    const std::string fname =
+        "BPJoinedArrayMultiblock_nproc_" + std::to_string(nproc) + ".bp";
+    int nMyTotalRows[nsteps];
+    int nTotalRows[nsteps];
+
+    // Writer
+    {
+        adios2::IO outIO = adios.DeclareIO("Output");
+
+        if (!engineName.empty())
+        {
+            outIO.SetEngine(engineName);
+        }
+
+        adios2::Engine writer = outIO.Open(fname, adios2::Mode::Write);
+        auto var = outIO.DefineVariable<double>(
+            "table", {adios2::JoinedDim, Ncols}, {}, {1, Ncols});
+
+        if (!rank)
+        {
+            std::cout << "Writing to " << fname << std::endl;
+        }
+
+        for (int step = 0; step < nsteps; step++)
+        {
+            // Application variables for output random size per process, 5..10
+            // each
+            std::vector<size_t> Nrows;
+            nMyTotalRows[step] = 0;
+            for (int i = 0; i < nblocks; ++i)
+            {
+                int n = rand() % 6 + 5;
+                Nrows.push_back(static_cast<size_t>(n));
+                nMyTotalRows[step] += n;
+            }
+
+            nTotalRows[step] = nMyTotalRows[step];
+#if ADIOS2_USE_MPI
+            MPI_Allreduce(&(nMyTotalRows[step]), &(nTotalRows[step]), 1,
+                          MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+#endif
+
+            if (!rank)
+            {
+                std::cout << "Writing " << nTotalRows[step] << " rows in step "
+                          << step << std::endl;
+            }
+
+            writer.BeginStep();
+            for (int block = 0; block < nblocks; ++block)
+            {
+                std::vector<double> mytable(Nrows[block] * Ncols);
+                for (size_t row = 0; row < Nrows[block]; row++)
+                {
+                    for (size_t col = 0; col < Ncols; col++)
+                    {
+                        mytable[row * Ncols + col] = static_cast<double>(
+                            (step + 1) * 1.0 + rank * 0.1 + block * 0.01 +
+                            row * 0.001 + col * 0.0001);
+                    }
+                }
+
+                var.SetSelection({{}, {Nrows[block], Ncols}});
+
+                std::cout << "Step " << step << " rank " << rank << " block "
+                          << block << " count (" << var.Count()[0] << ", "
+                          << var.Count()[1] << ")" << std::endl;
+
+                writer.Put(var, mytable.data(), adios2::Mode::Sync);
+            }
+            writer.EndStep();
+        }
+        writer.Close();
+    }
+
+    // Reader with streaming
+    {
+        adios2::IO inIO = adios.DeclareIO("Input");
+
+        if (!engineName.empty())
+        {
+            inIO.SetEngine(engineName);
+        }
+        adios2::Engine reader = inIO.Open(fname, adios2::Mode::Read);
+
+        if (!rank)
+        {
+            std::cout << "Reading as stream with BeginStep/EndStep:"
+                      << std::endl;
+        }
+
+        int step = 0;
+        while (true)
+        {
+            adios2::StepStatus status =
+                reader.BeginStep(adios2::StepMode::Read);
+
+            if (status != adios2::StepStatus::OK)
+            {
+                break;
+            }
+
+            auto var = inIO.InquireVariable<double>("table");
+            EXPECT_TRUE(var);
+
+            if (!rank)
+            {
+                std::cout << "Step " << step << " table shape ("
+                          << var.Shape()[0] << ", " << var.Shape()[1] << ")"
+                          << std::endl;
+            }
+
+            size_t Nrows = static_cast<size_t>(nTotalRows[step]);
+            EXPECT_EQ(var.Shape()[0], Nrows);
+            EXPECT_EQ(var.Shape()[1], Ncols);
+
+            var.SetSelection({{0, 0}, {Nrows, Ncols}});
+
+            // Check data on rank 0
+            if (!rank)
+            {
+                std::vector<double> data(Nrows * Ncols);
+                reader.Get(var, data.data());
+                reader.PerformGets();
+                for (size_t i = 0; i < Nrows; ++i)
+                {
+                    for (size_t j = 0; j < Ncols; ++j)
+                    {
+                        EXPECT_GE(data[i * Ncols + j], (step + 1) * 1.0);
+                        EXPECT_LT(data[i * Ncols + j],
+                                  (nsteps + 1) * 1.0 + 0.9999);
+                    }
+                }
+            }
+
+            reader.EndStep();
+            ++step;
+        }
+        reader.Close();
+        EXPECT_EQ(step, nsteps);
+    }
+}
+
+int main(int argc, char **argv)
+{
+#if ADIOS2_USE_MPI
+    int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
+    MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+
+    result = RUN_ALL_TESTS();
+
+#if ADIOS2_USE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}


### PR DESCRIPTION
Declaration:          auto var = outIO.DefineVariable<double>(table", {adios2::JoinedDim, Ncols}, {}, {1, Ncols});
Setting block size:   var.SetSelection({{}, {Nrows[block], Ncols}});