### PR TITLE
Bug fix in BP5 when memory selection is used with GPU buffers

### DIFF
--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -1803,7 +1803,7 @@ void BP5Writer::PutCommon(VariableBase &variable, const void *values, bool sync)
             variable.m_MemoryCount, sourceRowMajor, false, (char *)ptr,
             variable.m_MemoryStart, variable.m_Count, sourceRowMajor, false,
             ObjSize, helper::CoreDims(), helper::CoreDims(), helper::CoreDims(),
-            helper::CoreDims(), false /* safemode */, MemorySpace::Host);
+            helper::CoreDims(), false /* safemode */, variable.m_MemSpace);
     }
     else
     {


### PR DESCRIPTION
There was one place where we did not propagate the memory space and `Host` was used by default. This resulted in seg faults when using `SetMemorySelection` on a GPU buffer with BP5. Fixed in the first commit + adding a testing for memory selection with CUDA (for both BP4 and BP5)

This will close issue #3478 