### PR TITLE
Basic Xrootd remote fixes

### DIFF
--- a/examples/hello/hdf5SubFile/hdf5SubFile.cpp
+++ b/examples/hello/hdf5SubFile/hdf5SubFile.cpp
@@ -14,7 +14,9 @@
 #include <iostream> //std::cout
 #include <mpi.h>
 #include <stdexcept> //std::invalid_argument std::exception
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <vector>
 
 void writeMe(adios2::IO &hdf5IO, int rank, int size, const char *testFileName)

--- a/examples/hello/hdf5SubFile/hdf5SubFile.cpp
+++ b/examples/hello/hdf5SubFile/hdf5SubFile.cpp
@@ -36,8 +36,8 @@ void writeMe(adios2::IO &hdf5IO, int rank, int size, const char *testFileName)
     const std::size_t Nx = 1024;
     const std::size_t Ny = 1024 * scale;
 
-    std::vector<float> myFloats(Nx * Ny, 0.1 * rank);
-    std::vector<int> myInts(Nx * Ny, 1 + rank);
+    std::vector<float> myFloats(Nx * Ny, 0.1f * rank);
+    std::vector<int> myInts(Nx * Ny, (int)(1 + rank));
 
     hdf5IO.SetParameter("IdleH5Writer",
                         "true"); // set this if not all ranks are writting
@@ -103,7 +103,7 @@ void ReadVarData(adios2::IO h5IO, adios2::Engine &h5Reader, const std::string &n
 
     if (var)
     {
-        int nDims = var.Shape().size();
+        int nDims = (int)var.Shape().size();
         size_t totalSize = 1;
         for (int i = 0; i < nDims; i++)
         {

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -299,7 +299,7 @@ void BP5Reader::PerformGets()
         if (getenv("DoXRootD"))
         {
             m_Remote = std::unique_ptr<XrootdRemote>(new XrootdRemote());
-            m_Remote->Open("localhost", 1049, m_Name, m_OpenMode, RowMajorOrdering);
+            m_Remote->Open("localhost", 1094, m_Name, m_OpenMode, RowMajorOrdering);
         }
         else
 #endif
@@ -535,7 +535,7 @@ void BP5Reader::Init()
     // Don't try to open the remote file when we open local metadata.  Do that on demand.
     if (!m_Parameters.RemoteDataPath.empty())
         m_dataIsRemote = true;
-    if (getenv("DoRemote"))
+    if (getenv("DoRemote") || getenv("DoXRootD"))
         m_dataIsRemote = true;
 }
 

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -172,7 +172,7 @@ EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t Blo
     GetMsg.Dest = dest;
     CMwrite(m_conn, ev_state.GetRequestFormat, &GetMsg);
     CMCondition_wait(ev_state.cm, GetMsg.GetResponseCondition);
-    return GetMsg.GetResponseCondition;
+    return (Remote::GetHandle)(intptr_t)GetMsg.GetResponseCondition;
 }
 
 EVPathRemote::GetHandle EVPathRemote::Read(size_t Start, size_t Size, void *Dest)
@@ -186,12 +186,12 @@ EVPathRemote::GetHandle EVPathRemote::Read(size_t Start, size_t Size, void *Dest
     ReadMsg.Dest = Dest;
     CMwrite(m_conn, ev_state.ReadRequestFormat, &ReadMsg);
     CMCondition_wait(ev_state.cm, ReadMsg.ReadResponseCondition);
-    return ReadMsg.ReadResponseCondition;
+    return (Remote::GetHandle)(intptr_t)ReadMsg.ReadResponseCondition;
 }
 
 bool EVPathRemote::WaitForGet(GetHandle handle)
 {
-    return CMCondition_wait(ev_state.cm, (int)handle);
+    return CMCondition_wait(ev_state.cm, (int)(intptr_t)handle);
 }
 #else
 

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -43,8 +43,6 @@ public:
 
     void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename);
 
