### PR TITLE
yaml-cpp: support 0.8.0 version

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -71,11 +71,19 @@ add_subdirectory(nlohmann_json)
 adios2_add_thirdparty_target(nlohmann_json nlohmann_json_wrapper)
 
 if(ADIOS2_USE_EXTERNAL_YAMLCPP)
-  find_package(yaml-cpp REQUIRED)
+  find_package(yaml-cpp 0.7.0 REQUIRED)
 else()
   add_subdirectory(yaml-cpp)
 endif()
+
 adios2_add_thirdparty_target(yaml-cpp yaml-cpp)
+
+# YAML-cpp does not add the incdir/libdir to its target rather it exposes it
+# through the cmake variables YAML_CPP_INCLUDE_DIR and YAML_CPP_LIBRARY_DIR
+if(yaml-cpp_VERSION VERSION_GREATER_EQUAL 0.8)
+  target_include_directories(adios2::thirdparty::yaml-cpp INTERFACE ${YAML_CPP_INCLUDE_DIR})
+  target_link_directories(adios2::thirdparty::yaml-cpp INTERFACE ${YAML_CPP_LIBRARY_DIR})
+endif()
 
 if(WIN32)
   add_subdirectory(mingw-w64)


### PR DESCRIPTION
fixes: #3762

In this PR we add support to the new YAML-cpp version 0.8.0. We currently ship and support YAML-cpp 0.7.X. Before the 0.7, YAML-cpp was not a cmake project thus our minimum supported versions  0.7.X.

Some context: 

- I have tried building adios2 with 0.5.X(fail) 0.6.X(Fail) 0.7.X 0.8.X(Works with this change).