### PR TITLE
Fixed: When appending to BP5 with a different number of processes, bp…

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1801,6 +1801,11 @@ void *BP5Deserializer::GetMetadataBase(BP5VarRec *VarRec, size_t Step,
     MetaArrayRec *writer_meta_base = NULL;
     if (m_RandomAccessMode)
     {
+        if (Step >= m_ControlArray.size() ||
+            WriterRank >= m_ControlArray[Step].size())
+        {
+            return NULL; // we don't have this rank in this step
+        }
         ControlInfo *CI =
             m_ControlArray[Step][WriterRank]; // writer control array
         if (((*CI->MetaFieldOffset).size() <= VarRec->VarNum) ||


### PR DESCRIPTION
…ls -l fails because the minmax metadata request segfaults.

Note: this does not fix a bigger issue that appending with more processes than before is not working properly.