### PR TITLE
Add MinBlocksInfo to BP5 writer engine

### DIFF
--- a/source/adios2/common/ADIOSTypes.cpp
+++ b/source/adios2/common/ADIOSTypes.cpp
@@ -390,4 +390,54 @@ int TypeElementSize(DataType adiosvartype)
     }
 }
 
+static void PrintMBI(std::ostream &os, const MinBlockInfo &blk, int Dims)
+{
+    os << "Writer: " << blk.WriterID << ", Blk: " << blk.BlockID << ", Start: {";
+    if ((Dims == 0) || (blk.Start == NULL))
+        os << "NULL";
+    else
+    {
+        for (int i = 0; i < Dims; i++)
+        {
+            os << blk.Start[i];
+            if (i < Dims - 1)
+                os << ", ";
+        }
+    }
+    os << "}, Count: {";
+
+    if ((Dims == 0) || (blk.Count == NULL))
+        os << "NULL";
+    else
+    {
+        for (int i = 0; i < Dims; i++)
+        {
+            os << blk.Count[i];
+            if (i < Dims - 1)
+                os << ", ";
+        }
+    }
+    os << "}, Data: " << (void *)blk.BufferP << std::endl;
+}
+
+void PrintMVI(std::ostream &os, const MinVarInfo &mvi)
+{
+    os << "Step: " << mvi.Step << "  Dims: " << mvi.Dims << " Shape: {";
+    if ((mvi.Dims == 0) || (mvi.Shape == NULL))
+        os << "NULL";
+    else
+    {
+        for (int i = 0; i < mvi.Dims; i++)
+        {
+            os << mvi.Shape[i];
+            if (i < mvi.Dims - 1)
+                os << ", ";
+        }
+    }
+    os << "}, BlockCount: " << mvi.BlocksInfo.size() << " ";
+    for (const auto &blk : mvi.BlocksInfo)
+        PrintMBI(os, blk, mvi.Dims);
+    os << std::endl;
+}
+
 } // end namespace adios2

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -214,6 +214,7 @@ struct MinBlockInfo
     MinMaxStruct MinMax;
     void *BufferP = NULL;
 };
+
 struct MinVarInfo
 {
     size_t Step;
@@ -228,6 +229,8 @@ struct MinVarInfo
     {
     }
 };
+
+void PrintMVI(std::ostream &os, const MinVarInfo &mvi);
 
 // adios defaults
 #ifdef _WIN32

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -509,7 +509,7 @@ void BP5Writer::EndStep()
     for (const auto &varPair : vars)
     {
         auto baseVar = varPair.second.get();
-        auto mvi = MinBlocksInfo(*baseVar);
+        auto mvi = WriterMinBlocksInfo(*baseVar);
         if (mvi)
         {
             std::cout << "Info for Variable " << varPair.first << std::endl;
@@ -686,7 +686,7 @@ void BP5Writer::Init()
     InitBPBuffer();
 }
 
-MinVarInfo *BP5Writer::MinBlocksInfo(const core::VariableBase &Var)
+MinVarInfo *BP5Writer::WriterMinBlocksInfo(const core::VariableBase &Var)
 {
     return m_BP5Serializer.MinBlocksInfo(Var);
 }

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -497,14 +497,32 @@ void BP5Writer::MarshalAttributes()
 
 void BP5Writer::EndStep()
 {
-    /* Seconds ts = Now() - m_EngineStart;
-      std::cout << "END STEP starts at: " << ts.count() << std::endl; */
     m_BetweenStepPairs = false;
     PERFSTUBS_SCOPED_TIMER("BP5Writer::EndStep");
     m_Profiler.Start("ES");
 
     m_Profiler.Start("ES_close");
     MarshalAttributes();
+
+#ifdef NOT_DEF
+    const auto &vars = m_IO.GetVariables();
+    for (const auto &varPair : vars)
+    {
+        auto baseVar = varPair.second.get();
+        auto mvi = MinBlocksInfo(*baseVar);
+        if (mvi)
+        {
+            std::cout << "Info for Variable " << varPair.first << std::endl;
+            PrintMVI(std::cout, *mvi);
+            if (baseVar->m_Type == DataType::Double)
+                std::cout << "Double value is " << *((double *)mvi->BlocksInfo[0].BufferP)
+                          << std::endl;
+            delete mvi;
+        }
+        else
+            std::cout << "Variable " << varPair.first << " not written on this step" << std::endl;
+    }
+#endif
 
     // true: advances step
     auto TSInfo = m_BP5Serializer.CloseTimestep((int)m_WriterStep,
@@ -666,6 +684,11 @@ void BP5Writer::Init()
     InitAggregator();
     InitTransports();
     InitBPBuffer();
+}
+
+MinVarInfo *BP5Writer::MinBlocksInfo(const core::VariableBase &Var)
+{
+    return m_BP5Serializer.MinBlocksInfo(Var);
 }
 
 void BP5Writer::InitParameters()

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -115,7 +115,7 @@ private:
      */
     void NotifyEngineAttribute(std::string name, AttributeBase *Attr, void *data) noexcept;
 
-    MinVarInfo *MinBlocksInfo(const VariableBase &);
+    MinVarInfo *WriterMinBlocksInfo(const VariableBase &);
 
     void EnterComputationBlock() noexcept;
     /** Inform about computation block through User->ADIOS->IO */

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -115,6 +115,8 @@ private:
      */
     void NotifyEngineAttribute(std::string name, AttributeBase *Attr, void *data) noexcept;
 
+    MinVarInfo *MinBlocksInfo(const VariableBase &);
+
     void EnterComputationBlock() noexcept;
     /** Inform about computation block through User->ADIOS->IO */
     void ExitComputationBlock() noexcept;

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.h
@@ -127,6 +127,8 @@ public:
 
     size_t DebugGetDataBufferSize() const;
 
+    MinVarInfo *MinBlocksInfo(const core::VariableBase &Var);
+
     int m_StatsLevel = 1;
 
     /* Variables to help appending to existing file */
@@ -204,7 +206,7 @@ private:
 
     size_t m_PriorDataBufferSizeTotal = 0;
 
-    BP5WriterRec LookupWriterRec(void *Key);
+    BP5WriterRec LookupWriterRec(void *Key) const;
     BP5WriterRec CreateWriterRec(void *Variable, const char *Name, DataType Type, size_t ElemSize,
                                  size_t DimCount);
     void ValidateWriterRec(BP5WriterRec Rec, void *Variable);

--- a/source/adios2/toolkit/format/buffer/BufferV.h
+++ b/source/adios2/toolkit/format/buffer/BufferV.h
@@ -63,6 +63,8 @@ public:
 
     virtual void *GetPtr(int bufferIdx, size_t posInBuffer) = 0;
 
+    virtual void *GetPtr(size_t overallPosInVector) = 0;
+
 protected:
     std::vector<char> zero;
     const bool m_AlwaysCopy = false;

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
@@ -255,6 +255,30 @@ void *ChunkV::GetPtr(int bufferIdx, size_t posInBuffer)
     }
 }
 
