### PR TITLE
Update examples

### DIFF
--- a/examples/basics/globalArrayND/globalArrayNDWrite.cpp
+++ b/examples/basics/globalArrayND/globalArrayNDWrite.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
         // Get io settings from the config file or
         // create one with default settings here
         adios2::IO io = adios.DeclareIO("Output");
-        io.SetEngine("BP5");
+        io.SetEngine("BPFile");
         io.SetParameter("AggregationType", "TwoLevelShm");
         io.SetParameter("AggregatorRatio", "4");
 

--- a/examples/basics/joinedArray/joinedArrayWrite.cpp
+++ b/examples/basics/joinedArray/joinedArrayWrite.cpp
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
         // Get io settings from the config file or
         // create one with default settings here
         adios2::IO io = adios.DeclareIO("Output");
-        io.SetEngine("BP4");
+        io.SetEngine("BPFile");
 
         /*
          * Define joinable local array: type, name, global and local size

--- a/examples/basics/localArray/localArrayWrite.cpp
+++ b/examples/basics/localArray/localArrayWrite.cpp
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
         // Get io settings from the config file or
         // create one with default settings here
         adios2::IO io = adios.DeclareIO("Output");
-        io.SetEngine("BP5");
+        io.SetEngine("BPFile");
         io.SetParameters({{"verbose", "4"}});
 
         /*

--- a/examples/basics/values/valuesWrite.cpp
+++ b/examples/basics/values/valuesWrite.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
         // Get io settings from the config file or
         // create one with default settings here
         adios2::IO io = adios.DeclareIO("Output");
-        io.SetEngine("BP5");
+        io.SetEngine("BPFile");
         io.SetParameters({{"verbose", "4"}});
         /*
          * Define variables

--- a/examples/hello/bpAttributeWriter/bpAttributeWriter.cpp
+++ b/examples/hello/bpAttributeWriter/bpAttributeWriter.cpp
@@ -58,8 +58,12 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpWriter = bpIO.Open("fileAttributes.bp", adios2::Mode::Write);
 
+        bpWriter.BeginStep();
+
         /** Write variable for buffering */
         bpWriter.Put<float>(bpFloats, myFloats.data());
+
+        bpWriter.EndStep();
 
         /** Create bp file, engine becomes unreachable after this*/
         bpWriter.Close();
@@ -68,6 +72,7 @@ int main(int argc, char *argv[])
 
         adios2::Engine bpReaderEngine = bpReader.Open("fileAttributes.bp", adios2::Mode::Read);
 
+        bpReaderEngine.BeginStep();
         const auto attributesInfo = bpReader.AvailableAttributes();
 
         for (const auto &attributeInfoPair : attributesInfo)
@@ -80,6 +85,7 @@ int main(int argc, char *argv[])
             }
             std::cout << "\n";
         }
+        bpReaderEngine.EndStep();
 
         bpReaderEngine.Close();
     }

--- a/examples/hello/bpAttributeWriter/bpAttributeWriter_nompi.cpp
+++ b/examples/hello/bpAttributeWriter/bpAttributeWriter_nompi.cpp
@@ -48,8 +48,12 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpWriter = bpIO.Open("myVector.bp", adios2::Mode::Write);
 
+        bpWriter.BeginStep();
+
         /** Write variable for buffering */
         bpWriter.Put<float>(bpFloats, myFloats.data());
+
+        bpWriter.EndStep();
 
         /** Create bp file, engine becomes unreachable after this*/
         bpWriter.Close();

--- a/examples/hello/bpFWriteCRead/CppReader.cpp
+++ b/examples/hello/bpFWriteCRead/CppReader.cpp
@@ -35,6 +35,8 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpReader = bpIO.Open("FWriter.bp", adios2::Mode::Read);
 
+        bpReader.BeginStep();
+
         const std::map<std::string, adios2::Params> variables = bpIO.AvailableVariables();
 
         for (const auto &variablePair : variables)
@@ -52,6 +54,9 @@ int main(int argc, char *argv[])
         std::vector<float> data(bpData.SelectionSize());
 
         bpReader.Get(bpData, data.data());
+
+        bpReader.EndStep();
+
         bpReader.Close();
 
         std::cout << "Selection size: " << bpData.SelectionSize() << "\n";

