### PR TITLE
Fix plugin engine example

### DIFF
--- a/docs/user_guide/source/advanced/plugins.rst
+++ b/docs/user_guide/source/advanced/plugins.rst
@@ -131,6 +131,35 @@ If ``ADIOS2_PLUGIN_PATH`` is not set, and a path is not specified when loading y
 .. note::
     The ``ADIOS2_PLUGIN_PATH`` environment variable can contain multiple paths, which must be separated with a ``:``.
 
+
+When building on Windows, you will likely need to explicitly export the Create and Destroy symbols for your plugin, as symbols are invisible by default on Windows.
+To do this in a portable way across platforms, you can add something similar to the following lines to your CMakeLists.txt:
+
+.. code-block:: cmake
+
+    include(GenerateExportHeader)
+    generate_export_header(PluginEngineWrite BASE_NAME plugin_engine_write)
+    target_include_directories(PluginEngineWrite PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:include>)
+
+
+Then in your plugin header, you'll need to ``#include "plugin_engine_write_export.h"``. Then edit your function defintions as follows:
+
+.. code-block:: c++
+
+    extern "C" {
+
+    PLUGIN_ENGINE_WRITE_EXPORT adios2::plugin::ExampleWritePlugin *
+        EngineCreate(adios2::core::IO &io, const std::string &name,
+                 const adios2::Mode mode, adios2::helper::Comm comm);
+
+    PLUGIN_ENGINE_WRITE_EXPORT void
+        EngineDestroy(adios2::plugin::ExampleWritePlugin * obj);
+
+    }
+
+
 ***********************************
 Using Your Plugin in an Application
 ***********************************

--- a/examples/plugins/engine/CMakeLists.txt
+++ b/examples/plugins/engine/CMakeLists.txt
@@ -3,15 +3,26 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
+include(GenerateExportHeader)
 add_library(PluginEngineWrite
   ExampleWritePlugin.cpp
 )
 target_link_libraries(PluginEngineWrite adios2::cxx11 adios2_core)
