### PR TITLE
Implement BP5 (and BP4) reader-side memory selection, do testing

### DIFF
--- a/source/adios2/helper/adiosType.h
+++ b/source/adios2/helper/adiosType.h
@@ -134,6 +134,17 @@ public:
     typedef size_t *iterator;
     iterator begin() { return &DimensSpan[0]; }
     iterator end() { return &DimensSpan[DimCount]; }
+    friend std::ostream &operator<<(std::ostream &os, const CoreDims &m)
+    {
+        os << "{";
+        for (size_t i = 0; i < m.size(); i++)
+        {
+            os << m[i];
+            if (i < m.size() - 1)
+                os << ", ";
+        }
+        return os << "}";
+    }
 };
 
 class DimsArray : public CoreDims

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -603,7 +603,7 @@ void BP4Deserializer::PostDataRead(
         if (endianReverse)
         {
             helper::Throw<std::invalid_argument>(
-                "Toolkit", "format::bp::BP3Deserializer", "PostDataRead",
+                "Toolkit", "format::bp::BP4Deserializer", "PostDataRead",
                 "endianReverse "
                 "not supported with MemorySelection");
         }
@@ -611,7 +611,7 @@ void BP4Deserializer::PostDataRead(
         if (m_ReverseDimensions)
         {
             helper::Throw<std::invalid_argument>(
-                "Toolkit", "format::bp::BP3Deserializer", "PostDataRead",
+                "Toolkit", "format::bp::BP4Deserializer", "PostDataRead",
                 "ReverseDimensions not supported with "
                 "MemorySelection");
         }

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -598,11 +598,55 @@ void BP4Deserializer::PostDataRead(
             ? Dims(blockInfo.Count.size(), 0)
             : blockInfo.Start;
 
-    helper::ClipContiguousMemory(
-        blockInfo.Data, blockInfoStart, blockInfo.Count,
-        m_ThreadBuffers[threadID][0].data(), subStreamBoxInfo.BlockBox,
-        subStreamBoxInfo.IntersectionBox, m_IsRowMajor, m_ReverseDimensions,
-        endianReverse, blockInfo.MemSpace);
+    if (!blockInfo.MemoryStart.empty())
+    {
+        if (endianReverse)
+        {
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP3Deserializer", "PostDataRead",
+                "endianReverse "
+                "not supported with MemorySelection");
+        }
+
+        if (m_ReverseDimensions)
+        {
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::bp::BP3Deserializer", "PostDataRead",
+                "ReverseDimensions not supported with "
+                "MemorySelection");
+        }
+
+        helper::DimsArray intersectStart(
+            subStreamBoxInfo.IntersectionBox.first);
+        helper::DimsArray intersectCount(
+            subStreamBoxInfo.IntersectionBox.second);
+        helper::DimsArray blockStart(subStreamBoxInfo.BlockBox.first);
+        helper::DimsArray blockCount(subStreamBoxInfo.BlockBox.second);
+        helper::DimsArray memoryStart(blockInfoStart);
+        for (size_t d = 0; d < intersectStart.size(); d++)
+        {
+            // change {intersect,block}Count from [start, end] to {start, count}
+            intersectCount[d] -= (intersectStart[d] - 1);
+            blockCount[d] -= (blockStart[d] - 1);
+            // shift everything by MemoryStart
+            intersectStart[d] += blockInfo.MemoryStart[d];
+            blockStart[d] += blockInfo.MemoryStart[d];
+        }
+        helper::NdCopy(m_ThreadBuffers[threadID][0].data(), intersectStart,
+                       intersectCount, true, true,
+                       reinterpret_cast<char *>(blockInfo.Data), intersectStart,
+                       intersectCount, true, true, sizeof(T), intersectStart,
+                       blockCount, memoryStart,
+                       helper::DimsArray(blockInfo.MemoryCount), false);
+    }
+    else
+    {
+        helper::ClipContiguousMemory(
+            blockInfo.Data, blockInfoStart, blockInfo.Count,
+            m_ThreadBuffers[threadID][0].data(), subStreamBoxInfo.BlockBox,
+            subStreamBoxInfo.IntersectionBox, m_IsRowMajor, m_ReverseDimensions,
+            endianReverse, blockInfo.MemSpace);
+    }
 }
 
 void BP4Deserializer::BackCompatDecompress(

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -894,7 +894,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name,
                     lf_QueueSpanMinMax(*Span, ElemCount, (DataType)Rec->Type,
                                        MemSpace, Rec->MetaOffset,
                                        Rec->MinMaxOffset,
-                                       MetaEntry->BlockCount /*BlockNum*/);
+                                       MetaEntry->BlockCount - 1 /*BlockNum*/);
                 }
             }
 

