### PR TITLE
Throw an error when unsupported parameters are used with the ZFP CUDA backend

### DIFF
--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -304,6 +304,21 @@ zfp_stream *GetZFPStream(const Dims &dimensions, DataType type,
     zfp_stream_set_execution(stream, ZFP_DEFAULT_EXECUTION_POLICY);
     isSerial = ZFP_DEFAULT_EXECUTION_POLICY == zfp_exec_serial;
 
+#ifdef ADIOS2_HAVE_ZFP_CUDA
+    if (hasAccuracy)
+    {
+        helper::Throw<std::runtime_error>(
+            "Operator", "CompressZFP", "GetZfpField",
+            "The CUDA backend in ZFP cannot use the 'accuracy' parameter");
+    }
+    if (hasPrecision)
+    {
+        helper::Throw<std::runtime_error>(
+            "Operator", "CompressZFP", "GetZfpField",
+            "The CUDA backend in ZFP cannot use the 'precisiom' parameter");
+    }
+#endif
+
     if (hasBackend)
     {
         auto policy = ZFP_DEFAULT_EXECUTION_POLICY;


### PR DESCRIPTION
The ZFP compressor supports only the `rate` parameter when the GPU backend is used (even if the arrays are CPUs if ZFP is linked to CUDA, the `accuracy` and `precision` parameters will result in errors). This PR makes the errors easier to understand.

ZFP supported parameters:
<img width="600" alt="(de)compression mode" src="https://user-images.githubusercontent.com/16229479/228597518-6e515f4f-d93c-4c16-bc52-a2e1754ec6b9.png">

This is something that might change soon so it will be updated (the main reason why I am not adding this in testing).