### PR TITLE
Reorg Remote as base class in preparation for more remote subclasses

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -238,7 +238,7 @@ endif()
 
 if (ADIOS2_HAVE_SST)
   # EVPath-enabled remote file transport
-  target_sources(adios2_core PRIVATE toolkit/remote/remote_common.cpp toolkit/transport/file/FileRemote.cpp)
+  target_sources(adios2_core PRIVATE toolkit/remote/remote_common.cpp toolkit/transport/file/FileRemote.cpp toolkit/remote/EVPathRemote.cpp)
   target_link_libraries(adios2_core PRIVATE adios2::thirdparty::EVPath)
   add_subdirectory(toolkit/remote)
 endif()

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -293,8 +293,9 @@ void BP5Reader::PerformGets()
         {
             RemoteName = m_Name;
         }
+        (void)RowMajorOrdering; // Use in case no remotes available
 #ifdef ADIOS2_HAVE_SST
-        m_Remote = std::make_unique<EVPathRemote>();
+        m_Remote = std::unique_ptr<EVPathRemote>(new EVPathRemote());
         m_Remote->Open("localhost", EVPathRemoteCommon::ServerPort, RemoteName, m_OpenMode,
                        RowMajorOrdering);
 #endif

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -95,7 +95,7 @@ private:
     /* transport manager for managing the active flag file */
     transportman::TransportMan m_ActiveFlagFileManager;
     bool m_dataIsRemote = false;