--- a/testing/adios2/interface/CMakeLists.txt
+++ b/testing/adios2/interface/CMakeLists.txt
@@ -26,6 +26,9 @@ gtest_add_tests_helper(DefineVariable MPI_ALLOW ADIOS Interface. "")
 gtest_add_tests_helper(DefineAttribute MPI_ALLOW ADIOS Interface. "")
 gtest_add_tests_helper(Selection MPI_NONE ADIOS Interface.  .BP3
     WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3")
-gtest_add_tests_helper(Selection MPI_NONE ADIOS Interface.  .BPfile
-    WORKING_DIRECTORY ${BPfile_DIR} EXTRA_ARGS "BPfile")
+#  Some selection only supported by BP3 and BP5.  BPfile might default to BP4, so don't run
+if(ADIOS2_HAVE_BP5)
+    gtest_add_tests_helper(Selection MPI_NONE ADIOS Interface.  .BPfile
+    		           WORKING_DIRECTORY ${BPfile_DIR} EXTRA_ARGS "BPfile")
+endif()
 gtest_add_tests_helper(NoMpi MPI_NONE ADIOS Interface. "")

--- a/testing/adios2/interface/CMakeLists.txt
+++ b/testing/adios2/interface/CMakeLists.txt
@@ -26,9 +26,6 @@ gtest_add_tests_helper(DefineVariable MPI_ALLOW ADIOS Interface. "")
 gtest_add_tests_helper(DefineAttribute MPI_ALLOW ADIOS Interface. "")
 gtest_add_tests_helper(Selection MPI_NONE ADIOS Interface.  .BP3
     WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3")
-#  Some selection only supported by BP3 and BP5.  BPfile might default to BP4, so don't run
-if(ADIOS2_HAVE_BP5)
-    gtest_add_tests_helper(Selection MPI_NONE ADIOS Interface.  .BPfile
-    		           WORKING_DIRECTORY ${BPfile_DIR} EXTRA_ARGS "BPfile")
-endif()
+gtest_add_tests_helper(Selection MPI_NONE ADIOS Interface.  .BPfile
+    WORKING_DIRECTORY ${BPfile_DIR} EXTRA_ARGS "BPfile")
 gtest_add_tests_helper(NoMpi MPI_NONE ADIOS Interface. "")

--- a/testing/adios2/interface/CMakeLists.txt
+++ b/testing/adios2/interface/CMakeLists.txt
@@ -6,9 +6,26 @@
 # These tests should be *very* fast
 set(CTEST_TEST_TIMEOUT 10)
 
-gtest_add_tests_helper(Interface MPI_ALLOW ADIOS Interface. "")
+set(BP3_DIR ${CMAKE_CURRENT_BINARY_DIR}/bp3)
+set(BP4_DIR ${CMAKE_CURRENT_BINARY_DIR}/bp4)
+set(BP5_DIR ${CMAKE_CURRENT_BINARY_DIR}/bp5)
+set(BPfile_DIR ${CMAKE_CURRENT_BINARY_DIR}/bpfile)
+set(FS_DIR ${CMAKE_CURRENT_BINARY_DIR}/filestream)
+file(MAKE_DIRECTORY ${BP3_DIR})
+file(MAKE_DIRECTORY ${BP4_DIR})
+file(MAKE_DIRECTORY ${BP5_DIR})
+file(MAKE_DIRECTORY ${BPfile_DIR})
+file(MAKE_DIRECTORY ${FS_DIR})
+
+gtest_add_tests_helper(Interface MPI_ALLOW ADIOS Interface.  .BP3
+    WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3")
+gtest_add_tests_helper(Interface MPI_ALLOW ADIOS Interface.  .BPfile
+    WORKING_DIRECTORY ${BPfile_DIR} EXTRA_ARGS "BPfile")
 gtest_add_tests_helper(Write MPI_ALLOW ADIOSInterface Interface. "")
 gtest_add_tests_helper(DefineVariable MPI_ALLOW ADIOS Interface. "")
 gtest_add_tests_helper(DefineAttribute MPI_ALLOW ADIOS Interface. "")
-gtest_add_tests_helper(Selection MPI_NONE ADIOS Interface. "")
+gtest_add_tests_helper(Selection MPI_NONE ADIOS Interface.  .BP3
+    WORKING_DIRECTORY ${BP3_DIR} EXTRA_ARGS "BP3")
+gtest_add_tests_helper(Selection MPI_NONE ADIOS Interface.  .BPfile
+    WORKING_DIRECTORY ${BPfile_DIR} EXTRA_ARGS "BPfile")
 gtest_add_tests_helper(NoMpi MPI_NONE ADIOS Interface. "")

--- a/testing/adios2/interface/TestADIOSSelection.cpp
+++ b/testing/adios2/interface/TestADIOSSelection.cpp
@@ -129,7 +129,7 @@ MultiArray<T, 2> makeArray(std::initializer_list<std::initializer_list<T>> t)
     return arr;
 }
 
-std::string engine = "BPfile";
+std::string engine = "BPfile"; // default if no argument
 
 TEST(MultiArray, Constructor)
 {
@@ -259,7 +259,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionNone)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine = m_IOReader.Open("test_selection_none.bp", adios2::Mode::Read);
     engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
@@ -293,7 +292,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionWrite)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_selection_write.bp", adios2::Mode::Read);
     engine.BeginStep();
@@ -328,7 +326,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionWriteStart)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_selection_write_start.bp", adios2::Mode::Read);
     engine.BeginStep();
