### PR TITLE
Allowing Put/Get to receive Kokkos Views with HIP backend

### DIFF
--- a/bindings/CXX11/adios2/cxx11/KokkosView.h
+++ b/bindings/CXX11/adios2/cxx11/KokkosView.h
@@ -39,6 +39,26 @@ struct memspace_kokkos_to_adios2<Kokkos::CudaHostPinnedSpace>
 
 #endif
 
+#if defined(KOKKOS_ENABLE_HIP) && defined(ADIOS2_HAVE_GPU_SUPPORT)
+template <>
+struct memspace_kokkos_to_adios2<Kokkos::Experimental::HIPSpace>
+{
+    static constexpr adios2::MemorySpace value = adios2::MemorySpace::GPU;
+};
+
+template <>
+struct memspace_kokkos_to_adios2<Kokkos::Experimental::HIPHostPinnedSpace>
+{
+    static constexpr adios2::MemorySpace value = adios2::MemorySpace::GPU;
+};
+
+template <>
+struct memspace_kokkos_to_adios2<Kokkos::Experimental::HIPManagedSpace>
+{
+    static constexpr adios2::MemorySpace value = adios2::MemorySpace::GPU;
+};
+#endif
+
 } // namespace detail
 
 template <class T, class... Parameters>


### PR DESCRIPTION
This is not a bug, more of an oversight (we don't need this in the current release). 

I tested the Kokkos backend in ADIOS2 with HIP on Crusher and it works fine as long as we pass the pointer (i.e. `view.data()`). I forgot to add the HIP memory space in the part of ADIOS2 that allows submitting directly the `Kokkos::View`. This PR fixes that.

Tested on Crusher BP4/BP5.