+void *ChunkV::GetPtr(size_t OverallPosInBuffer)
+{
+    int bufferIdx = 0;
+    if (DataV.size() == 0)
+        return nullptr;
+    while (DataV[bufferIdx].Size <= OverallPosInBuffer)
+    {
+        OverallPosInBuffer -= DataV[bufferIdx].Size;
+        bufferIdx++;
+        if (static_cast<size_t>(bufferIdx) > DataV.size())
+        {
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "format::ChunkV", "GetPtr",
+                "ChunkV::GetPtr(" + std::to_string(OverallPosInBuffer) +
+                    ") refers to a non-existing or deferred memory chunk.");
+            return nullptr;
+        }
+    }
+    if (DataV[bufferIdx].External)
+        return ((char *)DataV[bufferIdx].External) + OverallPosInBuffer;
+
+    return (void *)((char *)DataV[bufferIdx].Base + OverallPosInBuffer);
+}
+
 std::vector<core::iovec> ChunkV::DataVec() noexcept
 {
     std::vector<core::iovec> iov(DataV.size());

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
@@ -38,6 +38,7 @@ public:
     virtual void DownsizeLastAlloc(const size_t oldSize, const size_t newSize);
 
     virtual void *GetPtr(int bufferIdx, size_t posInBuffer);
+    virtual void *GetPtr(size_t OverallPosInBuffer);
 
     void CopyDataToBuffer(const size_t size, const void *buf, size_t pos, MemorySpace MemSpace);
 

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
@@ -157,6 +157,8 @@ void *MallocV::GetPtr(int bufferIdx, size_t posInBuffer)
     }
 }
 
+void *MallocV::GetPtr(size_t posInBuffer) { return m_InternalBlock + posInBuffer; }
+
 std::vector<core::iovec> MallocV::DataVec() noexcept
 {
     std::vector<core::iovec> iov(DataV.size());

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.h
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.h
@@ -42,6 +42,7 @@ public:
     void DownsizeLastAlloc(const size_t oldSize, const size_t newSize);
 
     virtual void *GetPtr(int bufferIdx, size_t posInBuffer);
+    virtual void *GetPtr(size_t posInBuffer);
 
 private:
     char *m_InternalBlock = NULL;


### PR DESCRIPTION
This PR is in support of the Derived Variables work and includes example usage in an inactive #ifdef in the BP5 writer engine.  While it seems to be functional, the functions here won't be used until derived variable implementation is complete (or we introduce unit testing of some kind for this).  