### PR TITLE
Remove Slack as a contact mechanism

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -78,7 +78,6 @@ Once ADIOS2 is installed refer to:
 
 ADIOS2 is an open source project: Questions, discussion, and contributions are welcome. Join us at:
 
-- Slack workspace: [![Slack](https://img.shields.io/badge/slack-ADIOS2-pink.svg)](https://adios2.spack.io) 
 - Mailing list: adios-ecp@kitware.com 
 - Github Discussions: https://github.com/ornladios/ADIOS2/discussions
 


### PR DESCRIPTION
We've had slack in Readme.md forever, but it was misspelled "spack" in the link and you've never been able to join the ADIOS slack without an invite.  Couple that with the fact that nobody is really on the ADIOS slack anymore and I recommend we just eliminate this as a contact mechanism in Readme.md.