### PR TITLE
cmake: set correct soname

### DIFF
--- a/bindings/C/CMakeLists.txt
+++ b/bindings/C/CMakeLists.txt
@@ -46,7 +46,7 @@ set_target_properties(
   adios2_c ${maybe_adios2_c_mpi}
   PROPERTIES
   VERSION ${ADIOS2_LIBRARY_VERSION}
-  SOVERSION ${ADIOS2_VERSION_MAJOR}
+  SOVERSION ${ADIOS2_LIBRARY_SOVERSION}
 )
 
 install(TARGETS adios2_c ${maybe_adios2_c_mpi} EXPORT adios2CExports

--- a/bindings/CXX11/CMakeLists.txt
+++ b/bindings/CXX11/CMakeLists.txt
@@ -58,7 +58,7 @@ set_target_properties(
   adios2_cxx11 ${maybe_adios2_cxx11_mpi}
   PROPERTIES
   VERSION ${ADIOS2_LIBRARY_VERSION}
-  SOVERSION ${ADIOS2_VERSION_MAJOR}
+  SOVERSION ${ADIOS2_LIBRARY_SOVERSION}
 )
 
 install(TARGETS adios2_cxx11 ${maybe_adios2_cxx11_mpi} EXPORT adios2CXX11Exports

--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 # Set library version information
 set_target_properties(adios2_fortran PROPERTIES
   VERSION ${ADIOS2_LIBRARY_VERSION}
-  SOVERSION ${ADIOS2_VERSION_MAJOR}
+  SOVERSION ${ADIOS2_LIBRARY_SOVERSION}
 )
 
 add_library(adios2::fortran ALIAS adios2_fortran)
@@ -109,7 +109,7 @@ if(ADIOS2_HAVE_MPI)
     target_compile_definitions(adios2_fortran_mpi PRIVATE "$<$<COMPILE_LANGUAGE:Fortran>:ADIOS2_HAVE_FORTRAN_SUBMODULES;ADIOS2_HAVE_MPI_F>")
     set_target_properties(adios2_fortran_mpi PROPERTIES
       VERSION ${ADIOS2_LIBRARY_VERSION}
-      SOVERSION ${ADIOS2_VERSION_MAJOR}
+      SOVERSION ${ADIOS2_LIBRARY_SOVERSION}
     )
     set_property(TARGET adios2_fortran_mpi PROPERTY OUTPUT_NAME adios2${ADIOS2_LIBRARY_SUFFIX}_fortran_mpi)
   else()

--- a/cmake/ADIOSFunctions.cmake
+++ b/cmake/ADIOSFunctions.cmake
@@ -38,6 +38,9 @@ function(setup_version BASE)
   endif()
 
   set(ADIOS2_LIBRARY_VERSION ${BASE} PARENT_SCOPE)
+
+  string(REGEX MATCH "^([0-9]+\.[0-9]+)" ignore ${BASE})
+  set(ADIOS2_LIBRARY_SOVERSION ${CMAKE_MATCH_1} PARENT_SCOPE)
 endfunction()
 
 function(adios_option name description default)
@@ -224,3 +227,19 @@ program main
 end program
 ]] ${var} SRC_EXT F90)
 endmacro()
