### PR TITLE
Workaround for lammps and Scorpion to have a green CI

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -376,7 +376,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        code: [examples, lammps, scorpio, tau]
+        code: [examples, lammps, tau]
         include:
           - code: examples
             repo: ornladios/ADIOS2-Examples
@@ -384,9 +384,6 @@ jobs:
           - code: lammps
             repo: pnorbert/lammps
             ref: fix-deprecated-adios-init
-          - code: scorpio
-            repo: E3SM-Project/scorpio
-            ref: scorpio-v1.2.1
           - code: tau
             repo: ornladios/ADIOS2-Examples
             ref: master

--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -382,8 +382,8 @@ jobs:
             repo: ornladios/ADIOS2-Examples
             ref: master
           - code: lammps
-            repo: lammps/lammps
-            ref: patch_10Feb2021
+            repo: pnorbert/lammps
+            ref: fix-deprecated-adios-init
           - code: scorpio
             repo: E3SM-Project/scorpio
             ref: scorpio-v1.2.1

--- a/testing/contract/lammps/config.sh
+++ b/testing/contract/lammps/config.sh
@@ -15,5 +15,5 @@ cmake \
   -DBUILD_LIB=no \
   -DBUILD_DOC=no \
   -DLAMMPS_SIZES=smallbig \
-  -DPKG_USER-ADIOS=yes \
+  -DPKG_ADIOS=yes \
   ${source_dir}/cmake


### PR DESCRIPTION
followup: #3494 

While the Lammps and Scorpio applications are being updated to drop the Adios2 deprecated functions, we need to make some changes to keep our CI green. This MR:

- Uses @pnorbert lammps branch which includes the changes to use ADIOS 2.9
- Temporary disable the Scorpio contract as it will keep failing until their team updates
  their code to our current API.