### PR TITLE
Fix usage of DESTDIR for absolute paths

### DIFF
--- a/cmake/install/post/generate-adios2-config.sh.in
+++ b/cmake/install/post/generate-adios2-config.sh.in
@@ -66,7 +66,8 @@ then
   PREFIX="${DESTDIR:-$(pwd)}/$1"
 else
   # check if the PREFIX directory exists and prepend DESTDIR if not
-  if [ ! -d ${PREFIX} ]; then
+  if [ ! -d "${PREFIX}" ]
+  then
     PREFIX="${DESTDIR}$1"
   fi
 fi

--- a/cmake/install/post/generate-adios2-config.sh.in
+++ b/cmake/install/post/generate-adios2-config.sh.in
@@ -64,6 +64,11 @@ if [ "${1:0:1}" != "/" ]
 then
   # Convert relative paths to absolute based on DESTDIR
   PREFIX="${DESTDIR:-$(pwd)}/$1"
+else
+  # check if the PREFIX directory exists and prepend DESTDIR if not
+  if [ ! -d ${PREFIX} ]; then
+    PREFIX="${DESTDIR}$1"
+  fi
 fi
 
 shift


### PR DESCRIPTION
A possible solution to issue !3837.

In the `generate-adios2-config.sh` file, I added a code path in the case that the `CMAKE_INSTALL_PREFIX` is an absolute path but does not exist.  In this case the `DESTDIR` is prepended.