### PR TITLE
Fix Matlab build which depends on the C bindings not the C++ bindings.

### DIFF
--- a/bindings/Matlab/Makefile
+++ b/bindings/Matlab/Makefile
@@ -1,12 +1,12 @@
 ###  CORI
-#ADIOS_DIR=/global/homes/p/pnorbert/adios/2.2/login
+ADIOS_DIR=/global/homes/p/pnorbert/adios/master/login
 #ADIOS_LIBS=-Wl,-rpath=${ADIOS_DIR}/lib64 -L${ADIOS_DIR}/lib64 -ladios2 
 #ADIOS_INC=-I${ADIOS_DIR}/include
-#MEXLIBS="LDFLAGS=${ADIOS_LIBS}"
+MEXLIBS="LDFLAGS=${ADIOS_LIBS}"
 
 ###   TITAN
-ADIOS_DIR=/ccs/proj/e2e/pnorbert/ADIOS/ADIOS2/build.titan.gnu-nompi/install
-MEXLIBS=${ADIOS_LIBS}
+#ADIOS_DIR=/ccs/proj/e2e/pnorbert/ADIOS/ADIOS2/build.titan.gnu-nompi/install
+#MEXLIBS=${ADIOS_LIBS}
 
 ###  Kathleen's PC
 #ADIOS_DIR=/opt/adios/2.2-lean
@@ -16,7 +16,7 @@ MEXLIBS=${ADIOS_LIBS}
 
 ### General - this should work everywhere
 ADIOS_INC=-I${ADIOS_DIR}/include
-ADIOS_LIBS=`${ADIOS_DIR}/bin/adios2-config --cxx-libs`
+ADIOS_LIBS=`${ADIOS_DIR}/bin/adios2-config --c-libs`
 
 
 MEXOPTS=-largeArrayDims -DDEBUG CFLAGS="-g -std=c99 -fPIC -O0"

--- a/bindings/Matlab/README.txt
+++ b/bindings/Matlab/README.txt
@@ -12,15 +12,15 @@ The build requires that you have the MEX compiler ('mex') in the path.
 
 Finally, you need 
 1) to set MATLABPATH to this Matlab build directory (or wherever you copy the .m and .mexa64 files) and 
-2) to force Matlab to use the same stdc++ library as what ADIOS was built with (in contrast to the Matlab executable). You can do this at startup of Matlab:
+2) if necessary, to force Matlab to use the same stdc++ library as what ADIOS was built with (in contrast to the Matlab executable). You can do this at startup of Matlab:
 
 $ cd $ADIOS_INSTALL_DIR/lib
-$ ldd libadios2.so
+$ ldd libadios2_c.so
         libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00002adb84068000)
 
 $ export LD_LIBRARY_PATH=$ADIOS_INSTALL_DIR/lib:$LD_LIBRARY_PATH
 $ export MATLABPATH=<your Matlab/ directory>
-$ LD_PRELOAD=/usr/lib64/libstdc++.so.6.0.24     matlab -nojvm -nodesktop -nosplash
+$ LD_PRELOAD=/usr/lib64/libstdc++.so.6     matlab -nojvm -nodesktop -nosplash
 
 
 In the Matlab/test directory there is a sample file and test script. The test function should complete without errors (provided your current directory is Matlab/test)

--- a/bindings/Matlab/adiosopenc.c
+++ b/bindings/Matlab/adiosopenc.c
@@ -147,7 +147,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
     /********************************************************/
     /* Open ADIOS file now and get variables and attributes */
-    adiosobj = adios2_init();
+    adiosobj = adios2_init(false);
     group = adios2_declare_io(adiosobj, "matlabiogroup"); // name is arbitrary
     fp = adios2_open(group, fname, adios2_mode_read);
     if (fp == NULL)


### PR DESCRIPTION
Needs to merged to 2.9 as well