@@ -362,7 +359,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionRead)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine = m_IOReader.Open("test_selection_read.bp", adios2::Mode::Read);
     engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
@@ -396,7 +392,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionReadStart)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_selection_read_start.bp", adios2::Mode::Read);
     engine.BeginStep();
@@ -434,7 +429,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionNone)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_mem_selection_none.bp", adios2::Mode::Read);
     engine.BeginStep();
@@ -472,7 +466,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionWrite)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_mem_selection_write.bp", adios2::Mode::Read);
     engine.BeginStep();
@@ -510,7 +503,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionWriteStart)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine = m_IOReader.Open("test_mem_selection_write_start.bp",
                                   adios2::Mode::Read);
     engine.BeginStep();
@@ -546,7 +538,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionRead)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_mem_selection_read.bp", adios2::Mode::Read);
     engine.BeginStep();
@@ -583,7 +574,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionReadStart)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine = m_IOReader.Open("test_mem_selection_read_start.bp",
                                   adios2::Mode::ReadRandomAccess);
     var = m_IOReader.InquireVariable<DataType>("var");
@@ -631,7 +621,6 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionComplex)
 
     // read back center block, with bits from every block written
     auto arr_read = MultiArrayT(ref.dims());
-    //    m_IOReader.SetEngine("BP3");
     auto engine = m_IOReader.Open("test_mem_selection_complex.bp",
                                   adios2::Mode::ReadRandomAccess);
     var = m_IOReader.InquireVariable<DataType>("var");

--- a/testing/adios2/interface/TestADIOSSelection.cpp
+++ b/testing/adios2/interface/TestADIOSSelection.cpp
@@ -129,6 +129,8 @@ MultiArray<T, 2> makeArray(std::initializer_list<std::initializer_list<T>> t)
     return arr;
 }
 