-    Remote m_Remote;
+    std::unique_ptr<Remote> m_Remote;
     bool m_WriterIsActive = true;
     adios2::profiling::JSONProfiler m_JSONProfiler;
 

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -1,0 +1,219 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ */
+#include "EVPathRemote.h"
+#include "Remote.h"
+#include "adios2/core/ADIOS.h"
+#include "adios2/helper/adiosLog.h"
+#include "adios2/helper/adiosString.h"
+#include "adios2/helper/adiosSystem.h"
+#ifdef _MSC_VER
+#define strdup(x) _strdup(x)
+#endif
+
+#define ThrowUp(x)                                                                                 \
+    helper::Throw<std::invalid_argument>("Core", "Engine", "ThrowUp",                              \
+                                         "Non-overridden function " + std::string(x) +             \
+                                             " called in Remote")
+
+namespace adios2
+{
+
+EVPathRemote::EVPathRemote() {}
+
+#ifdef ADIOS2_HAVE_SST
+EVPathRemote::~EVPathRemote()
+{
+    if (m_conn)
+        CMConnection_close(m_conn);
+}
+
+void OpenResponseHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                         attr_list attrs)
+{
+    EVPathRemoteCommon::OpenResponseMsg open_response_msg =
+        static_cast<EVPathRemoteCommon::OpenResponseMsg>(vevent);
+
+    void *obj = CMCondition_get_client_data(cm, open_response_msg->OpenResponseCondition);
+    static_cast<EVPathRemote *>(obj)->m_ID = open_response_msg->FileHandle;
+    CMCondition_signal(cm, open_response_msg->OpenResponseCondition);
+    return;
+};
+
+void OpenSimpleResponseHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                               attr_list attrs)
+{
+    EVPathRemoteCommon::OpenSimpleResponseMsg open_response_msg =
+        static_cast<EVPathRemoteCommon::OpenSimpleResponseMsg>(vevent);
+
+    void *obj = CMCondition_get_client_data(cm, open_response_msg->OpenResponseCondition);
+    static_cast<EVPathRemote *>(obj)->m_ID = open_response_msg->FileHandle;
+    static_cast<EVPathRemote *>(obj)->m_Size = open_response_msg->FileSize;
+    CMCondition_signal(cm, open_response_msg->OpenResponseCondition);
+    return;
+};
+
+void ReadResponseHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
+                         attr_list attrs)
+{
+    EVPathRemoteCommon::ReadResponseMsg read_response_msg =
+        static_cast<EVPathRemoteCommon::ReadResponseMsg>(vevent);
+    memcpy(read_response_msg->Dest, read_response_msg->ReadData, read_response_msg->Size);
+    CMCondition_signal(cm, read_response_msg->ReadResponseCondition);
+    return;
+};
+
+CManagerSingleton &CManagerSingleton::Instance(EVPathRemoteCommon::Remote_evpath_state &ev_state)
+{
+    std::mutex mtx;
+    const std::lock_guard<std::mutex> lock(mtx);
+    static CManagerSingleton instance;
+    ev_state = instance.internalEvState;
+    return instance;
+}
+
+void EVPathRemote::InitCMData()
+{
+    (void)CManagerSingleton::Instance(ev_state);
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+        CMregister_handler(ev_state.OpenResponseFormat, (CMHandlerFunc)OpenResponseHandler,
+                           &ev_state);
+        CMregister_handler(ev_state.ReadResponseFormat, (CMHandlerFunc)ReadResponseHandler,
+                           &ev_state);
+        CMregister_handler(ev_state.OpenSimpleResponseFormat,
+                           (CMHandlerFunc)OpenSimpleResponseHandler, &ev_state);
+        CMregister_handler(ev_state.ReadResponseFormat, (CMHandlerFunc)ReadResponseHandler,
+                           &ev_state);
+    });
+}
+
+void EVPathRemote::Open(const std::string hostname, const int32_t port, const std::string filename,
+                        const Mode mode, bool RowMajorOrdering)
+{
+
+    EVPathRemoteCommon::_OpenFileMsg open_msg;
+    InitCMData();
+    attr_list contact_list = create_attr_list();
+    atom_t CM_IP_PORT = -1;
+    atom_t CM_IP_HOSTNAME = -1;
+    CM_IP_HOSTNAME = attr_atom_from_string("IP_HOST");
+    CM_IP_PORT = attr_atom_from_string("IP_PORT");
+    add_attr(contact_list, CM_IP_HOSTNAME, Attr_String, (attr_value)strdup(hostname.c_str()));
+    add_attr(contact_list, CM_IP_PORT, Attr_Int4, (attr_value)port);
+    m_conn = CMinitiate_conn(ev_state.cm, contact_list);
+    free_attr_list(contact_list);
+    if (!m_conn)
+        return;
+
+    memset(&open_msg, 0, sizeof(open_msg));
+    open_msg.FileName = (char *)filename.c_str();
+    switch (mode)
+    {
+    case Mode::Read:
+        open_msg.Mode = EVPathRemoteCommon::RemoteFileMode::RemoteOpen;
+        break;
+    case Mode::ReadRandomAccess:
+        open_msg.Mode = EVPathRemoteCommon::RemoteFileMode::RemoteOpenRandomAccess;
+        break;
+    default:
+        break;
+    }
+    open_msg.OpenResponseCondition = CMCondition_get(ev_state.cm, m_conn);
+    open_msg.RowMajorOrder = RowMajorOrdering;
+    CMCondition_set_client_data(ev_state.cm, open_msg.OpenResponseCondition, (void *)this);
+    CMwrite(m_conn, ev_state.OpenFileFormat, &open_msg);
+    CMCondition_wait(ev_state.cm, open_msg.OpenResponseCondition);
+    m_Active = true;
+}
+
+void EVPathRemote::OpenSimpleFile(const std::string hostname, const int32_t port,
+                                  const std::string filename)
+{
+
+    EVPathRemoteCommon::_OpenSimpleFileMsg open_msg;
+    InitCMData();
+    attr_list contact_list = create_attr_list();
+    atom_t CM_IP_PORT = -1;
+    atom_t CM_IP_HOSTNAME = -1;
+    CM_IP_HOSTNAME = attr_atom_from_string("IP_HOST");
+    CM_IP_PORT = attr_atom_from_string("IP_PORT");
+    add_attr(contact_list, CM_IP_HOSTNAME, Attr_String, (attr_value)strdup(hostname.c_str()));
+    add_attr(contact_list, CM_IP_PORT, Attr_Int4, (attr_value)port);
+    m_conn = CMinitiate_conn(ev_state.cm, contact_list);
+    free_attr_list(contact_list);
+    if (!m_conn)
+        return;
+
+    memset(&open_msg, 0, sizeof(open_msg));
+    open_msg.FileName = (char *)filename.c_str();
+    open_msg.OpenResponseCondition = CMCondition_get(ev_state.cm, m_conn);
+    CMCondition_set_client_data(ev_state.cm, open_msg.OpenResponseCondition, (void *)this);
+    CMwrite(m_conn, ev_state.OpenSimpleFileFormat, &open_msg);
+    CMCondition_wait(ev_state.cm, open_msg.OpenResponseCondition);
+    m_Active = true;
+}
+
+EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count,
+                                          Dims &Start, void *dest)
+{
+    EVPathRemoteCommon::_GetRequestMsg GetMsg;
+    memset(&GetMsg, 0, sizeof(GetMsg));
+    GetMsg.GetResponseCondition = CMCondition_get(ev_state.cm, m_conn);
+    GetMsg.FileHandle = m_ID;
+    GetMsg.VarName = VarName;
+    GetMsg.Step = Step;
+    GetMsg.BlockID = BlockID;
+    GetMsg.DimCount = (int)Count.size();
+    GetMsg.Count = Count.data();
+    GetMsg.Start = Start.data();
+    GetMsg.Dest = dest;
+    CMwrite(m_conn, ev_state.GetRequestFormat, &GetMsg);
+    CMCondition_wait(ev_state.cm, GetMsg.GetResponseCondition);
+    return GetMsg.GetResponseCondition;
+}
+
+EVPathRemote::GetHandle EVPathRemote::Read(size_t Start, size_t Size, void *Dest)
+{
+    EVPathRemoteCommon::_ReadRequestMsg ReadMsg;
+    memset(&ReadMsg, 0, sizeof(ReadMsg));
+    ReadMsg.ReadResponseCondition = CMCondition_get(ev_state.cm, m_conn);
+    ReadMsg.FileHandle = m_ID;
+    ReadMsg.Offset = Start;
+    ReadMsg.Size = Size;
+    ReadMsg.Dest = Dest;
+    CMwrite(m_conn, ev_state.ReadRequestFormat, &ReadMsg);
+    CMCondition_wait(ev_state.cm, ReadMsg.ReadResponseCondition);
+    return ReadMsg.ReadResponseCondition;
+}
+
+bool EVPathRemote::WaitForGet(GetHandle handle)
+{
+    return CMCondition_wait(ev_state.cm, (int)handle);
+}
+#else
+
+void EVPathRemote::Open(const std::string hostname, const int32_t port, const std::string filename,
+                        const Mode mode, bool RowMajorOrdering){};
+
+void EVPathRemote::OpenSimpleFile(const std::string hostname, const int32_t port,
+                                  const std::string filename){};
+
+EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count,
+                                          Dims &Start, void *dest)
+{
+    return static_cast<GetHandle>(0);
+};
+
+bool EVPathRemote::WaitForGet(GetHandle handle) { return false; }
+
+EVPathRemote::GetHandle EVPathRemote::Read(size_t Start, size_t Size, void *Dest)
+{
+    return static_cast<GetHandle>(0);
+};
+EVPathRemote::~EVPathRemote() {}
+#endif
+
+} // end namespace adios2

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -1,0 +1,89 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+
+#ifndef ADIOS2_TOOLKIT_REMOTE_EVPATHREMOTE_H_
+#define ADIOS2_TOOLKIT_REMOTE_EVPATHREMOTE_H_
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <mutex>
+#include <string>
+#include <vector>
+/// \endcond
+
+#include "adios2/toolkit/profiling/iochrono/IOChrono.h"
+
+#include "Remote.h"
+#include "adios2/common/ADIOSConfig.h"
+
+#include "remote_common.h"
+
+namespace adios2
+{
+
+class EVPathRemote : public Remote
+{
+
+public:
+    profiling::IOChrono m_Profiler; ///< profiles Open, Write/Read, Close
+
+    /**
+     * Base constructor that all derived classes pass
+     * @param type from derived class
+     * @param comm passed to m_Comm
+     */
+    EVPathRemote();
+    ~EVPathRemote();
+
+    explicit operator bool() const { return m_Active; }
+
+    void Open(const std::string hostname, const int32_t port, const std::string filename,
+              const Mode mode, bool RowMajorOrdering);
+
+    void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename);
+
+    typedef int GetHandle;
+
+    GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start, void *dest);
+
+    bool WaitForGet(GetHandle handle);
+
+    GetHandle Read(size_t Start, size_t Size, void *Dest);
+
+    int64_t m_ID;
+
+private:
+#ifdef ADIOS2_HAVE_SST
+    void InitCMData();
+    EVPathRemoteCommon::Remote_evpath_state ev_state;
+    CMConnection m_conn = NULL;
+    std::mutex m_CMInitMutex;
+#endif
+    bool m_Active = false;
+};
+
+#ifdef ADIOS2_HAVE_SST
+class CManagerSingleton
+{
+public:
+    static CManagerSingleton &Instance(EVPathRemoteCommon::Remote_evpath_state &ev_state);
+
+private:
+    CManager m_cm = NULL;
+    EVPathRemoteCommon::Remote_evpath_state internalEvState;
+    CManagerSingleton()
+    {
+        m_cm = CManager_create();
+        internalEvState.cm = m_cm;
+        RegisterFormats(internalEvState);
+        CMfork_comm_thread(internalEvState.cm);
+    }
+
+    ~CManagerSingleton() { CManager_close(m_cm); }
+};
+#endif
+
+} // end namespace adios2
+
+#endif /* ADIOS2_TOOLKIT_EVPATHREMOTE_REMOTE_H_ */

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -4,6 +4,7 @@
  *
  */
 #include "Remote.h"
