### PR TITLE
fix for ASAN issue related to JoinedDimArray handling in BP5 deserializer

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -779,8 +779,6 @@ void BP5Deserializer::InstallMetaData(void *MetadataBlock, size_t BlockLen, size
     }
     JoinedDimArray.resize(JDAIdx + 1);
     JoinedDimArray[JDAIdx].resize(writerCohortSize);
-    std::cout << "JoinedDimArray[" << JDAIdx << "] size = " << JoinedDimArray[JDAIdx].size()
-              << std::endl;
 
     (*m_MetadataBaseAddrs)[WriterRank] = BaseData;
 

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -190,9 +190,6 @@ private:
         nullptr; // may be a pointer into MetadataBaseArray or m_FreeableMBA
     std::vector<void *> *m_FreeableMBA = nullptr;
 
-    std::vector<void *> *m_JoinedDimenOffsetArrays = nullptr;
-    std::vector<void *> *m_FreeableJDOA = nullptr;
-
     // for random access mode, for each timestep, for each writerrank, what
     // metameta info applies to the metadata
     std::vector<std::vector<ControlInfo *>> m_ControlArray;
@@ -200,8 +197,9 @@ private:
     // address of the metadata
     std::vector<std::vector<void *> *> MetadataBaseArray;
     // for random access mode, for each timestep, for each writerrank, base
-    // address of the joined dim arrays
-    std::vector<std::vector<void *> *> JoinedDimArray;
+    // address of the joined dim arrays, for streaming use 0 index
+    std::vector<std::vector<size_t *>> JoinedDimArray;
+    size_t JDAIdx = 0;
 
     ControlInfo *ControlBlocks = nullptr;
     ControlInfo *GetPriorControl(FMFormat Format);


### PR DESCRIPTION
This is a quick fix to free a `vector<...>*` pointer in the destructor. However, this may be revised to use a vector instead of a pointer at all. 