### PR TITLE
update copyright.txt to include recent kitware authors

### DIFF
--- a/Copyright.txt
+++ b/Copyright.txt
@@ -16,9 +16,11 @@ limitations under the License.
 
 The following individuals and institutions are among the Contributors:
 
+* Ana Gainaru <gainarua@ornl.gov>
 * Caitlin Ross <caitlin.ross@kitware.com>
 * Chuck Atkins <chuck.atkins@kitware.com>
-* Greg S. Eisenhauer <eisen@cc.gatech.edu>
+* Greg Eisenhauer <eisen@cc.gatech.edu>
+* Dmitry Ganyushin <ganyushindi@ornl.gov> 
 * Junmin Gu <jgu@lbl.gov>
 * Norbert Podhorszki <pnorbert@ornl.gov>
 * Ruonan (Jason) Wang <wangr1@ornl.gov>

--- a/Copyright.txt
+++ b/Copyright.txt
@@ -20,7 +20,7 @@ The following individuals and institutions are among the Contributors:
 * Caitlin Ross <caitlin.ross@kitware.com>
 * Chuck Atkins <chuck.atkins@kitware.com>
 * Greg Eisenhauer <eisen@cc.gatech.edu>
-* Dmitry Ganyushin <ganyushindi@ornl.gov> 
+* Dmitry Ganyushin <ganyushindi@ornl.gov>
 * Junmin Gu <jgu@lbl.gov>
 * Norbert Podhorszki <pnorbert@ornl.gov>
 * Ruonan (Jason) Wang <wangr1@ornl.gov>

--- a/Copyright.txt
+++ b/Copyright.txt
@@ -16,12 +16,16 @@ limitations under the License.
 
 The following individuals and institutions are among the Contributors:
 
+* Caitlin Ross <caitlin.ross@kitware.com>
 * Chuck Atkins <chuck.atkins@kitware.com>
-* Greg S. Eisenhauer <eisen@cc.gatech.edu> 
-* William F. Godoy <godoywf@ornl.gov>
+* Greg S. Eisenhauer <eisen@cc.gatech.edu>
 * Junmin Gu <jgu@lbl.gov>
 * Norbert Podhorszki <pnorbert@ornl.gov>
 * Ruonan (Jason) Wang <wangr1@ornl.gov>
+* Scott Wittenburg <scott.wittenburg@kitware.com>
+* Spiros Tsalikis <spiros.tsalikis@kitware.com>
+* V. A. Bolea Sanchez <vicente.bolea@kitware.com>
+* William F. Godoy <godoywf@ornl.gov>
 
 See version control history for details of individual contributions.
 


### PR DESCRIPTION
Here we include recent Kitware authors to the copyright.txt. We are basing this file for other features such as the newly pip package.

X-Ref: #3960 