### PR TITLE
Fix python char

### DIFF
--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -92,6 +92,7 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
 #else
     m.attr("is_built_with_mpi") = false;
 #endif
+    m.attr("is_char_signed") = (char)-1 < 0;
 
     // enum classes
     pybind11::enum_<adios2::Mode>(m, "Mode")

--- a/python/adios2/stream.py
+++ b/python/adios2/stream.py
@@ -11,8 +11,14 @@ from adios2 import bindings, Adios, IO, Variable
 
 def type_adios_to_numpy(name):
     """Translation between numpy and adios2 types"""
+    if name == "char":
+        if bindings.is_char_signed:
+            print("type_adios_to_numpy char --> signed int8")
+            return np.int8
+        print("type_adios_to_numpy char --> unsigned uint8")
+        return np.uint8
+
     return {
-        "char": np.int8,
         "int8_t": np.int8,
         "uint8_t": np.uint8,
         "int16_t": np.int16,

--- a/source/adios2/common/ADIOSMacros.h
+++ b/source/adios2/common/ADIOSMacros.h
@@ -33,7 +33,6 @@
  </pre>
 */
 #define ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(MACRO)                                     \
-    MACRO(char)                                                                                    \
     MACRO(int8_t)                                                                                  \
     MACRO(int16_t)                                                                                 \
     MACRO(int32_t)                                                                                 \
@@ -44,7 +43,8 @@
     MACRO(uint64_t)                                                                                \
     MACRO(float)                                                                                   \
     MACRO(double)                                                                                  \
-    MACRO(long double)
+    MACRO(long double)                                                                             \
+    MACRO(char)
 
 #define ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)                                               \
     ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(MACRO)                                         \
@@ -52,16 +52,15 @@
     MACRO(std::complex<double>)
 
 #define ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_1ARG(MACRO)                                               \
-    MACRO(std::string)                                                                             \
-    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)
+    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)                                                   \
+    MACRO(std::string)
 
 #define ADIOS2_FOREACH_STDTYPE_1ARG(MACRO)                                                         \
-    MACRO(std::string)                                                                             \
-    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)
+    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(MACRO)                                                   \
+    MACRO(std::string)
 
 #define ADIOS2_FOREACH_TYPE_1ARG(MACRO)                                                            \
     MACRO(std::string)                                                                             \
-    MACRO(char)                                                                                    \
     MACRO(signed char)                                                                             \
     MACRO(unsigned char)                                                                           \
     MACRO(short)                                                                                   \
@@ -76,10 +75,10 @@
     MACRO(double)                                                                                  \
     MACRO(long double)                                                                             \
     MACRO(std::complex<float>)                                                                     \
-    MACRO(std::complex<double>)
+    MACRO(std::complex<double>)                                                                    \
+    MACRO(char)
 
 #define ADIOS2_FOREACH_PRIMITIVE_TYPE_1ARG(MACRO)                                                  \
-    MACRO(char)                                                                                    \
     MACRO(signed char)                                                                             \
     MACRO(unsigned char)                                                                           \
     MACRO(short)                                                                                   \
@@ -94,7 +93,8 @@
     MACRO(double)                                                                                  \
     MACRO(long double)                                                                             \
     MACRO(std::complex<float>)                                                                     \
-    MACRO(std::complex<double>)
+    MACRO(std::complex<double>)                                                                    \
+    MACRO(char)
 
 #define ADIOS2_FOREACH_COMPLEX_PRIMITIVE_TYPE_1ARG(MACRO)                                          \
     MACRO(float)                                                                                   \
@@ -102,9 +102,9 @@
     MACRO(long double)
 
 #define ADIOS2_FOREACH_CHAR_TYPE_1ARG(MACRO)                                                       \
-    MACRO(char)                                                                                    \
     MACRO(signed char)                                                                             \
-    MACRO(unsigned char)
+    MACRO(unsigned char)                                                                           \
+    MACRO(char)
 
 #define ADIOS2_FOREACH_NUMERIC_TYPE_1ARG(MACRO)                                                    \
     MACRO(short)                                                                                   \
@@ -123,7 +123,6 @@
 
 #define ADIOS2_FOREACH_ATTRIBUTE_TYPE_1ARG(MACRO)                                                  \
     MACRO(std::string)                                                                             \
-    MACRO(char)                                                                                    \
     MACRO(signed char)                                                                             \
     MACRO(unsigned char)                                                                           \
     MACRO(short)                                                                                   \
@@ -138,10 +137,10 @@
     MACRO(double)                                                                                  \
     MACRO(long double)                                                                             \
     MACRO(std::complex<float>)                                                                     \
-    MACRO(std::complex<double>)
+    MACRO(std::complex<double>)                                                                    \
+    MACRO(char)
 
 #define ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_TYPE_1ARG(MACRO)                                        \
-    MACRO(char)                                                                                    \
     MACRO(signed char)                                                                             \
     MACRO(unsigned char)                                                                           \
     MACRO(short)                                                                                   \
@@ -156,7 +155,8 @@
     MACRO(double)                                                                                  \
     MACRO(long double)                                                                             \
     MACRO(std::complex<float>)                                                                     \
