### PR TITLE
ci: work around bug in actions/cache

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -168,7 +168,7 @@ jobs:
         run: ccache -s
       - name: Save cache
         uses: actions/cache/save@v3
-        if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit == 'false' }}
+        if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit != 'true' }}
         id: save-cache
         with:
           path: .ccache
@@ -232,7 +232,7 @@ jobs:
         run: ccache -s
       - name: Save cache
         uses: actions/cache/save@v3
-        if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit == 'false' }}
+        if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit != 'true' }}
         id: save-cache
         with:
           path: .ccache
@@ -299,7 +299,7 @@ jobs:
         run: ccache -s
       - name: Save cache
         uses: actions/cache/save@v3
-        if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit == 'false' }}
+        if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit != 'true' }}
         id: save-cache
         with:
           path: .ccache


### PR DESCRIPTION
This PR hopefully *really* fixes the failures to save cache on `master` branch workflows.

I re-ran a `master` workflow with extra logging (which is handy), so [here](https://github.com/ornladios/ADIOS2/actions/runs/5731669038/job/15534531545) I could see why the cache was not getting saved: Instead of the restore action `cache-hit`output containing `false` or `true` as [documented](https://github.com/actions/cache/tree/main/restore#outputs), when no cache could be restored, it was set to `null`.

There was a [bug](https://github.com/actions/cache/issues/533) filed for this issue, but it was ignored and eventually closed automatically.