### PR TITLE
Deal with different data layouts between GPU and CPU

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Engine.cpp
+++ b/bindings/CXX11/adios2/cxx11/Engine.cpp
@@ -20,8 +20,10 @@ namespace adios2
 #ifdef ADIOS2_HAVE_GPU_SUPPORT
 void Engine::CheckMemorySpace(MemorySpace variableMem, MemorySpace bufferMem)
 {
-    if (variableMem != MemorySpace::Detect && variableMem != bufferMem)
-        helper::Throw<std::runtime_error>("CXX-Bindings", "Engine", "Put", "Memory space mismatch");
+    if (variableMem != bufferMem)
+        helper::Throw<std::runtime_error>(
+            "CXX-Bindings", "Engine", "Put",
+            "Memory space mismatch between the pre-set value and the Kokkos::View");
 }
 #endif
 

--- a/bindings/CXX11/adios2/cxx11/Engine.h
+++ b/bindings/CXX11/adios2/cxx11/Engine.h
@@ -214,8 +214,9 @@ public:
         auto bufferView = static_cast<AdiosView<U>>(data);
         auto bufferMem = bufferView.memory_space();
 #ifdef ADIOS2_HAVE_GPU_SUPPORT
-        auto variableMem = variable.GetMemorySpace();
-        CheckMemorySpace(variableMem, bufferMem);
+        auto varMemSpace = variable.GetDefaultMemorySpace();
+        if (varMemSpace != MemorySpace::Detect)
+            CheckMemorySpace(varMemSpace, bufferMem);
 #endif
         variable.SetMemorySpace(bufferMem);
         Put(variable, bufferView.data(), launch);
@@ -418,8 +419,13 @@ public:
     void Get(Variable<T> variable, U const &data, const Mode launch = Mode::Deferred)
     {
         auto adios_data = static_cast<AdiosView<U>>(data);
-        auto mem_space = adios_data.memory_space();
-        variable.SetMemorySpace(mem_space);
+        auto bufferMem = adios_data.memory_space();
+#ifdef ADIOS2_HAVE_GPU_SUPPORT
+        auto varMemSpace = variable.GetDefaultMemorySpace();
+        if (varMemSpace != MemorySpace::Detect)
+            CheckMemorySpace(varMemSpace, bufferMem);
+#endif
+        variable.SetMemorySpace(bufferMem);
         Get(variable, adios_data.data(), launch);
     }
 

--- a/bindings/CXX11/adios2/cxx11/Variable.cpp
+++ b/bindings/CXX11/adios2/cxx11/Variable.cpp
@@ -37,7 +37,7 @@ namespace adios2
     }                                                                                              \
                                                                                                    \
     template <>                                                                                    \
-    MemorySpace Variable<T>::GetMemorySpace()                                                      \
+    MemorySpace Variable<T>::GetDefaultMemorySpace()                                               \
     {                                                                                              \
         return m_Variable->m_MemSpace;                                                             \
     }                                                                                              \

--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -158,7 +158,7 @@ public:
      * Get the memory space that was set by the application
      * @return the memory space stored in the Variable object
      */
-    MemorySpace GetMemorySpace();
+    MemorySpace GetDefaultMemorySpace();
 
     /**
      * Set new shape, care must be taken when reading back the variable for

--- a/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.cpp
+++ b/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.cpp
@@ -3,144 +3,161 @@
  * accompanying file Copyright.txt for details.
  *
  * bpStepsWriteReadKokkos.cpp  Simple example of writing and reading bpFloats through ADIOS2 BP
- * engine with multiple simulations steps for every IO step using Kokkos
+ * engine using Kokkos on any memory space
  */
 #include <ios>
 #include <iostream>
-#include <stdexcept> //std::invalid_argument std::exception
 #include <vector>
 
 #include <adios2.h>
 
 #include <Kokkos_Core.hpp>
 