+std::string engine = "BPfile";
+
 TEST(MultiArray, Constructor)
 {
     using MultiArrayT = MultiArray<double, 4>;
@@ -247,7 +249,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionNone)
     // clang-format on
 
     // write
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer =
         m_IOWriter.Open("test_selection_none.bp", adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -257,11 +259,13 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionNone)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
+    //    m_IOReader.SetEngine("BP3");
     auto engine = m_IOReader.Open("test_selection_none.bp", adios2::Mode::Read);
+    engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 0}, {3, 4}});
     engine.Get(var, arr_read.data());
+    engine.EndStep();
     engine.Close();
 
     EXPECT_EQ(arr_read, ref);
@@ -279,7 +283,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionWrite)
     // clang-format on
 
     // write
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer =
         m_IOWriter.Open("test_selection_write.bp", adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -289,12 +293,14 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionWrite)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
+    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_selection_write.bp", adios2::Mode::Read);
+    engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 0}, {3, 4}});
     engine.Get(var, arr_read.data());
+    engine.EndStep();
     engine.Close();
 
     EXPECT_EQ(arr_read, ref);
@@ -312,7 +318,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionWriteStart)
     // clang-format on
 
     // write
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer =
         m_IOWriter.Open("test_selection_write_start.bp", adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -322,12 +328,14 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionWriteStart)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
+    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_selection_write_start.bp", adios2::Mode::Read);
+    engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 0}, {3, 4}});
     engine.Get(var, arr_read.data());
+    engine.EndStep();
     engine.Close();
 
     EXPECT_EQ(arr_read, ref);
@@ -344,7 +352,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionRead)
 			  {20., 21.}});
     // clang-format on
 
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer =
         m_IOWriter.Open("test_selection_read.bp", adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -354,11 +362,13 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionRead)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
+    //    m_IOReader.SetEngine("BP3");
     auto engine = m_IOReader.Open("test_selection_read.bp", adios2::Mode::Read);
+    engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 0}, {3, 2}});
     engine.Get(var, arr_read.data());
+    engine.EndStep();
     engine.Close();
 
     EXPECT_EQ(arr_read, ref);
@@ -376,7 +386,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionReadStart)
     // clang-format on
 
     // write
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer =
         m_IOWriter.Open("test_selection_read_start.bp", adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -386,12 +396,14 @@ TEST_F(ADIOS2_CXX11_API_Selection, SelectionReadStart)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
+    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_selection_read_start.bp", adios2::Mode::Read);
+    engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 2}, {3, 2}});
     engine.Get(var, arr_read.data());
+    engine.EndStep();
     engine.Close();
 
     EXPECT_EQ(arr_read, ref);
@@ -411,7 +423,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionNone)
     // clang-format on
 
     // write
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer =
         m_IOWriter.Open("test_mem_selection_none.bp", adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -422,12 +434,14 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionNone)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
+    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_mem_selection_none.bp", adios2::Mode::Read);
+    engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 0}, {3, 4}});
     engine.Get(var, arr_read.data());
+    engine.EndStep();
     engine.Close();
 
     EXPECT_EQ(arr_read, ref);
@@ -447,7 +461,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionWrite)
     // clang-format on
 
     // write
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer =
         m_IOWriter.Open("test_mem_selection_write.bp", adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -458,12 +472,14 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionWrite)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
+    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_mem_selection_write.bp", adios2::Mode::Read);
+    engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 0}, {3, 2}});
     engine.Get(var, arr_read.data());
+    engine.EndStep();
     engine.Close();
 
     EXPECT_EQ(arr_read, ref);
@@ -483,7 +499,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionWriteStart)
     // clang-format on
 
     // write
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer = m_IOWriter.Open("test_mem_selection_write_start.bp",
                                   adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -494,12 +510,14 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionWriteStart)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
