### PR TITLE
Adding missing HIP specific functionality

### DIFF
--- a/source/adios2/helper/adiosKokkos.cpp
+++ b/source/adios2/helper/adiosKokkos.cpp
@@ -90,6 +90,14 @@ bool IsGPUbuffer(const void *ptr)
         return true;
     }
 #endif
+#ifdef ADIOS2_HAVE_KOKKOS_HIP
+    hipPointerAttribute_t attr;
+    hipPointerGetAttributes(&attr, ptr);
+    if (attr.memoryType == hipMemoryTypeDevice)
+    {
+        return true;
+    }
+#endif
     return false;
 }
 

--- a/source/adios2/helper/adiosKokkos.cpp
+++ b/source/adios2/helper/adiosKokkos.cpp
@@ -111,6 +111,11 @@ void KokkosInit()
     cudaGetDevice(&device_id);
     settings.set_device_id(device_id);
 #endif
+#ifdef ADIOS2_HAVE_KOKKOS_HIP
+    int device_id;
+    hipGetDevice(&device_id);
+    settings.set_device_id(device_id);
+#endif
     Kokkos::initialize(settings);
 }
 


### PR DESCRIPTION
The functionality needed to set the device id and check if the buffer is allocated on the GPU was missing for the HIP backend. 

