### PR TITLE
WIP: ci: Improve performance of mpich tests in CI

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -108,7 +108,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-${{ matrix.compiler }}
+      image: ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-${{ matrix.compiler }}
       options: --shm-size=1g
       env:
         GH_YML_JOBNAME: ${{ matrix.os }}-${{ matrix.compiler }}${{ matrix.shared == 'static' && '-static' || ''}}-${{ matrix.parallel }}

--- a/scripts/ci/images/Dockerfile.ci-spack-ubuntu20.04-base
+++ b/scripts/ci/images/Dockerfile.ci-spack-ubuntu20.04-base
@@ -11,6 +11,14 @@ RUN . /spack/share/spack/setup-env.sh && \
     spack config add "config:checksum:false" && \
     spack config add "config:build_jobs:$(nproc)" && \
     spack config add "concretizer:unify:false" && \
+    spack env create adios2-ci-mpich && \
+    spack -e adios2-ci-mpich add ${ADIOS_SPEC_MPICH} && \
+    spack -e adios2-ci-mpich concretize && \
+    spack -e adios2-ci-mpich install \
+      --include-build-deps \
+      --no-check-signature \
+      --fail-fast \
+      --only dependencies && \
     spack env create adios2-ci-serial && \
     spack -e adios2-ci-serial add ${ADIOS_SPEC_NO_MPI} && \
     spack -e adios2-ci-serial concretize && \
@@ -23,14 +31,6 @@ RUN . /spack/share/spack/setup-env.sh && \
     spack -e adios2-ci-ompi add ${ADIOS_SPEC_OPENMPI} && \
     spack -e adios2-ci-ompi concretize && \
     spack -e adios2-ci-ompi install \
-      --include-build-deps \
-      --no-check-signature \
-      --fail-fast \
-      --only dependencies && \
-    spack env create adios2-ci-mpich && \
-    spack -e adios2-ci-mpich add ${ADIOS_SPEC_MPICH} && \
-    spack -e adios2-ci-mpich concretize && \
-    spack -e adios2-ci-mpich install \
       --include-build-deps \
       --no-check-signature \
       --fail-fast \

--- a/scripts/ci/images/build-ubuntu.sh
+++ b/scripts/ci/images/build-ubuntu.sh
@@ -3,25 +3,25 @@
 set -ex
 
 # Build the base image
-docker build --rm -f ./Dockerfile.ci-spack-ubuntu20.04-base -t ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-base .
+docker build --rm -f ./Dockerfile.ci-spack-ubuntu20.04-base -t ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-base .
 
 # Which is also the gcc11 image
-docker tag ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-base ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-gcc11
+docker tag ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-base ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-gcc11
 
 # Build the gcc8, gcc9, and gcc10 images
-docker build --rm --build-arg GCC_VERSION=8 -f ./Dockerfile.ci-spack-ubuntu20.04-gcc -t ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-gcc8 .
-docker build --rm --build-arg GCC_VERSION=9 -f ./Dockerfile.ci-spack-ubuntu20.04-gcc -t ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-gcc9 .
-docker build --rm --build-arg GCC_VERSION=10 -f ./Dockerfile.ci-spack-ubuntu20.04-gcc -t ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-gcc10 .
+docker build --rm --build-arg GCC_VERSION=8 -f ./Dockerfile.ci-spack-ubuntu20.04-gcc -t ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-gcc8 .
+docker build --rm --build-arg GCC_VERSION=9 -f ./Dockerfile.ci-spack-ubuntu20.04-gcc -t ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-gcc9 .
+docker build --rm --build-arg GCC_VERSION=10 -f ./Dockerfile.ci-spack-ubuntu20.04-gcc -t ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-gcc10 .
 
 # Build the clang6 and clang10 images
-docker build --rm --build-arg CLANG_VERSION=6.0 -f ./Dockerfile.ci-spack-ubuntu20.04-clang -t ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-clang6 .
-docker build --rm --build-arg CLANG_VERSION=10 -f ./Dockerfile.ci-spack-ubuntu20.04-clang -t ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-clang10 .
+docker build --rm --build-arg CLANG_VERSION=6.0 -f ./Dockerfile.ci-spack-ubuntu20.04-clang -t ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-clang6 .
+docker build --rm --build-arg CLANG_VERSION=10 -f ./Dockerfile.ci-spack-ubuntu20.04-clang -t ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-clang10 .
 
 # Push images to github container registry
-docker push ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-base
-docker push ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-gcc8
-docker push ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-gcc9
-docker push ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-gcc10
-docker push ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-gcc11
-docker push ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-clang6
-docker push ghcr.io/ornladios/adios2:ci-spack-ubuntu20.04-clang10
+docker push ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-base
+docker push ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-gcc8
+docker push ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-gcc9
+docker push ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-gcc10
+docker push ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-gcc11
+docker push ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-clang6
+docker push ghcr.io/scottwittenburg/adios2:ci-spack-ubuntu20.04-clang10

--- a/scripts/ci/images/packages.yaml
+++ b/scripts/ci/images/packages.yaml
@@ -3,7 +3,5 @@ packages:
     target: [haswell]
   adios2:
     require: '+blosc+bzip2+zfp+sz+png+sst+dataman+ssc+hdf5+python+fortran'
-  mpich:
-    require: 'device=ch3 netmod=tcp'
   openmpi:
     require: '@4.1'


### PR DESCRIPTION
Use the version of mpich built into the ecpe4s/ubuntu20.04:23.05 image instead of building a new one.  This replaces an mpich that used ch3/tcp with one that uses ch4/ofi.