+#include "EVPathRemote.h"
 #include "adios2/core/ADIOS.h"
 #include "adios2/helper/adiosLog.h"
 #include "adios2/helper/adiosString.h"
@@ -12,198 +13,45 @@
 #define strdup(x) _strdup(x)
 #endif
 
+#define ThrowUp(x)                                                                                 \
+    helper::Throw<std::invalid_argument>("Core", "Engine", "ThrowUp",                              \
+                                         "Non-overridden function " + std::string(x) +             \
+                                             " called in Remote")
+
 namespace adios2
 {
-
-Remote::Remote() {}
-
-#ifdef ADIOS2_HAVE_SST
-Remote::~Remote()
-{
-    if (m_conn)
-        CMConnection_close(m_conn);
-}
-
-void OpenResponseHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
-                         attr_list attrs)
-{
-    RemoteCommon::OpenResponseMsg open_response_msg =
-        static_cast<RemoteCommon::OpenResponseMsg>(vevent);
-
-    void *obj = CMCondition_get_client_data(cm, open_response_msg->OpenResponseCondition);
-    static_cast<Remote *>(obj)->m_ID = open_response_msg->FileHandle;
-    CMCondition_signal(cm, open_response_msg->OpenResponseCondition);
-    return;
-};
-
-void OpenSimpleResponseHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
-                               attr_list attrs)
-{
-    RemoteCommon::OpenSimpleResponseMsg open_response_msg =
-        static_cast<RemoteCommon::OpenSimpleResponseMsg>(vevent);
-
-    void *obj = CMCondition_get_client_data(cm, open_response_msg->OpenResponseCondition);
-    static_cast<Remote *>(obj)->m_ID = open_response_msg->FileHandle;
-    static_cast<Remote *>(obj)->m_Size = open_response_msg->FileSize;
-    CMCondition_signal(cm, open_response_msg->OpenResponseCondition);
-    return;
-};
-
-void ReadResponseHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
-                         attr_list attrs)
-{
-    RemoteCommon::ReadResponseMsg read_response_msg =
-        static_cast<RemoteCommon::ReadResponseMsg>(vevent);
-    memcpy(read_response_msg->Dest, read_response_msg->ReadData, read_response_msg->Size);
-    CMCondition_signal(cm, read_response_msg->ReadResponseCondition);
-    return;
-};
-
-CManagerSingleton &CManagerSingleton::Instance(RemoteCommon::Remote_evpath_state &ev_state)
-{
-    std::mutex mtx;
-    const std::lock_guard<std::mutex> lock(mtx);
-    static CManagerSingleton instance;
-    ev_state = instance.internalEvState;
-    return instance;
-}
-
-void Remote::InitCMData()
-{
-    (void)CManagerSingleton::Instance(ev_state);
-    static std::once_flag flag;
-    std::call_once(flag, [&]() {
-        CMregister_handler(ev_state.OpenResponseFormat, (CMHandlerFunc)OpenResponseHandler,
-                           &ev_state);
-        CMregister_handler(ev_state.ReadResponseFormat, (CMHandlerFunc)ReadResponseHandler,
-                           &ev_state);
-        CMregister_handler(ev_state.OpenSimpleResponseFormat,
-                           (CMHandlerFunc)OpenSimpleResponseHandler, &ev_state);
-        CMregister_handler(ev_state.ReadResponseFormat, (CMHandlerFunc)ReadResponseHandler,
-                           &ev_state);
-    });
-}
 
 void Remote::Open(const std::string hostname, const int32_t port, const std::string filename,
                   const Mode mode, bool RowMajorOrdering)
 {
-
-    RemoteCommon::_OpenFileMsg open_msg;
-    InitCMData();
-    attr_list contact_list = create_attr_list();
-    atom_t CM_IP_PORT = -1;
-    atom_t CM_IP_HOSTNAME = -1;
-    CM_IP_HOSTNAME = attr_atom_from_string("IP_HOST");
-    CM_IP_PORT = attr_atom_from_string("IP_PORT");
-    add_attr(contact_list, CM_IP_HOSTNAME, Attr_String, (attr_value)strdup(hostname.c_str()));
-    add_attr(contact_list, CM_IP_PORT, Attr_Int4, (attr_value)port);
-    m_conn = CMinitiate_conn(ev_state.cm, contact_list);
-    free_attr_list(contact_list);
-    if (!m_conn)
-        return;
-
-    memset(&open_msg, 0, sizeof(open_msg));
-    open_msg.FileName = (char *)filename.c_str();
-    switch (mode)
-    {
-    case Mode::Read:
-        open_msg.Mode = RemoteCommon::RemoteFileMode::RemoteOpen;
-        break;
-    case Mode::ReadRandomAccess:
-        open_msg.Mode = RemoteCommon::RemoteFileMode::RemoteOpenRandomAccess;
-        break;
-    default:
-        break;
-    }
-    open_msg.OpenResponseCondition = CMCondition_get(ev_state.cm, m_conn);
-    open_msg.RowMajorOrder = RowMajorOrdering;
-    CMCondition_set_client_data(ev_state.cm, open_msg.OpenResponseCondition, (void *)this);
-    CMwrite(m_conn, ev_state.OpenFileFormat, &open_msg);
-    CMCondition_wait(ev_state.cm, open_msg.OpenResponseCondition);
-    m_Active = true;
-}
+    ThrowUp(("RemoteOpen"));
+};
 
 void Remote::OpenSimpleFile(const std::string hostname, const int32_t port,
                             const std::string filename)
 {
-
-    RemoteCommon::_OpenSimpleFileMsg open_msg;
-    InitCMData();
-    attr_list contact_list = create_attr_list();
-    atom_t CM_IP_PORT = -1;
-    atom_t CM_IP_HOSTNAME = -1;
-    CM_IP_HOSTNAME = attr_atom_from_string("IP_HOST");
-    CM_IP_PORT = attr_atom_from_string("IP_PORT");
-    add_attr(contact_list, CM_IP_HOSTNAME, Attr_String, (attr_value)strdup(hostname.c_str()));
-    add_attr(contact_list, CM_IP_PORT, Attr_Int4, (attr_value)port);
-    m_conn = CMinitiate_conn(ev_state.cm, contact_list);
-    free_attr_list(contact_list);
-    if (!m_conn)
-        return;
-
-    memset(&open_msg, 0, sizeof(open_msg));
-    open_msg.FileName = (char *)filename.c_str();
-    open_msg.OpenResponseCondition = CMCondition_get(ev_state.cm, m_conn);
-    CMCondition_set_client_data(ev_state.cm, open_msg.OpenResponseCondition, (void *)this);
-    CMwrite(m_conn, ev_state.OpenSimpleFileFormat, &open_msg);
-    CMCondition_wait(ev_state.cm, open_msg.OpenResponseCondition);
-    m_Active = true;
-}
-
-Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
-                              void *dest)
-{
-    RemoteCommon::_GetRequestMsg GetMsg;
-    memset(&GetMsg, 0, sizeof(GetMsg));
-    GetMsg.GetResponseCondition = CMCondition_get(ev_state.cm, m_conn);
-    GetMsg.FileHandle = m_ID;
-    GetMsg.VarName = VarName;
-    GetMsg.Step = Step;
-    GetMsg.BlockID = BlockID;
-    GetMsg.DimCount = (int)Count.size();
-    GetMsg.Count = Count.data();
-    GetMsg.Start = Start.data();
-    GetMsg.Dest = dest;
-    CMwrite(m_conn, ev_state.GetRequestFormat, &GetMsg);
-    CMCondition_wait(ev_state.cm, GetMsg.GetResponseCondition);
-    return GetMsg.GetResponseCondition;
-}
-
-Remote::GetHandle Remote::Read(size_t Start, size_t Size, void *Dest)
-{
-    RemoteCommon::_ReadRequestMsg ReadMsg;
-    memset(&ReadMsg, 0, sizeof(ReadMsg));
-    ReadMsg.ReadResponseCondition = CMCondition_get(ev_state.cm, m_conn);
-    ReadMsg.FileHandle = m_ID;
-    ReadMsg.Offset = Start;
-    ReadMsg.Size = Size;
-    ReadMsg.Dest = Dest;
-    CMwrite(m_conn, ev_state.ReadRequestFormat, &ReadMsg);
-    CMCondition_wait(ev_state.cm, ReadMsg.ReadResponseCondition);
-    return ReadMsg.ReadResponseCondition;
-}
-
-bool Remote::WaitForGet(GetHandle handle) { return CMCondition_wait(ev_state.cm, (int)handle); }
-#else
-
-void Remote::Open(const std::string hostname, const int32_t port, const std::string filename,
-                  const Mode mode, bool RowMajorOrdering){};
-
-void Remote::OpenSimpleFile(const std::string hostname, const int32_t port,
-                            const std::string filename){};
-
-Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
-                              void *dest)
-{
-    return static_cast<GetHandle>(0);
+    ThrowUp("RemoteSimpleOpen");
 };
 
