### PR TITLE
ci,kokkos,cuda: remove warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ adios_option(Catalyst   "Enable support for in situ visualization plugin using P
 adios_option(AWSSDK     "Enable support for S3 compatible storage using AWS SDK's S3 module" AUTO)
 include(${PROJECT_SOURCE_DIR}/cmake/DetectOptions.cmake)
 
-if(ADIOS2_HAVE_CUDA)
+if(ADIOS2_HAVE_CUDA OR ADIOS2_HAVE_Kokkos_CUDA)
     set(CMAKE_CUDA_STANDARD 11)
     set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
     if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)

--- a/docs/user_guide/source/advanced/gpu_aware.rst
+++ b/docs/user_guide/source/advanced/gpu_aware.rst
@@ -37,7 +37,7 @@ When building ADIOS2 with CUDA enabled, the user is responsible with setting the
 Building with Kokkos enabled
 --------------------------
 
-The Kokkos library can be used to enable GPU within ADIOS2. Based on how Kokkos is build, either the CUDA or HIP backend will be enabled. Building with Kokkos requires ``-DADIOS2_USE_Kokkos=ON``. The user is not responsible to set the ``CMAKE_CUDA_ARCHITECTURES`` since it will be detected from the Kokkos installation.
+The Kokkos library can be used to enable GPU within ADIOS2. Based on how Kokkos is build, either the CUDA or HIP backend will be enabled. Building with Kokkos requires ``-DADIOS2_USE_Kokkos=ON``. The user is responsible to set the ``CMAKE_CUDA_ARCHITECTURES`` to the same architecture used when configuring the Kokkos library it links against.
 
 .. note::
     Kokkos version >= 3.7 is required to enable the GPU backend in ADIOS2


### PR DESCRIPTION
Followup #3446 

We missed this change, its to set the `CMAKE_CUDA_ARCHITECTURES` when using Kokkos_CUDA