-void writer(adios2::ADIOS &adios, const std::string &engine, const std::string &fname,
-            const size_t Nx, unsigned int nSteps)
+template <class MemSpace, class ExecSpace>
+int BPWrite(const std::string fname, const size_t Nx, const size_t Ny, const size_t nSteps,
+            const std::string engine)
 {
-    // Initialize the simulation bpFloats with the default memory space
-    using mem_space = Kokkos::DefaultExecutionSpace::memory_space;
-    Kokkos::View<float *, mem_space> gpuSimData("simBuffer", Nx);
-    Kokkos::parallel_for(
-        "initBuffer", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, Nx),
-        KOKKOS_LAMBDA(int i) { gpuSimData(i) = static_cast<float>(i); });
+    // Initialize the simulation data
+    Kokkos::View<float **, MemSpace> gpuSimData("simBuffer", Nx, Ny);
+    static_assert(Kokkos::SpaceAccessibility<ExecSpace, MemSpace>::accessible, "");
+    Kokkos::parallel_for("initBuffer", Kokkos::RangePolicy<ExecSpace>(0, Nx), KOKKOS_LAMBDA(int i) {
+        for (int j = 0; j < Ny; j++)
+            gpuSimData(i, j) = static_cast<float>(i);
+    });
     Kokkos::fence();
 
-    // Set up the ADIOS structures
-    adios2::IO bpIO = adios.DeclareIO("WriteIO");
-    bpIO.SetEngine(engine);
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("WriteIO");
+    io.SetEngine(engine);
 
-    const adios2::Dims shape{static_cast<size_t>(Nx)};
-    const adios2::Dims start{static_cast<size_t>(0)};
-    const adios2::Dims count{Nx};
-    auto bpFloats = bpIO.DefineVariable<float>("bpFloats", shape, start, count);
-    auto bpStep = bpIO.DefineVariable<unsigned int>("bpStep");
+    const adios2::Dims shape{Nx, Ny};
+    const adios2::Dims start{0, 0};
+    const adios2::Dims count{Nx, Ny};
+    auto data = io.DefineVariable<float>("bpFloats", shape, start, count);
 
-    adios2::Engine bpWriter = bpIO.Open(fname, adios2::Mode::Write);
+    adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
 
     // Simulation steps
     for (unsigned int step = 0; step < nSteps; ++step)
     {
-        // Make a 1D selection to describe the local dimensions of the
-        // variable we write and its offsets in the global spaces
-        adios2::Box<adios2::Dims> sel({0}, {Nx});
-        bpFloats.SetSelection(sel);
+        adios2::Box<adios2::Dims> sel({0, 0}, {Nx, Ny});
+        data.SetSelection(sel);
 
-        // Start IO step every write step
         bpWriter.BeginStep();
-        bpWriter.Put(bpFloats, gpuSimData.data());
-        bpWriter.Put(bpStep, step);
+        bpWriter.Put(data, gpuSimData.data());
         bpWriter.EndStep();
 
-        // Update values in the simulation bpFloats using the default
-        // execution space
-        Kokkos::parallel_for(
-            "updateBuffer", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, Nx),
-            KOKKOS_LAMBDA(int i) { gpuSimData(i) += 10; });
+        // Update values in the simulation data
+        Kokkos::parallel_for("updateBuffer", Kokkos::RangePolicy<ExecSpace>(0, Nx),
+                             KOKKOS_LAMBDA(int i) {
+                                 for (int j = 0; j < Ny; j++)
+                                     gpuSimData(i, j) += 10;
+                             });
         Kokkos::fence();
     }
 
     bpWriter.Close();
-    Kokkos::DefaultExecutionSpace exe_space;
+    ExecSpace exe_space;
     std::cout << "Done writing on memory space: " << exe_space.name() << std::endl;
+    return 0;
 }
 
-void reader(adios2::ADIOS &adios, const std::string &engine, const std::string &fname,
-            const size_t Nx, unsigned int /*nSteps*/)
+template <class MemSpace>
+std::array<size_t, 2> GetDimenstions(adios2::Variable<float> data)
 {
-    // Create ADIOS structures
-    adios2::IO bpIO = adios.DeclareIO("ReadIO");
-    bpIO.SetEngine(engine);
+    return {data.Shape()[1], data.Shape()[0]};
+}
 
