### PR TITLE
ci: Fix conditional expression syntax to fix cache save

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -168,7 +168,7 @@ jobs:
         run: ccache -s
       - name: Save cache
         uses: actions/cache/save@v3
-        if: github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit == 'false'
+        if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit == 'false' }}
         id: save-cache
         with:
           path: .ccache
@@ -232,7 +232,7 @@ jobs:
         run: ccache -s
       - name: Save cache
         uses: actions/cache/save@v3
-        if: github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit == 'false'
+        if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit == 'false' }}
         id: save-cache
         with:
           path: .ccache
@@ -299,7 +299,7 @@ jobs:
         run: ccache -s
       - name: Save cache
         uses: actions/cache/save@v3
-        if: github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit == 'false'
+        if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit == 'false' }}
         id: save-cache
         with:
           path: .ccache


### PR DESCRIPTION
Hopefully this fixes the issue with saving cache on workflows run on the `master` branch.  I described the situation with a few more details [here](https://github.com/ornladios/ADIOS2/pull/3705#issuecomment-1660835138).