### PR TITLE
Fix MATLAB bindings for MacOS, backported from master

### DIFF
--- a/bindings/C/adios2/c/adios2_c_adios.h
+++ b/bindings/C/adios2/c/adios2_c_adios.h
@@ -47,7 +47,7 @@ adios2_adios *adios2_init_config_mpi(const char *config_file, MPI_Comm comm);
 
 #else
 #define adios2_init() adios2_init_serial()
-#define adios2_init_config(config_file) adios2_init_config_seria(config_file)
+#define adios2_init_config(config_file) adios2_init_config_serial(config_file)
 #endif
 
 /**

--- a/bindings/Matlab/Makefile
+++ b/bindings/Matlab/Makefile
@@ -18,6 +18,16 @@ MEXLIBS="LDFLAGS=${ADIOS_LIBS}"
 ADIOS_INC=-I${ADIOS_DIR}/include
 ADIOS_LIBS=`${ADIOS_DIR}/bin/adios2-config --c-libs`
 
+### MacOS - example using homebrew installed ADIOS2 and Xcode 15 clang
+###      1) Install homebrew (https://brew.sh/) and Xcode (App Store)
+###      2) brew install adios2
+###      OR
+###      2) Compile Adios2 from scratch and update ADIOS_DIR below to match install directory
+#ADIOS_DIR=/opt/homebrew/opt/adios2
+#ADIOS_INC=-I${ADIOS_DIR}/include
+#ADIOS_LIBS=-Wl,-rpath,${ADIOS_DIR}/lib -shared -L${ADIOS_DIR}/lib -ladios2_c -ladios2_core
+#MEXLIBS="LDFLAGS=${ADIOS_LIBS}"
+
 
 MEXOPTS=-largeArrayDims -DDEBUG CFLAGS="-g -std=c99 -fPIC -O0"
 default:

--- a/bindings/Matlab/adiosopenc.c
+++ b/bindings/Matlab/adiosopenc.c
@@ -147,7 +147,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
 
     /********************************************************/
     /* Open ADIOS file now and get variables and attributes */
-    adiosobj = adios2_init(false);
+    adiosobj = adios2_init_serial();
     group = adios2_declare_io(adiosobj, "matlabiogroup"); // name is arbitrary
     fp = adios2_open(group, fname, adios2_mode_read);
     if (fp == NULL)


### PR DESCRIPTION
* Fix MATLAB bindings for MacOS - updated bindings/Matlab/Makefile, added preprocessor macro to check MPI usage and call the correct version of adios2_init() accordingly, fixed spelling error in bindings/C/adios2/c/adios2_c_adios.h

* Update adiosopenc.c to use adios2_init_serial regardless of MPI use.