### PR TITLE
Warning fix when finding the MGARD library

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -150,11 +150,11 @@ endif()
 
 # MGARD
 if(ADIOS2_USE_MGARD STREQUAL AUTO)
-  find_package(mgard)
+  find_package(mgard CONFIG)
 elseif(ADIOS2_USE_MGARD)
-  find_package(mgard REQUIRED)
+  find_package(mgard REQUIRED CONFIG)
 endif()
-if(MGARD_FOUND)
+if(mgard_FOUND)
   set(ADIOS2_HAVE_MGARD TRUE)
 endif()
 


### PR DESCRIPTION
Related to #3434 after cherry picking Jieyang's commits, we no longer need the FindMGARD file.
Making small changes so we don't have a warning related to this when MGARD is not used.