--- a/examples/hello/bpFWriteCRead/CppWriter.cpp
+++ b/examples/hello/bpFWriteCRead/CppWriter.cpp
@@ -42,7 +42,9 @@ int main(int argc, char *argv[])
         "data2D", {size * nx, ny}, {rank * nx, 0}, {nx, ny}, adios2::ConstantDims);
 
     adios2::Engine engine = io.Open("CppWriter.bp", adios2::Mode::Write);
+    engine.BeginStep();
     engine.Put(bpFloats, data.data());
+    engine.EndStep();
     engine.Close();
 
     MPI_Finalize();

--- a/examples/hello/bpFlushWriter/bpFlushWriter.cpp
+++ b/examples/hello/bpFlushWriter/bpFlushWriter.cpp
@@ -55,6 +55,7 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpWriter = bpIO.Open("myVectorFlush.bp", adios2::Mode::Write);
 
+        bpWriter.BeginStep();
         for (unsigned int t = 0; t < 100; ++t)
         {
             /** values to time step */
@@ -62,6 +63,7 @@ int main(int argc, char *argv[])
             /** Write variable for buffering */
             bpWriter.Put<float>(bpFloats, myFloats.data());
         }
+        bpWriter.EndStep();
 
         /** Create bp file, engine becomes unreachable after this*/
         bpWriter.Close();

--- a/examples/hello/bpFlushWriter/bpFlushWriter_nompi.cpp
+++ b/examples/hello/bpFlushWriter/bpFlushWriter_nompi.cpp
@@ -38,8 +38,12 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpWriter = bpIO.Open("myVector.bp", adios2::Mode::Write);
 
+        bpWriter.BeginStep();
+
         /** Write variable for buffering */
         bpWriter.Put<float>(bpFloats, myFloats.data());
+
+        bpWriter.EndStep();
 
         /** Create bp file, engine becomes unreachable after this*/
         bpWriter.Close();

--- a/examples/hello/bpReader/bpReader.cpp
+++ b/examples/hello/bpReader/bpReader.cpp
@@ -41,6 +41,7 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpReader = bpIO.Open(filename, adios2::Mode::Read);
 
+        bpReader.BeginStep();
         const std::map<std::string, adios2::Params> variables = bpIO.AvailableVariables();
 
         for (const auto &variablePair : variables)
@@ -96,6 +97,7 @@ int main(int argc, char *argv[])
                 std::cout << "\n";
             }
         }
+        bpReader.EndStep();
 
         /** Close bp file, engine becomes unreachable after this*/
         bpReader.Close();

--- a/examples/hello/bpReader/bpReaderHeatMap2D.cpp
+++ b/examples/hello/bpReader/bpReaderHeatMap2D.cpp
@@ -75,7 +75,9 @@ int main(int argc, char *argv[])
         /** Will create HeatMap.bp */
         adios2::Engine bpWriter = putHeatMap.Open("HeatMap2D.bp", adios2::Mode::Write);
 
+        bpWriter.BeginStep();
         bpWriter.Put(outTemperature, temperatures.data());
+        bpWriter.EndStep();
         bpWriter.Close();
 
         // ************************** READ
@@ -85,6 +87,7 @@ int main(int argc, char *argv[])
             adios2::Engine bpReader =
                 getHeatMap.Open("HeatMap2D.bp", adios2::Mode::Read, MPI_COMM_SELF);
 
+            bpReader.BeginStep();
             // this just discovers in the metadata file that the variable exists
             adios2::Variable<unsigned int> inTemperature =
                 getHeatMap.InquireVariable<unsigned int>("temperature");
@@ -111,6 +114,7 @@ int main(int argc, char *argv[])
                 }
                 std::cout << "\n";
             }
+            bpReader.EndStep();
 
             bpReader.Close();
         }

--- a/examples/hello/bpReader/bpReaderHeatMap2D.py
+++ b/examples/hello/bpReader/bpReaderHeatMap2D.py
@@ -46,7 +46,9 @@ varTemperature = ioWrite.DefineVariable(
 )
 
 obpStream = ioWrite.Open("HeatMap2D_py.bp", adios2.Mode.Write)
+obpStream.BeginStep()
 obpStream.Put(varTemperature, temperatures)
+obpStream.EndStep()
 obpStream.Close()
 
 