-bool Remote::WaitForGet(GetHandle handle) { return false; }
+Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
+                              void *dest)
+{
+    ThrowUp("RemoteGet");
+    return 0;
+};
+
+bool Remote::WaitForGet(GetHandle handle)
+{
+    ThrowUp("RemoteWaitForGet");
+    return false;
+}
 
 Remote::GetHandle Remote::Read(size_t Start, size_t Size, void *Dest)
 {
-    return static_cast<GetHandle>(0);
+    ThrowUp("RemoteRead");
+    return 0;
 };
 Remote::~Remote() {}
-#endif
+Remote::Remote() {}
+
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -16,72 +16,34 @@
 
 #include "adios2/common/ADIOSConfig.h"
 
-#include "remote_common.h"
-
 namespace adios2
 {
 class Remote
 {
 
 public:
-    profiling::IOChrono m_Profiler; ///< profiles Open, Write/Read, Close
-
-    /**
-     * Base constructor that all derived classes pass
-     * @param type from derived class
-     * @param comm passed to m_Comm
-     */
     Remote();
-    ~Remote();
+    virtual ~Remote();
 
-    explicit operator bool() const { return m_Active; }
+    virtual explicit operator bool() const { return false; }
 
-    void Open(const std::string hostname, const int32_t port, const std::string filename,
-              const Mode mode, bool RowMajorOrdering);
+    virtual void Open(const std::string hostname, const int32_t port, const std::string filename,
+                      const Mode mode, bool RowMajorOrdering);
 
-    void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename);
+    virtual void OpenSimpleFile(const std::string hostname, const int32_t port,
+                                const std::string filename);
 
     typedef int GetHandle;
 
-    GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start, void *dest);
+    virtual GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
+                          void *dest);
 
