### PR TITLE
Compress the expression string into one line for `bpls`

### DIFF
--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -482,7 +482,7 @@ public:
         return false;
     }
 
-    virtual const char *VariableExprStr(const VariableBase &) { return NULL; }
+    virtual std::string VariableExprStr(const VariableBase &) { return NULL; }
 
     /** Notify the engine when a new attribute is defined. Called from IO.tcc
      */

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -751,9 +751,18 @@ bool BP5Reader::VariableMinMax(const VariableBase &Var, const size_t Step, MinMa
     return m_BP5Deserializer->VariableMinMax(Var, Step, MinMax);
 }
 
-const char *BP5Reader::VariableExprStr(const VariableBase &Var)
+std::string BP5Reader::VariableExprStr(const VariableBase &Var)
 {
-    return static_cast<const char *>(m_BP5Deserializer->VariableExprStr(Var));
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    char *expPtr = m_BP5Deserializer->VariableExprStr(Var);
+    if (expPtr != nullptr)
+    {
+        derived::Expression expr(expPtr);
+        return expr.toStringExpr();
+    }
+#endif
+    std::string noDerive("");
+    return noDerive;
 }
 
 void BP5Reader::InitTransports()

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -57,7 +57,7 @@ public:
     MinVarInfo *MinBlocksInfo(const VariableBase &, const size_t Step) const;
     bool VarShape(const VariableBase &Var, const size_t Step, Dims &Shape) const;
     bool VariableMinMax(const VariableBase &, const size_t Step, MinMaxStruct &MinMax);
-    const char *VariableExprStr(const VariableBase &Var);
+    std::string VariableExprStr(const VariableBase &Var);
     void SetFlattenMode(bool flatten) { m_FlattenSteps = flatten; };
 
 private:

--- a/source/adios2/toolkit/derived/Expression.cpp
+++ b/source/adios2/toolkit/derived/Expression.cpp
@@ -167,6 +167,42 @@ void ExpressionTree::print()
     }
 }
 
+std::string ExpressionTree::toStringExpr()
+{
+    std::string result = "";
+    result += get_op_name(detail.operation) + "(";
+    for (std::tuple<ExpressionTree, std::string, bool> t : sub_exprs)
+    {
+        if (std::get<2>(t) == true)
+        {
+            result += std::get<0>(t).toStringExpr();
+        }
+        else
+        {
+            result += "{" + std::get<1>(t) + "}";
+            if (!detail.indices.empty())
+            {
+                result += "[ ";
+                for (std::tuple<int, int, int> idx : detail.indices)
+                {
+                    result += (std::get<0>(idx) < 0 ? "" : std::to_string(std::get<0>(idx))) + ":";
+                    result += (std::get<1>(idx) < 0 ? "" : std::to_string(std::get<1>(idx))) + ":";
+                    result += (std::get<2>(idx) < 0 ? "" : std::to_string(std::get<2>(idx))) + ",";
+                }
+                // remove last comma
+                result.pop_back();
+                result += " ]";
+            }
+        }
+        result += ",";
+    }
+    // remove last comma
+    result.pop_back();
+    result += ")";
+
+    return result;
+}
+
 Dims ExpressionTree::GetDims(std::map<std::string, Dims> NameToDims)
 {
     std::vector<Dims> exprDims;

--- a/source/adios2/toolkit/derived/Expression.cpp
+++ b/source/adios2/toolkit/derived/Expression.cpp
@@ -93,6 +93,8 @@ Dims Expression::GetStart() { return m_Start; }
 
 Dims Expression::GetCount() { return m_Count; }
 
+std::string Expression::toStringExpr() { return m_Expr.toStringExpr(); }
+
 void Expression::SetDims(std::map<std::string, std::tuple<Dims, Dims, Dims>> NameToDims)
 {
     std::map<std::string, Dims> NameToCount, NameToStart, NameToShape;

--- a/source/adios2/toolkit/derived/Expression.h
+++ b/source/adios2/toolkit/derived/Expression.h
@@ -54,6 +54,7 @@ public:
     ApplyExpression(DataType type, size_t numBlocks,
                     std::map<std::string, std::vector<DerivedData>> nameToData);
     void print();
+    std::string toStringExpr();
 };
 
 class Expression

--- a/source/adios2/toolkit/derived/Expression.h
+++ b/source/adios2/toolkit/derived/Expression.h
@@ -73,6 +73,7 @@ public:
     Dims GetShape();
     Dims GetStart();
     Dims GetCount();
+    std::string toStringExpr();
     void SetDims(std::map<std::string, std::tuple<Dims, Dims, Dims>> NameToDims);
     std::vector<std::string> VariableNameList();
     std::vector<DerivedData>

--- a/source/adios2/toolkit/derived/parser/lexer.l
+++ b/source/adios2/toolkit/derived/parser/lexer.l
@@ -149,6 +149,7 @@ void
 adios2::detail::ASTDriver::parse (const std::string input)
 {
   adios2::detail::parser parse (*this);
+  yy_flex_debug = trace_scanning;
   yy_scan_string(input.c_str());
   parse.set_debug_level (trace_parsing);
   parse ();

--- a/source/adios2/toolkit/derived/parser/pregen-source/lexer.cpp
+++ b/source/adios2/toolkit/derived/parser/pregen-source/lexer.cpp
@@ -1899,7 +1899,9 @@ void
 adios2::detail::ASTDriver::parse (const std::string input)
 {
   adios2::detail::parser parse (*this);
+  yy_flex_debug = trace_scanning;
   yy_scan_string(input.c_str());
   parse.set_debug_level (trace_parsing);
   parse ();
 }
+

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1307,11 +1307,9 @@ int printVariableInfo(core::Engine *fp, core::IO *io, core::Variable<T> *variabl
 
     if (show_derived_expr)
     {
-        const char *ExprPtr = fp->VariableExprStr(*variable);
-        if (ExprPtr != NULL)
+        std::string ExprStr = fp->VariableExprStr(*variable);
+        if (ExprStr.size() > 0)
         {
-            std::string ExprStr(ExprPtr);
-            std::replace(ExprStr.begin(), ExprStr.end(), '\n', ' ');
             fprintf(outf, "    Derived variable with expression: %s\n", ExprStr.c_str());
         }
     }


### PR DESCRIPTION
Related to PR #4145

Create a function that returns a single line string representation of a derived expression. This is mainly for `bpls` since one line has a more user friendly format. 

ExpressionTree to String Expression:
`ADD({sim1/Ux},{sim1/Uy},{sim1/Uz})`

```
$ ./bin/bpls expAdd.bp --show-derived -l
  float    derived/addU  2*{10, 3, 6} = 2.98842 / 28.085
    Derived variable with expression: ADD({sim1/Ux},{sim1/Uy},{sim1/Uz})
  float    sim1/Ux       2*{10, 3, 6} = 0.000224775 / 9.94031
  float    sim1/Uy       2*{10, 3, 6} = 0.0201616 / 9.83318
  float    sim1/Uz       2*{10, 3, 6} = 0.0031 / 9.95085
```

The current solution is not the best. We do not create derived variables on the read side so the BP5Reader provides an internal function to get the expression string from the deserializer, create an expression on it, and call the pretty-print function on the expression (which is overly complicated). I would still merge this PR like this. We will start creating derived variables on the read side and we can replace the logic with something cleaner at that point. This PR is one step in this direction since it moves the string conversion on the Expression class.