@@ -54,6 +56,8 @@ if rank == 0:
     ioRead = adios.DeclareIO("ioReader")
 
     ibpStream = ioRead.Open("HeatMap2D_py.bp", adios2.Mode.Read, MPI.COMM_SELF)
+
+    ibpStream.BeginStep()
 
     var_inTemperature = ioRead.InquireVariable("temperature2D")
 
@@ -74,4 +78,5 @@ if rank == 0:
             if (i + 1) % 4 == 0:
                 print()
 
+    ibpStream.EndStep()
     ibpStream.Close()

--- a/examples/hello/bpReader/bpReaderHeatMap3D.cpp
+++ b/examples/hello/bpReader/bpReaderHeatMap3D.cpp
@@ -87,7 +87,9 @@ int main(int argc, char *argv[])
         /** Will create HeatMap3D.bp */
         adios2::Engine bpWriter = putHeatMap.Open("HeatMap3D.bp", adios2::Mode::Write);
 
+        bpWriter.BeginStep();
         bpWriter.Put(outTemperature, temperatures.data());
+        bpWriter.EndStep();
         bpWriter.Close();
 
         // ************************** READ
@@ -97,6 +99,7 @@ int main(int argc, char *argv[])
             adios2::Engine bpReader =
                 getHeatMap.Open("HeatMap3D.bp", adios2::Mode::Read, MPI_COMM_SELF);
 
+            bpReader.BeginStep();
             // this just discovers in the metadata file that the variable exists
             adios2::Variable<unsigned int> inTemperature =
                 getHeatMap.InquireVariable<unsigned int>("temperature");
@@ -124,6 +127,7 @@ int main(int argc, char *argv[])
                 }
                 std::cout << "\n";
             }
+            bpReader.EndStep();
 
             bpReader.Close();
         }

--- a/examples/hello/bpReader/bpReader_nompi.cpp
+++ b/examples/hello/bpReader/bpReader_nompi.cpp
@@ -31,6 +31,7 @@ int main(int argc, char *argv[])
 
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpReader = bpIO.Open(filename, adios2::Mode::Read);
+        bpReader.BeginStep();
 
         const std::map<std::string, adios2::Params> variables = bpIO.AvailableVariables(true);
 
@@ -67,6 +68,7 @@ int main(int argc, char *argv[])
         {
             std::cout << "There are no integer datasets in " << filename << ".\n";
         }
+        bpReader.EndStep();
 
         /** Close bp file, engine becomes unreachable after this*/
         bpReader.Close();

--- a/examples/hello/bpThreadWrite/bpThreadWrite.cpp
+++ b/examples/hello/bpThreadWrite/bpThreadWrite.cpp
@@ -92,6 +92,7 @@ int main(int argc, char *argv[])
         // elements for last thread, add remainder
         const std::size_t last = stride + nx % nthreads;
 
+        engine.BeginStep();
         // launch threads
         for (std::size_t t = 0; t < nthreads; ++t)
         {
@@ -110,6 +111,7 @@ int main(int argc, char *argv[])
         {
             threadTask.join();
         }
+        engine.EndStep();
 
         engine.Close();
     }

--- a/examples/hello/bpWriteReadCuda/bpWriteReadCuda.cu
+++ b/examples/hello/bpWriteReadCuda/bpWriteReadCuda.cu
@@ -18,7 +18,7 @@
 
 __global__ void update_array(float *vect, int val) { vect[blockIdx.x] += val; }
 