-    Kokkos::DefaultExecutionSpace exe_space;
+template <>
+std::array<size_t, 2> GetDimenstions<Kokkos::HostSpace>(adios2::Variable<float> data)
+{
+    return {data.Shape()[0], data.Shape()[1]};
+}
+
+template <class MemSpace, class ExecSpace>
+int BPRead(const std::string fname, const std::string engine)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("ReadIO");
+    io.SetEngine(engine);
+
+    ExecSpace exe_space;
     std::cout << "Read on memory space: " << exe_space.name() << std::endl;
 
-    adios2::Engine bpReader = bpIO.Open(fname, adios2::Mode::Read);
+    adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
 
-    using mem_space = Kokkos::DefaultExecutionSpace::memory_space;
-    Kokkos::View<float *, mem_space> gpuSimData("simBuffer", Nx);
-    unsigned int inStep = 0;
-    for (unsigned int step = 0; bpReader.BeginStep() == adios2::StepStatus::OK; ++step)
+    unsigned int step = 0;
+    for (; bpReader.BeginStep() == adios2::StepStatus::OK; ++step)
     {
-        auto bpFloats = bpIO.InquireVariable<float>("bpFloats");
-        if (bpFloats)
+        auto data = io.InquireVariable<float>("bpFloats");
+        if (data.Shape().size() != 2)
         {
-            const adios2::Dims start{0};
-            const adios2::Dims count{Nx};
-            const adios2::Box<adios2::Dims> sel(start, count);
-            bpFloats.SetSelection(sel);
+            std::cout << "Error, the bpFloats variable in the BP file "
+                         " on step "
+                      << step << "needs to have two dimensions" << std::endl;
+            break;
+        }
 
-            bpReader.Get(bpFloats, gpuSimData.data());
-        }
-        auto bpStep = bpIO.InquireVariable<unsigned int>("bpStep");
-        if (bpStep)
-        {
-            bpReader.Get(bpStep, &inStep);
-        }
+        const adios2::Dims start{0, 0};
+        const adios2::Box<adios2::Dims> sel(start, data.Shape());
+        data.SetSelection(sel);
+
+        auto dims = GetDimenstions<MemSpace>(data);
+        size_t Nx = dims[0], Ny = dims[1];
+        Kokkos::View<float **, MemSpace> gpuSimData("simBuffer", Nx, Ny);
+        bpReader.Get(data, gpuSimData.data());
         bpReader.EndStep();
-        if (inStep != step)
+
+        auto cpuData = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, gpuSimData);
+        for (size_t i = 0; i < Nx; i++)
         {
-            std::cout << "ERROR: step mismatch\n";
-            return;
+            for (size_t j = 0; j < Ny; j++)
+                std::cout << cpuData(i, j) << " ";
+            std::cout << std::endl;
         }
     }
 
     bpReader.Close();
+    return 0;
 }
 
 int main(int argc, char **argv)
 {
-    Kokkos::initialize(argc, argv);
-
     const std::string engine = argv[1] ? argv[1] : "BPFile";
     std::cout << "Using engine " << engine << std::endl;
+    const size_t Nx = 6, Ny = 10, nSteps = 1;
+    const std::string fromMemSpace = "Default";
+    const std::string toMemSpace = "Default";
 
-    const std::string filename = engine + "StepsWriteReadCuda.bp";
-    const unsigned int nSteps = 10;
-    const unsigned int Nx = 6000;
-    try
+    const std::string filename = engine + "StepsWriteReadKokkos";
+    Kokkos::initialize(argc, argv);
     {
-        /** ADIOS class factory of IO class objects */
-        adios2::ADIOS adios;
+        std::cout << "Using engine " << engine << std::endl;
 
-        writer(adios, engine, filename, Nx, nSteps);
-        reader(adios, engine, filename, Nx, nSteps);
-    }
-    catch (std::invalid_argument &e)
-    {
-        std::cout << "Invalid argument exception, STOPPING PROGRAM\n";
-        std::cout << e.what() << "\n";
-    }
-    catch (std::ios_base::failure &e)
-    {
-        std::cout << "IO System base failure exception, STOPPING PROGRAM\n";
-        std::cout << e.what() << "\n";
-    }
-    catch (std::exception &e)
-    {
-        std::cout << "Exception, STOPPING PROGRAM\n";
-        std::cout << e.what() << "\n";
+        if (fromMemSpace == "Default")
+        {
+            using mem_space = Kokkos::DefaultExecutionSpace::memory_space;
+            std::cout << "Writing on memory space: DefaultMemorySpace" << std::endl;
+            BPWrite<mem_space, Kokkos::DefaultExecutionSpace>(filename + ".bp", Nx, Ny, nSteps,
+                                                              engine);
+        }
+        else
+        {
+            std::cout << "Writing on memory space: HostSpace" << std::endl;
+            BPWrite<Kokkos::HostSpace, Kokkos::Serial>(filename + ".bp", nSteps, Nx, Ny, engine);
+        }
+        if (toMemSpace == "Default")
+        {
+            using mem_space = Kokkos::DefaultExecutionSpace::memory_space;
+            std::cout << "Reading on memory space: DefaultMemorySpace" << std::endl;
+            BPRead<mem_space, Kokkos::DefaultExecutionSpace>(filename + ".bp", engine);
+        }
+        else
+        {
+            std::cout << "Reading on memory space: HostSpace" << std::endl;
+            BPRead<Kokkos::HostSpace, Kokkos::Serial>(filename + ".bp", engine);
+        }
     }
     Kokkos::finalize();
-
     return 0;
 }

