### PR TITLE
add line back to gs-pipeline.py

### DIFF
--- a/examples/simulations/gray-scott/catalyst/gs-pipeline.py
+++ b/examples/simulations/gray-scott/catalyst/gs-pipeline.py
@@ -65,6 +65,7 @@ def SetupFidesReader(json, bp, sst):
 
 # takes in a producer and view and sets up the visualization pipeline
 def SetupVisPipeline(producer, view):
+    Show(producer, view, 'UniformGridRepresentation')
     view.ResetCamera()
 
     # get color transfer function/color map for 'U'


### PR DESCRIPTION
This line was removed when bringing this script over from the ADIOS2-examples repo, but removing it changes the expected camera behavior, so it's being added back in.