-std::string engine("BP5");
+std::string engine("BPFile");
 
 int BPWrite(const std::string fname, const size_t N, int nSteps, const std::string engine)
 {

--- a/examples/hello/bpWriteReadHip/CMakeLists.txt
+++ b/examples/hello/bpWriteReadHip/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 if(ADIOS2_HAVE_Kokkos_HIP OR hip_FOUND)
   add_executable(adios2_hello_bpWriteReadHip bpWriteReadHip.cpp)
-  target_link_libraries(adios2_hello_bpWriteReadHip adios2::cxx11 hip::runtime)
+  target_link_libraries(adios2_hello_bpWriteReadHip adios2::cxx11 hip::device)
   set_target_properties(adios2_hello_bpWriteReadHip PROPERTIES LANGUAGE "HIP")
   install(TARGETS adios2_hello_bpWriteReadHip RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/examples/hello/bpWriteReadHip/bpWriteReadHip.cpp
+++ b/examples/hello/bpWriteReadHip/bpWriteReadHip.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
         std::cout << "[BPWrite] error: " << hipGetErrorString(hipExit) << std::endl;
         return 1;
     }
-    const std::vector<std::string> list_of_engines = {"BP4", "BP5"};
+    const std::vector<std::string> list_of_engines = {"BPFile"};
     const size_t N = 6000;
     int nSteps = 2, ret = 0;
 

--- a/examples/hello/bpWriteReadKokkos/bpWriteReadKokkos.cpp
+++ b/examples/hello/bpWriteReadKokkos/bpWriteReadKokkos.cpp
@@ -98,7 +98,7 @@ int BPRead(const std::string fname, const size_t N, int nSteps, const std::strin
 
 int main(int argc, char **argv)
 {
-    const std::vector<std::string> list_of_engines = {"BP4", "BP5"};
+    const std::vector<std::string> list_of_engines = {"BPFile"};
     const size_t N = 6000;
     int nSteps = 2, ret = 0;
 

--- a/examples/hello/bpWriter/bpPutDeferred.cpp
+++ b/examples/hello/bpWriter/bpPutDeferred.cpp
@@ -67,9 +67,11 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpFileWriter = bpIO.Open("myVectorDeferred.bp", adios2::Mode::Write);
 
+        bpFileWriter.BeginStep();
         /** Put variables for buffering, template type is optional */
         bpFileWriter.Put<float>(bpFloats, myFloats.data());
         bpFileWriter.Put(bpInts, myInts.data());
+        bpFileWriter.EndStep();
 
         /** Create bp file, engine becomes unreachable after this*/
         bpFileWriter.Close();

--- a/examples/hello/bpWriter/bpWriter.c
+++ b/examples/hello/bpWriter/bpWriter.c
@@ -68,6 +68,7 @@ int main(int argc, char *argv[])
     adios2_adios *adios = adios2_init_serial();
 #endif
 
+    adios2_step_status err;
     check_handler(adios, "adios");
 
     adios2_io *io = adios2_declare_io(adios, "BPFile_Write");
@@ -90,8 +91,12 @@ int main(int argc, char *argv[])
     adios2_engine *engine = adios2_open(io, "myVector_c.bp", adios2_mode_write);
     check_handler(engine, "engine");
 
+    adios2_begin_step(engine, adios2_step_mode_append, 0.0f, &err);
+
     errio = adios2_put(engine, variable, myFloats, adios2_mode_deferred);
     check_error(errio);
+
+    adios2_end_step(engine);
 
     errio = adios2_close(engine);
     check_error(errio);

--- a/examples/hello/bpWriter/bpWriter.cpp
+++ b/examples/hello/bpWriter/bpWriter.cpp
@@ -71,10 +71,12 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpFileWriter = bpIO.Open(filename, adios2::Mode::Write);
 
+        bpFileWriter.BeginStep();
         /** Put variables for buffering, template type is optional */
         bpFileWriter.Put<float>(bpFloats, myFloats.data());
         bpFileWriter.Put(bpInts, myInts.data());
         // bpFileWriter.Put(bpString, myString);
+        bpFileWriter.EndStep();
 
         /** Create bp file, engine becomes unreachable after this*/
         bpFileWriter.Close();

--- a/examples/hello/bpWriter/bpWriter.py
+++ b/examples/hello/bpWriter/bpWriter.py
@@ -41,5 +41,7 @@ ioArray = bpIO.DefineVariable(
 
 # ADIOS Engine
 bpFileWriter = bpIO.Open("npArray.bp", adios2.Mode.Write)
+bpFileWriter.BeginStep()
 bpFileWriter.Put(ioArray, myArray, adios2.Mode.Sync)
+bpFileWriter.EndStep()
 bpFileWriter.Close()

--- a/examples/hello/bpWriter/bpWriter.py
+++ b/examples/hello/bpWriter/bpWriter.py
@@ -23,7 +23,7 @@ adios = adios2.ADIOS(comm)
 
 # ADIOS IO
 bpIO = adios.DeclareIO("BPFile_N2N")
-bpIO.SetEngine("bp3")
+bpIO.SetEngine("BPFile")
 # bpIO.SetParameters( {"Threads" : "2", "ProfileUnits" : "Microseconds",
 # "InitialBufferSize" : "17Kb"} )
 bpIOParams = {}

--- a/examples/hello/bpWriter/bpWriter_nompi.py
+++ b/examples/hello/bpWriter/bpWriter_nompi.py
@@ -24,5 +24,7 @@ ioArray = bpIO.DefineVariable("bpArray", myArray, [], [], [Nx], adios2.ConstantD
 
 # ADIOS Engine
 bpFileWriter = bpIO.Open("npArray.bp", adios2.Mode.Write)
+bpFileWriter.BeginStep()
 bpFileWriter.Put(ioArray, myArray, adios2.Mode.Sync)
+bpFileWriter.EndStep()
 bpFileWriter.Close()

--- a/examples/hello/hdf5Reader/hdf5Reader.cpp
+++ b/examples/hello/hdf5Reader/hdf5Reader.cpp
@@ -99,6 +99,8 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine h5Reader = h5IO.Open(filename, adios2::Mode::Read);
 
+        h5Reader.BeginStep();
+
         const std::map<std::string, adios2::Params> variables = h5IO.AvailableVariables();
 
         for (const auto &variablePair : variables)
@@ -159,6 +161,7 @@ int main(int argc, char *argv[])
                 //... add more types if needed
             }
         }
+        h5Reader.EndStep();
 
         h5Reader.Close();
     }

--- a/examples/hello/hdf5Reader/hdf5Reader_nompi.cpp
+++ b/examples/hello/hdf5Reader/hdf5Reader_nompi.cpp
@@ -90,6 +90,8 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine h5Reader = h5IO.Open(filename, adios2::Mode::Read);
 
+        h5Reader.BeginStep();
+
         const std::map<std::string, adios2::Params> variables = h5IO.AvailableVariables();
 
         for (const auto &variablePair : variables)
@@ -122,6 +124,8 @@ int main(int argc, char *argv[])
 
         // ReadData<float>(h5IO, h5Reader, "h5Floats");
         // ReadData<int>(h5IO, h5Reader, "h5Ints");
+
+        h5Reader.EndStep();
 
         /** Close h5 file, engine becomes unreachable after this*/
         h5Reader.Close();

--- a/examples/hello/hdf5Writer/hdf5Writer_nompi.cpp
+++ b/examples/hello/hdf5Writer/hdf5Writer_nompi.cpp
@@ -39,8 +39,12 @@ int main(int argc, char *argv[])
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine hdf5Writer = hdf5IO.Open("myVector.h5", adios2::Mode::Write);
 
+        hdf5Writer.BeginStep();
+
         /** Write variable for buffering */
         hdf5Writer.Put<float>(bpFloats, myFloats.data());
+
+        hdf5Writer.EndStep();
 
         /** Create bp file, engine becomes unreachable after this*/
         hdf5Writer.Close();

--- a/examples/hello/helloWorld/hello-world.c
+++ b/examples/hello/helloWorld/hello-world.c
@@ -19,12 +19,15 @@
 
 void writer(adios2_adios *adios, const char *greeting)
 {
+    adios2_step_status status;
     adios2_io *io = adios2_declare_io(adios, "hello-world-writer");
     adios2_variable *var_greeting = adios2_define_variable(
         io, "Greeting", adios2_type_string, 0, NULL, NULL, NULL, adios2_constant_dims_true);
 
     adios2_engine *engine = adios2_open(io, "hello-world-c.bp", adios2_mode_write);
+    adios2_begin_step(engine, adios2_step_mode_append, -1., &status);
     adios2_put(engine, var_greeting, greeting, adios2_mode_deferred);
+    adios2_end_step(engine);
     adios2_close(engine);
 }
 

--- a/examples/hello/helloWorld/hello-world.cpp
+++ b/examples/hello/helloWorld/hello-world.cpp
@@ -23,7 +23,9 @@ void writer(adios2::ADIOS &adios, const std::string &greeting)
     adios2::Variable<std::string> varGreeting = io.DefineVariable<std::string>("Greeting");
 
     adios2::Engine writer = io.Open("hello-world-cpp.bp", adios2::Mode::Write);
+    writer.BeginStep();
     writer.Put(varGreeting, greeting);
+    writer.EndStep();
     writer.Close();
 }
 

--- a/examples/hello/helloWorld/hello-world.py
+++ b/examples/hello/helloWorld/hello-world.py
@@ -24,7 +24,9 @@ def writer(ad, greeting):
     io = ad.DeclareIO("hello-world-writer")
     var_greeting = io.DefineVariable("Greeting")
     w = io.Open(DATA_FILENAME, adios2.Mode.Write)
+    w.BeginStep()
     w.Put(var_greeting, greeting)
+    w.EndStep()
     w.Close()
     return 0
 

--- a/examples/hello/inlineFWriteCppRead/inlineMixedLang.cpp
+++ b/examples/hello/inlineFWriteCppRead/inlineMixedLang.cpp
@@ -28,6 +28,9 @@ void FC_GLOBAL(open_reader, OPEN_READER)(adios2::IO *io)
 
 void FC_GLOBAL(analyze_data, ANALYZE_DATA)()
 {
+    // begin step on the reader
+    reader.BeginStep();
+
     // grab the desired variable
     auto u = adiosIO->InquireVariable<float>("data2D");
     if (!u)
@@ -36,9 +39,6 @@ void FC_GLOBAL(analyze_data, ANALYZE_DATA)()
         return;
     }
     auto shape = u.Shape();
-
-    // begin step on the reader
-    reader.BeginStep();
 
     // get the data pointer and do some stuff with it
     float *data = nullptr;

--- a/examples/hello/inlineMWE/inlineMWE.cpp
+++ b/examples/hello/inlineMWE/inlineMWE.cpp
@@ -31,5 +31,7 @@ int main(int argc, char *argv[])
         std::cout << "Getting data from address " << data << " via inline reader\n";
         reader.EndStep();
     }