-    typedef int GetHandle;
-
     GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start, void *dest);
 
     bool WaitForGet(GetHandle handle);

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -37,7 +37,7 @@ Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t BlockID, Dims &
                               void *dest)
 {
     ThrowUp("RemoteGet");
-    return 0;
+    return (intptr_t)0;
 };
 
 bool Remote::WaitForGet(GetHandle handle)

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -37,7 +37,7 @@ Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t BlockID, Dims &
                               void *dest)
 {
     ThrowUp("RemoteGet");
-    return (intptr_t)0;
+    return (Remote::GetHandle)(intptr_t)0;
 };
 
 bool Remote::WaitForGet(GetHandle handle)
@@ -49,7 +49,7 @@ bool Remote::WaitForGet(GetHandle handle)
 Remote::GetHandle Remote::Read(size_t Start, size_t Size, void *Dest)
 {
     ThrowUp("RemoteRead");
-    return 0;
+    return (Remote::GetHandle)0;
 };
 Remote::~Remote() {}
 Remote::Remote() {}

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -33,7 +33,7 @@ public:
     virtual void OpenSimpleFile(const std::string hostname, const int32_t port,
                                 const std::string filename);
 
-    typedef int GetHandle;
+    typedef void *GetHandle;
 
     virtual GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
                           void *dest);

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -98,11 +98,10 @@ public:
     void Open(const std::string hostname, const int32_t port, const std::string filename,
               const Mode mode, bool RowMajorOrdering);
 
-    typedef int GetHandle;
-
     GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start, void *dest);
 
     GetHandle Read(size_t Start, size_t Size, void *Dest);
+    bool WaitForGet(GetHandle handle);
 };
 
 } // end namespace adios2

--- a/source/utils/xrootd-plugin/XrdSsiSvService.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvService.cpp
@@ -456,7 +456,6 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
         m_engine = m_io.Open(reqData, adios2::Mode::ReadRandomAccess);
         std::string VarName = requestParams[0];
         auto var = m_io.InquireVariable(VarName);
-
         adios2::DataType TypeOfVar = m_io.InquireVariableType(VarName);
         try
         {
@@ -469,7 +468,7 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
         adios2::Variable<T> var = m_io.InquireVariable<T>(VarName);                                \
         std::vector<T> resBuffer;                                                                  \
         size_t step = std::stoi(requestParams[1]);                                                 \
-        var.SetStepSelection({step, step + 1});                                                    \
+        var.SetStepSelection({step, 1});                                                           \
         size_t paramLength = (requestParams.size() - 3) / 2;                                       \
         adios2::Dims s(paramLength);                                                               \
         adios2::Dims c(paramLength);                                                               \
@@ -482,9 +481,9 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
         var.SetSelection(varSel);                                                                  \
         m_engine.Get(var, resBuffer, adios2::Mode::Sync);                                          \
         size_t responseSize = resBuffer.size();                                                    \
-        responseBuffer = new char[responseSize * sizeof(float)];                                   \
-        responseBufferSize = responseSize * sizeof(float);                                         \
-        memcpy(responseBuffer, resBuffer.data(), responseSize * sizeof(float));                    \
+        responseBuffer = new char[responseSize * sizeof(T)];                                       \
+        responseBufferSize = responseSize * sizeof(T);                                             \
+        memcpy(responseBuffer, resBuffer.data(), responseSize * sizeof(T));                        \
         XrdSysThread::Run(&tid, SvAdiosGet, (void *)this, 0, "get");                               \
     }
             ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(GET)


### PR DESCRIPTION
Change all RemoteHandle types to void * and make them appear only in the base class, change Xroot request/response sync to use future/promises, fix server-side type handling to use the right size for the type.  These changes are sufficient to pass a the simple TestCommonRead test using Xrootd remote server.  (No actual testing in CI yet, so you'll have to take my word for it.)