### PR TITLE
Update documentation for 2.10 changes to the GPU-backend

### DIFF
--- a/docs/user_guide/source/advanced/gpu_aware.rst
+++ b/docs/user_guide/source/advanced/gpu_aware.rst
@@ -2,12 +2,13 @@
  GPU-aware I/O
 #################
 
-The ``Put`` and ``Get`` functions in the BP4 and BP5 engines can receive user buffers allocated on the host or the device in both Sync and Deferred modes.
+The ``Put`` and ``Get`` functions in the default file engine (BP5) and some streaming engines (SST, DataMan) can receive user buffers allocated on the host or the device in both Sync and Deferred modes.
 
 .. note::
-    CUDA, HIP and SYCL allocated buffers are supported for device data.
+    Buffers allocated on the device with CUDA, HIP and SYCL are supported.
 
-If ADIOS2 is built without GPU support, only buffers allocated on the host are supported. If ADIOS2 is built with any GPU support, by default, the library will automatically detect where does the buffer memory physically resides.
+If ADIOS2 is built without GPU support, only buffers allocated on the host are supported.
+When GPU support is enabled, the default behavior is for ADIOS2 to automatically detect where the buffer memory physically resides.
 
 Users can also provide information about where the buffer was allocated by using the ``SetMemorySpace`` function within each variable.
 
@@ -20,17 +21,20 @@ Users can also provide information about where the buffer was allocated by using
         GPU     ///< GPU memory spaces
     };
 
+If ADIOS2 is built without GPU support, the available MemorySpace values are only ``Detect`` and ``Host``.
+
 ADIOS2 can use a CUDA or Kokkos backend for enabling GPU support. Only one backend can be active at a given time based on how ADIOS2 is build.
 
 **********************************
 Building ADIOS2 with a GPU backend
 **********************************
 
+By default both backends are ``OFF`` even if CUDA or Kokkos are installed and available to avoid a possible conflict between if both backends are enabled at the same time.
 
 Building with CUDA enabled
 --------------------------
 
-If there is no CUDA toolkit installed, cmake will turn CUDA off automatically. ADIOS2 default behavior for ``ADIOS2_USE_CUDA`` is to enable CUDA if it can find a CUDA toolkit on the system. In case the system has a CUDA toolkit installed, but it is desired to build ADIOS2 without CUDA enabled ``-DADIOS2_USE_CUDA=OFF`` must be used.
+The ADIOS2 default behavior is to turn ``OFF`` the CUDA backend. Building with the CUDA backend requires ``-DADIOS2_USE_Kokkos=ON`` and an available CUDA toolkit on the system.
 
 When building ADIOS2 with CUDA enabled, the user is responsible with setting the correct ``CMAKE_CUDA_ARCHITECTURES`` (e.g. for Summit the ``CMAKE_CUDA_ARCHITECTURES`` needs to be set to 70 to match the NVIDIA Volta V100).
 
@@ -43,11 +47,23 @@ The Kokkos library can be used to enable GPU within ADIOS2. Based on how Kokkos 
     Kokkos version >= 3.7 is required to enable the GPU backend in ADIOS2
 
 
-****************
-Writing GPU code
-****************
+*******************
+Writing GPU buffers
+*******************
 
-The following is a simple example of writing data to storage directly from a GPU buffer allocated with CUDA relying on the automatic detection of device pointers in ADIOS2. The ADIOS2 API is identical to codes using Host buffers for both the read and write logic.
+The ADIOS2 API for Device pointers is identical to using Host buffers for both the read and write logic.
+Internally each ADIOS2 variable holds a memory space for the data it receives. Once the memory space is set (eithr directly by the user through calls to ``SetMemorySpace`` or after detecting the buffer memory space the first ``Put`` or ``Get`` call) to either Host or Device, it cannot be changed.
+
+The `examples/hello` folder contains several codes that use Device buffers:
+ - `bpStepsWriteRead{Cuda|Hip}` show CUDA and HIP codes using BP5 with GPU pointers
+ - `bpStepsWriteReadKokkos contains` Fortran and C++ codes using ``Kokkos::View`` with different memory spaces and a Kokkos code using different layouts on Host buffers
+ - `datamanKokkos` shows an example of streaming a ``Kokkos::View`` with DataMan using different memory spaces
+ - `sstKokkos` shows an example of streaming a ``Kokkos::View`` with SST using different memory spaces
+
+Example using a Device buffer
+-----------------------------
+
+The following is a simple example of writing data to storage directly from a GPU buffer allocated with CUDA relying on the automatic detection of device pointers in ADIOS2.
 
 .. code-block:: c++
 
@@ -56,7 +72,7 @@ The following is a simple example of writing data to storage directly from a GPU
     cudaMemset(gpuSimData, 0, N);
     auto data = io.DefineVariable<float>("data", shape, start, count);
 
-    io.SetEngine("BP5"); // or BPFile
+    io.SetEngine("BP5");
     adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
     // Simulation steps
     for (size_t step = 0; step < nSteps; ++step)
@@ -82,13 +98,13 @@ If the ``SetMemorySpace`` function is used, the ADIOS2 library will not detect a
 Underneath, ADIOS2 relies on the backend used at build time to transfer the data. If ADIOS2 was build with CUDA, only CUDA buffers can be provided. If ADIOS2 was build with Kokkos (with CUDA enabled) only CUDA buffers can be provided. If ADIOS2 was build with Kokkos (with HIP enabled) only HIP buffers can be provided.
 
 .. note::
-    The SYCL backend in Kokkos can be used to run on Nvida, AMD and Intel GPUs
+    The SYCL backend in Kokkos can be used to run on Nvida, AMD and Intel GPUs, but we recommand using SYCL for Intel, HIP for AMD and CUDA for Nvidia.
 
 
 Kokkos applications
 --------------------
 
-ADIOS2 supports GPU buffers provided in the form of ``Kokkos::View`` directly in the Put/Get calls. The memory space can be automatically detected or provided by the user, in the same way as in the CUDA example.
+ADIOS2 supports GPU buffers provided in the form of ``Kokkos::View`` directly in the Put/Get calls. The memory space is automatically detected from the View information. In addition to the memory space, for ``Kokkos::View`` ADIOS2 also extracts the layout of the array and adjust the variable dimensions to be able to build the global shape (across ranks) of the array.
 
 .. code-block:: c++
 


### PR DESCRIPTION
- Updated the paths to the example codes
- Updated the default behavior when building ADIOS2 with Kokkos/CUDA available
- Added info about the new Shape function for the Read side 

This is my contribution to issue #4073 