### PR TITLE
Fix bug when writing null blocks 

### DIFF
--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
@@ -118,7 +118,13 @@ inline void BP4Serializer::PutVariablePayload(
     }
     else
     {
-        PutOperationPayloadInBuffer(variable, blockInfo);
+        const bool isZeroCount =
+            std::all_of(blockInfo.Count.begin(), blockInfo.Count.end(),
+                        [](const size_t i) { return i == 0; });
+        if (!isZeroCount)
+        {
+            PutOperationPayloadInBuffer(variable, blockInfo);
+        }
     }
 
     /* Now we can update the varLength including payload size including the


### PR DESCRIPTION
This solves a fix for WarpX where processes write different number of blocks.

Related to PR #3465 and issue #3460

*Note:* This only affects BP4