### PR TITLE
Remote Data access via Get() or Transport

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -88,6 +88,8 @@ add_library(adios2_core
   toolkit/query/XmlWorker.cpp
   toolkit/query/BlockIndex.cpp
 
+  toolkit/remote/Remote.cpp
+
   toolkit/transport/Transport.cpp
   toolkit/transport/file/FileStdio.cpp
   toolkit/transport/file/FileFStream.cpp
@@ -157,6 +159,13 @@ if(ADIOS2_HAVE_AWSSDK)
   target_link_libraries(adios2_core PRIVATE ${AWSSDK_LINK_LIBRARIES})
 endif()
 
+if (ADIOS2_HAVE_SST)
+  # EVPath-enabled remote file transport
+  target_sources(adios2_core PRIVATE toolkit/remote/remote_common.cpp toolkit/transport/file/FileRemote.cpp)
+  target_link_libraries(adios2_core PRIVATE EVPath::EVPath)
+  add_subdirectory(toolkit/remote)
+endif()
+   
 if (ADIOS2_HAVE_BP5)
   target_sources(adios2_core PRIVATE
     engine/bp5/BP5Engine.cpp

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -154,6 +154,7 @@ public:
     MACRO(StatsBlockSize, SizeBytes, size_t, DefaultStatsBlockSize)                                \
     MACRO(Threads, UInt, unsigned int, 0)                                                          \
     MACRO(UseOneTimeAttributes, Bool, bool, true)                                                  \
+    MACRO(RemoteDataPath, String, std::string, "")                                                 \
     MACRO(MaxOpenFilesAtOnce, UInt, unsigned int, UINT_MAX)
 
     struct BP5Params

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -18,6 +18,7 @@
 #include "adios2/helper/adiosComm.h"
 #include "adios2/helper/adiosRangeFilter.h"
 #include "adios2/toolkit/format/bp5/BP5Deserializer.h"
+#include "adios2/toolkit/remote/Remote.h"
 #include "adios2/toolkit/transportman/TransportMan.h"
 
 #include <chrono>
@@ -92,6 +93,7 @@ private:
 
     /* transport manager for managing the active flag file */
     transportman::TransportMan m_ActiveFlagFileManager;
+    Remote m_Remote;
     bool m_WriterIsActive = true;
 
     /** used for per-step reads, TODO: to be moved to BP5Deserializer */
@@ -239,6 +241,10 @@ private:
     std::map<uint64_t, WriterMapStruct> m_WriterMap;
     // step -> writermap index (for all steps)
     std::vector<uint64_t> m_WriterMapIndex;
+
+    void PerformLocalGets();
+
+    void PerformRemoteGets();
 
     void DestructorClose(bool Verbose) noexcept;
 

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -568,7 +568,7 @@ void BP5Deserializer::SetupForStep(size_t Step, size_t WriterCount)
     }
     else
     {
-        PendingRequests.clear();
+        PendingGetRequests.clear();
 
         for (auto RecPair : VarByKey)
         {
@@ -1196,7 +1196,7 @@ bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData)
 {
     if (!m_RandomAccessMode)
     {
-        return QueueGetSingle(variable, DestData, CurTimestep);
+        return QueueGetSingle(variable, DestData, CurTimestep, CurTimestep);
     }
     else
     {
@@ -1229,7 +1229,7 @@ bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData)
                 if (GetMetadataBase(VarRec, AbsStep, WriterRank))
                 {
                     // This writer wrote on this timestep
-                    ret = QueueGetSingle(variable, DestData, AbsStep);
+                    ret = QueueGetSingle(variable, DestData, AbsStep, RelStep);
                     size_t increment = variable.TotalSize() * variable.m_ElementSize;
                     DestData = (void *)((char *)DestData + increment);
                     break;
@@ -1290,7 +1290,8 @@ void BP5Deserializer::StructQueueReadChecks(core::VariableStruct *variable, BP5V
     VarRec->ReaderDef = variable->m_ReadStructDefinition;
 }
 
-bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestData, size_t Step)
+bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestData, size_t AbsStep,
+                                     size_t RelStep)
 {
     BP5VarRec *VarRec = VarByKey[&variable];
     if (variable.m_Type == adios2::DataType::Struct)
@@ -1300,10 +1301,10 @@ bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestDat
 
     if (VarRec->OrigShapeID == ShapeID::GlobalValue)
     {
-        const size_t writerCohortSize = WriterCohortSize(Step);
+        const size_t writerCohortSize = WriterCohortSize(AbsStep);
         for (size_t WriterRank = 0; WriterRank < writerCohortSize; WriterRank++)
         {
-            if (GetSingleValueFromMetadata(variable, VarRec, DestData, Step, WriterRank))
+            if (GetSingleValueFromMetadata(variable, VarRec, DestData, AbsStep, WriterRank))
                 return false;
         }
         return false;
@@ -1314,7 +1315,7 @@ bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestDat
         for (size_t WriterRank = variable.m_Start[0];
              WriterRank < variable.m_Count[0] + variable.m_Start[0]; WriterRank++)
         {
-            (void)GetSingleValueFromMetadata(variable, VarRec, DestData, Step, WriterRank);
+            (void)GetSingleValueFromMetadata(variable, VarRec, DestData, AbsStep, WriterRank);
             DestData = (char *)DestData + variable.m_ElementSize; // use variable.m_ElementSize
                                                                   // because it's the size in local
                                                                   // memory, VarRec->ElementSize is
@@ -1329,20 +1330,23 @@ bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestDat
     {
         BP5ArrayRequest Req;
         Req.VarRec = VarRec;
+        Req.VarName = (char *)variable.m_Name.c_str();
         Req.RequestType = Global;
-        Req.BlockID = variable.m_BlockID;
+        Req.BlockID = (size_t)-1;
         Req.Count = variable.m_Count;
         Req.Start = variable.m_Start;
-        Req.Step = Step;
+        Req.Step = AbsStep;
+        Req.RelStep = RelStep;
         Req.MemSpace = MemSpace;
         Req.Data = DestData;
-        PendingRequests.push_back(Req);
+        PendingGetRequests.push_back(Req);
     }
     else if ((variable.m_SelectionType == adios2::SelectionType::WriteBlock) ||
              (variable.m_ShapeID == ShapeID::LocalArray))
     {
         BP5ArrayRequest Req;
         Req.VarRec = VarByKey[&variable];
+        Req.VarName = (char *)variable.m_Name.c_str();
         Req.RequestType = Local;
         Req.BlockID = variable.m_BlockID;
         if (variable.m_SelectionType == adios2::SelectionType::BoundingBox)
@@ -1352,8 +1356,9 @@ bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestDat
         }
         Req.Data = DestData;
         Req.MemSpace = MemSpace;
-        Req.Step = Step;
-        PendingRequests.push_back(Req);
+        Req.Step = AbsStep;
+        Req.RelStep = RelStep;
+        PendingGetRequests.push_back(Req);
     }
     else
     {
@@ -1447,7 +1452,7 @@ bool BP5Deserializer::IsContiguousTransfer(BP5ArrayRequest *Req, size_t *offsets
      * involve contiguous blocks, but for now all multimensional
      * requests are assumed to be non-contiguous.
      */
-    return (Req->VarRec->DimCount == 1);
+    return (((struct BP5VarRec *)Req->VarRec)->DimCount == 1);
 }
 
 std::vector<BP5Deserializer::ReadRequest>
@@ -1456,18 +1461,19 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
     std::vector<BP5Deserializer::ReadRequest> Ret;
     *maxReadSize = 0;
 
-    for (size_t ReqIndex = 0; ReqIndex < PendingRequests.size(); ReqIndex++)
+    for (size_t ReqIndex = 0; ReqIndex < PendingGetRequests.size(); ReqIndex++)
     {
-        auto Req = &PendingRequests[ReqIndex];
-        VariableBase *VB = static_cast<VariableBase *>(Req->VarRec->Variable);
+        auto Req = &PendingGetRequests[ReqIndex];
+        auto VarRec = (struct BP5VarRec *)Req->VarRec;
+        VariableBase *VB = static_cast<VariableBase *>(VarRec->Variable);
         if (Req->RequestType == Local)
         {
             const size_t writerCohortSize = WriterCohortSize(Req->Step);
             size_t NodeFirstBlock = 0;
             for (size_t WriterRank = 0; WriterRank < writerCohortSize; WriterRank++)
             {
-                MetaArrayRecOperator *writer_meta_base =
-                    (MetaArrayRecOperator *)GetMetadataBase(Req->VarRec, Req->Step, WriterRank);
+                MetaArrayRecOperator *writer_meta_base = (MetaArrayRecOperator *)GetMetadataBase(
+                    (struct BP5VarRec *)Req->VarRec, Req->Step, WriterRank);
                 if (!writer_meta_base)
                 {
                     continue; // Not writen on this step
@@ -1477,7 +1483,7 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
                 {
                     // block is here
                     size_t NeededBlock = Req->BlockID - NodeFirstBlock;
-                    size_t StartDim = NeededBlock * Req->VarRec->DimCount;
+                    size_t StartDim = NeededBlock * VarRec->DimCount;
                     ReadRequest RR;
                     RR.Timestep = Req->Step;
                     RR.WriterRank = WriterRank;
@@ -1489,21 +1495,19 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
                             IsContiguousTransfer(Req, &writer_meta_base->Offsets[StartDim],
                                                  &writer_meta_base->Count[StartDim]);
                     RR.ReadLength =
-                        helper::GetDataTypeSize(Req->VarRec->Type) *
-                        CalcBlockLength(Req->VarRec->DimCount, &writer_meta_base->Count[StartDim]);
+                        helper::GetDataTypeSize(VarRec->Type) *
+                        CalcBlockLength(VarRec->DimCount, &writer_meta_base->Count[StartDim]);
                     RR.OffsetInBlock = 0;
                     if (RR.DirectToAppMemory)
                     {
                         RR.DestinationAddr = (char *)Req->Data;
                         if (Req->Start.size() != 0)
                         {
-                            RR.ReadLength =
-                                helper::GetDataTypeSize(Req->VarRec->Type) *
-                                CalcBlockLength(Req->VarRec->DimCount, Req->Count.data());
+                            RR.ReadLength = helper::GetDataTypeSize(VarRec->Type) *
+                                            CalcBlockLength(VarRec->DimCount, Req->Count.data());
                             /* DirectToAppMemory handles only 1D, so offset calc
                              * is 1D only for the moment */
-                            RR.StartOffset +=
-                                helper::GetDataTypeSize(Req->VarRec->Type) * Req->Start[0];
+                            RR.StartOffset += helper::GetDataTypeSize(VarRec->Type) * Req->Start[0];
                         }
                     }
                     else
@@ -1530,8 +1534,8 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
             const size_t writerCohortSize = WriterCohortSize(Req->Step);
             for (size_t WriterRank = 0; WriterRank < writerCohortSize; WriterRank++)
             {
-                MetaArrayRecOperator *writer_meta_base =
-                    (MetaArrayRecOperator *)GetMetadataBase(Req->VarRec, Req->Step, WriterRank);
+                MetaArrayRecOperator *writer_meta_base = (MetaArrayRecOperator *)GetMetadataBase(
+                    (struct BP5VarRec *)Req->VarRec, Req->Step, WriterRank);
                 if (!writer_meta_base)
                     continue; // Not writen on this step
 
@@ -1541,14 +1545,14 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
                     std::array<size_t, helper::MAX_DIMS> intersectionend;
                     std::array<size_t, helper::MAX_DIMS> intersectioncount;
 
-                    size_t StartDim = Block * Req->VarRec->DimCount;
-                    if (IntersectionStartCount(Req->VarRec->DimCount, Req->Start.data(),
+                    size_t StartDim = Block * VarRec->DimCount;
+                    if (IntersectionStartCount(VarRec->DimCount, Req->Start.data(),
                                                Req->Count.data(),
                                                &writer_meta_base->Offsets[StartDim],
                                                &writer_meta_base->Count[StartDim],
                                                &intersectionstart[0], &intersectioncount[0]))
                     {
-                        if (Req->VarRec->Operator != NULL)
+                        if (VarRec->Operator != NULL)
                         {
                             // need the whole thing for decompression anyway
                             ReadRequest RR;
@@ -1571,24 +1575,22 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
                         }
                         else
                         {
-                            for (size_t Dim = 0; Dim < Req->VarRec->DimCount; Dim++)
+                            for (size_t Dim = 0; Dim < VarRec->DimCount; Dim++)
                             {
                                 intersectionstart[Dim] -= writer_meta_base->Offsets[StartDim + Dim];
                             }
                             size_t StartOffsetInBlock =
-                                VB->m_ElementSize * LinearIndex(Req->VarRec->DimCount,
-                                                                &writer_meta_base->Count[StartDim],
-                                                                &intersectionstart[0],
-                                                                m_ReaderIsRowMajor);
-                            for (size_t Dim = 0; Dim < Req->VarRec->DimCount; Dim++)
+                                VB->m_ElementSize *
+                                LinearIndex(VarRec->DimCount, &writer_meta_base->Count[StartDim],
+                                            &intersectionstart[0], m_ReaderIsRowMajor);
+                            for (size_t Dim = 0; Dim < VarRec->DimCount; Dim++)
                             {
                                 intersectionend[Dim] =
                                     intersectionstart[Dim] + intersectioncount[Dim] - 1;
                             }
                             size_t EndOffsetInBlock =
                                 VB->m_ElementSize *
-                                (LinearIndex(Req->VarRec->DimCount,
-                                             &writer_meta_base->Count[StartDim],
+                                (LinearIndex(VarRec->DimCount, &writer_meta_base->Count[StartDim],
                                              &intersectionend[0], m_ReaderIsRowMajor) +
                                  1);
                             ReadRequest RR;
@@ -1645,15 +1647,15 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
 
 void BP5Deserializer::FinalizeGet(const ReadRequest &Read, const bool freeAddr)
 {
-    auto Req = PendingRequests[Read.ReqIndex];
+    auto Req = PendingGetRequests[Read.ReqIndex];
 
     // if we could do this, nothing else to do
     if (Read.DirectToAppMemory)
         return;
 
-    int ElementSize = Req.VarRec->ElementSize;
-    MetaArrayRec *writer_meta_base =
-        (MetaArrayRec *)GetMetadataBase(Req.VarRec, Req.Step, Read.WriterRank);
+    int ElementSize = ((struct BP5VarRec *)Req.VarRec)->ElementSize;
+    MetaArrayRec *writer_meta_base = (MetaArrayRec *)GetMetadataBase(
+        ((struct BP5VarRec *)Req.VarRec), Req.Step, Read.WriterRank);
 
     size_t *GlobalDimensions = writer_meta_base->Shape;
     auto DimCount = writer_meta_base->Dims;
@@ -1667,10 +1669,10 @@ void BP5Deserializer::FinalizeGet(const ReadRequest &Read, const bool freeAddr)
     char *IncomingData = Read.DestinationAddr;
     char *VirtualIncomingData = Read.DestinationAddr - Read.OffsetInBlock;
     std::vector<char> decompressBuffer;
-    if (Req.VarRec->Operator != NULL)
+    if (((struct BP5VarRec *)Req.VarRec)->Operator != NULL)
     {
-        size_t DestSize = Req.VarRec->ElementSize;
-        for (size_t dim = 0; dim < Req.VarRec->DimCount; dim++)
+        size_t DestSize = ((struct BP5VarRec *)Req.VarRec)->ElementSize;
+        for (size_t dim = 0; dim < ((struct BP5VarRec *)Req.VarRec)->DimCount; dim++)
         {
             DestSize *= writer_meta_base->Count[dim + Read.BlockID * writer_meta_base->Dims];
         }
@@ -1711,7 +1713,7 @@ void BP5Deserializer::FinalizeGet(const ReadRequest &Read, const bool freeAddr)
         }
     }
 
-    VariableBase *VB = static_cast<VariableBase *>(Req.VarRec->Variable);
+    VariableBase *VB = static_cast<VariableBase *>(((struct BP5VarRec *)Req.VarRec)->Variable);
     DimsArray inStart(DimCount, RankOffset);
     DimsArray inCount(DimCount, RankSize);
     DimsArray outStart(DimCount, SelOffset);
@@ -1790,7 +1792,7 @@ void BP5Deserializer::FinalizeGets(std::vector<ReadRequest> &Reads)
     {
         FinalizeGet(Read, true);
     }
-    PendingRequests.clear();
+    PendingGetRequests.clear();
 }
 
 void BP5Deserializer::MapGlobalToLocalIndex(size_t Dims, const size_t *GlobalIndex,
@@ -1847,8 +1849,8 @@ int BP5Deserializer::FindOffset(size_t Dims, const size_t *Size, const size_t *I
 
 BP5Deserializer::BP5Deserializer(bool WriterIsRowMajor, bool ReaderIsRowMajor,
                                  bool RandomAccessMode)
-: m_WriterIsRowMajor{WriterIsRowMajor}, m_ReaderIsRowMajor{ReaderIsRowMajor},
-  m_RandomAccessMode{RandomAccessMode}
+: m_WriterIsRowMajor{WriterIsRowMajor}, m_ReaderIsRowMajor{ReaderIsRowMajor}, m_RandomAccessMode{
+                                                                                  RandomAccessMode}
 {
     FMContext Tmp = create_local_FMcontext();
     ReaderFFSContext = create_FFSContext_FM(Tmp);

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1849,8 +1849,8 @@ int BP5Deserializer::FindOffset(size_t Dims, const size_t *Size, const size_t *I
 
 BP5Deserializer::BP5Deserializer(bool WriterIsRowMajor, bool ReaderIsRowMajor,
                                  bool RandomAccessMode)
-: m_WriterIsRowMajor{WriterIsRowMajor}, m_ReaderIsRowMajor{ReaderIsRowMajor}, m_RandomAccessMode{
-                                                                                  RandomAccessMode}
+: m_WriterIsRowMajor{WriterIsRowMajor}, m_ReaderIsRowMajor{ReaderIsRowMajor},
+  m_RandomAccessMode{RandomAccessMode}
 {
     FMContext Tmp = create_local_FMcontext();
     ReaderFFSContext = create_FFSContext_FM(Tmp);

--- a/source/adios2/toolkit/remote/CMakeLists.txt
+++ b/source/adios2/toolkit/remote/CMakeLists.txt
@@ -1,0 +1,19 @@
+#------------------------------------------------------------------------------#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#------------------------------------------------------------------------------#
+
+add_executable(remote_server ./remote_server.cpp remote_common.cpp)
+
+target_link_libraries(remote_server
+		      PUBLIC EVPath::EVPath
+                      PUBLIC adios2_core adios2sys
+                      PRIVATE adios2::thirdparty::pugixml $<$<PLATFORM_ID:Windows>:shlwapi>)
+target_include_directories(remote_server PRIVATE ${PROJECT_BINARY_DIR})
+
+set_property(TARGET remote_server PROPERTY OUTPUT_NAME remote_server${ADIOS2_EXECUTABLE_SUFFIX})
+install(TARGETS remote_server EXPORT adios2
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_tools-runtime
+)
+
+

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -54,7 +54,6 @@ void Remote::InitCMData()
 {
     std::lock_guard<std::mutex> lockGuard(m_CMInitMutex);
     bool first = true;
-    ;
     auto &CM = CManagerSingleton::Instance(first);
     ev_state.cm = CM.m_cm;
     RegisterFormats(ev_state);
@@ -77,7 +76,6 @@ void Remote::Open(const std::string hostname, const int32_t port, const std::str
 {
 
     RemoteCommon::_OpenFileMsg open_msg;
-    bool first;
     InitCMData();
     attr_list contact_list = create_attr_list();
     atom_t CM_IP_PORT = -1;

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -1,0 +1,194 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ */
+#include "Remote.h"
+#include "adios2/core/ADIOS.h"
+#include "adios2/helper/adiosLog.h"
+#include "adios2/helper/adiosString.h"
+#include "adios2/helper/adiosSystem.h"
+
+namespace adios2
+{
+
+Remote::Remote() {}
+
+#ifdef ADIOS2_HAVE_SST
+void OpenResponseHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                         attr_list attrs)
+{
+    RemoteCommon::OpenResponseMsg open_response_msg =
+        static_cast<RemoteCommon::OpenResponseMsg>(vevent);
+
+    void *obj = CMCondition_get_client_data(cm, open_response_msg->OpenResponseCondition);
+    static_cast<Remote *>(obj)->m_ID = open_response_msg->FileHandle;
+    CMCondition_signal(cm, open_response_msg->OpenResponseCondition);
+    return;
+};
+
+void OpenSimpleResponseHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                               attr_list attrs)
+{
+    RemoteCommon::OpenSimpleResponseMsg open_response_msg =
+        static_cast<RemoteCommon::OpenSimpleResponseMsg>(vevent);
+
+    void *obj = CMCondition_get_client_data(cm, open_response_msg->OpenResponseCondition);
+    static_cast<Remote *>(obj)->m_ID = open_response_msg->FileHandle;
+    static_cast<Remote *>(obj)->m_Size = open_response_msg->FileSize;
+    CMCondition_signal(cm, open_response_msg->OpenResponseCondition);
+    return;
+};
+
+void ReadResponseHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                         attr_list attrs)
+{
+    RemoteCommon::ReadResponseMsg read_response_msg =
+        static_cast<RemoteCommon::ReadResponseMsg>(vevent);
+    memcpy(read_response_msg->Dest, read_response_msg->ReadData, read_response_msg->Size);
+    CMCondition_signal(cm, read_response_msg->ReadResponseCondition);
+    return;
+};
+
+void Remote::InitCMData()
+{
+    std::lock_guard<std::mutex> lockGuard(m_CMInitMutex);
+    bool first = true;
+    ;
+    auto &CM = CManagerSingleton::Instance(first);
+    ev_state.cm = CM.m_cm;
+    RegisterFormats(ev_state);
+    if (first)
+    {
+        CMfork_comm_thread(ev_state.cm);
+        CMregister_handler(ev_state.OpenResponseFormat, (CMHandlerFunc)OpenResponseHandler,
+                           &ev_state);
+        CMregister_handler(ev_state.ReadResponseFormat, (CMHandlerFunc)ReadResponseHandler,
+                           &ev_state);
+        CMregister_handler(ev_state.OpenSimpleResponseFormat,
+                           (CMHandlerFunc)OpenSimpleResponseHandler, &ev_state);
+        CMregister_handler(ev_state.ReadResponseFormat, (CMHandlerFunc)ReadResponseHandler,
+                           &ev_state);
+    }
+}
+
+void Remote::Open(const std::string hostname, const int32_t port, const std::string filename,
+                  const Mode mode)
+{
+
+    RemoteCommon::_OpenFileMsg open_msg;
+    bool first;
+    InitCMData();
+    attr_list contact_list = create_attr_list();
+    atom_t CM_IP_PORT = -1;
+    atom_t CM_IP_HOSTNAME = -1;
+    CM_IP_HOSTNAME = attr_atom_from_string("IP_HOST");
+    CM_IP_PORT = attr_atom_from_string("IP_PORT");
+    add_attr(contact_list, CM_IP_HOSTNAME, Attr_String, (attr_value)hostname.c_str());
+    add_attr(contact_list, CM_IP_PORT, Attr_Int4, (attr_value)port);
+    m_conn = CMinitiate_conn(ev_state.cm, contact_list);
+    if (!m_conn)
+        return;
+
+    memset(&open_msg, 0, sizeof(open_msg));
+    open_msg.FileName = (char *)filename.c_str();
+    switch (mode)
+    {
+    case Mode::Read:
+        open_msg.Mode = RemoteCommon::RemoteFileMode::RemoteOpen;
+        break;
+    case Mode::ReadRandomAccess:
+        open_msg.Mode = RemoteCommon::RemoteFileMode::RemoteOpenRandomAccess;
+        break;
+    default:
+        break;
+    }
+    open_msg.OpenResponseCondition = CMCondition_get(ev_state.cm, m_conn);
+    CMCondition_set_client_data(ev_state.cm, open_msg.OpenResponseCondition, (void *)this);
+    CMwrite(m_conn, ev_state.OpenFileFormat, &open_msg);
+    CMCondition_wait(ev_state.cm, open_msg.OpenResponseCondition);
+    m_Active = true;
+}
+
+void Remote::OpenSimpleFile(const std::string hostname, const int32_t port,
+                            const std::string filename)
+{
+
+    RemoteCommon::_OpenSimpleFileMsg open_msg;
+    InitCMData();
+    attr_list contact_list = create_attr_list();
+    atom_t CM_IP_PORT = -1;
+    atom_t CM_IP_HOSTNAME = -1;
+    CM_IP_HOSTNAME = attr_atom_from_string("IP_HOST");
+    CM_IP_PORT = attr_atom_from_string("IP_PORT");
+    add_attr(contact_list, CM_IP_HOSTNAME, Attr_String, (attr_value)hostname.c_str());
+    add_attr(contact_list, CM_IP_PORT, Attr_Int4, (attr_value)port);
+    m_conn = CMinitiate_conn(ev_state.cm, contact_list);
+    if (!m_conn)
+        return;
+
+    memset(&open_msg, 0, sizeof(open_msg));
+    open_msg.FileName = (char *)filename.c_str();
+    open_msg.OpenResponseCondition = CMCondition_get(ev_state.cm, m_conn);
+    CMCondition_set_client_data(ev_state.cm, open_msg.OpenResponseCondition, (void *)this);
+    CMwrite(m_conn, ev_state.OpenSimpleFileFormat, &open_msg);
+    CMCondition_wait(ev_state.cm, open_msg.OpenResponseCondition);
+    m_Active = true;
+}
+
+Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
+                              void *dest)
+{
+    RemoteCommon::_GetRequestMsg GetMsg;
+    memset(&GetMsg, 0, sizeof(GetMsg));
+    GetMsg.GetResponseCondition = CMCondition_get(ev_state.cm, m_conn);
+    GetMsg.FileHandle = m_ID;
+    GetMsg.VarName = VarName;
+    GetMsg.Step = Step;
+    GetMsg.BlockID = BlockID;
+    GetMsg.DimCount = Count.size();
+    GetMsg.Count = Count.data();
+    GetMsg.Start = Start.data();
+    GetMsg.Dest = dest;
+    CMwrite(m_conn, ev_state.GetRequestFormat, &GetMsg);
+    CMCondition_wait(ev_state.cm, GetMsg.GetResponseCondition);
+    return GetMsg.GetResponseCondition;
+}
+
+Remote::GetHandle Remote::Read(size_t Start, size_t Size, void *Dest)
+{
+    RemoteCommon::_ReadRequestMsg ReadMsg;
+    memset(&ReadMsg, 0, sizeof(ReadMsg));
+    ReadMsg.ReadResponseCondition = CMCondition_get(ev_state.cm, m_conn);
+    ReadMsg.FileHandle = m_ID;
+    ReadMsg.Offset = Start;
+    ReadMsg.Size = Size;
+    ReadMsg.Dest = Dest;
+    CMwrite(m_conn, ev_state.ReadRequestFormat, &ReadMsg);
+    CMCondition_wait(ev_state.cm, ReadMsg.ReadResponseCondition);
+    return ReadMsg.ReadResponseCondition;
+}
+
+bool Remote::WaitForGet(GetHandle handle) { return CMCondition_wait(ev_state.cm, (int)handle); }
+#else
+
+void Remote::Open(const std::string hostname, const int32_t port, const std::string filename,
+                  const Mode mode){};
+
+void Remote::OpenSimpleFile(const std::string hostname, const int32_t port,
+                            const std::string filename){};
+
+Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
+                              void *dest)
+{
+    return static_cast<GetHandle>(0);
+};
+
+bool Remote::WaitForGet(GetHandle handle) { return false; }
+
+Remote::GetHandle Remote::Read(size_t Start, size_t Size, void *Dest)
+{
+    return static_cast<GetHandle>(0);
+};
+#endif
+} // end namespace adios2

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -1,0 +1,109 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+
+#ifndef ADIOS2_TOOLKIT_REMOTE_REMOTE_H_
+#define ADIOS2_TOOLKIT_REMOTE_REMOTE_H_
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <mutex>
+#include <string>
+#include <vector>
+/// \endcond
+
+#include "adios2/toolkit/profiling/iochrono/IOChrono.h"
+
+#include "adios2/common/ADIOSConfig.h"
+
+#ifdef ADIOS2_HAVE_SST
+#include "remote_common.h"
+#endif
+
+namespace adios2
+{
+class Remote
+{
+
+public:
+    profiling::IOChrono m_Profiler; ///< profiles Open, Write/Read, Close
+
+    /**
+     * Base constructor that all derived classes pass
+     * @param type from derived class
+     * @param comm passed to m_Comm
+     */
+    Remote();
+
+    explicit operator bool() const { return m_Active; }
+
+    void Open(const std::string hostname, const int32_t port, const std::string filename,
+              const Mode mode);
+
+    void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename);
+
+    typedef int GetHandle;
+
+    GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start, void *dest);
+
+    bool WaitForGet(GetHandle handle);
+
+    GetHandle Read(size_t Start, size_t Size, void *Dest);
+
+    int64_t m_ID;
+    size_t m_Size;
+
+private:
+#ifdef ADIOS2_HAVE_SST
+    void InitCMData();
+    RemoteCommon::Remote_evpath_state ev_state;
+    CMConnection m_conn;
+    std::mutex m_CMInitMutex;
+#endif
+    bool m_Active = false;
+};
+
+class CManagerSingleton
+{
+public:
+#ifdef ADIOS2_HAVE_SST
+    CManager m_cm = NULL;
+#endif
+    static CManagerSingleton &Instance(bool &first)
+    {
+        // Since it's a static variable, if the class has already been created,
+        // it won't be created again.
+        // And it **is** thread-safe in C++11.
+        static CManagerSingleton myInstance;
+        static bool internal_first = true;
+        // Return a reference to our instance.
+
+        first = internal_first;
+        internal_first = false;
+        return myInstance;
+    }
+
+    // delete copy and move constructors and assign operators
+    CManagerSingleton(CManagerSingleton const &) = delete;            // Copy construct
+    CManagerSingleton(CManagerSingleton &&) = delete;                 // Move construct
+    CManagerSingleton &operator=(CManagerSingleton const &) = delete; // Copy assign
+    CManagerSingleton &operator=(CManagerSingleton &&) = delete;      // Move assign
+
+    // Any other public methods.
+
+protected:
+#ifdef ADIOS2_HAVE_SST
+    CManagerSingleton() { m_cm = CManager_create(); }
+
+    ~CManagerSingleton() { CManager_close(m_cm); }
+#else
+    CManagerSingleton() {}
+
+    ~CManagerSingleton() {}
+#endif
+    // And any other protected methods.
+};
+
+} // end namespace adios2
+
+#endif /* ADIOS2_TOOLKIT_REMOTE_REMOTE_H_ */

--- a/source/adios2/toolkit/remote/remote_common.cpp
+++ b/source/adios2/toolkit/remote/remote_common.cpp
@@ -1,0 +1,111 @@
+#include "remote_common.h"
+#include <evpath.h>
+
+namespace adios2
+{
+namespace RemoteCommon
+{
+
+FMField OpenFileList[] = {{"OpenResponseCondition", "integer", sizeof(long),
+                           FMOffset(OpenFileMsg, OpenResponseCondition)},
+                          {"FileName", "string", sizeof(char *), FMOffset(OpenFileMsg, FileName)},
+                          {"Mode", "integer", sizeof(RemoteFileMode), FMOffset(OpenFileMsg, Mode)},
+                          {NULL, NULL, 0, 0}};
+
+FMStructDescRec OpenFileStructs[] = {{"OpenFile", OpenFileList, sizeof(struct _OpenFileMsg), NULL},
+                                     {NULL, NULL, 0, NULL}};
+
+FMField OpenSimpleFileList[] = {
+    {"OpenResponseCondition", "integer", sizeof(long),
+     FMOffset(OpenSimpleFileMsg, OpenResponseCondition)},
+    {"FileName", "string", sizeof(char *), FMOffset(OpenSimpleFileMsg, FileName)},
+    {NULL, NULL, 0, 0}};
+
+FMStructDescRec OpenSimpleFileStructs[] = {
+    {"OpenSimpleFile", OpenSimpleFileList, sizeof(struct _OpenSimpleFileMsg), NULL},
+    {NULL, NULL, 0, NULL}};
+
+FMField OpenResponseList[] = {
+    {"OpenResponseCondition", "integer", sizeof(long),
+     FMOffset(OpenResponseMsg, OpenResponseCondition)},
+    {"FileHandle", "integer", sizeof(intptr_t), FMOffset(OpenResponseMsg, FileHandle)},
+    {NULL, NULL, 0, 0}};
+
+FMStructDescRec OpenResponseStructs[] = {
+    {"OpenResponse", OpenResponseList, sizeof(struct _OpenResponseMsg), NULL},
+    {NULL, NULL, 0, NULL}};
+
+FMField OpenSimpleResponseList[] = {
+    {"OpenResponseCondition", "integer", sizeof(long),
+     FMOffset(OpenSimpleResponseMsg, OpenResponseCondition)},
+    {"FileHandle", "integer", sizeof(intptr_t), FMOffset(OpenSimpleResponseMsg, FileHandle)},
+    {"FileSize", "integer", sizeof(size_t), FMOffset(OpenSimpleResponseMsg, FileSize)},
+    {"FileContents", "char[FileSize]", sizeof(char), FMOffset(OpenSimpleResponseMsg, FileContents)},
+    {NULL, NULL, 0, 0}};
+
+FMStructDescRec OpenSimpleResponseStructs[] = {
+    {"OpenSimpleResponse", OpenSimpleResponseList, sizeof(struct _OpenSimpleResponseMsg), NULL},
+    {NULL, NULL, 0, NULL}};
+
+FMField GetRequestList[] = {
+    {"GetResponseCondition", "integer", sizeof(int), FMOffset(GetRequestMsg, GetResponseCondition)},
+    {"FileHandle", "integer", sizeof(int64_t), FMOffset(GetRequestMsg, FileHandle)},
+    {"RequestType", "integer", sizeof(int), FMOffset(GetRequestMsg, RequestType)},
+    {"Step", "integer", sizeof(size_t), FMOffset(GetRequestMsg, Step)},
+    {"VarName", "string", sizeof(char *), FMOffset(GetRequestMsg, VarName)},
+    {"BlockID", "integer", sizeof(int64_t), FMOffset(GetRequestMsg, BlockID)},
+    {"DimCount", "integer", sizeof(size_t), FMOffset(GetRequestMsg, DimCount)},
+    {"Count", "integer[DimCount]", sizeof(size_t), FMOffset(GetRequestMsg, Count)},
+    {"Start", "integer[DimCount]", sizeof(size_t), FMOffset(GetRequestMsg, Start)},
+    {"Dest", "integer", sizeof(size_t), FMOffset(GetRequestMsg, Dest)},
+    {NULL, NULL, 0, 0}};
+
+FMStructDescRec GetRequestStructs[] = {{"Get", GetRequestList, sizeof(struct _GetRequestMsg), NULL},
+                                       {NULL, NULL, 0, NULL}};
+
+FMField ReadRequestList[] = {
+    {"ReadResponseCondition", "integer", sizeof(long),
+     FMOffset(ReadRequestMsg, ReadResponseCondition)},
+    {"FileHandle", "integer", sizeof(intptr_t), FMOffset(ReadRequestMsg, FileHandle)},
+    {"Offset", "integer", sizeof(size_t), FMOffset(ReadRequestMsg, Offset)},
+    {"Size", "integer", sizeof(size_t), FMOffset(ReadRequestMsg, Size)},
+    {"Dest", "integer", sizeof(void *), FMOffset(ReadRequestMsg, Dest)},
+    {NULL, NULL, 0, 0}};
+
+FMStructDescRec ReadRequestStructs[] = {
+    {"Read", ReadRequestList, sizeof(struct _ReadRequestMsg), NULL}, {NULL, NULL, 0, NULL}};
+
+FMField ReadResponseList[] = {
+    {"ReadResponseCondition", "integer", sizeof(long),
+     FMOffset(ReadResponseMsg, ReadResponseCondition)},
+    {"Dest", "integer", sizeof(void *), FMOffset(ReadResponseMsg, Dest)},
+    {"Size", "integer", sizeof(size_t), FMOffset(ReadResponseMsg, Size)},
+    {"ReadData", "char[Size]", sizeof(char), FMOffset(ReadResponseMsg, ReadData)},
+    {NULL, NULL, 0, 0}};
+
+FMStructDescRec ReadResponseStructs[] = {
+    {"ReadResponse", ReadResponseList, sizeof(struct _ReadResponseMsg), NULL},
+    {NULL, NULL, 0, NULL}};
+
+FMField CloseFileList[] = {
+    {"FileHandle", "integer", sizeof(intptr_t), FMOffset(CloseFileMsg, FileHandle)},
+    {NULL, NULL, 0, 0}};
+
+FMStructDescRec CloseFileStructs[] = {{"Close", CloseFileList, sizeof(struct _CloseFileMsg), NULL},
+                                      {NULL, NULL, 0, NULL}};
+
+void RegisterFormats(RemoteCommon::Remote_evpath_state &ev_state)
+{
+    ev_state.OpenFileFormat = CMregister_format(ev_state.cm, RemoteCommon::OpenFileStructs);
+    ev_state.OpenSimpleFileFormat =
+        CMregister_format(ev_state.cm, RemoteCommon::OpenSimpleFileStructs);
+    ev_state.OpenResponseFormat = CMregister_format(ev_state.cm, RemoteCommon::OpenResponseStructs);
+    ev_state.OpenSimpleResponseFormat =
+        CMregister_format(ev_state.cm, RemoteCommon::OpenSimpleResponseStructs);
+    ev_state.GetRequestFormat = CMregister_format(ev_state.cm, RemoteCommon::GetRequestStructs);
+    ev_state.ReadRequestFormat = CMregister_format(ev_state.cm, RemoteCommon::ReadRequestStructs);
+    ev_state.ReadResponseFormat = CMregister_format(ev_state.cm, RemoteCommon::ReadResponseStructs);
+    ev_state.CloseFileFormat = CMregister_format(ev_state.cm, RemoteCommon::CloseFileStructs);
+}
+}
+}

--- a/source/adios2/toolkit/remote/remote_common.h
+++ b/source/adios2/toolkit/remote/remote_common.h
@@ -1,0 +1,118 @@
+#include "evpath.h"
+#include <stddef.h>
+
+namespace adios2
+{
+namespace RemoteCommon
+{
+
+enum RemoteFileMode
+{
+    RemoteOpen,
+    RemoteOpenRandomAccess,
+};
+/*
+ */
+typedef struct _OpenFileMsg
+{
+    int OpenResponseCondition;
+    char *FileName;
+    RemoteFileMode Mode;
+} *OpenFileMsg;
+
+typedef struct _OpenResponseMsg
+{
+    int OpenResponseCondition;
+    int64_t FileHandle;
+} *OpenResponseMsg;
+
+typedef struct _OpenSimpleFileMsg
+{
+    int OpenResponseCondition;
+    char *FileName;
+} *OpenSimpleFileMsg;
+
+typedef struct _OpenSimpleResponseMsg
+{
+    int OpenResponseCondition;
+    int64_t FileHandle;
+    size_t FileSize;    // may be used for Contents size
+    char *FileContents; // used for OpenReadComplete mode
+} *OpenSimpleResponseMsg;
+
+/*
+ */
+typedef struct _GetRequestMsg
+{
+    int GetResponseCondition;
+    int RequestType;
+    int64_t FileHandle;
+    char *VarName;
+    size_t Step;
+    int64_t BlockID;
+    int DimCount;
+    size_t *Count;
+    size_t *Start;
+    void *Dest;
+} *GetRequestMsg;
+
+/*
+ */
+typedef struct _ReadRequestMsg
+{
+    int ReadResponseCondition;
+    int64_t FileHandle;
+    size_t Offset;
+    size_t Size;
+    void *Dest;
+} *ReadRequestMsg;
+
+/*
+ * Reader register messages are sent from reader rank 0 to writer rank 0
+ * They contain basic info, plus contact information for each reader rank
+ */
+typedef struct _ReadResponseMsg
+{
+    int ReadResponseCondition;
+    void *Dest;
+    size_t Size;
+    char *ReadData;
+} *ReadResponseMsg;
+
+/*
+ */
+typedef struct _CloseFileMsg
+{
+    void *FileHandle;
+} *CloseFileMsg;
+
+enum VerbosityLevel
+{
+    NoVerbose = 0,       // Generally no output (but not absolutely quiet?)
+    CriticalVerbose = 1, // Informational output for failures only
+    SummaryVerbose = 2,  // One-time summary output containing general info (transports used,
+                         // timestep count, stream duration, etc.)
+    PerStepVerbose = 3,  // One-per-step info, generally from rank 0 (metadata
+                         // read, Begin/EndStep verbosity, etc.)
+    PerRankVerbose = 4,  // Per-step info from each rank (for those things that
+                         // might be different per rank).
+    TraceVerbose = 5,    // All debugging available
+};
+
+struct Remote_evpath_state
+{
+    CManager cm;
+    CMFormat OpenFileFormat;
+    CMFormat OpenSimpleFileFormat;
+    CMFormat OpenResponseFormat;
+    CMFormat OpenSimpleResponseFormat;
+    CMFormat GetRequestFormat;
+    CMFormat ReadRequestFormat;
+    CMFormat ReadResponseFormat;
+    CMFormat CloseFileFormat;
+};
+
+void RegisterFormats(struct Remote_evpath_state &ev_state);
+
+}; // end of namespace remote_common
+}; // end of namespace adios2

--- a/source/adios2/toolkit/remote/remote_server.cpp
+++ b/source/adios2/toolkit/remote/remote_server.cpp
@@ -1,0 +1,352 @@
+#include <iostream>
+#include <random>
+
+#include "adios2/common/ADIOSConfig.h"
+#include "adios2/common/ADIOSMacros.h"
+#include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/ADIOS.h"
+#include "adios2/core/Engine.h"
+#include "adios2/core/IO.h"
+#include "adios2/core/Variable.h"
+#include "adios2/helper/adiosFunctions.h"
+#include <evpath.h>
+
+#include <cstdio>  // remove
+#include <cstring> // strerror
+#include <errno.h> // errno
+#include <fcntl.h> // open
+#include <regex>
+#include <sys/stat.h>  // open, fstat
+#include <sys/types.h> // open
+#include <unistd.h>    // write, close, ftruncate
+
+#include "remote_common.h"
+
+using namespace adios2::RemoteCommon;
+
+using namespace adios2::core;
+using namespace adios2;
+
+int verbose = 1;
+ADIOS adios("C++");
+
+std::string readable_size(uint64_t size)
+{
+    constexpr const char FILE_SIZE_UNITS[8][3]{"B ", "KB", "MB", "GB", "TB", "PB", "EB", "ZB"};
+    uint64_t s = size, r = 0;
+    int idx = 0;
+    while (s / 1024 > 0)
+    {
+        r = s % 1024;
+        s = s / 1024;
+        idx++;
+    }
+    int point = r / 100;
+    std::ostringstream out;
+    out << "" << s;
+    if (point != 0)
+        out << "." << point;
+    out << " " << std::string(FILE_SIZE_UNITS[idx]);
+    return out.str();
+}
+
+std::string lf_random_string()
+{
+    std::string str("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+
+    std::random_device rd;
+    std::mt19937 generator(rd());
+
+    std::shuffle(str.begin(), str.end(), generator);
+
+    return str.substr(0, 8);
+}
+
+class AnonADIOSFile
+{
+public:
+    IO *m_io = NULL;
+    Engine *m_engine = NULL;
+    int64_t m_ID;
+    int64_t currentStep = -1;
+    std::string m_IOname;
+    std::string m_FileName;
+    size_t m_BytesSent = 0;
+    size_t m_OperationCount = 0;
+    RemoteFileMode m_mode = RemoteCommon::RemoteFileMode::RemoteOpen;
+    AnonADIOSFile(std::string FileName, RemoteCommon::RemoteFileMode mode)
+    {
+        Mode adios_read_mode = adios2::Mode::Read;
+        m_FileName = FileName;
+        m_IOname = lf_random_string();
+        m_io = &adios.DeclareIO(m_IOname);
+        m_mode = mode;
+        if (m_mode == RemoteOpenRandomAccess)
+            adios_read_mode = adios2::Mode::ReadRandomAccess;
+        m_engine = &m_io->Open(FileName, adios_read_mode);
+        memcpy(&m_ID, m_IOname.c_str(), sizeof(m_ID));
+    }
+    ~AnonADIOSFile()
+    {
+        m_engine->Close();
+        adios.RemoveIO(m_IOname);
+    }
+};
+
+class AnonSimpleFile
+{
+public:
+    int64_t m_ID;
+    int m_FileDescriptor;
+    int m_Errno = 0;
+    size_t m_Size = -1;
+    size_t m_CurrentOffset = 0;
+    std::string m_FileName;
+    size_t m_BytesSent = 0;
+    size_t m_OperationCount = 0;
+    AnonSimpleFile(std::string FileName)
+    {
+        m_FileName = FileName;
+        std::string tmpname = lf_random_string();
+        struct stat fileStat;
+
+        memcpy(&m_ID, tmpname.c_str(), sizeof(m_ID));
+        errno = 0;
+        m_FileDescriptor = open(FileName.c_str(), O_RDONLY);
+        m_Errno = errno;
+        if (fstat(m_FileDescriptor, &fileStat) == -1)
+        {
+            m_Errno = errno;
+        }
+        m_Size = static_cast<size_t>(fileStat.st_size);
+    }
+    ~AnonSimpleFile() { close(m_FileDescriptor); }
+};
+
+std::unordered_map<uint64_t, AnonADIOSFile *> ADIOSFileMap;
+std::unordered_map<uint64_t, AnonSimpleFile *> SimpleFileMap;
+std::unordered_multimap<void *, uint64_t> ConnToFileMap;
+
+static void ConnCloseHandler(CManager cm, CMConnection conn, void *client_data)
+{
+    auto it = ConnToFileMap.equal_range(conn);
+    for (auto it1 = it.first; it1 != it.second; it1++)
+    {
+        AnonADIOSFile *file = ADIOSFileMap[it1->second];
+        if (file)
+        {
+            if (verbose >= 1)
+                std::cout << "closing ADIOS file \"" << file->m_FileName << "\" total sent "
+                          << readable_size(file->m_BytesSent) << " in " << file->m_OperationCount
+                          << " Get()s" << std::endl;
+            ADIOSFileMap.erase(it1->second);
+            delete file;
+        }
+        AnonSimpleFile *sfile = SimpleFileMap[it1->second];
+        if (sfile)
+        {
+            if (verbose >= 1)
+                std::cout << "closing simple file " << sfile->m_FileName << "\" total sent "
+                          << readable_size(sfile->m_BytesSent) << " in " << sfile->m_OperationCount
+                          << " Read()s" << std::endl;
+            SimpleFileMap.erase(it1->second);
+            delete file;
+        }
+    }
+    ConnToFileMap.erase(conn);
+}
+
+static void OpenHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                        attr_list attrs)
+{
+    OpenFileMsg open_msg = static_cast<OpenFileMsg>(vevent);
+    struct Remote_evpath_state *ev_state = static_cast<struct Remote_evpath_state *>(client_data);
+    _OpenResponseMsg open_response_msg;
+    std::cout << "Got an open request for file " << open_msg->FileName << std::endl;
+    AnonADIOSFile *f = new AnonADIOSFile(open_msg->FileName, open_msg->Mode);
+    memset(&open_response_msg, 0, sizeof(open_response_msg));
+    open_response_msg.FileHandle = f->m_ID;
+    open_response_msg.OpenResponseCondition = open_msg->OpenResponseCondition;
+    CMwrite(conn, ev_state->OpenResponseFormat, &open_response_msg);
+    CMconn_register_close_handler(conn, ConnCloseHandler, NULL);
+    ADIOSFileMap[f->m_ID] = f;
+    ConnToFileMap.emplace(conn, f->m_ID);
+}
+
+static void OpenSimpleHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                              attr_list attrs)
+{
+    OpenSimpleFileMsg open_msg = static_cast<OpenSimpleFileMsg>(vevent);
+    struct Remote_evpath_state *ev_state = static_cast<struct Remote_evpath_state *>(client_data);
+    _OpenSimpleResponseMsg open_response_msg;
+    std::cout << "Got an open simple request for file " << open_msg->FileName << std::endl;
+    AnonSimpleFile *f = new AnonSimpleFile(open_msg->FileName);
+    f->m_FileName = open_msg->FileName;
+    memset(&open_response_msg, 0, sizeof(open_response_msg));
+    open_response_msg.FileHandle = f->m_ID;
+    open_response_msg.FileSize = f->m_Size;
+    open_response_msg.OpenResponseCondition = open_msg->OpenResponseCondition;
+
+    CMwrite(conn, ev_state->OpenSimpleResponseFormat, &open_response_msg);
+    CMconn_register_close_handler(conn, ConnCloseHandler, NULL);
+    SimpleFileMap[f->m_ID] = f;
+    ConnToFileMap.emplace(conn, f->m_ID);
+}
+
+static void GetRequestHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                              attr_list attrs)
+{
+    GetRequestMsg GetMsg = static_cast<GetRequestMsg>(vevent);
+    AnonADIOSFile *f = ADIOSFileMap[GetMsg->FileHandle];
+    struct Remote_evpath_state *ev_state = static_cast<struct Remote_evpath_state *>(client_data);
+    if (f->m_mode == RemoteOpen)
+    {
+        if (f->currentStep == -1)
+        {
+            f->m_engine->BeginStep();
+            f->currentStep++;
+        }
+        while (f->m_engine->CurrentStep() < GetMsg->Step)
+        {
+            if (verbose >= 2)
+                std::cout << "Advancing a step" << std::endl;
+            f->m_engine->EndStep();
+            f->m_engine->BeginStep();
+            f->currentStep++;
+        }
+    }
+
+    std::string VarName = std::string(GetMsg->VarName);
+    adios2::DataType TypeOfVar = f->m_io->InquireVariableType(VarName);
+    Box<Dims> b;
+    if (GetMsg->Count)
+    {
+        for (int i = 0; i < GetMsg->DimCount; i++)
+        {
+            b.first.push_back(GetMsg->Start[i]);
+            b.second.push_back(GetMsg->Count[i]);
+        }
+    }
+
+    if (TypeOfVar == adios2::DataType::None)
+    {
+    }
+#define GET(T)                                                                                     \
+    else if (TypeOfVar == helper::GetDataType<T>())                                                \
+    {                                                                                              \
+        _ReadResponseMsg Response;                                                                 \
+        memset(&Response, 0, sizeof(Response));                                                    \
+        std::vector<T> RetData;                                                                    \
+        auto var = f->m_io->InquireVariable<T>(VarName);                                           \
+        if (f->m_mode == RemoteOpenRandomAccess)                                                   \
+            var->SetStepSelection({GetMsg->Step, 1});                                              \
+        if (GetMsg->BlockID != -1)                                                                 \
+            var->SetBlockSelection(GetMsg->BlockID);                                               \
+        if (GetMsg->Start)                                                                         \
+            var->SetSelection(b);                                                                  \
+        f->m_engine->Get(*var, RetData, Mode::Sync);                                               \
+        Response.Size = RetData.size() * sizeof(T);                                                \
+        Response.ReadData = (char *)RetData.data();                                                \
+        Response.ReadResponseCondition = GetMsg->GetResponseCondition;                             \
+        Response.Dest = GetMsg->Dest; /* final data destination in client memory space */          \
+        if (verbose >= 2)                                                                          \
+            std::cout << "Returning " << Response.Size << " " << readable_size(Response.Size)      \
+                      << " for Get<" << TypeOfVar << ">(" << VarName << ")" << b << std::endl;     \
+        f->m_BytesSent += Response.Size;                                                           \
+        f->m_OperationCount++;                                                                     \
+        CMwrite(conn, ev_state->ReadResponseFormat, &Response);                                    \
+    }
+    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(GET)
+#undef GET
+}
+
+static void ReadRequestHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                               attr_list attrs)
+{
+    ReadRequestMsg ReadMsg = static_cast<ReadRequestMsg>(vevent);
+    AnonSimpleFile *f = SimpleFileMap[ReadMsg->FileHandle];
+    struct Remote_evpath_state *ev_state = static_cast<struct Remote_evpath_state *>(client_data);
+    if (f->m_CurrentOffset != ReadMsg->Offset)
+    {
+        lseek(f->m_FileDescriptor, ReadMsg->Offset, SEEK_SET);
+        f->m_CurrentOffset = ReadMsg->Offset;
+    }
+    char *tmp = (char *)malloc(ReadMsg->Size);
+    read(f->m_FileDescriptor, tmp, ReadMsg->Size);
+    f->m_CurrentOffset += ReadMsg->Size;
+    _ReadResponseMsg Response;
+    memset(&Response, 0, sizeof(Response));
+    Response.Size = ReadMsg->Size;
+    Response.ReadData = (char *)tmp;
+    Response.ReadResponseCondition = ReadMsg->ReadResponseCondition;
+    Response.Dest = ReadMsg->Dest;
+    if (verbose >= 2)
+        std::cout << "Returning " << readable_size(Response.Size) << " for Read " << std::endl;
+    f->m_BytesSent += Response.Size;
+    f->m_OperationCount++;
+    CMwrite(conn, ev_state->ReadResponseFormat, &Response);
+    free(tmp);
+}
+
+void REVPServerRegisterHandlers(struct Remote_evpath_state &ev_state)
+{
+    CMregister_handler(ev_state.OpenFileFormat, OpenHandler, &ev_state);
+    CMregister_handler(ev_state.OpenSimpleFileFormat, OpenSimpleHandler, &ev_state);
+    CMregister_handler(ev_state.GetRequestFormat, GetRequestHandler, &ev_state);
+    CMregister_handler(ev_state.ReadRequestFormat, ReadRequestHandler, &ev_state);
+}
+
+static atom_t CM_IP_PORT = -1;
+const int ServerPort = 26200;
+int main(int argc, char **argv)
+{
+    CManager cm;
+    struct Remote_evpath_state ev_state;
+
+    (void)argc;
+    (void)argv;
+    cm = CManager_create();
+    CM_IP_PORT = attr_atom_from_string("IP_PORT");
+    attr_list listen_list = NULL;
+
+    if (listen_list == NULL)
+        listen_list = create_attr_list();
+    add_attr(listen_list, CM_IP_PORT, Attr_Int4, (attr_value)ServerPort);
+    CMlisten_specific(cm, listen_list);
+
+    attr_list contact_list = CMget_contact_list(cm);
+    if (contact_list)
+    {
+        char *string_list = attr_list_to_string(contact_list);
+        std::cout << "Listening at port " << ServerPort << std::endl;
+        free(string_list);
+    }
+    ev_state.cm = cm;
+
+    while (argv[1] && (argv[1][0] == '-'))
+    {
+        size_t i = 1;
+        while (argv[1][i] != 0)
+        {
+            if (argv[1][i] == 'v')
+            {
+                verbose++;
+            }
+            else if (argv[1][i] == 'q')
+            {
+                verbose--;
+            }
+            i++;
+        }
+        argv++;
+        argc--;
+    }
+
+    RegisterFormats(ev_state);
+
+    REVPServerRegisterHandlers(ev_state);
+
+    std::cout << "doing Run Network" << std::endl;
+    CMrun_network(cm);
+    return 0;
+}

--- a/source/adios2/toolkit/remote/remote_server.cpp
+++ b/source/adios2/toolkit/remote/remote_server.cpp
@@ -99,7 +99,7 @@ public:
     int64_t m_ID;
     int m_FileDescriptor;
     int m_Errno = 0;
-    size_t m_Size = -1;
+    size_t m_Size = (size_t)-1;
     size_t m_CurrentOffset = 0;
     std::string m_FileName;
     size_t m_BytesSent = 0;

--- a/source/adios2/toolkit/transport/file/FileRemote.cpp
+++ b/source/adios2/toolkit/transport/file/FileRemote.cpp
@@ -1,0 +1,230 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ */
+#include "FileRemote.h"
+#include "adios2/core/ADIOS.h"
+#include "adios2/helper/adiosLog.h"
+#include "adios2/helper/adiosString.h"
+#include "adios2/helper/adiosSystem.h"
+
+#include <cstdio>  // remove
+#include <cstring> // strerror
+#include <errno.h> // errno
+#include <fcntl.h> // open
+#include <regex>
+#include <sys/stat.h>  // open, fstat
+#include <sys/types.h> // open
+#include <unistd.h>    // write, close, ftruncate
+
+namespace adios2
+{
+namespace transport
+{
+
+FileRemote::FileRemote(helper::Comm const &comm)
+: Transport("File", "Remote", comm) /*, m_Impl(&m_ImplSingleton)*/
+{
+}
+
+FileRemote::~FileRemote()
+{
+    if (m_IsOpen)
+    {
+        Close();
+    }
+}
+
+void FileRemote::SetParameters(const Params &params)
+{
+    // Parameters are set from config parameters if present
+    // Otherwise, they are set from environment if present
+    // Otherwise, they remain at their default value
+
+    helper::SetParameterValue("cache", params, m_CachePath);
+    if (m_CachePath.empty())
+    {
+        if (const char *Env = std::getenv("AWS_CACHE"))
+        {
+            m_CachePath = std::string(Env);
+        }
+    }
+}
+
+void FileRemote::WaitForOpen() {}
+
+void FileRemote::SetUpCache()
+{
+    if (!m_CachePath.empty())
+    {
+        if (helper::EndsWith(m_FileName, "md.idx") || helper::EndsWith(m_FileName, "md.0") ||
+            helper::EndsWith(m_FileName, "mmd.0"))
+        {
+            m_CachingThisFile = true;
+        }
+    }
+
+    if (m_CachingThisFile)
+    {
+    }
+}
+
+void FileRemote::Open(const std::string &name, const Mode openMode, const bool async,
+                      const bool directio)
+{
+    m_Name = name;
+    size_t pos = name.find(PathSeparator);
+    if (pos == std::string::npos)
+    {
+        helper::Throw<std::invalid_argument>("Toolkit", "transport::file::FileRemote", "Open",
+                                             "invalid 'bucket/object' name " + name);
+    }
+    m_OpenMode = openMode;
+    switch (m_OpenMode)
+    {
+
+    case Mode::Write:
+    case Mode::Append:
+        helper::Throw<std::ios_base::failure>("Toolkit", "transport::file::FileRemote", "Open",
+                                              "does not support writing yet " + m_Name);
+        break;
+
+    case Mode::Read: {
+        ProfilerStart("open");
+        m_Remote.OpenSimpleFile("localhost", 26200, m_Name);
+        ProfilerStop("open");
+        m_Size = m_Remote.m_Size;
+        break;
+    }
+    default:
+        CheckFile("unknown open mode for file " + m_Name + ", in call to Remote open");
+    }
+}
+
+void FileRemote::OpenChain(const std::string &name, Mode openMode, const helper::Comm &chainComm,
+                           const bool async, const bool directio)
+{
+    int token = 1;
+    if (chainComm.Rank() > 0)
+    {
+        chainComm.Recv(&token, 1, chainComm.Rank() - 1, 0, "Chain token in FileRemote::OpenChain");
+    }
+
+    Open(name, openMode, async, directio);
+
+    if (chainComm.Rank() < chainComm.Size() - 1)
+    {
+        chainComm.Isend(&token, 1, chainComm.Rank() + 1, 0,
+                        "Sending Chain token in FileRemote::OpenChain");
+    }
+}
+
+void FileRemote::Write(const char *buffer, size_t size, size_t start)
+{
+    helper::Throw<std::ios_base::failure>("Toolkit", "transport::file::FileRemote", "Write",
+                                          "does not support writing yet " + m_Name);
+}
+
+void FileRemote::Read(char *buffer, size_t size, size_t start)
+{
+    WaitForOpen();
+
+    if (start != MaxSizeT)
+    {
+        if (start >= m_Size)
+        {
+            helper::Throw<std::ios_base::failure>(
+                "Toolkit", "transport::file::FileRemote", "Read",
+                "couldn't move to start position " + std::to_string(start) +
+                    " beyond the size of " + m_Name + " which is " + std::to_string(m_Size));
+        }
+        m_SeekPos = start;
+        errno = 0;
+        m_Errno = errno;
+    }
+
+    if (m_SeekPos + size > m_Size)
+    {
+        helper::Throw<std::ios_base::failure>("Toolkit", "transport::file::FileRemote", "Read",
+                                              "can't read " + std::to_string(size) +
+                                                  " bytes from position " +
+                                                  std::to_string(m_SeekPos) + " from " + m_Name +
+                                                  " whose size is " + std::to_string(m_Size));
+    }
+
+    m_Remote.Read(start, size, buffer);
+    if (m_IsCached)
+    {
+    }
+}
+
+size_t FileRemote::GetSize()
+{
+    WaitForOpen();
+    switch (m_OpenMode)
+    {
+    case Mode::Write:
+    case Mode::Append:
+        return 0;
+    case Mode::Read:
+        return m_Size;
+    default:
+        return 0;
+    }
+}
+
+void FileRemote::Flush() {}
+
+void FileRemote::Close()
+{
+    WaitForOpen();
+    ProfilerStart("close");
+    errno = 0;
+    m_Errno = errno;
+    if (m_IsCached)
+    {
+    }
+
+    m_IsOpen = false;
+    ProfilerStop("close");
+}
+
+void FileRemote::Delete()
+{
+    WaitForOpen();
+    if (m_IsOpen)
+    {
+        Close();
+    }
+    std::remove(m_Name.c_str());
+}
+
+void FileRemote::CheckFile(const std::string hint) const {}
+
+void FileRemote::SeekToEnd() { m_SeekPos = MaxSizeT; }
+
+void FileRemote::SeekToBegin() { m_SeekPos = 0; }
+
+void FileRemote::Seek(const size_t start)
+{
+    if (start != MaxSizeT)
+    {
+        m_SeekPos = start;
+    }
+    else
+    {
+        SeekToEnd();
+    }
+}
+
+void FileRemote::Truncate(const size_t length)
+{
+    helper::Throw<std::ios_base::failure>("Toolkit", "transport::file::FileRemote", "Truncate",
+                                          "does not support truncating " + m_Name);
+}
+
+void FileRemote::MkDir(const std::string &fileName) {}
+
+} // end namespace transport
+} // end namespace adios2

--- a/source/adios2/toolkit/transport/file/FileRemote.h
+++ b/source/adios2/toolkit/transport/file/FileRemote.h
@@ -1,0 +1,96 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ */
+
+#ifndef ADIOS2_TOOLKIT_TRANSPORT_FILE_Remote_H_
+#define ADIOS2_TOOLKIT_TRANSPORT_FILE_Remote_H_
+
+#include <future> //std::async, std::future
+
+#include "adios2/common/ADIOSConfig.h"
+#include "adios2/toolkit/remote/Remote.h"
+#include "adios2/toolkit/transport/Transport.h"
+
+#include <evpath.h>
+namespace adios2
+{
+namespace helper
+{
+class Comm;
+}
+namespace transport
+{
+
+/** File descriptor transport using the AWSSDK IO library */
+class FileRemote : public Transport
+{
+
+public:
+    FileRemote(helper::Comm const &comm);
+
+    ~FileRemote();
+
+    void SetParameters(const Params &parameters);
+
+    void Open(const std::string &name, const Mode openMode, const bool async = false,
+              const bool directio = false) final;
+
+    void OpenChain(const std::string &name, Mode openMode, const helper::Comm &chainComm,
+                   const bool async = false, const bool directio = false) final;
+
+    void Write(const char *buffer, size_t size, size_t start = MaxSizeT) final;
+
+#ifdef REALLY_WANT_WRITEV
+    /* Actual writev() function, inactive for now */
+    void WriteV(const core::iovec *iov, const int iovcnt, size_t start = MaxSizeT) final;
+#endif
+
+    void Read(char *buffer, size_t size, size_t start = MaxSizeT) final;
+
+    size_t GetSize() final;
+
+    /** Does nothing, each write is supposed to flush */
+    void Flush() final;
+
+    void Close() final;
+
+    void Delete() final;
+
+    void SeekToEnd() final;
+
+    void SeekToBegin() final;
+
+    void Seek(const size_t start = MaxSizeT) final;
+
+    void Truncate(const size_t length) final;
+
+    void MkDir(const std::string &fileName) final;
+
+private:
+    // class Impl;
+    // static class Impl m_ImplSingleton;
+    // Impl *m_Impl;
+    // std::unique_ptr<Impl> m_Impl;
+    Remote m_Remote;
+    int m_Errno = 0;
+    bool m_IsOpening = false;
+    std::future<int> m_OpenFuture;
+    size_t m_SeekPos = 0;
+    size_t m_Size = 0;
+
+    void SetUpCache();
+    std::string m_FileName;
+    std::string m_CachePath;        // local cache directory
+    bool m_CachingThisFile = false; // save content to local cache
+    bool m_IsCached = false;        // true if file is already in cache
+    void CheckFile(const std::string hint) const;
+    void WaitForOpen();
+    std::string SysErrMsg() const;
+};
+
+} // end namespace transport
+} // end namespace adios2
+
+#endif /* ADIOS2_TRANSPORT_FILE_Remote_H_ */


### PR DESCRIPTION
This is a replacement for the prior WIP Remote PR (which I will delete when this is merged).  This has been reformatted with the new clang-format parameters and contains a tiny bit of Norbert's campaign tweaks (the RemoteDataPath parameter).  However, it can still be activated with the `DoRemote` environment variable (activates Get()-level remote data access) and the `DoFileRemote` environment variable (activates transport-level remote data access).  If only DoRemote is activated, the metadata is read locally and Get() operations sent to the remote server.  If only DoFileRemote is activated, _**all**_ file access is sent to the remote server, including metadata reads.  (This is a temporary measure to test the mechanism, not a final solution.). If both are activated, metadata access happens via the remote data mechanism and data access (via Get()) is done via the remote Get() mechanism.