--- a/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.cpp
+++ b/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.cpp
@@ -20,10 +20,11 @@ int BPWrite(const std::string fname, const size_t Nx, const size_t Ny, const siz
     // Initialize the simulation data
     Kokkos::View<float **, MemSpace> gpuSimData("simBuffer", Nx, Ny);
     static_assert(Kokkos::SpaceAccessibility<ExecSpace, MemSpace>::accessible, "");
-    Kokkos::parallel_for("initBuffer", Kokkos::RangePolicy<ExecSpace>(0, Nx), KOKKOS_LAMBDA(int i) {
-        for (int j = 0; j < Ny; j++)
-            gpuSimData(i, j) = static_cast<float>(i);
-    });
+    Kokkos::parallel_for(
+        "initBuffer", Kokkos::RangePolicy<ExecSpace>(0, Nx), KOKKOS_LAMBDA(int i) {
+            for (int j = 0; j < Ny; j++)
+                gpuSimData(i, j) = static_cast<float>(i);
+        });
     Kokkos::fence();
 
     adios2::ADIOS adios;
@@ -48,11 +49,11 @@ int BPWrite(const std::string fname, const size_t Nx, const size_t Ny, const siz
         bpWriter.EndStep();
 
         // Update values in the simulation data
-        Kokkos::parallel_for("updateBuffer", Kokkos::RangePolicy<ExecSpace>(0, Nx),
-                             KOKKOS_LAMBDA(int i) {
-                                 for (int j = 0; j < Ny; j++)
-                                     gpuSimData(i, j) += 10;
-                             });
+        Kokkos::parallel_for(
+            "updateBuffer", Kokkos::RangePolicy<ExecSpace>(0, Nx), KOKKOS_LAMBDA(int i) {
+                for (int j = 0; j < Ny; j++)
+                    gpuSimData(i, j) += 10;
+            });
         Kokkos::fence();
     }
 

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -45,17 +45,15 @@ size_t VariableBase::TotalSize() const noexcept { return helper::GetTotalSize(m_
 MemorySpace VariableBase::GetMemorySpace(const void *ptr)
 {
 #ifdef ADIOS2_HAVE_GPU_SUPPORT
-    if (m_MemSpace != MemorySpace::Detect)
+    if (m_MemSpace == MemorySpace::Detect)
     {
-        return m_MemSpace;
-    }
-
-    if (helper::IsGPUbuffer(ptr))
-    {
-        return MemorySpace::GPU;
+        if (helper::IsGPUbuffer(ptr))
+            m_MemSpace = MemorySpace::GPU;
+        else
+            m_MemSpace = MemorySpace::Host;
     }
 #endif
-    return MemorySpace::Host;
+    return m_MemSpace;
 }
 
 void VariableBase::SetMemorySpace(const MemorySpace mem) { m_MemSpace = mem; }

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -1715,7 +1715,8 @@ void BP5Writer::PutCommon(VariableBase &variable, const void *values, bool sync)
     }
 
     // if the user buffer is allocated on the GPU always use sync mode
-    if (variable.GetMemorySpace(values) != MemorySpace::Host)
+    auto memSpace = variable.GetMemorySpace(values);
+    if (memSpace != MemorySpace::Host)
         sync = true;
 
     size_t *Shape = NULL;
@@ -1786,8 +1787,7 @@ void BP5Writer::PutCommon(VariableBase &variable, const void *values, bool sync)
         helper::NdCopy((const char *)values, helper::CoreDims(ZeroDims), MemoryCount,
                        sourceRowMajor, false, (char *)ptr, MemoryStart, varCount, sourceRowMajor,
                        false, (int)ObjSize, helper::CoreDims(), helper::CoreDims(),
-                       helper::CoreDims(), helper::CoreDims(), false /* safemode */,
-                       variable.m_MemSpace);
+                       helper::CoreDims(), helper::CoreDims(), false /* safemode */, memSpace);
     }
     else
     {

--- a/source/adios2/engine/daos/DaosWriter.cpp
+++ b/source/adios2/engine/daos/DaosWriter.cpp
@@ -1708,7 +1708,8 @@ void DaosWriter::PutCommon(VariableBase &variable, const void *values, bool sync
     }
 
     // if the user buffer is allocated on the GPU always use sync mode
-    if (variable.GetMemorySpace(values) != MemorySpace::Host)
+    auto memSpace = variable.GetMemorySpace(values);
+    if (memSpace != MemorySpace::Host)
         sync = true;
 
     size_t *Shape = NULL;
@@ -1769,8 +1770,7 @@ void DaosWriter::PutCommon(VariableBase &variable, const void *values, bool sync
         helper::NdCopy((const char *)values, helper::CoreDims(ZeroDims), variable.m_MemoryCount,
                        sourceRowMajor, false, (char *)ptr, variable.m_MemoryStart, variable.m_Count,
                        sourceRowMajor, false, ObjSize, helper::CoreDims(), helper::CoreDims(),
-                       helper::CoreDims(), helper::CoreDims(), false /* safemode */,
-                       variable.m_MemSpace);
+                       helper::CoreDims(), helper::CoreDims(), false /* safemode */, memSpace);
     }
     else
     {

--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -37,6 +37,7 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
                                         "BeginStep/EndStep pairs");
     }
 
