### PR TITLE
adios2-config: set the policy directly

### DIFF
--- a/cmake/adios2-config-install.cmake.in
+++ b/cmake/adios2-config-install.cmake.in
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_policy(PUSH)
+cmake_policy(VERSION 3.12)
 
 set(_ADIOS2_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
@@ -30,3 +31,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/adios2-config-common.cmake")
 
 set(CMAKE_MODULE_PATH ${_ADIOS2_CMAKE_MODULE_PATH})
 unset(_ADIOS2_CMAKE_MODULE_PATH)
+
+cmake_policy(POP)


### PR DESCRIPTION
`cmake_minimum_required` is intended for top-level projects and scripts to set. Instead, just use the policy version.