### PR TITLE
Add adios2_mode_readRandomAccess to fortran bindings

### DIFF
--- a/bindings/Fortran/modules/adios2_parameters_mod.f90
+++ b/bindings/Fortran/modules/adios2_parameters_mod.f90
@@ -55,6 +55,8 @@ module adios2_parameters_mod
     integer, parameter :: adios2_mode_write = 1
     integer, parameter :: adios2_mode_read = 2
     integer, parameter :: adios2_mode_append = 3
+    integer, parameter :: adios2_mode_readRandomAccess = 6
+
     integer, parameter :: adios2_mode_deferred = 4
     integer, parameter :: adios2_mode_sync = 5
 


### PR DESCRIPTION
Resubmitting to the release branch.   Note that there is fragility here because the numerical values in the fortran bindings must match the numerical values in the C bindings and we have nothing that guarantees that.  Also, there are modes for different things mixed in the different lists.  Sigh.