### PR TITLE
Remote Server Improvements

### DIFF
--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -470,12 +470,12 @@ void BP5Reader::Init()
     bool RowMajorOrdering = (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor);
     if (!m_Parameters.RemoteDataPath.empty())
     {
-        m_Remote.Open("localhost", 26200, m_Parameters.RemoteDataPath, m_OpenMode,
-                      RowMajorOrdering);
+        m_Remote.Open("localhost", RemoteCommon::ServerPort, m_Parameters.RemoteDataPath,
+                      m_OpenMode, RowMajorOrdering);
     }
     else if (getenv("DoRemote"))
     {
-        m_Remote.Open("localhost", 26200, m_Name, m_OpenMode, RowMajorOrdering);
+        m_Remote.Open("localhost", RemoteCommon::ServerPort, m_Name, m_OpenMode, RowMajorOrdering);
     }
 }
 

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -16,9 +16,7 @@
 
 #include "adios2/common/ADIOSConfig.h"
 
-#ifdef ADIOS2_HAVE_SST
 #include "remote_common.h"
-#endif
 
 namespace adios2
 {

--- a/source/adios2/toolkit/remote/remote_common.cpp
+++ b/source/adios2/toolkit/remote/remote_common.cpp
@@ -1,3 +1,5 @@
+#include "adios2/common/ADIOSConfig.h"
+
 #include "remote_common.h"
 #include <evpath.h>
 

--- a/source/adios2/toolkit/remote/remote_common.h
+++ b/source/adios2/toolkit/remote/remote_common.h
@@ -1,4 +1,6 @@
+#ifdef ADIOS2_HAVE_SST
 #include "evpath.h"
+#endif
 #include <stddef.h>
 
 namespace adios2
@@ -6,6 +8,9 @@ namespace adios2
 namespace RemoteCommon
 {
 
+const int ServerPort = 26200;
+
+#ifdef ADIOS2_HAVE_SST
 enum RemoteFileMode
 {
     RemoteOpen,
@@ -127,6 +132,7 @@ struct Remote_evpath_state
 };
 
 void RegisterFormats(struct Remote_evpath_state &ev_state);
+#endif
 
 }; // end of namespace remote_common
 }; // end of namespace adios2

--- a/source/adios2/toolkit/transport/file/FileRemote.cpp
+++ b/source/adios2/toolkit/transport/file/FileRemote.cpp
@@ -92,7 +92,7 @@ void FileRemote::Open(const std::string &name, const Mode openMode, const bool a
 
     case Mode::Read: {
         ProfilerStart("open");
-        m_Remote.OpenSimpleFile("localhost", 26200, m_Name);
+        m_Remote.OpenSimpleFile("localhost", RemoteCommon::ServerPort, m_Name);
         ProfilerStop("open");
         m_Size = m_Remote.m_Size;
         break;


### PR DESCRIPTION
- Add idle timeout to server.  Unless the -no_timeout flag is specified, the server will exit after 10 minutes of idle time
- Specify the server port with a single constant in remote_common.h, rather than several explicit constants.