### PR TITLE
match type of timestep for h5 engine to size_t (same as adios Variabl…

### DIFF
--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -210,7 +210,7 @@ void HDF5ReaderP::UseHDFRead(Variable<T> &variable, T *data, hid_t h5Type)
     }
 
     T *values = data;
-    // unsigned int ts = 0;
+
     size_t ts = 0;
     size_t variableStart = variable.m_StepsStart;
     /*

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -77,13 +77,6 @@ void HDF5ReaderP::Init()
     m_H5File.ParseParameters(m_IO);
 
     /*
-    int ts = m_H5File.GetNumAdiosSteps();
-
-    if (ts == 0)
-    {
-        helper::Throw<std::runtime_error>( "Engine", "HDF5ReaderP", "Init",
-    "This h5 file is NOT written by ADIOS2");
-    }
     */
     m_H5File.ReadAttrToIO(m_IO);
     if (!m_InStreamMode)
@@ -103,37 +96,6 @@ void HDF5ReaderP::Init()
 template <class T>
 size_t HDF5ReaderP::ReadDataset(hid_t dataSetId, hid_t h5Type, Variable<T> &variable, T *values)
 {
-    /*
-    size_t variableStart = variable.m_StepsStart;
-
-    if ((m_H5File.m_IsGeneratedByAdios) && (ts >= 0))
-      {
-              try
-              {
-                  m_H5File.SetAdiosStep(variableStart + ts);
-              }
-              catch (std::exception &e)
-              {
-                  printf("[Not fatal] %s\n", e.what());
-                  return 0;
-                  //break;
-              }
-          }
-
-          std::vector<hid_t> chain;
-          if (!m_H5File.OpenDataset(variable.m_Name, chain)) {
-            return -1;
-          }
-
-          hid_t dataSetId = chain.back();
-          interop::HDF5DatasetGuard g(chain);
-          //hid_t dataSetId =
-          //  H5Dopen(m_H5File.m_GroupId, variable.m_Name.c_str(), H5P_DEFAULT);
-          if (dataSetId < 0)
-          {
-              return 0;
-          }
-    */
     hid_t fileSpace = H5Dget_space(dataSetId);
     interop::HDF5TypeGuard g_fs(fileSpace, interop::E_H5_SPACE);
 
@@ -248,8 +210,8 @@ void HDF5ReaderP::UseHDFRead(Variable<T> &variable, T *data, hid_t h5Type)
     }
 
     T *values = data;
-    unsigned int ts = 0;
-    // T *values = data;
+    //unsigned int ts = 0;
+    size_t ts = 0;
     size_t variableStart = variable.m_StepsStart;
     /*
       // looks like m_StepsStart is defaulted to be 0 now.
@@ -278,8 +240,7 @@ void HDF5ReaderP::UseHDFRead(Variable<T> &variable, T *data, hid_t h5Type)
         }
         hid_t dataSetId = chain.back();
         interop::HDF5DatasetGuard g(chain);
-        // hid_t dataSetId =
-        //  H5Dopen(m_H5File.m_GroupId, variable.m_Name.c_str(), H5P_DEFAULT);
+
         if (dataSetId < 0)
         {
             return;
@@ -291,8 +252,6 @@ void HDF5ReaderP::UseHDFRead(Variable<T> &variable, T *data, hid_t h5Type)
         {
             break;
         }
-        // H5Sclose(fileSpace);
-        // H5Dclose(dataSetId);
 
         ts++;
         values += slabsize;
@@ -304,7 +263,7 @@ void HDF5ReaderP::UseHDFRead(Variable<T> &variable, T *data, hid_t h5Type)
 
 StepStatus HDF5ReaderP::BeginStep(StepMode mode, const float timeoutSeconds)
 {
-    const unsigned int ts = m_H5File.GetNumAdiosSteps();
+    const size_t ts = m_H5File.GetNumAdiosSteps();
 
     if (m_StreamAt >= ts)
     {

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -77,7 +77,7 @@ void HDF5ReaderP::Init()
     m_H5File.ParseParameters(m_IO);
 
     /*
-    */
+     */
     m_H5File.ReadAttrToIO(m_IO);
     if (!m_InStreamMode)
     {
@@ -210,7 +210,7 @@ void HDF5ReaderP::UseHDFRead(Variable<T> &variable, T *data, hid_t h5Type)
     }
 
     T *values = data;
