### PR TITLE
Blosc2 USE ON: Fix Module Fallback

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -76,7 +76,7 @@ if(ADIOS2_USE_Blosc2 STREQUAL AUTO)
   endif()
 elseif(ADIOS2_USE_Blosc2)
   # Prefect CONFIG mode
-  find_package(Blosc2 2.4 CONFIG REQUIRED)
+  find_package(Blosc2 2.4 CONFIG)
   if(NOT Blosc2_FOUND)
     find_package(Blosc2 2.4 MODULE REQUIRED)
   endif()


### PR DESCRIPTION
Avoid that for older C-Blosc2 releases, with `ADIOS2_USE_Blosc2=ON`, the search logic errors out after the config module was not found.

Regression introduced in #3715 (after rebase).