### PR TITLE
Fix bug in BP3/BP4 attribute merging process. When a global attribute…

### DIFF
--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.cpp
@@ -482,13 +482,13 @@ BP3Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
             size_t indexPosition = localPosition;
             const ElementIndexHeader header = ReadElementIndexHeader(
                 serialized, indexPosition, helper::IsLittleEndian());
-            if (isRankConstant && deserialized.count(header.Name) == 1)
-            {
-                return;
-            }
-
             const size_t bufferSize = static_cast<size_t>(header.Length) + 4;
 
+            if (isRankConstant && deserialized.count(header.Name) == 1)
+            {
+                localPosition += bufferSize;
+                continue;
+            }
             std::vector<BP3Base::SerialElementIndex> *deserializedIndexes =
                 nullptr;
             auto search = deserialized.find(header.Name);

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
@@ -841,12 +841,14 @@ void BP4Serializer::AggregateCollectiveMetadataIndices(helper::Comm const &comm,
 
             lf_GetCharacteristics(serialized, indexPosition, header.DataType,
                                   count, length, timeStep);
-            if (indicesInfo[timeStep][header.Name].size() == 1)
-            {
-                return;
-            }
 
             size_t attrIndexBufferSize = static_cast<size_t>(header.Length) + 4;
+
+            if (indicesInfo[timeStep][header.Name].size() == 1)
+            {
+                localPosition += attrIndexBufferSize;
+                continue;
+            }
 
             auto stepSearch = indicesInfo.find(timeStep);
             if (stepSearch == indicesInfo.end())

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributesMultirank.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributesMultirank.cpp
@@ -55,6 +55,9 @@ TEST_F(BPWriteReadAttributeTestMultirank, ADIOS2BPWriteReadArrayTypes)
     {
         adios2::IO io = adios.DeclareIO("TestIO");
 
+        io.DefineAttribute<std::string>("GlobalAttribute",
+                                        "Defined on all ranks");
+
         auto var = io.DefineVariable<int>(varpath);
         auto attr = io.DefineAttribute<std::string>(attrpath, desc);
         (void)var;


### PR DESCRIPTION
… was found in the serialized metadata of a rank, processing ended and dropped all the rest of attributes.
Fixes #3433