### PR TITLE
Replace the only PERFSTUBS_SCOPED_TIMER_FUNC() call in BP5 to get rid…

### DIFF
--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -431,7 +431,7 @@ void BP5Writer::NotifyEngineAttribute(std::string name, AttributeBase *Attr, voi
 
 void BP5Writer::MarshalAttributes()
 {
-    PERFSTUBS_SCOPED_TIMER_FUNC();
+    PERFSTUBS_SCOPED_TIMER("BP5Writer::MarshalAttributes");
     const auto &attributes = m_IO.GetAttributes();
 
     // if there are no new attributes, nothing to do


### PR DESCRIPTION
… of an ASAN error blocking local testing.