+
+# Set VERSION/SOVERSION of every shared library target in the given directory
+# to be the same as the ADIOS VERSION/SOVERSION.  This is important for the
+# third-party libraries bundled with ADIOS2.
+function(setup_libversion_dir dir)
+  get_directory_property(DIR_TARGETS DIRECTORY "${dir}" BUILDSYSTEM_TARGETS)
+  foreach(target ${DIR_TARGETS})
+    get_target_property(type ${target} TYPE)
+    if (${type} STREQUAL "SHARED_LIBRARY")
+      set_target_properties(${target} PROPERTIES
+          VERSION ${ADIOS2_LIBRARY_VERSION}
+          SOVERSION ${ADIOS2_LIBRARY_SOVERSION}
+      )
+    endif()
+  endforeach()
+endfunction()

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -408,7 +408,7 @@ set_target_properties(
   adios2_core ${maybe_adios2_core_mpi}
   PROPERTIES
   VERSION ${ADIOS2_LIBRARY_VERSION}
-  SOVERSION ${ADIOS2_VERSION_MAJOR}
+  SOVERSION ${ADIOS2_LIBRARY_SOVERSION}
 )
 
 install(FILES common/ADIOSMacros.h common/ADIOSTypes.h common/ADIOSTypes.inl

--- a/source/adios2/toolkit/sst/CMakeLists.txt
+++ b/source/adios2/toolkit/sst/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 set_target_properties(sst PROPERTIES
   OUTPUT_NAME adios2${ADIOS2_LIBRARY_SUFFIX}_sst
   VERSION ${ADIOS2_LIBRARY_VERSION}
-  SOVERSION ${ADIOS2_VERSION_MAJOR}
+  SOVERSION ${ADIOS2_LIBRARY_SOVERSION}
 )
 
 #------------------------------------------------------------------------------#

--- a/thirdparty/EVPath/CMakeLists.txt
+++ b/thirdparty/EVPath/CMakeLists.txt
@@ -18,5 +18,6 @@ set(EVPATH_HEADER_COMPONENT adios2_evpath-development)
 
 add_subdirectory(EVPath)
 set(EVPath_DIR ${CMAKE_CURRENT_BINARY_DIR}/EVPath CACHE INTERNAL "")
+setup_libversion_dir(EVPath)
 
 message_end_thirdparty()

--- a/thirdparty/atl/CMakeLists.txt
+++ b/thirdparty/atl/CMakeLists.txt
@@ -15,5 +15,6 @@ set(ATL_HEADER_COMPONENT adios2_atl-development)
 
 add_subdirectory(atl)
 set(atl_DIR ${CMAKE_CURRENT_BINARY_DIR}/atl CACHE INTERNAL "")
+setup_libversion_dir(atl)
 
 message_end_thirdparty()

--- a/thirdparty/dill/CMakeLists.txt
+++ b/thirdparty/dill/CMakeLists.txt
@@ -14,5 +14,6 @@ set(DILL_HEADER_COMPONENT adios2_dill-development)
 
 add_subdirectory(dill)
 set(dill_DIR ${CMAKE_CURRENT_BINARY_DIR}/dill CACHE INTERNAL "")
+setup_libversion_dir(dill)
 
 message_end_thirdparty()

--- a/thirdparty/enet/CMakeLists.txt
+++ b/thirdparty/enet/CMakeLists.txt
@@ -13,5 +13,6 @@ set(BUILD_DOCS OFF)
 
 add_subdirectory(enet)
 set(enet_DIR ${CMAKE_CURRENT_BINARY_DIR}/enet CACHE INTERNAL "")
+setup_libversion_dir(enet)
 
 message_end_thirdparty()

--- a/thirdparty/ffs/CMakeLists.txt
+++ b/thirdparty/ffs/CMakeLists.txt
@@ -18,5 +18,6 @@ set(FFS_HEADER_COMPONENT adios2_ffs-development)
 
 add_subdirectory(ffs)
 set(ffs_DIR ${CMAKE_CURRENT_BINARY_DIR}/ffs CACHE INTERNAL "")
+setup_libversion_dir(ffs)
 
 message_end_thirdparty()

--- a/thirdparty/perfstubs/perfstubs/CMakeLists.txt
+++ b/thirdparty/perfstubs/perfstubs/CMakeLists.txt
@@ -5,7 +5,11 @@ configure_file(
 
 add_library(perfstubs perfstubs_api/timer.c)
 
-set_property(TARGET perfstubs PROPERTY OUTPUT_NAME adios2${ADIOS2_LIBRARY_SUFFIX}_perfstubs)
+set_target_properties(perfstubs PROPERTIES
+  OUTPUT_NAME adios2${ADIOS2_LIBRARY_SUFFIX}_perfstubs
+  VERSION ${ADIOS2_LIBRARY_VERSION}
+  SOVERSION ${ADIOS2_LIBRARY_SOVERSION}
+)
 
 target_link_libraries(perfstubs INTERFACE dl m)
 


### PR DESCRIPTION
In the installation tree, we need to set the soname/version of our third library same as our ADIOS soname/soversion. This is needed for package manager to deal with multiple versions of ADIOS installed in their system.