+    writer.Close();
+    reader.Close();
     return 0;
 }

--- a/examples/hello/skeleton/skeletonReader.cpp
+++ b/examples/hello/skeleton/skeletonReader.cpp
@@ -53,14 +53,8 @@ int main(int argc, char *argv[])
         adios2::Dims count, start;
         std::vector<float> myArray;
 
-        while (true)
+        while (reader.BeginStep(adios2::StepMode::Read, 60.0f) == adios2::StepStatus::OK)
         {
-            adios2::StepStatus status = reader.BeginStep(adios2::StepMode::Read, 60.0f);
-            if (status != adios2::StepStatus::OK)
-            {
-                break;
-            }
-
             if (step == 0)
             {
                 // this just discovers in the metadata file that the variable
@@ -88,7 +82,7 @@ int main(int argc, char *argv[])
                     start.push_back(settings.offsy);
 
                     vMyArray.SetSelection({start, count});
-                    size_t elementsSize = count[0] * count[1];
+                    const size_t elementsSize = count[0] * count[1];
                     myArray.resize(elementsSize);
                 }
             }

--- a/examples/plugins/engine/examplePluginEngineRead.cpp
+++ b/examples/plugins/engine/examplePluginEngineRead.cpp
@@ -16,47 +16,12 @@
 
 #include "adios2.h"
 
