### PR TITLE
Option in `bpls` to show the expression string for derived variables

### DIFF
--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -482,6 +482,8 @@ public:
         return false;
     }
 
+    virtual const char *VariableExprStr(const VariableBase &) { return NULL; }
+
     /** Notify the engine when a new attribute is defined. Called from IO.tcc
      */
     virtual void NotifyEngineAttribute(std::string name, DataType type) noexcept;

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -726,6 +726,11 @@ bool BP5Reader::VariableMinMax(const VariableBase &Var, const size_t Step, MinMa
     return m_BP5Deserializer->VariableMinMax(Var, Step, MinMax);
 }
 
+const char *BP5Reader::VariableExprStr(const VariableBase &Var)
+{
+    return static_cast<const char *>(m_BP5Deserializer->VariableExprStr(Var));
+}
+
 void BP5Reader::InitTransports()
 {
     if (m_IO.m_TransportsParameters.empty())

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -57,6 +57,7 @@ public:
     MinVarInfo *MinBlocksInfo(const VariableBase &, const size_t Step) const;
     bool VarShape(const VariableBase &Var, const size_t Step, Dims &Shape) const;
     bool VariableMinMax(const VariableBase &, const size_t Step, MinMaxStruct &MinMax);
+    const char *VariableExprStr(const VariableBase &Var);
 
 private:
     format::BP5Deserializer *m_BP5Deserializer = nullptr;

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -2443,5 +2443,11 @@ bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
     return true;
 }
 
+char *BP5Deserializer::VariableExprStr(const VariableBase &Var)
+{
+    BP5VarRec *VarRec = LookupVarByKey((void *)&Var);
+    return VarRec->ExprStr;
+}
+
 }
 }

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -82,6 +82,7 @@ public:
     MinVarInfo *MinBlocksInfo(const VariableBase &Var, const size_t Step);
     bool VarShape(const VariableBase &, const size_t Step, Dims &Shape) const;
     bool VariableMinMax(const VariableBase &var, const size_t Step, MinMaxStruct &MinMax);
+    char *VariableExprStr(const VariableBase &var);
     void GetAbsoluteSteps(const VariableBase &variable, std::vector<size_t> &keys) const;
 
     const bool m_WriterIsRowMajor;

--- a/testing/utils/cwriter/TestUtilsCWriter.bplsh.expected.txt
+++ b/testing/utils/cwriter/TestUtilsCWriter.bplsh.expected.txt
@@ -31,6 +31,7 @@ The time dimension is the first dimension then.
   --error     | -X string    Specify read accuracy (error,norm,rel|abs)
                              e.g. error="0.0,0.0,abs"
                              L2 norm = 0.0, Linf = inf
+  --show-derived             Show the expression string for derived vars
   --transport-parameters | -T         Specify File transport parameters
                                       e.g. "Library=stdio"
   --engine               | -E <name>  Specify ADIOS Engine


### PR DESCRIPTION
Added the option `--show-derived` in bpls to print the expression string for derived variables.

```
$ ./bin/bpls expAdd.bp --show-derived -l
  float    derived/addU  2*{10, 3, 6} = 2.98842 / 28.085
    Derived variable with expression: x =sim1/Ux  y =sim1/Uy  z =sim1/Uz  x+y+z
  float    sim1/Ux       2*{10, 3, 6} = 0.000224775 / 9.94031
  float    sim1/Uy       2*{10, 3, 6} = 0.0201616 / 9.83318
  float    sim1/Uz       2*{10, 3, 6} = 0.0031 / 9.95085
```