### PR TITLE
Have HDF5 write raise error if operator(s) requested

### DIFF
--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -1709,6 +1709,16 @@ void HDF5Common::StaticGetAdiosStepString(std::string &stepName, size_t ts)
     stepName = "/Step" + std::to_string(ts);
 }
 
+void HDF5Common::CheckVariableOperations(const core::VariableBase &variable) const
+{
+    if (!variable.m_Operations.empty())
+    {
+        helper::Throw<std::runtime_error>("Toolkit", "interop::hdf5::HDF5Common",
+                                          "CheckVariableOperations",
+                                          "ADIOS2 Operators are not supported for HDF5 engine");
+    }
+}
+
 #define declare_template_instantiation(T)                                                          \
     template void HDF5Common::Write(core::Variable<T> &, const T *);
 

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -245,6 +245,8 @@ private:
     void GetHDF5SpaceSpec(const core::Variable<T> &variable, std::vector<hsize_t> &,
                           std::vector<hsize_t> &, std::vector<hsize_t> &);
 
+    void CheckVariableOperations(const core::VariableBase &variable) const;
+
     bool m_WriteMode = false;
 
     size_t m_NumAdiosSteps = 0;

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
@@ -25,6 +25,7 @@ namespace interop
 template <class T>
 void HDF5Common::DefineDataset(core::Variable<T> &variable)
 {
+    CheckVariableOperations(variable);
     size_t dimSize = std::max(variable.m_Shape.size(), variable.m_Count.size());
     hid_t h5Type = GetHDF5Type<T>();
 
@@ -118,6 +119,7 @@ template <class T>
 void HDF5Common::Write(core::Variable<T> &variable, const T *values)
 {
     CheckWriteGroup();
+    CheckVariableOperations(variable);
     size_t dimSize = std::max(variable.m_Shape.size(), variable.m_Count.size());
     hid_t h5Type = GetHDF5Type<T>();
 


### PR DESCRIPTION
Discussion in #3942 suggests that support for operators in "secondary" (for want of a better term) engines is not planned. My suggestion that ADIOS should let the user know this won't happen is added in this PR.