-void testStreaming(adios2::Engine &reader, std::vector<float> &myFloats,
-                   adios2::Variable<float> &var)
-{
-    for (int i = 0; i < 2; i++)
-    {
-        if (i == 1)
-        {
-            for (auto &num : myFloats)
-            {
-                num *= 2;
-            }
-        }
-
-        reader.BeginStep();
-        std::vector<float> readFloats;
-        reader.Get(var, readFloats);
-        reader.EndStep();
-
-        if (readFloats == myFloats)
-        {
-            std::cout << "data was read correctly!" << std::endl;
-        }
-        else
-        {
-            std::cout << "data was not read correctly!" << std::endl;
-        }
-    }
-}
-
 int main(int argc, char *argv[])
 {
     std::string config;
     if (argc > 1)
     {
         config = std::string(argv[1]);
-    }
-
-    bool streaming = false;
-    if (argc > 2)
-    {
-        streaming = std::atoi(argv[2]) == 1;
     }
 
     std::vector<float> myFloats = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -82,30 +47,38 @@ int main(int argc, char *argv[])
         }
         adios2::Engine reader = io.Open("TestPlugin", adios2::Mode::Read);
 
-        auto var = io.InquireVariable<float>("data");
-        if (!var)
+        // test streaming
+        for (int i = 0; i < 2; i++)
         {
-            std::cout << "variable does not exist" << std::endl;
-        }
-
-        if (streaming)
-        {
-            testStreaming(reader, myFloats, var);
-        }
-        else
-        {
-            std::vector<float> readFloats;
-            reader.Get<float>(var, readFloats);
-            reader.PerformGets();
-
-            if (readFloats == myFloats)
+            if (i == 1)
             {
-                std::cout << "data was read correctly!" << std::endl;
+                for (auto &num : myFloats)
+                {
+                    num *= 2;
+                }
+            }
+
+            reader.BeginStep();
+            auto var = io.InquireVariable<float>("data");
+            if (!var)
+            {
+                std::cout << "variable does not exist" << std::endl;
             }
             else
             {
-                std::cout << "data was not read correctly!" << std::endl;
+                std::vector<float> readFloats;
+                reader.Get(var, readFloats);
+
+                if (readFloats == myFloats)
+                {
+                    std::cout << "data was read correctly!" << std::endl;
+                }
+                else
+                {
+                    std::cout << "data was not read correctly!" << std::endl;
+                }
             }
+            reader.EndStep();
         }
 
         /** Engine becomes unreachable after this*/