+    auto memSpace = variable.GetMemorySpace(values);
     if ((Params.MarshalMethod == SstMarshalFFS) || (Params.MarshalMethod == SstMarshalBP5))
     {
         size_t *Shape = NULL;
@@ -107,7 +108,7 @@ void SstWriter::PutSyncCommon(Variable<T> &variable, const T *values)
                                sourceRowMajor, false, (char *)ptr, MemoryStart, varCount,
                                sourceRowMajor, false, (int)ObjSize, helper::CoreDims(),
                                helper::CoreDims(), helper::CoreDims(), helper::CoreDims(),
-                               false /* safemode */, variable.m_MemSpace);
+                               false /* safemode */, memSpace);
             }
             else
             {

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -1276,7 +1276,7 @@ void BP5Serializer::CollectFinalShapeValues()
             MetaArrayRec *MetaEntry = (MetaArrayRec *)((char *)(MetadataBuf) + Rec->MetaOffset);
             if (memSpace != MemorySpace::Host)
             {
-                for (size_t i = 0; i < Rec->DimCount; ++i)
+                for (int i = 0; i < Rec->DimCount; ++i)
                     MetaEntry->Shape[Rec->DimCount - 1 - i] = VB->Shape().data()[i];
             }
             else

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.h
@@ -232,9 +232,9 @@ private:
     char *BuildArrayDBCountName(const char *base_name, const int type, const int element_size);
     char *BuildArrayBlockCountName(const char *base_name, const int type, const int element_size);
     char *TranslateADIOS2Type2FFS(const DataType Type);
-    size_t *CopyDims(const size_t Count, const size_t *Vals);
+    size_t *CopyDims(const size_t Count, const size_t *Vals, MemorySpace memSpace);
     size_t *AppendDims(size_t *OldDims, const size_t OldCount, const size_t Count,
-                       const size_t *Vals);
+                       const size_t *Vals, MemorySpace memSpace);
 
     void DumpDeferredBlocks(bool forceCopyDeferred = false);
     void VariableStatsEnabled(void *Variable);

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
@@ -239,7 +239,8 @@ void HDF5Common::Write(core::Variable<T> &variable, const T *values)
 #ifdef NO_STAT
     size_t valuesSize = adios2::helper::GetTotalSize(variable.m_Count);
     T min, max;