+generate_export_header(PluginEngineWrite BASE_NAME plugin_engine_write)
+target_include_directories(PluginEngineWrite PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 
 add_library(PluginEngineRead
   ExampleReadPlugin.cpp
 )
 target_link_libraries(PluginEngineRead adios2::cxx11 adios2_core)
+generate_export_header(PluginEngineRead BASE_NAME plugin_engine_read)
+target_include_directories(PluginEngineRead PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 
 add_executable(examplePluginEngine_write
   examplePluginEngine_write.cpp

--- a/examples/plugins/engine/ExampleReadPlugin.h
+++ b/examples/plugins/engine/ExampleReadPlugin.h
@@ -15,6 +15,8 @@
 #ifndef EXAMPLEREADPLUGIN_H_
 #define EXAMPLEREADPLUGIN_H_
 
+#include "plugin_engine_read_export.h"
+
 #include <fstream>
 #include <string>
 
@@ -80,11 +82,11 @@ private:
 
 extern "C" {
 
-adios2::plugin::ExampleReadPlugin *EngineCreate(adios2::core::IO &io,
-                                                const std::string &name,
-                                                const adios2::Mode mode,
-                                                adios2::helper::Comm comm);
-void EngineDestroy(adios2::plugin::ExampleReadPlugin *obj);
+PLUGIN_ENGINE_READ_EXPORT adios2::plugin::ExampleReadPlugin *
+EngineCreate(adios2::core::IO &io, const std::string &name,
+             const adios2::Mode mode, adios2::helper::Comm comm);
+PLUGIN_ENGINE_READ_EXPORT void
+EngineDestroy(adios2::plugin::ExampleReadPlugin *obj);
 }
 
 #endif /* EXAMPLEREADPLUGIN_H_ */

--- a/examples/plugins/engine/ExampleWritePlugin.h
+++ b/examples/plugins/engine/ExampleWritePlugin.h
@@ -14,6 +14,8 @@
 #ifndef EXAMPLEWRITEPLUGIN_H_
 #define EXAMPLEWRITEPLUGIN_H_
 
+#include "plugin_engine_write_export.h"
+
 #include <fstream>
 #include <memory>
 #include <string>
@@ -81,11 +83,11 @@ private:
 
 extern "C" {
 
-adios2::plugin::ExampleWritePlugin *EngineCreate(adios2::core::IO &io,
-                                                 const std::string &name,
-                                                 const adios2::Mode mode,
-                                                 adios2::helper::Comm comm);
-void EngineDestroy(adios2::plugin::ExampleWritePlugin *obj);
+PLUGIN_ENGINE_WRITE_EXPORT adios2::plugin::ExampleWritePlugin *
+EngineCreate(adios2::core::IO &io, const std::string &name,
+             const adios2::Mode mode, adios2::helper::Comm comm);
+PLUGIN_ENGINE_WRITE_EXPORT void
+EngineDestroy(adios2::plugin::ExampleWritePlugin *obj);
 }
 
 #endif /* EXAMPLEWRITEPLUGIN_H_ */

--- a/examples/plugins/engine/examplePluginEngine_read.cpp
+++ b/examples/plugins/engine/examplePluginEngine_read.cpp
@@ -77,6 +77,7 @@ int main(int argc, char *argv[])
             adios2::Params params;
             params["PluginName"] = "ReadPlugin";
             params["PluginLibrary"] = "PluginEngineRead";
+            params["verbose"] = "5";
             io.SetParameters(params);
         }
         adios2::Engine reader = io.Open("TestPlugin", adios2::Mode::Read);

--- a/examples/plugins/engine/examplePluginEngine_read.cpp
+++ b/examples/plugins/engine/examplePluginEngine_read.cpp
@@ -61,6 +61,7 @@ int main(int argc, char *argv[])
 
     std::vector<float> myFloats = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
+    bool success = false;
     try
     {
         /** ADIOS class factory of IO class objects */
@@ -108,6 +109,7 @@ int main(int argc, char *argv[])
 
         /** Engine becomes unreachable after this*/
         reader.Close();
+        success = true;
     }
     catch (std::invalid_argument &e)
     {
@@ -125,5 +127,5 @@ int main(int argc, char *argv[])
         std::cout << e.what() << "\n";
     }
 
-    return 0;
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/plugins/engine/examplePluginEngine_write.cpp
+++ b/examples/plugins/engine/examplePluginEngine_write.cpp
@@ -73,6 +73,7 @@ int main(int argc, char *argv[])
             adios2::Params params;
             params["PluginName"] = "WritePlugin";
             params["PluginLibrary"] = "PluginEngineWrite";
+            params["verbose"] = "5";
             io.SetParameters(params);
         }
         adios2::Engine writer = io.Open("TestPlugin", adios2::Mode::Write);

--- a/examples/plugins/engine/examplePluginEngine_write.cpp
+++ b/examples/plugins/engine/examplePluginEngine_write.cpp
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
         else
         {
             writer.Put<float>(var, myFloats.data());
+            writer.PerformPuts();
         }
 
         /** Engine becomes unreachable after this*/

--- a/examples/plugins/engine/examplePluginEngine_write.cpp
+++ b/examples/plugins/engine/examplePluginEngine_write.cpp
@@ -52,6 +52,7 @@ int main(int argc, char *argv[])
     std::vector<float> myFloats = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     const std::size_t Nx = myFloats.size();
 
+    bool success = false;
     try
     {
         /** ADIOS class factory of IO class objects */
@@ -88,6 +89,7 @@ int main(int argc, char *argv[])
 
         /** Engine becomes unreachable after this*/
         writer.Close();
+        success = true;
     }
     catch (std::invalid_argument &e)
     {
@@ -105,5 +107,5 @@ int main(int argc, char *argv[])
         std::cout << e.what() << "\n";
     }
 
-    return 0;
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/plugins/operator/examplePluginOperator_read.cpp
+++ b/examples/plugins/operator/examplePluginOperator_read.cpp
@@ -40,6 +40,7 @@ int main(int argc, char *argv[])
         0.0001,
     };
 
