### PR TITLE
Allow plugin operators to take advantage of the estimated size API

### DIFF
--- a/plugins/operators/EncryptionOperator.cpp
+++ b/plugins/operators/EncryptionOperator.cpp
@@ -166,6 +166,16 @@ EncryptionOperator::InverseOperate(const char *bufferIn, const size_t sizeIn, ch
 
 bool EncryptionOperator::IsDataTypeValid(const DataType type) const { return true; }
 
+size_t EncryptionOperator::GetEstimatedSize(const size_t ElemCount, const size_t ElemSize,
+                                            const size_t ndims, const size_t *dims) const
+{
+    size_t sizeIn = ElemCount * ElemSize;
+    return (sizeof(size_t)                // Data size
+            + crypto_secretbox_NONCEBYTES // Nonce
+            + sizeIn                      // Data
+            + crypto_secretbox_MACBYTES   // MAC
+    );
+}
 } // end namespace plugin
 } // end namespace adios2
 

--- a/plugins/operators/EncryptionOperator.h
+++ b/plugins/operators/EncryptionOperator.h
@@ -41,6 +41,9 @@ public:
 
     bool IsDataTypeValid(const DataType type) const override;
 
+    size_t GetEstimatedSize(const size_t ElemCount, const size_t ElemSize, const size_t ndims,
+                            const size_t *dims) const override;
+
 private:
     struct EncryptImpl;
     std::unique_ptr<EncryptImpl> Impl;

--- a/source/adios2/operator/plugin/PluginOperator.h
+++ b/source/adios2/operator/plugin/PluginOperator.h
@@ -37,6 +37,9 @@ public:
     PluginOperator(const Params &parameters);
     virtual ~PluginOperator();
 
+    size_t GetEstimatedSize(const size_t ElemCount, const size_t ElemSize, const size_t ndims,
+                            const size_t *dims) const override;
+
     size_t Operate(const char *dataIn, const Dims &blockStart, const Dims &blockCount,
                    const DataType type, char *bufferOut) override;
 


### PR DESCRIPTION
Hi Team ADIOS!

I greatly appreciate the new `GetEstimatedSize` API for operators - thanks @pnorbert (as I see you committed that in 931941e).

I would like this to work for plugin operators also, so please consider these changes which implement this :) 

I am of course happy to accept revisions.