### PR TITLE
Automatize close issues

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,26 @@
+#######################################
+# Repo Maintance tasks
+#######################################
+name: Close inactive issues
+on:
+  schedule:
+  - cron: 00 2 * * *
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - uses: actions/stale@v5
+      with:
+        days-before-issue-stale: 182
+        days-before-issue-close: 365
+        exempt-issue-labels: [ 'evergreen' ]
+        stale-issue-label: stale
+        stale-issue-message: This issue is stale because it has been open for 182 days
+          with no activity.
+        close-issue-message: This issue was closed because it has been inactive for
+          365 days since being marked as stale.
+        days-before-pr-stale: -1
+        days-before-pr-close: -1
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automatically close issues that has been inactive for over a year.

https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues

https://github.com/marketplace/actions/close-stale-issues