+    //    m_IOReader.SetEngine("BP3");
     auto engine = m_IOReader.Open("test_mem_selection_write_start.bp",
                                   adios2::Mode::Read);
+    engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 0}, {3, 2}});
     engine.Get(var, arr_read.data());
+    engine.EndStep();
     engine.Close();
 
     EXPECT_EQ(arr_read, ref);
@@ -518,7 +536,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionRead)
 			  {0.,  0.,  0., 0.}});
     // clang-format on
 
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer =
         m_IOWriter.Open("test_mem_selection_read.bp", adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -528,13 +546,15 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionRead)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
+    //    m_IOReader.SetEngine("BP3");
     auto engine =
         m_IOReader.Open("test_mem_selection_read.bp", adios2::Mode::Read);
+    engine.BeginStep();
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 0}, {3, 2}});
     var.SetMemorySelection({{1, 1}, {5, 4}});
     engine.Get(var, arr_read.data());
+    engine.EndStep();
     engine.Close();
 
     EXPECT_EQ(arr_read, ref);
@@ -553,7 +573,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionReadStart)
 			  {0.,  0.,  0., 0.}});
     // clang-format on
 
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer = m_IOWriter.Open("test_mem_selection_read_start.bp",
                                   adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {3, 4});
@@ -563,9 +583,9 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionReadStart)
 
     // read back
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
-    auto engine =
-        m_IOReader.Open("test_mem_selection_read_start.bp", adios2::Mode::Read);
+    //    m_IOReader.SetEngine("BP3");
+    auto engine = m_IOReader.Open("test_mem_selection_read_start.bp",
+                                  adios2::Mode::ReadRandomAccess);
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{0, 2}, {3, 2}});
     var.SetMemorySelection({{1, 1}, {5, 4}});
@@ -590,7 +610,7 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionComplex)
 			  {0.,  0.,  0., 0.}});
     // clang-format on
 
-    m_IOWriter.SetEngine("BP3");
+    m_IOWriter.SetEngine(engine);
     auto writer =
         m_IOWriter.Open("test_mem_selection_complex.bp", adios2::Mode::Write);
     auto var = m_IOWriter.DefineVariable<DataType>("var", {4, 4});
@@ -611,9 +631,9 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionComplex)
 
     // read back center block, with bits from every block written
     auto arr_read = MultiArrayT(ref.dims());
-    m_IOReader.SetEngine("BP3");
-    auto engine =
-        m_IOReader.Open("test_mem_selection_complex.bp", adios2::Mode::Read);
+    //    m_IOReader.SetEngine("BP3");
+    auto engine = m_IOReader.Open("test_mem_selection_complex.bp",
+                                  adios2::Mode::ReadRandomAccess);
     var = m_IOReader.InquireVariable<DataType>("var");
     var.SetSelection({{1, 1}, {2, 2}});
     var.SetMemorySelection({{1, 1}, {4, 4}});
@@ -626,5 +646,10 @@ TEST_F(ADIOS2_CXX11_API_Selection, MemorySelectionComplex)
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
+    if (argc > 1)
+    {
+        engine = argv[1];
+        std::cout << "Running with engine " << engine << std::endl;
+    }
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Despite this having changes in testing/adios/interface, it actually doesn't involve any changes in the API or ABI. The story is this: There is a call, SetMemorySelection(), that affects how ADIOS accesses memory on both the writer and reader side. While there are tests for SetMemorySelection() on the writer side in testing/adios/bp, the only place where reader-side SetMemorySelection was tested was in testing/adios/interface, and oddly those tests were hard-coded to only use the BP3 engine (which hasn't been the default forever). Turns out that the reason that it was hard-coded is that that reader-side functionality was missing from BP4 and BP5. This PR implements that missing functionality in those engines and tweaks the testing so that the engine is no longer hard-coded as BP3 in the test, but is specified on the command line so that we can actually test this with BP3, BP4 and BP5. We might want to think about further steps, like moving this test into engine/bp or staging-common and cleaning up other things, but this PR at least adds the missing functionality and tests it.

