### PR TITLE
cmake: do not install empty sst dirs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+# KW's stuff
+**/CMakeLists.txt        @vicentebolea @caitlinross
+*.cmake                  @vicentebolea @caitlinross
+
+# Vicente's stuff
+*.sh @vicentebolea
+*.bash @vicentebolea
+*.in @vicentebolea
+*.yml @vicentebolea
+*.yaml @vicentebolea
+*.in @vicentebolea
+*.json @vicentebolea
+*.txt  @vicentebolea
+scripts/ @vicentebolea
+.github/ @vicentebolea
+.circleci/ @vicentebolea
+source/adios2/toolkit/sst/dp/mpi_dp.c @vicentebolea

--- a/scripts/ci/images-v2/Dockerfile.ci-spack-el8-base
+++ b/scripts/ci/images-v2/Dockerfile.ci-spack-el8-base
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=almalinux/almalinux:8
+ARG BASE_IMAGE=almalinux:8
 FROM $BASE_IMAGE
 
 RUN dnf upgrade -y && \

--- a/scripts/ci/images-v2/Dockerfile.ci-spack-el8-cuda-base
+++ b/scripts/ci/images-v2/Dockerfile.ci-spack-el8-cuda-base
@@ -1,0 +1,14 @@
+ARG BASE_IMAGE=ornladios/adios2:ci-spack-el8-base
+FROM $BASE_IMAGE
+
+RUN yum config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+
+# Install the gcc fortran compiler missing from the base image
+RUN dnf install -y gcc-gfortran cuda && \
+    dnf clean all
+
+# Add the compilers to spack
+RUN . /opt/spack/share/spack/setup-env.sh && \
+    spack compiler rm --scope system gcc && \
+    spack compiler add --scope system && \
+    spack config --scope system add "packages:all:compiler:[gcc]"

--- a/scripts/ci/images-v2/Dockerfile.ci-spack-el8-leaf
+++ b/scripts/ci/images-v2/Dockerfile.ci-spack-el8-leaf
@@ -1,7 +1,7 @@
 # vim: ft=dockerfile
 ARG COMPILER_IMG_BASE
 
-FROM almalinux/almalinux:8 AS builder
+FROM almalinux:8 AS builder
 ARG COMPILER_IMG_BASE
 
 WORKDIR /root

--- a/scripts/ci/images-v2/build-base.sh
+++ b/scripts/ci/images-v2/build-base.sh
@@ -5,7 +5,7 @@ source "${BASE_DIR}/build-functions.sh"
 
 message1 "Building ci-spack-el8 base image"
 if ! build_squash \
-  almalinux/almalinux:8 \
+  almalinux:8 \
   ornladios/adios2:ci-spack-el8-base \
   Dockerfile.ci-spack-el8-base
 then

--- a/scripts/ci/images-v2/build-cuda.sh
+++ b/scripts/ci/images-v2/build-cuda.sh
@@ -4,10 +4,20 @@ set -ex
 BASE_DIR=$(dirname $(readlink -f ${BASH_SOURCE}))
 source "${BASE_DIR}/build-functions.sh"
 
-message1 "Building ci-spack-el8 leaf image"
-build_conf=gcc8
+message1 "Building cuda base image"
 if ! build_squash \
-    ornladios/adios2:ci-spack-el8-gcc8-base \
+  ornladios/adios2:ci-spack-el8-base \
+  ornladios/adios2:ci-spack-el8-cuda-base \
+  Dockerfile.ci-spack-el8-cuda-base
+then
+  echo "Error: Failed to build cuda base image"
+  exit 3
+fi
+
+message1 "Building ci-spack-el8 leaf image"
+build_conf=cuda
+if ! build_squash \
+    ornladios/adios2:ci-spack-el8-cuda-base \
     ornladios/adios2:ci-spack-el8-cuda-serial \
     Dockerfile.ci-spack-el8-leaf \
     "--build-arg=COMPILER_IMG_BASE=${build_conf}

--- a/scripts/ci/images-v2/build.sh
+++ b/scripts/ci/images-v2/build.sh
@@ -71,7 +71,7 @@ if [ $enable_base -eq 1 ]
 then
   message1 "Building ci base image"
   if ! build_squash \
-    almalinux/almalinux:8 \
+    almalinux:8 \
     ornladios/adios2:ci-spack-el8-base \
     Dockerfile.ci-spack-el8-base
   then

--- a/scripts/ci/images-v2/specs.yaml.in
+++ b/scripts/ci/images-v2/specs.yaml.in
@@ -3,7 +3,7 @@ spack:
   specs:
     - libsodium%$(COMPILER)
 $if(DEVICE == "CUDA")\
-    - kokkos@3.6.01%gcc+cuda+wrapper+cuda_lambda cuda_arch=52
+    - kokkos@3.7.00%gcc+cuda+wrapper+cuda_lambda cuda_arch=52
 $endif\
 $if(COMPILER_IMG_BASE == "gcc10")\
     - libcatalyst@3f7871c0a2e737cb9ed35fc1c2208456fcc00a0e%$(COMPILER)$(MPI_VARIANT)

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -436,6 +436,8 @@ install(DIRECTORY toolkit/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/adios2/toolkit COMPONENT adios2_core-development
   FILES_MATCHING PATTERN "*/*.h"
   PATTERN "*/*.inl"
+  REGEX "sst/util" EXCLUDE
+  REGEX "sst/dp" EXCLUDE
 )
 
 # Library installation


### PR DESCRIPTION
Fixes: #3205 

Ideally we want to have an install test that fails when it sees empty dirs in the installation tree.
