### PR TITLE
Adapt libfabric dataplane of SST to Cray CXI provider

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -450,6 +450,14 @@ if(ADIOS2_USE_SST AND NOT WIN32)
     if(CrayDRC_FOUND)
       set(ADIOS2_SST_HAVE_CRAY_DRC TRUE)
     endif()
+
+    try_compile(ADIOS2_SST_HAVE_CRAY_CXI
+      ${ADIOS2_BINARY_DIR}/check_libfabric_cxi
+      ${ADIOS2_SOURCE_DIR}/cmake/check_libfabric_cxi.c
+      CMAKE_FLAGS
+        "-DINCLUDE_DIRECTORIES=${LIBFABRIC_INCLUDE_DIRS}"
+        "-DLINK_DIRECTORIES=${LIBFABRIC_LIBRARIES}")
+    message(STATUS "Libfabric support for the HPE CXI provider: ${ADIOS2_SST_HAVE_CRAY_CXI}")
   endif()
   if(ADIOS2_HAVE_MPI)
     set(CMAKE_REQUIRED_LIBRARIES "MPI::MPI_C;Threads::Threads")

--- a/cmake/check_libfabric_cxi.c
+++ b/cmake/check_libfabric_cxi.c
@@ -1,0 +1,5 @@
+#include <stdbool.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_cxi_ext.h>
+
+int main() {}

--- a/source/adios2/toolkit/sst/CMakeLists.txt
+++ b/source/adios2/toolkit/sst/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SST_CONFIG_OPTS
   UCX
   FI_GNI
   CRAY_DRC
+  CRAY_CXI
   NVStream
   MPI
 )

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -20,8 +20,9 @@
 #include <rdma/fi_rma.h>
 
 #ifdef SST_HAVE_CRAY_CXI
-// Needs to be included before rdma/fi_cxi_ext.h
 #include <stdbool.h>
+// This comment prevents clang-format from reordering these includes.
+// The CXI extension header requires the bool header, but does not include it on its own.
 #include <rdma/fi_cxi_ext.h>
 #endif
 


### PR DESCRIPTION
This PR is a first step towards trying to make use of libfabric+CXI on Frontier for SST streaming.

It successfully connects to the provider in `init_fabric()` in my tests, and the hello_sst examples finishes without error – but for some reason without loading any data. I will provide a detailed run log later (I lost my earlier logs somehow and a new job is currently enqueued), but essentially `fi_cq_sread` returns one finished task from the queue that reports a successful remote read of zero bytes.

When changing the data size in the helloSst examples, different errors occur (permission violations or (if I remember correctly) error code 90 - message too long) depending on the chosen data size.

As you can see in the diff, the configuration of libfabric is somewhat different from the one used in SST so far.
The most important differences are:

* Use of FI_MR_ENDPOINT is mandatory. I have adapted all calls to `fi_mr_reg()`, but maybe this flag has more implications.
* ~~The old implementation uses FI_MR_BASIC which implies FI_MR_LOCAL. I just noticed that I did not set this flag for some reason. I don't remember if this is necessary or if I just forgot this. I will need to try this out.~~ Setting FI_MR_LOCAL does not make a difference, I pushed a commit containing it.
* Use of FI_PROGRESS_MANUAL is mandatory (contradicting the libfabric documentation that says that AUTO should always be supported). I don't really know the implications of this. From the libfabric documentation of this parameter that I found, this reads more like a performance implication, turning `fi_cq_sread()` into a blocking/synchronous operation (it is called without a timeout in ADIOS2).

~~Note that I did not test the latest two commits (cleanup and documentation) yet, but their changes are not major.~~

Most things in this PR are currently hardcoded specifically for the requirements of the CXI provider.

Once I get a job on the system again, I will try to be a bit more specific in some things and answer some questions above, and provide a logfile.

cc @pnorbert @eisenhauer 

I used this submission script in my tests:

```bash
#!/bin/bash
#SBATCH -N 2
#SBATCH --ntasks-per-node=1
#SBATCH --cpus-per-task=1
#SBATCH -t 1:00
#SBATCH -A <project id>
#SBATCH -o out.txt
#SBATCH -e err.txt
#SBATCH --network=single_node_vni,job_vni

export FABRIC_IFACE=cxi2
export SstVerbose=5
echo Allocating jobs
srun --network=single_node_vni,job_vni -N 1 --ntasks=1 ../build/bin/hello_sstWriter > sst1.txt 2>&1 &
echo Allocated job 1
srun --network=single_node_vni,job_vni -N 1 --ntasks=1 ../build/bin/hello_sstReader > sst2.txt 2>&1 &
echo Allocated job 2
wait
echo Completed
```

Current diff: https://github.com/ornladios/ADIOS2/compare/release_29...franzpoeschel:ADIOS2:libfabric-cray