### PR TITLE
Close more FDs because XRootd plays games in library init

### DIFF
--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -171,7 +171,6 @@ EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t Blo
     GetMsg.Start = Start.data();
     GetMsg.Dest = dest;
     CMwrite(m_conn, ev_state.GetRequestFormat, &GetMsg);
-    CMCondition_wait(ev_state.cm, GetMsg.GetResponseCondition);
     return (Remote::GetHandle)(intptr_t)GetMsg.GetResponseCondition;
 }
 

--- a/source/adios2/toolkit/remote/remote_server.cpp
+++ b/source/adios2/toolkit/remote/remote_server.cpp
@@ -619,9 +619,14 @@ int main(int argc, char **argv)
         }
         /* I'm the child, close IO FDs so that ctest continues.  No verbosity here */
         verbose = 0;
-        close(0);
-        close(1);
-        close(2);
+
+        //  Why close a bunch of FDs here?  Because something in the xrootd library is opening new
+        //  fds (upon library init, so before main()) and perhaps using it to track instances?
+        //  Whatever it is doing is interfering with CTest and putting things in the background
+        for (int fd = 0; fd < 13; fd++)
+        {
+            close(fd);
+        }
 #endif
     }
 

--- a/source/adios2/toolkit/remote/remote_server.cpp
+++ b/source/adios2/toolkit/remote/remote_server.cpp
@@ -627,7 +627,7 @@ int main(int argc, char **argv)
         //  been dup()'d in library initialization.  We don't need those FDs and we have to close
         //  them to make sure we disassociate from the CTest parent (or else fixture startup hangs).
         //  It doesn't seem to work to close them before the fork, so we close them afterwards.
-        for (int fd = 0; fd <= 128; fd++)
+        for (int fd = 0; fd <= 16; fd++)
         {
             if (fd_is_valid(fd))
             {


### PR DESCRIPTION
Also fix an oversight in EVPath remote