+    bool success = false;
     try
     {
         /** ADIOS class factory of IO class objects */
@@ -85,6 +86,7 @@ int main(int argc, char *argv[])
 
         /** Engine becomes unreachable after this*/
         reader.Close();
+        success = true;
     }
     catch (std::invalid_argument &e)
     {
@@ -102,5 +104,5 @@ int main(int argc, char *argv[])
         std::cout << e.what() << "\n";
     }
 
-    return 0;
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/examples/plugins/operator/examplePluginOperator_write.cpp
+++ b/examples/plugins/operator/examplePluginOperator_write.cpp
@@ -41,6 +41,7 @@ int main(int argc, char *argv[])
     };
     const std::size_t Nx = myDoubles.size();
 
+    bool success = false;
     try
     {
         /** ADIOS class factory of IO class objects */
@@ -73,6 +74,7 @@ int main(int argc, char *argv[])
 
         /** Engine becomes unreachable after this*/
         writer.Close();
+        success = true;
     }
     catch (std::invalid_argument &e)
     {
@@ -90,5 +92,5 @@ int main(int argc, char *argv[])
         std::cout << e.what() << "\n";
     }
 
-    return 0;
+    return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/source/adios2/engine/plugin/PluginEngine.cpp
+++ b/source/adios2/engine/plugin/PluginEngine.cpp
@@ -57,6 +57,7 @@ PluginEngine::PluginEngine(core::IO &io, const std::string &name,
     }
 
     auto &pluginManager = PluginManager::GetInstance();
+    pluginManager.SetParameters(m_IO.m_Parameters);
     pluginManager.LoadPlugin(pluginNameIt->second, pluginLibIt->second);
     m_Impl->m_HandleCreate =
         pluginManager.GetEngineCreateFun(pluginNameIt->second);

--- a/source/adios2/helper/adiosPluginManager.cpp
+++ b/source/adios2/helper/adiosPluginManager.cpp
@@ -135,9 +135,11 @@ bool PluginManager::LoadPlugin(const std::string &pluginName,
         }
         catch (std::exception &e)
         {
+            // this is not necessarily an error, because you could have
+            // multiple paths in ADIOS2_PLUGIN_PATH variable
             helper::Log("Plugins", "PluginManager", "LoadPlugin",
-                        std::string("Exception caught: ") + e.what(),
-                        helper::LogMode::WARNING);
+                        std::string("OpenPlugin failed: ") + e.what(), 5,
+                        m_Impl->m_Verbosity, helper::LogMode::INFO);
             loaded = false;
         }
         ++pathIt;
@@ -233,6 +235,9 @@ bool PluginManager::OpenPlugin(const std::string &pluginName,
                     m_Impl->m_Verbosity, helper::LogMode::INFO);
         return true;
     }
+    helper::Throw<std::runtime_error>(
+        "Plugins", "PluginManager", "OpenPlugin",
+        "Unable to locate Create/Destroy symbols in library " + pluginLibrary);
     return false;
 }
 

