### PR TITLE
blosc2: do not export blosc2 lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,9 @@ adios_option(Campaign   "Enable support for Campaigns (requires SQLite3 and ZLIB
 adios_option(AWSSDK     "Enable support for S3 compatible storage using AWS SDK's S3 module" OFF)
 adios_option(Derived_Variable    "Enable support for derived variables" OFF)
 adios_option(PIP        "Enable support for pip packaging" OFF)
+
+option(ADIOS2_Blosc2_PREFER_SHARED "Prefer shared Blosc2 libraries" ON)
+mark_as_advanced(ADIOS2_Blosc2_PREFER_SHARED)
 mark_as_advanced(ADIOS2_USE_PIP)
 include(${PROJECT_SOURCE_DIR}/cmake/DetectOptions.cmake)
 
@@ -216,9 +219,6 @@ if(ADIOS2_HAVE_MPI)
   # Workaround for MPI forcing the link of C++ bindings
   add_definitions(-DOMPI_SKIP_MPICXX -DMPICH_SKIP_MPICXX)
 endif()
-
-cmake_dependent_option(ADIOS2_Blosc2_PREFER_SHARED "Prefer shared Blosc2 libraries"
-  ON "Blosc2_shlib_available" OFF)
 
 #------------------------------------------------------------------------------#
 # POSIX O_DIRECT is only working for Unix in adios for now

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -92,15 +92,14 @@ if(Blosc2_FOUND)
 
   set(adios2_blosc2_tgt Blosc2::Blosc2)
   if (Blosc2_VERSION VERSION_GREATER_EQUAL 2.10.1)
-    if (Blosc2_shlib_available)
-      set(adios2_blosc2_tgt Blosc2::blosc2_$<IF:$<BOOL:${ADIOS2_Blosc2_PREFER_SHARED}>,shared,static>)
+    if (Blosc2_shlib_available AND ADIOS2_Blosc2_PREFER_SHARED)
+      set(adios2_blosc2_tgt Blosc2::blosc2_shared)
     else()
       set(adios2_blosc2_tgt Blosc2::blosc2_static)
     endif()
   endif()
 
-  add_library(adios2_blosc2 INTERFACE)
-  target_link_libraries(adios2_blosc2 INTERFACE ${adios2_blosc2_tgt})
+  add_library(adios2_blosc2 ALIAS ${adios2_blosc2_tgt})
 endif()
 
 # BZip2

--- a/cmake/adios2-config-common.cmake.in
+++ b/cmake/adios2-config-common.cmake.in
@@ -81,11 +81,6 @@ else()
 endif()
 
 if(NOT @BUILD_SHARED_LIBS@)
-  set(ADIOS2_HAVE_Blosc2 @ADIOS2_HAVE_Blosc2@)
-  if(ADIOS2_HAVE_Blosc2)
-    find_dependency(Blosc2)
-  endif()
-
   set(ADIOS2_HAVE_BZip2 @ADIOS2_HAVE_BZip2@)
   if(ADIOS2_HAVE_BZip2)
     find_dependency(BZip2)

--- a/cmake/install/pre/CMakeLists.txt
+++ b/cmake/install/pre/CMakeLists.txt
@@ -4,7 +4,7 @@ install(CODE "
 "
   COMPONENT adios2_core-development
 )
-file(GLOB ADIOS2_MODULE_FILES 
+file(GLOB ADIOS2_MODULE_FILES
   "${ADIOS2_SOURCE_DIR}/cmake/Find*.cmake"
   "${ADIOS2_SOURCE_DIR}/cmake/CMake*.cmake"
 )

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -480,7 +480,7 @@ install(DIRECTORY toolkit/
 )
 
 # Library installation
-install(TARGETS adios2_core ${maybe_adios2_core_mpi} ${maybe_adios2_core_cuda} ${maybe_adios2_core_kokkos} ${maybe_adios2_blosc2} ${maybe_adios2_core_derived} EXPORT adios2Exports
+install(TARGETS adios2_core ${maybe_adios2_core_mpi} ${maybe_adios2_core_cuda} ${maybe_adios2_core_kokkos} ${maybe_adios2_core_derived} EXPORT adios2Exports
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_core-runtime
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT adios2_core-libraries NAMELINK_COMPONENT adios2_core-development
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT adios2_core-development


### PR DESCRIPTION
Blosc2 is a private dependency thus we do not have to export its targets.