-    bool WaitForGet(GetHandle handle);
+    virtual bool WaitForGet(GetHandle handle);
 
-    GetHandle Read(size_t Start, size_t Size, void *Dest);
+    virtual GetHandle Read(size_t Start, size_t Size, void *Dest);
 
-    int64_t m_ID;
     size_t m_Size;
-
-private:
-#ifdef ADIOS2_HAVE_SST
-    void InitCMData();
-    RemoteCommon::Remote_evpath_state ev_state;
-    CMConnection m_conn = NULL;
-    std::mutex m_CMInitMutex;
-#endif
-    bool m_Active = false;
 };
-
-#ifdef ADIOS2_HAVE_SST
-class CManagerSingleton
-{
-public:
-    static CManagerSingleton &Instance(RemoteCommon::Remote_evpath_state &ev_state);
-
-private:
-    CManager m_cm = NULL;
-    RemoteCommon::Remote_evpath_state internalEvState;
-    CManagerSingleton()
-    {
-        m_cm = CManager_create();
-        internalEvState.cm = m_cm;
-        RegisterFormats(internalEvState);
-        CMfork_comm_thread(internalEvState.cm);
-    }
-
-    ~CManagerSingleton() { CManager_close(m_cm); }
-};
-#endif
 
 } // end namespace adios2
 