--- a/source/adios2/helper/adiosPluginManager.cpp
+++ b/source/adios2/helper/adiosPluginManager.cpp
@@ -115,8 +115,15 @@ bool PluginManager::LoadPlugin(const std::string &pluginName,
     {
         return OpenPlugin(pluginName, pluginLibrary, "");
     }
-    auto pathsSplit =
-        adios2sys::SystemTools::SplitString(allPluginPaths, ':', false);
+
+#ifdef _WIN32
+    char platform_separator = ';';
+#else
+    char platform_separator = ':';
+#endif
+
+    auto pathsSplit = adios2sys::SystemTools::SplitString(
+        allPluginPaths, platform_separator, false);
 
     bool loaded = false;
     auto pathIt = pathsSplit.begin();
@@ -126,9 +133,11 @@ bool PluginManager::LoadPlugin(const std::string &pluginName,
         {
             loaded = OpenPlugin(pluginName, pluginLibrary, *pathIt);
         }
-        catch (...)
+        catch (std::exception &e)
         {
-            std::cout << "catch block\n";
+            helper::Log("Plugins", "PluginManager", "LoadPlugin",
+                        std::string("Exception caught: ") + e.what(),
+                        helper::LogMode::WARNING);
             loaded = false;
         }
         ++pathIt;

--- a/source/adios2/operator/plugin/PluginOperator.cpp
+++ b/source/adios2/operator/plugin/PluginOperator.cpp
@@ -72,6 +72,7 @@ void PluginOperator::PluginInit(const std::string &pluginName,
     }
 
     auto &pluginManager = PluginManager::GetInstance();
+    pluginManager.SetParameters(m_Parameters);
     pluginManager.LoadPlugin(pluginName, pluginLibrary);
 
     m_Impl->m_HandleCreate = pluginManager.GetOperatorCreateFun(pluginName);

--- a/testing/install/EnginePlugin/CMakeLists.txt
+++ b/testing/install/EnginePlugin/CMakeLists.txt
@@ -23,6 +23,9 @@ add_library(PluginEngineRead
 )
 target_link_libraries(PluginEngineRead adios2::cxx11 adios2::core)
 
+file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}" plugin_path)
+set(ENV{ADIOS2_PLUGIN_PATH} "${plugin_path}")
+
 # add write test
 add_executable(adios_plugin_engine_write_test
   ../../../examples/plugins/engine/examplePluginEngine_write.cpp

--- a/testing/install/EnginePlugin/CMakeLists.txt
+++ b/testing/install/EnginePlugin/CMakeLists.txt
@@ -23,8 +23,11 @@ add_library(PluginEngineRead
 )
 target_link_libraries(PluginEngineRead adios2::cxx11 adios2::core)
 
-file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}" plugin_path)
-set(ENV{ADIOS2_PLUGIN_PATH} "${plugin_path}")
+if (WIN32)
+  file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/Debug" plugin_path)
+else()
+  set(plugin_path "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
 
 # add write test
 add_executable(adios_plugin_engine_write_test
@@ -32,6 +35,9 @@ add_executable(adios_plugin_engine_write_test
 )
 target_link_libraries(adios_plugin_engine_write_test adios2::cxx11)
 add_test(NAME adios_plugin_engine_write_test COMMAND adios_plugin_engine_write_test)
+set_tests_properties(adios_plugin_engine_write_test PROPERTIES
+  ENVIRONMENT ADIOS2_PLUGIN_PATH=${plugin_path}
+  )
 
 # add read test
 add_executable(adios_plugin_engine_read_test
@@ -40,5 +46,7 @@ add_executable(adios_plugin_engine_read_test
 target_link_libraries(adios_plugin_engine_read_test adios2::cxx11)
 add_test(NAME adios_plugin_engine_read_test COMMAND adios_plugin_engine_read_test)
 set_tests_properties(adios_plugin_engine_read_test PROPERTIES
-    DEPENDS adios_plugin_engine_write_test)
+  ENVIRONMENT ADIOS2_PLUGIN_PATH=${plugin_path}
+  DEPENDS adios_plugin_engine_write_test
+)
 

--- a/testing/install/EnginePlugin/CMakeLists.txt
+++ b/testing/install/EnginePlugin/CMakeLists.txt
@@ -13,15 +13,27 @@ option(BUILD_SHARED_LIBS "build shared libs" ON)
 
 #---------- Engine Plugin Tests
 
+include(GenerateExportHeader)
+
 add_library(PluginEngineWrite
   ../../../examples/plugins/engine/ExampleWritePlugin.cpp
 )
 target_link_libraries(PluginEngineWrite adios2::cxx11 adios2::core)
+generate_export_header(PluginEngineWrite BASE_NAME plugin_engine_write)
+target_include_directories(PluginEngineWrite PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 
 add_library(PluginEngineRead
   ../../../examples/plugins/engine/ExampleReadPlugin.cpp
 )
 target_link_libraries(PluginEngineRead adios2::cxx11 adios2::core)
+generate_export_header(PluginEngineRead BASE_NAME plugin_engine_read)
+target_include_directories(PluginEngineRead PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 
 if (WIN32)
   file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/Debug" plugin_path)


### PR DESCRIPTION
Fixes #3492. For some reason a `PerformPuts()` was removed that causes the example to break. The example is used in one of the install tests, but it wasn't returning failure states when it happens so that's why we missed in CI. That's been fixed as well. It also turns out that that has been failing for awhile due to not being able to find the plugin libs, so that should be fixed now too.