-    //unsigned int ts = 0;
+    // unsigned int ts = 0;
     size_t ts = 0;
     size_t variableStart = variable.m_StepsStart;
     /*

--- a/source/adios2/engine/hdf5/HDF5ReaderP.h
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.h
@@ -54,7 +54,8 @@ private:
     void Init() final;
 
     bool m_InStreamMode = false; // default is not streaming, i.e. set var timestep range
-    unsigned int m_StreamAt = 0; // stream step counter
+  //unsigned int m_StreamAt = 0; // stream step counter
+    size_t m_StreamAt = 0 ;
 #define declare_type(T)                                                                            \
     void DoGetSync(Variable<T> &, T *) final;                                                      \
     void DoGetDeferred(Variable<T> &, T *) final;                                                  \

--- a/source/adios2/engine/hdf5/HDF5ReaderP.h
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.h
@@ -54,8 +54,8 @@ private:
     void Init() final;
 
     bool m_InStreamMode = false; // default is not streaming, i.e. set var timestep range
-  //unsigned int m_StreamAt = 0; // stream step counter
-    size_t m_StreamAt = 0 ;
+                                 // unsigned int m_StreamAt = 0; // stream step counter
+    size_t m_StreamAt = 0;
 #define declare_type(T)                                                                            \
     void DoGetSync(Variable<T> &, T *) final;                                                      \
     void DoGetDeferred(Variable<T> &, T *) final;                                                  \

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -362,7 +362,7 @@ void HDF5Common::ReadAllVariables(core::IO &io)
     GetNumAdiosSteps();
     // unsigned int i = 0;
 
-    for (auto i = 0; i < m_NumAdiosSteps; i++)
+    for (size_t i = 0; i < m_NumAdiosSteps; i++)
     {
         ReadVariables(i, io);
     }
@@ -1479,7 +1479,7 @@ void HDF5Common::LocateAttrParent(const std::string &attrName, std::vector<std::
     if (list.size() >= 1)
     {
         std::string ts;
-        for (auto i = 0; i < m_CurrentAdiosStep; i++)
+        for (size_t i = 0; i < m_CurrentAdiosStep; i++)
         {
             StaticGetAdiosStepString(ts, i);
             for (size_t j = 0; j < list.size() - 1; j++)

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -295,7 +295,6 @@ void HDF5Common::WriteAdiosSteps()
     else
         attr = H5Aopen(m_FileId, ATTRNAME_NUM_STEPS.c_str(), H5P_DEFAULT);
 
-    // unsigned int totalAdiosSteps = m_CurrentAdiosStep + 1;
     size_t totalAdiosSteps = m_CurrentAdiosStep + 1;
 
     if (m_GroupId < 0)
@@ -360,7 +359,6 @@ void HDF5Common::ReadAllVariables(core::IO &io)
     }
 
     GetNumAdiosSteps();
-    // unsigned int i = 0;
 
     for (size_t i = 0; i < m_NumAdiosSteps; i++)
     {
@@ -369,7 +367,7 @@ void HDF5Common::ReadAllVariables(core::IO &io)
 }
 
 void HDF5Common::FindVarsFromH5(core::IO &io, hid_t top_id, const char *gname, const char *heritage,
-                                unsigned int ts)
+                                size_t ts)
 {
     // int i = 0;
     // std::string stepStr;
@@ -431,44 +429,9 @@ void HDF5Common::FindVarsFromH5(core::IO &io, hid_t top_id, const char *gname, c
         }
     }
 }
-/*
-void HDF5Common::ReadNativeGroup(hid_t hid, IO& io)
-{
-H5G_info_t group_info;
-herr_t result = H5Gget_info(hid, &group_info);
-
-if (result < 0) {
-  // error
-  helper::Throw<std::ios_base::failure>( "Toolkit", "interop::hdf5::HDF5Common",
-"ReadNativeGroup", "Unable to get group info");
-}
-
-if (group_info.nlinks == 0) {
-  return;
-}
-
-char tmpstr[1024];
-
-hsize_t idx;
-for (idx=0; idx<group_info.nlinks; idx++) {
-  int currType = H5Gget_objtype_by_idx(hid, idx);
-  if (currType < 0) {
-  helper::Throw<std::ios_base::failure>( "Toolkit", "interop::hdf5::HDF5Common",
-"ReadNativeGroup", "unable to get type info of idx"+idx);
-  }
-
-
-  ssize_t curr= H5Gget_objname_by_idx(hid, idx, tmpstr, sizeof(tmpstr));
-  if (curr > 0) { // got a name
-    std::cout<<" ... printing a name: "<<tmpstr<<",
-type:[0=G/1=D/2=T/3=L/4=UDL]"<<currType<<std::endl;
-  }
-}
-}
-*/
 
 // read variables from the input timestep
