### PR TITLE
Backport readthedocs fixes

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,17 +2,16 @@ name: adios2-python-docs
 
 channels:
   - conda-forge
-  - williamfgc
 
 dependencies:
-  - adios2-openmpi
-  - breathe==4.33.0
+  - breathe==4.35.0
+  - cmake
   - docutils==0.17
-  - python
-  - sphinx=4
-#  - funcparserlib>=0.3.6
+  - libpython-static
+  - numpy
   - pip
+  - sphinx=5.3
   - pip:
     - blockdiag==3.0.0
     - sphinxcontrib-blockdiag==3.0.0
-    - sphinx_rtd_theme==1.0.0
+    - sphinx_rtd_theme==1.1.1

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,9 +1,18 @@
 # .readthedocs.yml
 version: 2
 
-conda: 
+conda:
   environment: docs/environment.yml
-    
-python:
-   version: 3.7
-   system_packages: true
+
+build:
+    os: "ubuntu-22.04"
+    tools:
+        python: "miniconda3-4.7"
+    jobs:
+        pre_install:
+            - cmake -B build -S . -DADIOS2_USE_PYTHON=ON -DBUILD_TESTING=OFF -DADIOS2_BUILD_EXAMPLES=OFF
+            - cmake --build build
+            - cmake --install build --prefix "$HOME/.local"
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
Readthedocs is deprecating features that we still use in the release branch.

@eisenhauer 

X-ref: #3782 