-    adios2::helper::GetMinMaxThreads(values, valuesSize, min, max, 1, variable.m_MemSpace);
+    auto memSpace = variable.GetMemorySpace(values);
+    adios2::helper::GetMinMaxThreads(values, valuesSize, min, max, 1, memSpace);
 
     int chainSize = chain.size();
     hid_t parentId = m_GroupId;


### PR DESCRIPTION
**Short description**
We need to update the adios2 variable dimensions for GPU pointers for multidimensional arrays to deal with the different layout between CPU and GPU. One side effect of the changes is that a variable now can only write GPU or CPU data (which is now forced in the code), we assume there will be no application that wants to mix them.
- The BP Kokkos example was updated to use 2D arrays and a mix of memory spaces for write/read

After this PR, if the writer puts a 2D array with `data(i, j)=i+1` created on the GPU, reading it from the GPU and printing it will show:
```
Read on memory space: Cuda
1 1 1 1 1 1 1 1 1 1
2 2 2 2 2 2 2 2 2 2
3 3 3 3 3 3 3 3 3 3
4 4 4 4 4 4 4 4 4 4
5 5 5 5 5 5 5 5 5 5
6 6 6 6 6 6 6 6 6 6
```
Reading and printing on the CPU will show:
```
 ./bin/bpls -l BPFileStepsWriteReadKokkos.bp/ -d bpFloats -D -n 6
  float    bpFloats  {10, 6} = 1 / 6
        step 0:
          block 0: [0:9, 0:5] = 1 / 6
    (0,0)    1 2 3 4 5 6
    (1,0)    1 2 3 4 5 6
    (2,0)    1 2 3 4 5 6
    (3,0)    1 2 3 4 5 6
    (4,0)    1 2 3 4 5 6
    (5,0)    1 2 3 4 5 6
    (6,0)    1 2 3 4 5 6
    (7,0)    1 2 3 4 5 6
    (8,0)    1 2 3 4 5 6
    (9,0)    1 2 3 4 5 6
```

**Details**
One assumption I am making is that we do not know if a variable is receiving GPU or CPU at creation (this would require changing the code function to template the variable over a memory space). The moment this is set is either if the user calls `SetMemorySpace` on a variable or during the first `Put` or `Get` when we detect the memory space and we fix it to a value.

This created a bit of a nightmare switching the dimensions since this is done in many places (@eisenhauer I hope you can double check I am covering all cases). The write side works perfectly, on the read side however, `InquireVariable` will not know that the user will be reading the data on the GPU or CPU so the shape returned will assume CPU. When allocating the buffer space on the GPU the dimensions need to be fliped by the user. The nicest solution I could find (in the example) is to create a function to return the dimensions of a variable based on the memory space:
```
template <class MemSpace>
std::array<size_t, 2> GetDimenstions(adios2::Variable<float> data)
{
    return {data.Shape()[1], data.Shape()[0]};
}

template <>
std::array<size_t, 2> GetDimenstions<Kokkos::HostSpace>(adios2::Variable<float> data)
{
    return {data.Shape()[0], data.Shape()[1]};
}
```

The buffer will then use these dimensions to allocate data.

**Discussion points**

1. Do we want to template a variable on the memory space (this value will be defaulted to Host if nothing is provided). It would make this code much cleaner and it would not require changes to SST and DataMan?
2. I think we should have the option of having a `variable.detectShape<MemorySpace>()` that basically implements the two functions above but internally in adios2. What do you guys think?

This needs more testing (me in about a week or anyone else in the mean time). I have the code for SST and DataMan as well but won't push this until I am sure there are no corner cases I missed and until we discuss the two points.