--- a/examples/plugins/engine/examplePluginEngineWrite.cpp
+++ b/examples/plugins/engine/examplePluginEngineWrite.cpp
@@ -16,36 +16,12 @@
 
 #include "adios2.h"
 
-void testStreaming(adios2::Engine &writer, std::vector<float> &myFloats,
-                   adios2::Variable<float> &var)
-{
-    for (int i = 0; i < 2; i++)
-    {
-        if (i == 1)
-        {
-            for (auto &num : myFloats)
-            {
-                num *= 2;
-            }
-        }
-        writer.BeginStep();
-        writer.Put<float>(var, myFloats.data());
-        writer.EndStep();
-    }
-}
-
 int main(int argc, char *argv[])
 {
     std::string config;
     if (argc > 1)
     {
         config = std::string(argv[1]);
-    }
-
-    bool streaming = false;
-    if (argc > 2)
-    {
-        streaming = std::atoi(argv[2]) == 1;
     }
 
     /** Application variable */
@@ -78,14 +54,19 @@ int main(int argc, char *argv[])
         }
         adios2::Engine writer = io.Open("TestPlugin", adios2::Mode::Write);
 
-        if (streaming)
+        // test streaming
+        for (int i = 0; i < 2; i++)
         {
-            testStreaming(writer, myFloats, var);
-        }
-        else
-        {
+            if (i == 1)
+            {
+                for (auto &num : myFloats)
+                {
+                    num *= 2;
+                }
+            }
+            writer.BeginStep();
             writer.Put<float>(var, myFloats.data());
-            writer.PerformPuts();
+            writer.EndStep();
         }
 
         /** Engine becomes unreachable after this*/