--- a/source/adios2/toolkit/remote/remote_common.cpp
+++ b/source/adios2/toolkit/remote/remote_common.cpp
@@ -5,7 +5,7 @@
 
 namespace adios2
 {
-namespace RemoteCommon
+namespace EVPathRemoteCommon
 {
 
 FMField OpenFileList[] = {
@@ -134,23 +134,30 @@ FMStructDescRec StatusResponseStructs[] = {
     {"StatusResponse", StatusResponseList, sizeof(struct _StatusResponseMsg), NULL},
     {NULL, NULL, 0, NULL}};
 
-void RegisterFormats(RemoteCommon::Remote_evpath_state &ev_state)
+void RegisterFormats(EVPathRemoteCommon::Remote_evpath_state &ev_state)
 {
-    ev_state.OpenFileFormat = CMregister_format(ev_state.cm, RemoteCommon::OpenFileStructs);
+    ev_state.OpenFileFormat = CMregister_format(ev_state.cm, EVPathRemoteCommon::OpenFileStructs);
     ev_state.OpenSimpleFileFormat =
-        CMregister_format(ev_state.cm, RemoteCommon::OpenSimpleFileStructs);
-    ev_state.OpenResponseFormat = CMregister_format(ev_state.cm, RemoteCommon::OpenResponseStructs);
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::OpenSimpleFileStructs);
+    ev_state.OpenResponseFormat =
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::OpenResponseStructs);
     ev_state.OpenSimpleResponseFormat =
-        CMregister_format(ev_state.cm, RemoteCommon::OpenSimpleResponseStructs);
-    ev_state.GetRequestFormat = CMregister_format(ev_state.cm, RemoteCommon::GetRequestStructs);
-    ev_state.ReadRequestFormat = CMregister_format(ev_state.cm, RemoteCommon::ReadRequestStructs);
-    ev_state.ReadResponseFormat = CMregister_format(ev_state.cm, RemoteCommon::ReadResponseStructs);
-    ev_state.CloseFileFormat = CMregister_format(ev_state.cm, RemoteCommon::CloseFileStructs);
-    ev_state.KillServerFormat = CMregister_format(ev_state.cm, RemoteCommon::KillServerStructs);
-    ev_state.KillResponseFormat = CMregister_format(ev_state.cm, RemoteCommon::KillResponseStructs);
-    ev_state.StatusServerFormat = CMregister_format(ev_state.cm, RemoteCommon::StatusServerStructs);
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::OpenSimpleResponseStructs);
+    ev_state.GetRequestFormat =
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::GetRequestStructs);
+    ev_state.ReadRequestFormat =
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::ReadRequestStructs);
+    ev_state.ReadResponseFormat =
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::ReadResponseStructs);
+    ev_state.CloseFileFormat = CMregister_format(ev_state.cm, EVPathRemoteCommon::CloseFileStructs);
+    ev_state.KillServerFormat =
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::KillServerStructs);
+    ev_state.KillResponseFormat =
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::KillResponseStructs);
+    ev_state.StatusServerFormat =
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::StatusServerStructs);
     ev_state.StatusResponseFormat =
