### PR TITLE
Fix segfault when asking for BlocksInfo for a variable name that does…

### DIFF
--- a/bindings/Python/py11Engine.cpp
+++ b/bindings/Python/py11Engine.cpp
@@ -267,12 +267,18 @@ std::vector<std::map<std::string, std::string>> Engine::BlocksInfo(std::string &
                                                                    const size_t step) const
 {
     std::vector<std::map<std::string, std::string>> rv;
+    auto &varMap = m_Engine->m_IO.GetVariables();
+    auto itVariable = varMap.find(var_name);
+    if (itVariable == varMap.end())
+    {
+        return rv;
+    }
 
     // Grab the specified variable object and get its type string
     adios2::DataType var_type = m_Engine->GetIO().InquireVariableType(var_name);
 
     MinVarInfo *minBlocksInfo = nullptr;
-    auto itVariable = m_Engine->m_IO.GetVariables().find(var_name);
+
     auto Variable = itVariable->second.get();
     minBlocksInfo = m_Engine->MinBlocksInfo(*Variable, 0);
     if (minBlocksInfo)
@@ -293,7 +299,8 @@ std::vector<std::map<std::string, std::string>> Engine::BlocksInfo(std::string &
                     {
                         start_ss << ",";
                     }
-                    start_ss << info.Start[i];
+                    start_ss << (minBlocksInfo->WasLocalValue ? reinterpret_cast<size_t>(info.Start)
+                                                              : info.Start[i]);
                 }
             }
             info_map["Start"] = start_ss.str();
@@ -310,7 +317,8 @@ std::vector<std::map<std::string, std::string>> Engine::BlocksInfo(std::string &
                     {
                         count_ss << ",";
                     }
-                    count_ss << info.Count[i];
+                    count_ss << (minBlocksInfo->WasLocalValue ? reinterpret_cast<size_t>(info.Count)
+                                                              : info.Count[i]);
                 }
             }
             info_map["Count"] = count_ss.str();


### PR DESCRIPTION
… not exist. Return value is now empty dictionary. Also fix handling 1D arrays made from LocalValues. Now this code works for examples/basics/values/valuesWrite.cpp ProcessID:

    with adios2.Stream("values.bp", 'rra') as f:
        e = f.engine
        bi = e.blocks_info("ProcessID", 0)
        print(f"Blocks info = {bi}")