### PR TITLE
Adding hooks to gather performance for derived variables

### DIFF
--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -507,9 +507,11 @@ void BP5Writer::MarshalAttributes()
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
 void BP5Writer::ComputeDerivedVariables()
 {
+    PERFSTUBS_SCOPED_TIMER("BP5Writer::ComputeDerivedVariables");
     auto const &m_VariablesDerived = m_IO.GetDerivedVariables();
     auto const &m_Variables = m_IO.GetVariables();
     // parse all derived variables
+    m_Profiler.Start("DeriveVars");
     for (auto it = m_VariablesDerived.begin(); it != m_VariablesDerived.end(); it++)
     {
         // identify the variables used in the derived variable
@@ -562,6 +564,7 @@ void BP5Writer::ComputeDerivedVariables()
             free(std::get<0>(derivedBlock));
         }
     }
+    m_Profiler.Stop("DeriveVars");
 }
 #endif
 

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -5,6 +5,7 @@
 #include "Function.tcc"
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/helper/adiosFunctions.h"
+#include <adios2-perfstubs-interface.h>
 #include <cmath>
 
 namespace adios2
@@ -14,6 +15,7 @@ namespace derived
 
 DerivedData AddFunc(std::vector<DerivedData> inputData, DataType type)
 {
+    PERFSTUBS_SCOPED_TIMER("derived::Function::AddFunc");
     size_t dataSize = std::accumulate(std::begin(inputData[0].Count), std::end(inputData[0].Count),
                                       1, std::multiplies<size_t>());
 
@@ -31,6 +33,7 @@ DerivedData AddFunc(std::vector<DerivedData> inputData, DataType type)
 
 DerivedData MagnitudeFunc(std::vector<DerivedData> inputData, DataType type)
 {
+    PERFSTUBS_SCOPED_TIMER("derived::Function::MagnitudeFunc");
     size_t dataSize = std::accumulate(std::begin(inputData[0].Count), std::end(inputData[0].Count),
                                       1, std::multiplies<size_t>());
 #define declare_type_mag(T)                                                                        \
@@ -147,6 +150,7 @@ float linear_interp(DerivedData input, size_t index, size_t dim)
  */
 DerivedData Curl3DFunc(const std::vector<DerivedData> inputData, DataType type)
 {
+    PERFSTUBS_SCOPED_TIMER("derived::Function::Curl3DFunc");
     size_t dataSize = inputData[0].Count[0] * inputData[0].Count[1] * inputData[0].Count[2];
 
     DerivedData curl;

--- a/source/adios2/toolkit/profiling/iochrono/IOChrono.cpp
+++ b/source/adios2/toolkit/profiling/iochrono/IOChrono.cpp
@@ -56,6 +56,8 @@ JSONProfiler::JSONProfiler(helper::Comm const &comm) : m_Comm(comm)
     AddTimerWatch("DC_WaitOnAsync2");
     AddTimerWatch("PDW");
 
+    AddTimerWatch("DeriveVars");
+
     m_Profiler.m_Bytes.emplace("buffering", 0);
     AddTimerWatch("DataRead");
     m_Profiler.m_Bytes.emplace("dataread", 0);


### PR DESCRIPTION
In the profile.json file
```
[
{ "rank":0, "start":"Fri_May_10_17:06:59_2024","DeriveVars_mus": 193012033, "DeriveVars":{"mus":193012033, "nCalls":1},"ES_mus": 416417, "ES":{"mus":416417, "nCalls":1},"ES_meta1_mus": 26, "ES_meta1":{"mus":26, "nCalls":1},"ES_meta2_mus": 130, "ES_meta2":{"mus":130, "nCalls":1},"ES_close_mus": 2093, "ES_close":{"mus":2093, "nCalls":1},"ES_AWD_mus": 414157, "ES_AWD":{"mus":414157, "nCalls":1}, "databytes":0, "metadatabytes":0, "metametadatabytes":0, "transport_0":{"type":"File_POSIX", "wbytes":786432000, "close":{"mus":271, "nCalls":1}, "write":{"mus":406584, "nCalls":4}, "open":{"mus":20610, "nCalls":1}}, "transport_1":{"type":"File_POSIX", "wbytes":752, "close":{"mus":153, "nCalls":1}, "write":{"mus":19, "nCalls":4}, "open":{"mus":984, "nCalls":1}} }
]
```

and when using TAU
```
NODE 0;CONTEXT 0;THREAD 0:
---------------------------------------------------------------------------------------
%Time    Exclusive    Inclusive       #Call      #Subrs  Inclusive Name
              msec   total msec                          usec/call
---------------------------------------------------------------------------------------
100.0        0.922     3:14.763           1           1  194763742 .TAU application
100.0        1,309     3:14.762           1           8  194762820 int taupreload_main(int, char **, char **)
 99.1          166     3:13.012           1           1  193012066 BP5Writer::ComputeDerivedVariables
 99.0     3:12.845     3:12.845           1           0  192845760 derived::Function::Curl3DFunc
  0.2          416          416           1           1     416465 BP5Writer::EndStep
  0.0        0.632           21           1           1      21861 IO::Open
  0.0        0.922           21           1           4      21229 BP5Writer::Open
  0.0           20           20           4           0       5077 pthread_join
  0.0            1            1           1           0       1963 BP5Writer::Close
  0.0        0.604        0.641           1           3        641 IO::DefineDerivedVariable
  0.0        0.085        0.085           3           0         28 IO::DefineVariable
  0.0        0.037        0.037           3           0         12 IO::other
  0.0        0.013        0.013           1           0         13 BP5Writer::MarshalAttributes
```

This is needed to understand the performance of derived functions.