### PR TITLE
Add API call to reset memory selection

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Variable.h
+++ b/bindings/CXX11/adios2/cxx11/Variable.h
@@ -214,7 +214,7 @@ public:
      * variable.Count() = {Ny,Nx}, then memoryCount = {Ny+2,Nx+2}
      * </pre>
      */
-    void SetMemorySelection(const adios2::Box<adios2::Dims> &memorySelection);
+    void SetMemorySelection(const adios2::Box<adios2::Dims> &memorySelection = {{}, {}});
 
     /**
      * Sets a step selection modifying current startStep, countStep

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -221,7 +221,7 @@ void VariableBase::SetMemorySelection(const Box<Dims> &memorySelection)
     const Dims &memoryStart = memorySelection.first;
     const Dims &memoryCount = memorySelection.second;
 
-    if(memoryStart.empty() && memoryCount.empty())
+    if (memoryStart.empty() && memoryCount.empty())
     {
         m_MemoryStart.clear();
         m_MemoryCount.clear();

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -221,6 +221,13 @@ void VariableBase::SetMemorySelection(const Box<Dims> &memorySelection)
     const Dims &memoryStart = memorySelection.first;
     const Dims &memoryCount = memorySelection.second;
 
+    if(memoryStart.empty() && memoryCount.empty())
+    {
+        m_MemoryStart.clear();
+        m_MemoryCount.clear();
+        return;
+    }
+
     if (m_SingleValue)
     {
         helper::Throw<std::invalid_argument>("Core", "VariableBase", "SetMemorySelection",


### PR DESCRIPTION
I'm currently adding support for memory selections to the openPMD-api on https://github.com/openPMD/openPMD-api/pull/1620. 
While working on it, I noticed that the selection specified in `Variable<T>::SetMemorySelection(...)` sticks to **all** subsequent `Put()` calls, without a  way to remove the memory selection again.

Is it intended that the setting will stick to the Variable or is that a bug? If it is intended, this PR adds a way to remove the setting again. Otherwise, this PR should be discarded and instead, the memory selection should be removed automatically after calling `Put()`.

cc @pnorbert 