### PR TITLE
Update ADIOS2 HDF5 VOL with basic set of capability flags

### DIFF
--- a/source/h5vol/H5VolReadWrite.h
+++ b/source/h5vol/H5VolReadWrite.h
@@ -32,6 +32,8 @@ extern herr_t H5VL_adios2_beginstep(const char *engine_name, adios2_step_mode m)
 
 extern herr_t H5VL_adios2_endstep(const char *engine_nane);
 
+static herr_t H5VL_adios2_introspect_get_cap_flags(const void *info, uint64_t *cap_flags);
+
 static herr_t H5VL_adios2_introspect_opt_query(void *obj, H5VL_subclass_t cls, int opt_type,
                                                uint64_t *supported)
 {
@@ -51,11 +53,11 @@ static herr_t H5VL_adios2_datatype_close(void *dt, hid_t H5_ATTR_UNUSED dxpl_id,
 static const H5VL_class_t H5VL_adios2_def = {
     H5VL_VERSION, /* Version # of connector, needed for v1.13 */
     (H5VL_class_value_t)H5VL_ADIOS2_VALUE,
-    H5VL_ADIOS2_NAME,    /* name */
-    H5VL_ADIOS2_VERSION, /* version of this vol, not as important  */
-    H5VL_CAP_FLAG_NONE,  /* Capability flags for connector */
-    H5VL_adios2_init,    /* initialize */
-    H5VL_adios2_term,    /* terminate */
+    H5VL_ADIOS2_NAME,      /* name */
+    H5VL_ADIOS2_VERSION,   /* version of this vol, not as important  */
+    H5VL_ADIOS2_CAP_FLAGS, /* Capability flags for connector */
+    H5VL_adios2_init,      /* initialize */
+    H5VL_adios2_term,      /* terminate */
     {
         /* info_cls */
         (size_t)0, /* info size    */
@@ -117,8 +119,8 @@ static const H5VL_class_t H5VL_adios2_def = {
     {
         /* introspect_cls */
         NULL, // H5VL_pass_through_introspect_get_conn_cls,  /* get_conn_cls */
-        NULL, /* get_cap_flags */
-        H5VL_adios2_introspect_opt_query, /* opt_query */
+        H5VL_adios2_introspect_get_cap_flags, /* get_cap_flags */
+        H5VL_adios2_introspect_opt_query,     /* opt_query */
     },
     {
         /* request_cls */
@@ -144,5 +146,11 @@ static const H5VL_class_t H5VL_adios2_def = {
     },
     NULL /*/optional*/
 };
+
+static herr_t H5VL_adios2_introspect_get_cap_flags(const void *info, uint64_t *cap_flags)
+{
+    *cap_flags = H5VL_adios2_def.cap_flags;
+    return 0;
+}
 
 #endif // ADIOS_VOL_WRITER_H

--- a/source/h5vol/H5Vol_def.h
+++ b/source/h5vol/H5Vol_def.h
@@ -19,6 +19,9 @@
 #define H5VL_ADIOS2_NAME "ADIOS2_VOL"
 #define H5VL_ADIOS2_VALUE 511 /* VOL connector ID */
 #define H5VL_ADIOS2_VERSION 0
+#define H5VL_ADIOS2_CAP_FLAGS                                                                      \
+    (H5VL_CAP_FLAG_FILE_BASIC | H5VL_CAP_FLAG_GROUP_BASIC | H5VL_CAP_FLAG_DATASET_BASIC |          \
+     H5VL_CAP_FLAG_ATTR_BASIC | H5VL_CAP_FLAG_OBJECT_BASIC)
 
 typedef struct H5VL_ADIOS2_t
 {


### PR DESCRIPTION
This PR updates the ADIOS2 HDF5 VOL connector to return a basic set of capability flags so that it can be tested with the [HDF5 VOL tests repository](https://github.com/HDFGroup/vol-tests/). Otherwise, the tests would fail when trying to call the H5Pget_vol_cap_flags API routine to retrieve the connector's capability flags.

Defining the new H5VL_adios2_introspect_get_cap_flags callback function allows HDF5 to properly resolve situations where the connector may have other connectors stacked on top of it that pass operations down and need to check if the connectors below it support certain functionality.