-    MACRO(std::complex<double>)
+    MACRO(std::complex<double>)                                                                    \
+    MACRO(char)
 
 /**
  <pre>
@@ -185,7 +185,6 @@
 #define ADIOS2_FOREACH_ATTRIBUTE_STDTYPE_2ARGS(MACRO)                                              \
     MACRO(std::string, string)                                                                     \
     MACRO(int8_t, int8)                                                                            \
-    MACRO(char, char)                                                                              \
     MACRO(uint8_t, uint8)                                                                          \
     MACRO(int16_t, int16)                                                                          \
     MACRO(uint16_t, uint16)                                                                        \
@@ -197,11 +196,11 @@
     MACRO(double, double)                                                                          \
     MACRO(long double, ldouble)                                                                    \
     MACRO(std::complex<float>, cfloat)                                                             \
-    MACRO(std::complex<double>, cdouble)
+    MACRO(std::complex<double>, cdouble)                                                           \
+    MACRO(char, char)
 
 #define ADIOS2_FOREACH_PRIMITVE_STDTYPE_2ARGS(MACRO)                                               \
     MACRO(int8_t, int8)                                                                            \
-    MACRO(char, char)                                                                              \
     MACRO(uint8_t, uint8)                                                                          \
     MACRO(int16_t, int16)                                                                          \
     MACRO(uint16_t, uint16)                                                                        \
@@ -213,7 +212,8 @@
     MACRO(double, double)                                                                          \
     MACRO(long double, ldouble)                                                                    \
     MACRO(std::complex<float>, cfloat)                                                             \
-    MACRO(std::complex<double>, cdouble)
+    MACRO(std::complex<double>, cdouble)                                                           \
+    MACRO(char, char)
 
 #define ADIOS2_FOREACH_MINMAX_STDTYPE_2ARGS(MACRO)                                                 \
     MACRO(int8_t, int8)                                                                            \

--- a/testing/adios2/engine/SmallTestData.h
+++ b/testing/adios2/engine/SmallTestData.h
@@ -66,6 +66,16 @@ struct SmallTestData
 
     std::array<char, 10> CHAR = {{'a', 'b', 'c', 'y', 'z', 'A', 'B', 'C', 'Y', 'Z'}};
     std::array<bool, 10> TF = {{true, false, true, true, false, false, true, false, false, true}};
+
+    std::array<char, 10> CHARS = {(char)0, (char)1,  (char)-2, (char)3,  (char)-4,
+                                  (char)5, (char)-6, (char)7,  (char)-8, (char)9};
+    std::array<signed char, 10> SCHARS = {
+        (signed char)0, (signed char)1,  (signed char)-2, (signed char)3,  (signed char)-4,
+        (signed char)5, (signed char)-6, (signed char)7,  (signed char)-8, (signed char)9};
+    std::array<unsigned char, 10> UCHARS = {(unsigned char)0,  (unsigned char)1,  (unsigned char)-2,
+                                            (unsigned char)3,  (unsigned char)-4, (unsigned char)5,
+                                            (unsigned char)-6, (unsigned char)7,  (unsigned char)-8,
+                                            (unsigned char)9};
 };
 
 SmallTestData generateNewSmallTestData(SmallTestData in, size_t step, size_t rank, size_t size)
@@ -109,6 +119,12 @@ SmallTestData generateNewSmallTestData(SmallTestData in, size_t step, size_t ran
         }
     });
 
+    std::for_each(in.CHARS.begin(), in.CHARS.end(), [&](char &v) { v += static_cast<char>(j); });
+    std::for_each(in.SCHARS.begin(), in.SCHARS.end(),
+                  [&](signed char &v) { v += static_cast<signed char>(j); });
+    std::for_each(in.UCHARS.begin(), in.UCHARS.end(),
+                  [&](unsigned char &v) { v += static_cast<unsigned char>(j); });
+
     return in;
 }
 
@@ -149,6 +165,12 @@ void UpdateSmallTestData(SmallTestData &in, int step, int rank, int size)
             v = 'A' + (v - 'Z') - 1;
         }
     });
+
+    std::for_each(in.CHARS.begin(), in.CHARS.end(), [&](char &v) { v += static_cast<char>(j); });
+    std::for_each(in.SCHARS.begin(), in.SCHARS.end(),
+                  [&](signed char &v) { v += static_cast<signed char>(j); });
+    std::for_each(in.UCHARS.begin(), in.UCHARS.end(),
+                  [&](unsigned char &v) { v += static_cast<unsigned char>(j); });
 }
 
 #endif // TESTING_ADIOS2_ENGINE_SMALLTESTDATA_H_

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -121,6 +121,12 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
             EXPECT_TRUE(var_r32);
             auto var_r64 = io.DefineVariable<double>("r64", shape, start, count);
             EXPECT_TRUE(var_r64);
+            auto var_chars = io.DefineVariable<char>("chars", shape, start, count);
+            EXPECT_TRUE(var_chars);
+            auto var_schars = io.DefineVariable<signed char>("schars", shape, start, count);
+            EXPECT_TRUE(var_schars);
+            auto var_uchars = io.DefineVariable<unsigned char>("uchars", shape, start, count);
+            EXPECT_TRUE(var_uchars);
         }
 
         if (!engineName.empty())
@@ -169,6 +175,9 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
             auto var_u64 = io.InquireVariable<uint64_t>("u64");
             auto var_r32 = io.InquireVariable<float>("r32");
             auto var_r64 = io.InquireVariable<double>("r64");
+            auto var_chars = io.InquireVariable<char>("chars");
+            auto var_schars = io.InquireVariable<signed char>("schars");
+            auto var_uchars = io.InquireVariable<unsigned char>("uchars");
 
             // Make a 1D selection to describe the local dimensions of the
             // variable we write and its offsets in the global spaces
@@ -187,6 +196,9 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
             var_u64.SetSelection(sel);
             var_r32.SetSelection(sel);
             var_r64.SetSelection(sel);
+            var_chars.SetSelection(sel);
+            var_schars.SetSelection(sel);
+            var_uchars.SetSelection(sel);
 
             // Write each one
             // fill in the variable with values from starting index to
@@ -206,6 +218,9 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
             bpWriter.Put(var_u64, currentTestData.U64.data());
             bpWriter.Put(var_r32, currentTestData.R32.data());
             bpWriter.Put(var_r64, currentTestData.R64.data());
+            bpWriter.Put(var_chars, currentTestData.CHARS.data());
+            bpWriter.Put(var_schars, currentTestData.SCHARS.data());
+            bpWriter.Put(var_uchars, currentTestData.UCHARS.data());
 
             bpWriter.EndStep();
         }
@@ -307,6 +322,24 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
         ASSERT_EQ(var_r64.Steps(), NSteps);
         ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
 
+        auto var_chars = io.InquireVariable<char>("chars");
+        EXPECT_TRUE(var_chars);
+        ASSERT_EQ(var_chars.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_chars.Steps(), NSteps);
+        ASSERT_EQ(var_chars.Shape()[0], mpiSize * Nx);
+
+        auto var_schars = io.InquireVariable<signed char>("schars");
+        EXPECT_TRUE(var_schars);
+        ASSERT_EQ(var_schars.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_schars.Steps(), NSteps);
+        ASSERT_EQ(var_schars.Shape()[0], mpiSize * Nx);
+
+        auto var_uchars = io.InquireVariable<unsigned char>("uchars");
+        EXPECT_TRUE(var_uchars);
+        ASSERT_EQ(var_uchars.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_uchars.Steps(), NSteps);
+        ASSERT_EQ(var_uchars.Shape()[0], mpiSize * Nx);
+
         // TODO: other types
 
         SmallTestData testData;
@@ -324,6 +357,9 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
         std::array<double, Nx> R64;
         std::array<char, Nx> CHAR;
         // std::array<bool, Nx> TF;
+        std::array<char, Nx> CHARS;
+        std::array<signed char, Nx> SCHARS;
+        std::array<unsigned char, Nx> UCHARS;
 
         const adios2::Dims start{mpiRank * Nx};
         const adios2::Dims count{Nx};
@@ -346,6 +382,10 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
         var_r32.SetSelection(sel);
         var_r64.SetSelection(sel);
 
+        var_chars.SetSelection(sel);
+        var_schars.SetSelection(sel);
+        var_uchars.SetSelection(sel);
+
         for (size_t t = 0; t < NSteps; ++t)
         {
             // var_bool.SetStepSelection({t, 1});
@@ -363,6 +403,10 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
 
             var_r32.SetStepSelection({t, 1});
             var_r64.SetStepSelection({t, 1});
+
+            var_chars.SetStepSelection({t, 1});
+            var_schars.SetStepSelection({t, 1});
+            var_uchars.SetStepSelection({t, 1});
 
             // Generate test data for each rank uniquely
             SmallTestData currentTestData =
@@ -384,6 +428,9 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
             bpReader.Get(var_r32, R32.data());
             bpReader.Get(var_r64, R64.data());
 
+            bpReader.Get(var_chars, CHARS.data());
+            bpReader.Get(var_schars, SCHARS.data());
+            bpReader.Get(var_uchars, UCHARS.data());
             bpReader.PerformGets();
 
             EXPECT_EQ(IString, currentTestData.S1);
@@ -406,6 +453,9 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
                 EXPECT_EQ(U64[i], currentTestData.U64[i]) << msg;
                 EXPECT_EQ(R32[i], currentTestData.R32[i]) << msg;
                 EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+                EXPECT_EQ(CHARS[i], currentTestData.CHARS[i]) << msg;
+                EXPECT_EQ(SCHARS[i], currentTestData.SCHARS[i]) << msg;
+                EXPECT_EQ(UCHARS[i], currentTestData.UCHARS[i]) << msg;
             }
         }
         bpReader.Close();


### PR DESCRIPTION
- based on char signess in installed adios library, use numpy.int8 or numpy.uint8 to read char arrays from BP files
- move char as last type in adios type macros, so that unsigned char always becomes uint8_t and signed char becomes int8_t in output (char arrays still become  char in output)
- add C++ test to write and read char/signed char/unsigned char arrays

fixes #4140 