### PR TITLE
Use adios2_mode_readRandomAccess in matlab open to make it work for BP5

### DIFF
--- a/bindings/Matlab/adiosopenc.c
+++ b/bindings/Matlab/adiosopenc.c
@@ -149,7 +149,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
     /* Open ADIOS file now and get variables and attributes */
     adiosobj = adios2_init_serial();
     group = adios2_declare_io(adiosobj, "matlabiogroup"); // name is arbitrary
-    fp = adios2_open(group, fname, adios2_mode_read);
+    fp = adios2_open(group, fname, adios2_mode_readRandomAccess);
     if (fp == NULL)
     {
         mexErrMsgIdAndTxt("MATLAB:adiosopenc:open",


### PR DESCRIPTION
Matlab was still using `adios2_mode_read` that only works for BP4 file. 