### PR TITLE
SST ASAN buffer fix

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -14,35 +14,16 @@ set(MEMORYCHECK_SUPPRESSIONS_FILE ${CMAKE_SOURCE_DIR}/scripts/dashboard/nightly/
 
 # Ignore tests that are currently failing, remove tests here as they are fixed
 list(APPEND CTEST_CUSTOM_MEMCHECK_IGNORE 
-Staging.TimeoutReader.1x1.CommMin.BP5.SST
-Staging.1x1Struct.BP5
-Staging.WriteMemorySelectionRead.1x1.CommMin.BP.SST
-Staging.1x1.Local2.CommMin.BP.SST
-Staging.OnDemandSingle.1x1.CommMin.BP5.SST
-Staging.AllToAllDistribution.1x1x3.CommMin.BP5.SST
-Staging.RoundRobinDistribution.1x1x3.CommMin.BP5.SST
-Staging.1x1.LocalMultiblock.CommMin.BP5.SST
-Staging.1x1.SstRUDP.CommMin.BP5.SST
-Staging.WriteMemorySelectionRead.1x1.CommMin.BP5.SST
-Staging.1x1LockGeometry.CommMin.BP5.SST
-Staging.1x1.ForcePreload.CommMin.BP5.SST
-Staging.1x1.NoPreload.CommMin.BP5.SST
-Staging.DiscardWriter.1x1.CommMin.BP5.SST
-Staging.LatestReaderHold.1x1.CommMin.BP5.SST
-Staging.LatestReader.1x1.CommMin.BP5.SST
 Engine.BP.BPWriteReadAsStreamTestADIOS2.ReaderWriterDefineVariable.BP5.Serial
-Staging.ZFPCompression.3x5.CommMin.BP5.SST
-Staging.ZFPCompression.1x1.CommMin.BP5.SST
-Staging.1x1Joined.CommMin.BP5.SST
-Staging.1x1Struct.CommMin.BP5.SST
-Staging.1x1.Local2.CommMin.BP5.SST
-Staging.1x1VarDestruction.CommMin.BP5.SST
-Staging.1x1.ModAttrs.CommMin.BP5.SST
-Staging.1x1.Attrs.CommMin.BP5.SST
-Staging.1x1.CommMin.BP5.SST
-Engine.SST.SstWriteFails.InvalidBeginStep.Serial
-remoteServerCleanup
-Remote.BPWriteMemorySelectionRead.FileRemote
-Remote.BPWriteMemorySelectionRead.GetRemote
 Remote.BPWriteReadADIOS2stdio.GetRemote
+Remote.BPWriteMemorySelectionRead.GetRemote
+Remote.BPWriteMemorySelectionRead.FileRemote
+remoteServerCleanup
+Engine.SST.SstWriteFails.InvalidBeginStep.Serial
+Staging.1x1.Local2.CommMin.BP5.SST
+Staging.1x1Struct.CommMin.BP5.SST
+Staging.WriteMemorySelectionRead.1x1.CommMin.BP5.SST
+Staging.1x1.Local2.CommMin.BP.SST
+Staging.WriteMemorySelectionRead.1x1.CommMin.BP.SST
+Staging.1x1Struct.BP5
 )

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -293,6 +293,7 @@ void SstWriter::EndStep()
             //  Free data and metadata blocks here.  BlockToFree is the newblock
             //  value in the enclosing function.
             free(BlockToFree->MetaMetaBlocks);
+            delete BlockToFree->TSInfo->DataBuffer;
             delete BlockToFree->TSInfo;
             delete BlockToFree;
         };


### PR DESCRIPTION
This deletes BP5 marshalling buffers for SST after use to fix a memory leak.  We may want to look into reusing those buffers, particularly for SST where we use the MallocV buffer subclass that grows with realloc() to keep things contiguous.  Reuse would potentially avoid the large-copy-on-realloc problem that happens apps that generate a lot of data.