-void HDF5Common::ReadVariables(unsigned int ts, core::IO &io)
+void HDF5Common::ReadVariables(size_t ts, core::IO &io)
 {
     std::string stepStr;
     hsize_t numObj;
@@ -476,7 +439,7 @@ void HDF5Common::ReadVariables(unsigned int ts, core::IO &io)
     StaticGetAdiosStepString(stepStr, ts);
     hid_t gid = H5Gopen2(m_FileId, stepStr.c_str(), H5P_DEFAULT);
     HDF5TypeGuard g(gid, E_H5_GROUP);
-    ///    if (gid > 0) {
+
     herr_t ret = H5Gget_num_objs(gid, &numObj);
     if (ret >= 0)
     {
@@ -512,12 +475,9 @@ void HDF5Common::ReadVariables(unsigned int ts, core::IO &io)
             }
         }
     }
-    /// H5Gclose(gid);
-    ///}
 }
 
-void HDF5Common::AddSingleString(core::IO &io, std::string const &name, hid_t datasetId,
-                                 unsigned int ts)
+void HDF5Common::AddSingleString(core::IO &io, std::string const &name, hid_t datasetId, size_t ts)
 {
     try
     {
@@ -542,8 +502,7 @@ void HDF5Common::AddSingleString(core::IO &io, std::string const &name, hid_t da
     }
 }
 
-void HDF5Common::AddVarString(core::IO &io, std::string const &name, hid_t datasetId,
-                              unsigned int ts)
+void HDF5Common::AddVarString(core::IO &io, std::string const &name, hid_t datasetId, size_t ts)
 {
     core::Variable<std::string> *v = io.InquireVariable<std::string>(name);
     if (v != NULL)
@@ -560,7 +519,6 @@ void HDF5Common::AddVarString(core::IO &io, std::string const &name, hid_t datas
     H5Sget_simple_extent_dims(dspace, dims.data(), NULL);
     H5Sclose(dspace);
 
-    // if ( (ndims > 1) || ( (ndims == 1) && (dims[0] > 1) ) ) {
     if ((ndims > 0))
     {
         bool isSingleElement = true;
@@ -625,7 +583,7 @@ void HDF5Common::AddVarString(core::IO &io, std::string const &name, hid_t datas
 }
 
 template <class T>
-void HDF5Common::AddVar(core::IO &io, std::string const &name, hid_t datasetId, unsigned int ts)
+void HDF5Common::AddVar(core::IO &io, std::string const &name, hid_t datasetId, size_t ts)
 {
     core::Variable<T> *v = io.InquireVariable<T>(name);
     if (NULL == v)
@@ -690,7 +648,7 @@ void HDF5Common::AddVar(core::IO &io, std::string const &name, hid_t datasetId, 
 }
 
 void HDF5Common::CreateVar(core::IO &io, hid_t datasetId, std::string const &nameSuggested,
-                           unsigned int ts)
+                           size_t ts)
 {
     std::string name;
     ReadADIOSName(datasetId, name);
@@ -823,7 +781,6 @@ void HDF5Common::SetAdiosStep(size_t step)
 
     GetNumAdiosSteps();
 
-    // unsigned int ustep = static_cast<unsigned int>(step);
     if (step >= m_NumAdiosSteps)
         helper::Throw<std::ios_base::failure>("Toolkit", "interop::hdf5::HDF5Common",
                                               "SetAdiosStep",

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -14,10 +14,10 @@
 #include <complex>
 #include <ios>
 #include <iostream>
+#include <limits>
 #include <mutex>
 #include <stdexcept>
 #include <vector>
-#include <limits>
 
 #include "adios2/helper/adiosFunctions.h" // IsRowMajor
 #include <cstring>                        // strlen
@@ -88,12 +88,12 @@ HDF5Common::HDF5Common()
     m_PropertyTxfID = H5Pcreate(H5P_DATASET_XFER);
 
     size_t size_t_max = (size_t)-1;
-    if (size_t_max  <=  std::numeric_limits<unsigned int>::max())
-      m_TimeStepH5T =  H5T_NATIVE_UINT;
-    else if (size_t_max  <= std::numeric_limits<unsigned long>::max()) 
-      m_TimeStepH5T =  H5T_NATIVE_ULONG;
-      
-    // default is m_TimeStepH5T =  H5T_NATIVE_ULLONG;        
+    if (size_t_max <= std::numeric_limits<unsigned int>::max())
+        m_TimeStepH5T = H5T_NATIVE_UINT;
+    else if (size_t_max <= std::numeric_limits<unsigned long>::max())
+        m_TimeStepH5T = H5T_NATIVE_ULONG;
+
+    // default is m_TimeStepH5T =  H5T_NATIVE_ULLONG;
 }
 
 HDF5Common::~HDF5Common() { Close(); }
@@ -295,7 +295,7 @@ void HDF5Common::WriteAdiosSteps()
     else
         attr = H5Aopen(m_FileId, ATTRNAME_NUM_STEPS.c_str(), H5P_DEFAULT);
 
-    //unsigned int totalAdiosSteps = m_CurrentAdiosStep + 1;
+    // unsigned int totalAdiosSteps = m_CurrentAdiosStep + 1;
     size_t totalAdiosSteps = m_CurrentAdiosStep + 1;
 
     if (m_GroupId < 0)
@@ -316,8 +316,8 @@ size_t HDF5Common::GetNumAdiosSteps()
 {
     if (m_WriteMode)
     {
-      //return static_cast<unsigned int>(-1);
-      return 0; 
+        // return static_cast<unsigned int>(-1);
+        return 0;
     }
 
     if (m_FileId < 0)
@@ -360,7 +360,7 @@ void HDF5Common::ReadAllVariables(core::IO &io)
     }
 
     GetNumAdiosSteps();
-    //unsigned int i = 0;
+    // unsigned int i = 0;
 
     for (auto i = 0; i < m_NumAdiosSteps; i++)
     {
@@ -823,7 +823,7 @@ void HDF5Common::SetAdiosStep(size_t step)
 
     GetNumAdiosSteps();
 
-    //unsigned int ustep = static_cast<unsigned int>(step);
+    // unsigned int ustep = static_cast<unsigned int>(step);
     if (step >= m_NumAdiosSteps)
         helper::Throw<std::ios_base::failure>("Toolkit", "interop::hdf5::HDF5Common",
                                               "SetAdiosStep",

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -172,10 +172,11 @@ public:
 
     void ReadNativeAttrToIO(core::IO &io, hid_t datasetId, std::string const &pathFromRoot);
 
-    void SetAdiosStep(int ts);
+    //void SetAdiosStep(int ts);
+    void SetAdiosStep(size_t ts);
 
-    unsigned int GetNumAdiosSteps();
-    unsigned int GetAdiosStep() const;
+    size_t GetNumAdiosSteps();
+    size_t GetAdiosStep() const;
     void WriteAdiosSteps();
 
     void ReadVariables(unsigned int ts, core::IO &io);
@@ -200,7 +201,7 @@ public:
     void AddNonStringAttribute(core::IO &io, std::string const &attrName, hid_t attrId,
                                hid_t h5Type, hsize_t arraySize);
 
-    static void StaticGetAdiosStepString(std::string &adiosStepName, int ts);
+    static void StaticGetAdiosStepString(std::string &adiosStepName, size_t ts);
 
     hid_t m_PropertyListId = -1;
     hid_t m_PropertyTxfID = -1;
@@ -212,7 +213,8 @@ public:
     hid_t m_DefH5TypeComplexFloat;
     hid_t m_DefH5TypeBlockStat;
 
-    unsigned int m_CurrentAdiosStep = 0;
+    //unsigned int m_CurrentAdiosStep = 0;
+    size_t m_CurrentAdiosStep = 0;
 
     void CheckWriteGroup();
 
@@ -247,7 +249,8 @@ private:
                           std::vector<hsize_t> &, std::vector<hsize_t> &);
 
     bool m_WriteMode = false;
-    unsigned int m_NumAdiosSteps = 0;
+    //unsigned int m_NumAdiosSteps = 0;
+    size_t m_NumAdiosSteps = 0;
 
     MPI_API const *m_MPI = nullptr;
     int m_CommRank = 0;
@@ -258,6 +261,7 @@ private:
     template <class T>
     void AddStats(const core::Variable<T> &variable, hid_t parentId, std::vector<T> &stats);
 
+    hid_t m_TimeStepH5T = H5T_NATIVE_ULLONG;;
     hid_t m_ChunkPID;
     int m_ChunkDim;
     std::set<std::string> m_ChunkVarNames;

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -172,7 +172,7 @@ public:
 
     void ReadNativeAttrToIO(core::IO &io, hid_t datasetId, std::string const &pathFromRoot);
 
-    //void SetAdiosStep(int ts);
+    // void SetAdiosStep(int ts);
     void SetAdiosStep(size_t ts);
 
     size_t GetNumAdiosSteps();
@@ -213,7 +213,7 @@ public:
     hid_t m_DefH5TypeComplexFloat;
     hid_t m_DefH5TypeBlockStat;
 
-    //unsigned int m_CurrentAdiosStep = 0;
+    // unsigned int m_CurrentAdiosStep = 0;
     size_t m_CurrentAdiosStep = 0;
 
     void CheckWriteGroup();
@@ -249,7 +249,7 @@ private:
                           std::vector<hsize_t> &, std::vector<hsize_t> &);
 
     bool m_WriteMode = false;
-    //unsigned int m_NumAdiosSteps = 0;
+    // unsigned int m_NumAdiosSteps = 0;
     size_t m_NumAdiosSteps = 0;
 
     MPI_API const *m_MPI = nullptr;
@@ -261,7 +261,8 @@ private:
     template <class T>
     void AddStats(const core::Variable<T> &variable, hid_t parentId, std::vector<T> &stats);
 
-    hid_t m_TimeStepH5T = H5T_NATIVE_ULLONG;;
+    hid_t m_TimeStepH5T = H5T_NATIVE_ULLONG;
+    ;
     hid_t m_ChunkPID;
     int m_ChunkDim;
     std::set<std::string> m_ChunkVarNames;

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -172,30 +172,28 @@ public:
 
     void ReadNativeAttrToIO(core::IO &io, hid_t datasetId, std::string const &pathFromRoot);
 
-    // void SetAdiosStep(int ts);
     void SetAdiosStep(size_t ts);
 
     size_t GetNumAdiosSteps();
     size_t GetAdiosStep() const;
     void WriteAdiosSteps();
 
-    void ReadVariables(unsigned int ts, core::IO &io);
-    void FindVarsFromH5(core::IO &io, hid_t gid, const char *name, const char *heritage,
-                        unsigned int ts);
+    void ReadVariables(size_t ts, core::IO &io);
+    void FindVarsFromH5(core::IO &io, hid_t gid, const char *name, const char *heritage, size_t ts);
     void ReadAllVariables(core::IO &io);
 
     void ReadStringScalarDataset(hid_t dataSetId, std::string &result);
     hid_t GetTypeStringScalar(const std::string &input);
-    void CreateVar(core::IO &io, hid_t h5Type, std::string const &name, unsigned int ts);
+    void CreateVar(core::IO &io, hid_t h5Type, std::string const &name, size_t ts);
 
     template <class T>
-    void AddVar(core::IO &io, std::string const &name, hid_t datasetId, unsigned int ts);
+    void AddVar(core::IO &io, std::string const &name, hid_t datasetId, size_t ts);
 
     // adios only allows a scalar string var
-    void AddSingleString(core::IO &io, std::string const &name, hid_t datasetId, unsigned int ts);
+    void AddSingleString(core::IO &io, std::string const &name, hid_t datasetId, size_t ts);
 
     // decompose array string vars
-    void AddVarString(core::IO &io, std::string const &name, hid_t datasetId, unsigned int ts);
+    void AddVarString(core::IO &io, std::string const &name, hid_t datasetId, size_t ts);
 
     template <class T>
     void AddNonStringAttribute(core::IO &io, std::string const &attrName, hid_t attrId,
@@ -213,7 +211,6 @@ public:
     hid_t m_DefH5TypeComplexFloat;
     hid_t m_DefH5TypeBlockStat;
 
-    // unsigned int m_CurrentAdiosStep = 0;
     size_t m_CurrentAdiosStep = 0;
 
     void CheckWriteGroup();
@@ -249,7 +246,7 @@ private:
                           std::vector<hsize_t> &, std::vector<hsize_t> &);
 
     bool m_WriteMode = false;
-    // unsigned int m_NumAdiosSteps = 0;
+
     size_t m_NumAdiosSteps = 0;
 
     MPI_API const *m_MPI = nullptr;


### PR DESCRIPTION
…eBase class)

when storing to hdf5, check the limit of size_t and match to the right type (uint, ulong, default ulonglong)