### PR TITLE
pip: also run pypi upload job on workflow_dispatch

### DIFF
--- a/.github/workflows/pypackaging.yml
+++ b/.github/workflows/pypackaging.yml
@@ -70,7 +70,12 @@ jobs:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'release' &&
+        github.event.action == 'published'
+      )
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Currently when we run a manual workflow, the upload to pypi job is getting skipped due to insufficient conditions guarding that job.  This PR adds `workflow_dispatch` to the conditions under which it will be run.