--- a/examples/plugins/operator/examplePluginOperatorRead.cpp
+++ b/examples/plugins/operator/examplePluginOperatorRead.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
 
         if (config.empty())
         {
-            io.SetEngine("BP4");
+            io.SetEngine("BPFile");
             /* PluginName -> <operator name> is required. If your operator needs
              * other parameters, they can be passed in here as well. */
             adios2::Params params;

--- a/examples/plugins/operator/examplePluginOperatorRead.cpp
+++ b/examples/plugins/operator/examplePluginOperatorRead.cpp
@@ -51,6 +51,7 @@ int main(int argc, char *argv[])
         /** global array: name, { shape (total dimensions) }, { start (local) },
          * { count (local) }, all are constant dimensions */
         adios2::Engine reader = io.Open("testOperator.bp", adios2::Mode::Read);
+        reader.BeginStep();
         auto var = io.InquireVariable<double>("data");
         if (!var)
         {
@@ -81,6 +82,7 @@ int main(int argc, char *argv[])
         {
             std::cout << "data was not read correctly!" << std::endl;
         }
+        reader.EndStep();
 
         /** Engine becomes unreachable after this*/
         reader.Close();

--- a/examples/plugins/operator/examplePluginOperatorWrite.cpp
+++ b/examples/plugins/operator/examplePluginOperatorWrite.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
 
         if (config.empty())
         {
-            io.SetEngine("BP4");
+            io.SetEngine("BPFile");
             /* PluginName -> <operator name> is required. If your operator needs
              * other parameters, they can be passed in here as well. */
             adios2::Params params;

--- a/examples/plugins/operator/examplePluginOperatorWrite.cpp
+++ b/examples/plugins/operator/examplePluginOperatorWrite.cpp
@@ -68,7 +68,9 @@ int main(int argc, char *argv[])
 
         adios2::Engine writer = io.Open("testOperator.bp", adios2::Mode::Write);
 
+        writer.BeginStep();
         writer.Put<double>(var, myDoubles.data());
+        writer.EndStep();
 
         /** Engine becomes unreachable after this*/
         writer.Close();

--- a/examples/simulations/heatTransfer/read/heatRead.cpp
+++ b/examples/simulations/heatTransfer/read/heatRead.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
         {
             // if not defined by user, we can change the default settings
             // BPFile is the default engine
-            inIO.SetEngine("BP3");
+            inIO.SetEngine("BPFile");
             inIO.SetParameters({{"num_threads", "1"}});
 
             // ISO-POSIX file output is the default transport (called "File")

--- a/examples/simulations/heatTransfer/write/IO_adios2.cpp
+++ b/examples/simulations/heatTransfer/write/IO_adios2.cpp
@@ -51,11 +51,6 @@ IO::IO(const Settings &s, MPI_Comm comm)
                                        // local size, could be defined later using SetSelection()
                                        {s.ndx, s.ndy});
 
-    if (bpio.EngineType() == "BP3")
-    {
-        varT.SetMemorySelection({{1, 1}, {s.ndx + 2, s.ndy + 2}});
-    }
-
     bpWriter = bpio.Open(m_outputfilename, adios2::Mode::Write, comm);
 
     // Promise that we are not going to change the variable sizes nor add new
@@ -72,17 +67,8 @@ void IO::write(int step, const HeatTransfer &ht, const Settings &s, MPI_Comm com
     // We need to have the vector object here not to destruct here until the end
     // of function.
     // added support for MemorySelection
-    if (bpWriter.Type() == "BP3")
-    {
-        bpWriter.BeginStep();
-        bpWriter.Put<double>(varT, ht.data());
-        bpWriter.EndStep();
-    }
-    else
-    {
-        bpWriter.BeginStep();
-        std::vector<double> v = ht.data_noghost();
-        bpWriter.Put<double>(varT, v.data());
-        bpWriter.EndStep();
-    }
+    bpWriter.BeginStep();
+    std::vector<double> v = ht.data_noghost();
+    bpWriter.Put<double>(varT, v.data());
+    bpWriter.EndStep();
 }

--- a/examples/simulations/lorenz_ode/lorenzReader.cpp
+++ b/examples/simulations/lorenz_ode/lorenzReader.cpp
@@ -30,6 +30,7 @@ void read_solution()
         return;
     }
     adios2::Engine adios_engine = io.Open("lorenz.bp", adios2::Mode::Read);
+    adios_engine.BeginStep();
     auto sigma_att = io.InquireAttribute<Real>("σ");
     std::cout << "Lorenz system solved with ";
     if (sigma_att)
@@ -105,6 +106,7 @@ void read_solution()
         // For more information than we want:
         // std::cout << solution << "\n";
     }
+    adios_engine.EndStep();
     adios_engine.Close();
 }
 

--- a/examples/useCases/fidesOneCell/fidesOneCell.cpp
+++ b/examples/useCases/fidesOneCell/fidesOneCell.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
     const int64_t cell[NCELLS * NPOINTS] = {0, 1, 2, 3, 4, 5, 6, 7};
 
     adios2::IO io = adios.DeclareIO("Output");
-    io.SetEngine("BP5");
+    io.SetEngine("BPFile");
 
     /*
      * Define global array: type, name, global dimensions


### PR DESCRIPTION
1. Examples: Add BeginStep/EndStep wherever it was missing
2. Examples: Use BPFile instead of BP3/4/5 for future-proof
3. Update the bpWriterReadHip example's cmake to run on crusher

This PR fixes https://github.com/ornladios/ADIOS2/issues/3855, https://github.com/ornladios/ADIOS2/issues/3840.