### PR TITLE
BP5Serializer: handle local variables that use operators

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -733,7 +733,8 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
             for (size_t i = 0; i < DimCount; i++)
             {
                 tmpCount.push_back(Count[i]);
-                tmpOffsets.push_back(Offsets[i]);
+                if (Offsets)
+                    tmpOffsets.push_back(Offsets[i]);
             }
             size_t AllocSize = ElemCount * ElemSize + 100;
             BufferV::BufferPos pos = CurDataBuffer->Allocate(AllocSize, ElemSize);


### PR DESCRIPTION
This fixes the bug brought up in #3856. 

I was going to add a test for it, but it's not working and I'm not sure why. I was planning to modify `testing/adios2/engine/bp/TestBPWriteReadLocalVariables.cpp` so that one of the variables created has a bzip operator added to it, but I get failures that I'm confused by. I get various failures depending on which variable I add the operator to. If I add it to the float variable I get the following in all cases (it's not just BP5, but 3 and 4 as well).

```
C++ exception with description "[Thu Oct 19 17:34:06 2023] [ADIOS2 EXCEPTION] <Operator> <CompressBZIP2> <CheckStatus> : BZ_OUTBUFF_FULL BZIP2 detected size of compressed data is larger than destination length in call to ADIOS2 BZIP2 Compress batch 0
```

If I switch to adding the operator on the double variable, then some tests now pass, some may hang (I think in the PerformGets, though I'd have to run back through a debugger to double check), some have the same error as above, and one test gets a different error:
```
C++ exception with description "[Thu Oct 19 17:49:50 2023] [ADIOS2 EXCEPTION] <Operator> <CompressBZIP2> <CheckStatus> : BZ_DATA_ERROR, BZIP2 library detected integrity errors in compressed data in call to ADIOS2 BZIP2 Decompress batch 0
```

Maybe I just don't know how to use operators correctly, but I looked at `TestBPWriteReadBZIP2.cpp` and am setting it up the same way and the variety of errors makes me think that's not the issue. Digging through the operator tests, they're never tested on local variables as far as I can tell.

For the bug found in #3856, we can go ahead and merge this (assuming all current tests pass), and once that PR is merged, the EncryptionOperator test will at least test the fix made here. And then in another PR we can add tests for using operators with local variables?