-        CMregister_format(ev_state.cm, RemoteCommon::StatusResponseStructs);
+        CMregister_format(ev_state.cm, EVPathRemoteCommon::StatusResponseStructs);
 }
 }
 }

--- a/source/adios2/toolkit/remote/remote_common.h
+++ b/source/adios2/toolkit/remote/remote_common.h
@@ -5,7 +5,7 @@
 
 namespace adios2
 {
-namespace RemoteCommon
+namespace EVPathRemoteCommon
 {
 
 const int ServerPort = 26200;

--- a/source/adios2/toolkit/remote/remote_server.cpp
+++ b/source/adios2/toolkit/remote/remote_server.cpp
@@ -36,7 +36,7 @@
 
 #include "remote_common.h"
 
-using namespace adios2::RemoteCommon;
+using namespace adios2::EVPathRemoteCommon;
 
 using namespace adios2::core;
 using namespace adios2;
@@ -94,8 +94,9 @@ public:
     std::string m_FileName;
     size_t m_BytesSent = 0;
     size_t m_OperationCount = 0;
-    RemoteFileMode m_mode = RemoteCommon::RemoteFileMode::RemoteOpen;
-    AnonADIOSFile(std::string FileName, RemoteCommon::RemoteFileMode mode, bool RowMajorArrays)
+    RemoteFileMode m_mode = EVPathRemoteCommon::RemoteFileMode::RemoteOpen;
+    AnonADIOSFile(std::string FileName, EVPathRemoteCommon::RemoteFileMode mode,
+                  bool RowMajorArrays)
     {
         Mode adios_read_mode = adios2::Mode::Read;
         m_FileName = FileName;

--- a/source/adios2/toolkit/transport/file/FileRemote.cpp
+++ b/source/adios2/toolkit/transport/file/FileRemote.cpp
@@ -8,6 +8,7 @@
 #include "adios2/helper/adiosLog.h"
 #include "adios2/helper/adiosString.h"
 #include "adios2/helper/adiosSystem.h"
+#include "adios2/toolkit/remote/EVPathRemote.h"
 
 #include <cstdio>  // remove
 #include <cstring> // strerror
@@ -95,9 +96,10 @@ void FileRemote::Open(const std::string &name, const Mode openMode, const bool a
 
     case Mode::Read: {
         ProfilerStart("open");
-        m_Remote.OpenSimpleFile("localhost", RemoteCommon::ServerPort, m_Name);
+        m_Remote = std::make_unique<EVPathRemote>();
+        m_Remote->OpenSimpleFile("localhost", EVPathRemoteCommon::ServerPort, m_Name);
         ProfilerStop("open");
-        m_Size = m_Remote.m_Size;
+        m_Size = m_Remote->m_Size;
         break;
     }
     default:
@@ -156,7 +158,7 @@ void FileRemote::Read(char *buffer, size_t size, size_t start)
                                                   " whose size is " + std::to_string(m_Size));
     }
 
-    m_Remote.Read(start, size, buffer);
+    m_Remote->Read(start, size, buffer);
     if (m_IsCached)
     {
     }

--- a/source/adios2/toolkit/transport/file/FileRemote.cpp
+++ b/source/adios2/toolkit/transport/file/FileRemote.cpp
@@ -96,7 +96,7 @@ void FileRemote::Open(const std::string &name, const Mode openMode, const bool a
 
     case Mode::Read: {
         ProfilerStart("open");
-        m_Remote = std::make_unique<EVPathRemote>();
+        m_Remote = std::unique_ptr<EVPathRemote>(new EVPathRemote());
         m_Remote->OpenSimpleFile("localhost", EVPathRemoteCommon::ServerPort, m_Name);
         ProfilerStop("open");
         m_Size = m_Remote->m_Size;

--- a/source/adios2/toolkit/transport/file/FileRemote.h
+++ b/source/adios2/toolkit/transport/file/FileRemote.h
@@ -73,7 +73,7 @@ private:
     // static class Impl m_ImplSingleton;
     // Impl *m_Impl;
     // std::unique_ptr<Impl> m_Impl;
-    Remote m_Remote;
+    std::unique_ptr<Remote> m_Remote;
     int m_Errno = 0;
     bool m_IsOpening = false;
     std::future<int> m_OpenFuture;


### PR DESCRIPTION
No functional changes here.  Just reshuffling the code so that we can subclass remote for various underlying protocols.  This doesn't change any interactions with the current EVPath based remote adios server, but it sets the stage to have an Xroot-based remote protocol implementation without overly disrupting the places these calls are made.