### PR TITLE
Backport 3877 to master

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -34,14 +34,14 @@ namespace format
 BP5Serializer::BP5Serializer() { Init(); }
 BP5Serializer::~BP5Serializer()
 {
-    if (Info.RecList)
+    if (!Info.RecMap.empty())
     {
-        for (int i = 0; i < Info.RecCount; i++)
+        for (auto &rec : Info.RecMap)
         {
-            if (Info.RecList[i].OperatorType)
-                free(Info.RecList[i].OperatorType);
+            if (rec.second.OperatorType)
+                free(rec.second.OperatorType);
         }
-        free(Info.RecList);
+        Info.RecMap.clear();
     }
     if (Info.MetaFieldCount)
         free_FMfield_list(Info.MetaFields);
@@ -64,7 +64,6 @@ void BP5Serializer::Init()
     // Re-init Info to zero
     Info = FFSWriterMarshalBase();
     Info.RecCount = 0;
-    Info.RecList = (BP5Serializer::BP5WriterRec)malloc(sizeof(Info.RecList[0]));
     Info.MetaFieldCount = 0;
     Info.MetaFields = NULL;
     Info.LocalFMContext = create_local_FMcontext();
@@ -82,14 +81,11 @@ void BP5Serializer::Init()
 }
 BP5Serializer::BP5WriterRec BP5Serializer::LookupWriterRec(void *Key) const
 {
-    for (int i = 0; i < Info.RecCount; i++)
+    auto it = Info.RecMap.find(Key);
+    if (it != Info.RecMap.end())
     {
-        if (Info.RecList[i].Key == Key)
-        {
-            return &Info.RecList[i];
-        }
+        return const_cast<BP5WriterRec>(&(it->second));
     }
-
     return NULL;
 }
 
@@ -424,9 +420,8 @@ BP5Serializer::BP5WriterRec BP5Serializer::CreateWriterRec(void *Variable, const
                                                            size_t DimCount)
 {
     core::VariableBase *VB = static_cast<core::VariableBase *>(Variable);
-    Info.RecList =
-        (BP5WriterRec)realloc(Info.RecList, (Info.RecCount + 1) * sizeof(Info.RecList[0]));
-    BP5WriterRec Rec = &Info.RecList[Info.RecCount];
+    auto obj = Info.RecMap.insert(std::make_pair(Variable, _BP5WriterRec()));
+    BP5WriterRec Rec = &obj.first->second;
     if (Type == DataType::String)
         ElemSize = sizeof(char *);
     Rec->Key = Variable;
@@ -1128,9 +1123,9 @@ BufferV *BP5Serializer::ReinitStepData(BufferV *DataBuffer, bool forceCopyDeferr
 
 void BP5Serializer::CollectFinalShapeValues()
 {
-    for (int i = 0; i < Info.RecCount; i++)
+    for (auto it : Info.RecMap)
     {
-        BP5WriterRec Rec = &Info.RecList[i];
+        BP5WriterRec Rec = &it.second;
         if (Rec->Shape == ShapeID::GlobalArray)
         {
             core::VariableBase *VB = static_cast<core::VariableBase *>(Rec->Key);

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.h
@@ -21,6 +21,8 @@
 #pragma warning(disable : 4250)
 #endif
 
+#include <unordered_map>
+
 namespace adios2
 {
 namespace format
@@ -156,7 +158,6 @@ private:
     struct FFSWriterMarshalBase
     {
         int RecCount = 0;
-        BP5WriterRec RecList = NULL;
         FMContext LocalFMContext = {0};
         int MetaFieldCount = 0;
         FMFieldList MetaFields = NULL;
@@ -166,6 +167,7 @@ private:
         FMFormat AttributeFormat = NULL;
         void *AttributeData = NULL;
         int AttributeSize = 0;
+        std::unordered_map<void *, _BP5WriterRec> RecMap;
     };
 
     FMFormat GenericAttributeFormat = NULL;


### PR DESCRIPTION
Backport of #3877 

> …map. For 250k variables, time goes from 21sec to ~1sec in WSL. The order of entries in RecList was not necessary for the serializer to work correctly.

(cherry picked from commit 2e8bcaf558c1d96cd1bd88a612f1cbc119aee495)