### PR TITLE
Change default marshalling for SST to BP5

### DIFF
--- a/source/adios2/toolkit/sst/sst_data.h
+++ b/source/adios2/toolkit/sst/sst_data.h
@@ -54,7 +54,7 @@ typedef struct _SstStats
 } * SstStats;
 
 #define SST_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                \
-    MACRO(MarshalMethod, MarshalMethod, size_t, SstMarshalBP)                  \
+    MACRO(MarshalMethod, MarshalMethod, size_t, SstMarshalBP5)                 \
     MACRO(verbose, Int, int, 0)                                                \
     MACRO(RegistrationMethod, RegMethod, size_t, 0)                            \
     MACRO(StepDistributionMode, StepDistributionMode, size_t, StepsAllToAll)   \


### PR DESCRIPTION
Changing this default is potentially less problematic than changing the file default, simply because SST streams aren't persistent.  So, doing the file default in another PR.