### PR TITLE
Bug fix for Kokkos applications without GPU backend

### DIFF
--- a/bindings/CXX11/adios2/cxx11/KokkosView.h
+++ b/bindings/CXX11/adios2/cxx11/KokkosView.h
@@ -8,6 +8,7 @@ namespace adios2
 namespace detail
 {
 
+#ifdef ADIOS2_HAVE_GPU_SUPPORT
 template <typename T>
 struct memspace_kokkos_to_adios2
 {
@@ -19,6 +20,13 @@ struct memspace_kokkos_to_adios2<Kokkos::HostSpace>
 {
     static constexpr adios2::MemorySpace value = adios2::MemorySpace::Host;
 };
+#else
+template <typename T>
+struct memspace_kokkos_to_adios2
+{
+    static constexpr adios2::MemorySpace value = adios2::MemorySpace::Host;
+};
+#endif
 
 } // namespace detail
 


### PR DESCRIPTION
Found by Norbert today when trying to compile the Kokkos example from the `ADIOS2-Examples` repo. This happens only when using Kokkos without any GPU backend.