### PR TITLE
Fix: std::min w/ windows.h in C-Blosc2

### DIFF
--- a/source/adios2/operator/compress/CompressBlosc.cpp
+++ b/source/adios2/operator/compress/CompressBlosc.cpp
@@ -181,8 +181,8 @@ size_t CompressBlosc::Operate(const char *dataIn, const Dims &blockStart,
         for (; inputOffset < sizeIn; ++chunk)
         {
             size_t inputChunkSize =
-                std::min(sizeIn - inputOffset,
-                         static_cast<size_t>(BLOSC2_MAX_BUFFERSIZE));
+                std::min<size_t>(sizeIn - inputOffset,
+                                 static_cast<size_t>(BLOSC2_MAX_BUFFERSIZE));
             bloscSize_t maxIntputSize =
                 static_cast<bloscSize_t>(inputChunkSize);
 
@@ -375,8 +375,8 @@ size_t CompressBlosc::DecompressChunkedFormat(const char *bufferIn,
             char *out_ptr = dataOut + currentOutputSize;
 
             size_t outputChunkSize =
-                std::min(uncompressedSize - currentOutputSize,
-                         static_cast<size_t>(BLOSC2_MAX_BUFFERSIZE));
+                std::min<size_t>(uncompressedSize - currentOutputSize,
+                                 static_cast<size_t>(BLOSC2_MAX_BUFFERSIZE));
             bloscSize_t max_output_size =
                 static_cast<bloscSize_t>(outputChunkSize);
 

--- a/source/adios2/toolkit/format/bp/bpBackCompatOperation/compress/BPBackCompatBlosc.cpp
+++ b/source/adios2/toolkit/format/bp/bpBackCompatOperation/compress/BPBackCompatBlosc.cpp
@@ -142,8 +142,8 @@ size_t BPBackCompatBlosc::DecompressChunkedFormat(const void *bufferIn,
             uint8_t *out_ptr = outputBuff + currentOutputSize;
 
             size_t outputChunkSize =
-                std::min(uncompressedSize - currentOutputSize,
-                         static_cast<size_t>(BLOSC2_MAX_BUFFERSIZE));
+                std::min<size_t>(uncompressedSize - currentOutputSize,
+                                 static_cast<size_t>(BLOSC2_MAX_BUFFERSIZE));
             bloscSize_t max_output_size =
                 static_cast<bloscSize_t>(outputChunkSize);
 


### PR DESCRIPTION
Explictly specialize to avoid macro resolution when windows.h is included. What a world to live in.

X-ref: https://github.com/ornladios/ADIOS2/issues/3680#issuecomment-1615308336

@vicentebolea did I do this right? This PR should go in `master` and `release_29` alike.