### PR TITLE
Set the CMAKE GPU architectures to what is used for Kokkos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,8 +173,12 @@ if(ADIOS2_HAVE_CUDA OR ADIOS2_HAVE_Kokkos_CUDA)
     set(CMAKE_CUDA_STANDARD 11)
     set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
     if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-        # Mininum common non-deprecated architecture
-        set(CMAKE_CUDA_ARCHITECTURES 52)
+        if(DEFINED Kokkos_CUDA_ARCHITECTURES)
+            set(CMAKE_CUDA_ARCHITECTURES Kokkos_CUDA_ARCHITECTURES)
+        else()
+            # Mininum common non-deprecated architecture
+            set(CMAKE_CUDA_ARCHITECTURES 52)
+        endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,10 @@ if(ADIOS2_HAVE_CUDA OR ADIOS2_HAVE_Kokkos_CUDA)
     endif()
 endif()
 
+if(NOT DEFINED CMAKE_HIP_ARCHITECTURES AND DEFINED Kokkos_HIP_ARCHITECTURES)
+    set(CMAKE_HIP_ARCHITECTURES Kokkos_HIP_ARCHITECTURES)
+endif()
+
 if(ADIOS2_HAVE_MPI)
   if(MPIEXEC_MAX_NUMPROCS LESS 4 AND "$ENV{OMPI_MCA_rmaps_base_oversubscribe}")
     message(STATUS "OpenMPI oversubscribe detected: raising MPIEXEC_MAX_NUMPROCS to 4 for testing")


### PR DESCRIPTION
Using the newly introduced `Kokkos_CUDA_ARCHITECTURES` and `Kokkos_HIP_ARCHITECTURES`

If the user sets the `-D CMAKE_CUDA_ARCHITECTURES` to something else, the user defined variable will be used (the same for HIP) so we cover the case when the used intends to use a different architecture.