### PR TITLE
Fix the `ADIOS_USE_{}` variable names to use ADIOS2

### DIFF
--- a/cmake/ADIOSFunctions.cmake
+++ b/cmake/ADIOSFunctions.cmake
@@ -97,7 +97,7 @@ function(GenerateADIOSHeaderConfig)
   foreach(OPT IN LISTS ARGN)
     string(TOUPPER ${OPT} OPT_UPPER)
     string(APPEND ADIOS2_CONFIG_DEFINES "
-/* CMake Option: ADIOS_USE_${OPT}=OFF */
+/* CMake Option: ADIOS2_USE_${OPT}=OFF */
 #cmakedefine ADIOS2_HAVE_${OPT_UPPER}
 ")
     if(ADIOS2_HAVE_${OPT})

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -193,8 +193,8 @@ endif()
 
 set(mpi_find_components C)
 
-if(ADIOS_USE_Kokkos AND ADIOS_USE_CUDA)
-  message(FATAL_ERROR "ADIOS2_USE_Kokkos is incompatible with ADIOS_USE_CUDA")
+if(ADIOS2_USE_Kokkos AND ADIOS2_USE_CUDA)
+  message(FATAL_ERROR "ADIOS2_USE_Kokkos is incompatible with ADIOS2_USE_CUDA")
 endif()
 
 # Kokkos
@@ -239,7 +239,7 @@ if(ADIOS2_USE_CUDA)
   endif()
 endif()
 
-if(ADIOS_HAVE_Kokkos AND ADIOS_HAVE_CUDA)
+if(ADIOS2_HAVE_Kokkos AND ADIOS2_HAVE_CUDA)
     message(FATAL_ERROR "The Kokkos and CUDA backends cannot be active concurrently")
 endif()
 

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -8,11 +8,11 @@ Provides tests and illustrates how to use very basic functionality in adios2
 1. bpTimeWriter
     * Write BP format files for two Variables (one is timestep) using time aggregation   
     
-1. datamanReader (to be deprecated, ADIOS_USE_DataMan=ON)
+1. datamanReader (to be deprecated, ADIOS2_USE_DataMan=ON)
     * Read real-time WAN streams using dataman 
     
 1. datamanWriter  
     * Write real-time WAN streams using dataman    
     
-1. hdf5Writer (-DADIOS_USE_HDF5=ON)  
+1. hdf5Writer (-DADIOS2_USE_HDF5=ON)  
     * Write HDF5 files using interoperability through the adios2 interface    


### PR DESCRIPTION
Randomly found this bug when testing the query code.