### PR TITLE
Fix data length calculation for hash

### DIFF
--- a/thirdparty/ffs/ffs/fm/fm_formats.c
+++ b/thirdparty/ffs/ffs/fm/fm_formats.c
@@ -1987,7 +1987,7 @@ generate_format3_server_ID(server_ID_type *server_ID,
     INT4 hash1 = 0, hash2 = 0;
     UINT4 server_format_rep_length = ntohs(server_format_rep->format_rep_length);
     if (server_format_rep->server_rep_version > 0) {
-	server_format_rep_length += (ntohs(server_format_rep->top_bytes_format_rep_length) >> 16);
+	server_format_rep_length += (ntohs(server_format_rep->top_bytes_format_rep_length) << 16);
     }
     if (server_format_rep_length > (1 << 26)) fprintf(stderr, "Format rep too long in generate_format_server_ID\n");
     server_ID->length = 12;


### PR DESCRIPTION
Turns out that master already has this fix because it migrated into FFS master in July.  However, we haven't pulled in fresh FFS to release because there were significant API changes and we didn't want those in a patch release.  So this is a one-line change that fixes our hash issues (which were not really hash issues, but instead "calculating the length over which to do a hash" issues).