### PR TITLE
Campaign with S3 support

### DIFF
--- a/examples/hello/bpWriter/bpWriter.cpp
+++ b/examples/hello/bpWriter/bpWriter.cpp
@@ -1,27 +1,41 @@
 /*
- * Distributed under the OSI-approved Apache License, Version 2.0.  See
- * accompanying file Copyright.txt for details.
- *
- * bpWriter.cpp: Simple self-descriptive example of how to write a variable
- * to a BP File that lives in several MPI processes.
- *
- *  Created on: Feb 16, 2017
- *      Author: William F Godoy godoywf@ornl.gov
- */
-
+Take the bpwriter C++ code and modify this to create several 1D arrays, taking an input of the size
+of the array N, from the user input, and then allocate these arrays to memory X [ 0:2 * PI  done F =
+cos(X) (although we will change this later) done deriv = - sin(X), determine this exactly and write
+this. done DF/DX = the center derivative of F to 2nd order...  done DF/DX4 = the center derivative
+of F to 4th order done DF/DX2F = the forward difference derivative to 2nd order done DF/DX2B = the
+backward difference derivative to 2nd order done Write out these arrays to an adios file, along with
+writing out an attribute (whatever you want) to the ADIOS file. see the readdocs to understand how
+to do this. Now we want to read in the data from the ADIOS file  (call yourname.bp; ethan.bp) in
+python. done Then we want to use matplotlib to graph the functions, and then to create several
+variables   E1, E2, E3, E4, which are the errors from the actual derivative to the numerical
+approximation E1 = deriv - DF/DX, E2= deriv-DF/DX4. make sure you also plot the errors Once this is
+done, then we want to change the C++ program a little to use multiple processors, so that when the
+user specifies N, we will divide this up amongst all of the processors, and we will have to use
+send/receive with MPI to communicate the boundary points. Then run the MPI program, and then make
+sure we get the same output from P processors (P<12) as we get with 1 processor.
+*/
 #include <ios>       //std::ios_base::failure
 #include <iostream>  //std::cout
 #include <stdexcept> //std::invalid_argument std::exception
 #include <vector>
 
 #include <adios2.h>
+#include <math.h>  // This allows me to use cosine
+#include <stdio.h> // This allows me to use printf
 #if ADIOS2_USE_MPI
 #include <mpi.h>
+
 #endif
+
+#define PI 3.141592653589793
+using namespace std;
 
 int main(int argc, char *argv[])
 {
+
     int rank, size;
+
 #if ADIOS2_USE_MPI
     int provided;
 
@@ -35,11 +49,98 @@ int main(int argc, char *argv[])
 #endif
 
     /** Application variable */
-    std::vector<float> myFloats = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    std::vector<int> myInts = {0, -1, -2, -3, -4, -5, -6, -7, -8, -9};
+
+    // std::vector<float>* e_dat = new std::vector<float>;
+
+    // std::vector<float> e_dat = new std::vector<float>;
+
+    std::vector<float> myFloats = {0, 1, 2, 3, 4, 5, 6, 7, 8, -99, 100, 200, 300};
+    // We comment this out so that we can create our own 1D array and then we will put the contents
+    // into an ADIOS file
+    std::vector<int> myInts = {0, -1, -2, -3, -4, -5, -6, -7, -8, -9, 10};
     const std::size_t Nx = myFloats.size();
 
-    const std::string myString("Hello Variable String from rank " + std::to_string(rank));
+    const std::string myString(
+        "Hello I just made a change to THIS CODE!,  Variable String from rank " +
+        std::to_string(rank));
+
+    int i;
+
+    // std::cout<<"Enter the size of the array"<<endl;
+    size_t len = 1000;
+    // std::cin>>len;
+
+    // x values and y values of cos
+    float *x = new float[len]();
+    float *F = new float[len]();
+    // centertered difference
+    float *DFDX = new float[len]();
+    float *DFDX4 = new float[len]();
+    // foward differnce
+    float *DFDX2F = new float[len]();
+
+    // backward difference
+    float *DFDX2B = new float[len]();
+    // true deriveative -sin
+    float *deriv = new float[len]();
+
+    std::string filename = "ethan.bp";
+
+    float h = (2 * PI - 0) / (len - 1);
+
+    // the values of the Function F; the x coordinates x[i]; and the actual derivative deriv[i]
+    for (i = 0; i < len; i++)
+    {
+        x[i] = 0.0 + i * h;
+        F[i] = cos(x[i]);
+        deriv[i] = -1 * sin(x[i]);
+    }
+    // These points cannot be calcaulated using this formula
+    DFDX[0] = 0;
+    DFDX[len - 1] = 0;
+
+    for (i = 1; i < len - 1; i++)
+    {
+        DFDX[i] = 1 / (2 * h) * (F[i + 1] - F[i - 1]);
+    }
+
+    // cannot first two and last two values with the formula, but we can use equation above the two
+    // of them
+    DFDX4[0] = 0;
+    DFDX4[1] = DFDX[1];
+    DFDX4[len - 2] = DFDX[len - 2];
+    DFDX4[len - 1] = 0;
+    for (i = 2; i < len - 2; i++)
+    {
+        DFDX4[i] = 1 / (12 * h) * (-F[i + 2] + (8 * F[i + 1]) - (8 * F[i - 1]) + F[i - 2]);
+    }
+
+    // fowarc differncd: DF/DX2F  2nd order
+    DFDX2F[len - 1] = 0;
+    for (i = 0; i < len - 2; i++)
+    {
+        DFDX2F[i] = 1 / (2 * h) * ((-3 * F[i]) + (4 * F[i + 1]) - F[i + 2]);
+    }
+
+    // backward difference:DF/DX2B 2nd order
+    DFDX2B[0] = 0;
+    for (i = 2; i < len; i++)
+    {
+        DFDX2B[i] = 1 / (h * 2) * ((3 * F[i]) - (4 * F[i - 1]) + F[i - 2]);
+    }
+
+    // now lets get the values of that are set to 0
+    DFDX[0] = DFDX2F[0];
+    DFDX[len - 1] = DFDX2B[len - 1];
+    DFDX4[0] = DFDX2F[0];
+    DFDX4[len - 1] = DFDX2B[len - 1];
+
+    // foward difference
+    DFDX2F[len - 2] = DFDX2B[len - 2];
+    DFDX2F[len - 1] = DFDX2B[len - 1];
+    // backward differnce
+    DFDX2B[0] = DFDX2F[0];
+    DFDX2B[1] = DFDX2F[1];
 
     try
     {
@@ -49,7 +150,7 @@ int main(int argc, char *argv[])
 #else
         adios2::ADIOS adios;
 #endif
-
+        std::cout << "\n from processor" << rank << "\n";
         /*** IO class object: settings and factory of Settings: Variables,
          * Parameters, Transports, and Execution: Engines */
         adios2::IO bpIO = adios.DeclareIO("BPFile_N2N");
@@ -57,25 +158,37 @@ int main(int argc, char *argv[])
         /** global array : name, { shape (total) }, { start (local) }, {
          * count
          * (local) }, all are constant dimensions */
-        adios2::Variable<float> bpFloats = bpIO.DefineVariable<float>(
-            "bpFloats", {size * Nx}, {rank * Nx}, {Nx}, adios2::ConstantDims);
 
-        adios2::Variable<int> bpInts = bpIO.DefineVariable<int>("bpInts", {size * Nx}, {rank * Nx},
-                                                                {Nx}, adios2::ConstantDims);
+        adios2::Variable<float> xOut = bpIO.DefineVariable<float>("x", {size * len}, {rank * len},
+                                                                  {len}, adios2::ConstantDims);
 
-        adios2::Variable<std::string> bpString = bpIO.DefineVariable<std::string>("bpString");
-        (void)bpString; // For the sake of the example we create an unused
-                        // variable
+        adios2::Variable<float> yOut = bpIO.DefineVariable<float>("y", {size * len}, {rank * len},
+                                                                  {len}, adios2::ConstantDims);
 
-        std::string filename = "myVector_cpp.bp";
+        adios2::Variable<float> derivOut = bpIO.DefineVariable<float>(
+            "DFDX", {size * len}, {rank * len}, {len}, adios2::ConstantDims);
+
+        adios2::Variable<float> derivOut4 = bpIO.DefineVariable<float>(
+            "DFDX4", {size * len}, {rank * len}, {len}, adios2::ConstantDims);
+
+        adios2::Variable<float> derivfor = bpIO.DefineVariable<float>(
+            "DFDX2F", {size * len}, {rank * len}, {len}, adios2::ConstantDims);
+
+        adios2::Variable<float> derivbac = bpIO.DefineVariable<float>(
+            "DFDX2B", {size * len}, {rank * len}, {len}, adios2::ConstantDims);
+
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpWriter = bpIO.Open(filename, adios2::Mode::Write);
 
         bpWriter.BeginStep();
         /** Put variables for buffering, template type is optional */
-        bpWriter.Put(bpFloats, myFloats.data());
-        bpWriter.Put(bpInts, myInts.data());
-        // bpWriter.Put(bpString, myString);
+        bpWriter.Put(xOut, x);
+        bpWriter.Put(yOut, F);
+        bpWriter.Put(derivOut, DFDX);
+        bpWriter.Put(derivOut4, DFDX4);
+        bpWriter.Put(derivfor, DFDX2F);
+        bpWriter.Put(derivbac, DFDX2B);
+
         bpWriter.EndStep();
 
         /** Create bp file, engine becomes unreachable after this*/

--- a/examples/hello/bpWriter/bpWriter.cpp
+++ b/examples/hello/bpWriter/bpWriter.cpp
@@ -1,41 +1,27 @@
 /*
-Take the bpwriter C++ code and modify this to create several 1D arrays, taking an input of the size
-of the array N, from the user input, and then allocate these arrays to memory X [ 0:2 * PI  done F =
-cos(X) (although we will change this later) done deriv = - sin(X), determine this exactly and write
-this. done DF/DX = the center derivative of F to 2nd order...  done DF/DX4 = the center derivative
-of F to 4th order done DF/DX2F = the forward difference derivative to 2nd order done DF/DX2B = the
-backward difference derivative to 2nd order done Write out these arrays to an adios file, along with
-writing out an attribute (whatever you want) to the ADIOS file. see the readdocs to understand how
-to do this. Now we want to read in the data from the ADIOS file  (call yourname.bp; ethan.bp) in
-python. done Then we want to use matplotlib to graph the functions, and then to create several
-variables   E1, E2, E3, E4, which are the errors from the actual derivative to the numerical
-approximation E1 = deriv - DF/DX, E2= deriv-DF/DX4. make sure you also plot the errors Once this is
-done, then we want to change the C++ program a little to use multiple processors, so that when the
-user specifies N, we will divide this up amongst all of the processors, and we will have to use
-send/receive with MPI to communicate the boundary points. Then run the MPI program, and then make
-sure we get the same output from P processors (P<12) as we get with 1 processor.
-*/
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * bpWriter.cpp: Simple self-descriptive example of how to write a variable
+ * to a BP File that lives in several MPI processes.
+ *
+ *  Created on: Feb 16, 2017
+ *      Author: William F Godoy godoywf@ornl.gov
+ */
+
 #include <ios>       //std::ios_base::failure
 #include <iostream>  //std::cout
 #include <stdexcept> //std::invalid_argument std::exception
 #include <vector>
 
 #include <adios2.h>
-#include <math.h>  // This allows me to use cosine
-#include <stdio.h> // This allows me to use printf
 #if ADIOS2_USE_MPI
 #include <mpi.h>
-
 #endif
-
-#define PI 3.141592653589793
-using namespace std;
 
 int main(int argc, char *argv[])
 {
-
     int rank, size;
-
 #if ADIOS2_USE_MPI
     int provided;
 
@@ -49,98 +35,11 @@ int main(int argc, char *argv[])
 #endif
 
     /** Application variable */
-
-    // std::vector<float>* e_dat = new std::vector<float>;
-
-    // std::vector<float> e_dat = new std::vector<float>;
-
-    std::vector<float> myFloats = {0, 1, 2, 3, 4, 5, 6, 7, 8, -99, 100, 200, 300};
-    // We comment this out so that we can create our own 1D array and then we will put the contents
-    // into an ADIOS file
-    std::vector<int> myInts = {0, -1, -2, -3, -4, -5, -6, -7, -8, -9, 10};
+    std::vector<float> myFloats = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::vector<int> myInts = {0, -1, -2, -3, -4, -5, -6, -7, -8, -9};
     const std::size_t Nx = myFloats.size();
 
-    const std::string myString(
-        "Hello I just made a change to THIS CODE!,  Variable String from rank " +
-        std::to_string(rank));
-
-    int i;
-
-    // std::cout<<"Enter the size of the array"<<endl;
-    size_t len = 1000;
-    // std::cin>>len;
-
-    // x values and y values of cos
-    float *x = new float[len]();
-    float *F = new float[len]();
-    // centertered difference
-    float *DFDX = new float[len]();
-    float *DFDX4 = new float[len]();
-    // foward differnce
-    float *DFDX2F = new float[len]();
-
-    // backward difference
-    float *DFDX2B = new float[len]();
-    // true deriveative -sin
-    float *deriv = new float[len]();
-
-    std::string filename = "ethan.bp";
-
-    float h = (2 * PI - 0) / (len - 1);
-
-    // the values of the Function F; the x coordinates x[i]; and the actual derivative deriv[i]
-    for (i = 0; i < len; i++)
-    {
-        x[i] = 0.0 + i * h;
-        F[i] = cos(x[i]);
-        deriv[i] = -1 * sin(x[i]);
-    }
-    // These points cannot be calcaulated using this formula
-    DFDX[0] = 0;
-    DFDX[len - 1] = 0;
-
-    for (i = 1; i < len - 1; i++)
-    {
-        DFDX[i] = 1 / (2 * h) * (F[i + 1] - F[i - 1]);
-    }
-
-    // cannot first two and last two values with the formula, but we can use equation above the two
-    // of them
-    DFDX4[0] = 0;
-    DFDX4[1] = DFDX[1];
-    DFDX4[len - 2] = DFDX[len - 2];
-    DFDX4[len - 1] = 0;
-    for (i = 2; i < len - 2; i++)
-    {
-        DFDX4[i] = 1 / (12 * h) * (-F[i + 2] + (8 * F[i + 1]) - (8 * F[i - 1]) + F[i - 2]);
-    }
-
-    // fowarc differncd: DF/DX2F  2nd order
-    DFDX2F[len - 1] = 0;
-    for (i = 0; i < len - 2; i++)
-    {
-        DFDX2F[i] = 1 / (2 * h) * ((-3 * F[i]) + (4 * F[i + 1]) - F[i + 2]);
-    }
-
-    // backward difference:DF/DX2B 2nd order
-    DFDX2B[0] = 0;
-    for (i = 2; i < len; i++)
-    {
-        DFDX2B[i] = 1 / (h * 2) * ((3 * F[i]) - (4 * F[i - 1]) + F[i - 2]);
-    }
-
-    // now lets get the values of that are set to 0
-    DFDX[0] = DFDX2F[0];
-    DFDX[len - 1] = DFDX2B[len - 1];
-    DFDX4[0] = DFDX2F[0];
-    DFDX4[len - 1] = DFDX2B[len - 1];
-
-    // foward difference
-    DFDX2F[len - 2] = DFDX2B[len - 2];
-    DFDX2F[len - 1] = DFDX2B[len - 1];
-    // backward differnce
-    DFDX2B[0] = DFDX2F[0];
-    DFDX2B[1] = DFDX2F[1];
+    const std::string myString("Hello Variable String from rank " + std::to_string(rank));
 
     try
     {
@@ -150,7 +49,7 @@ int main(int argc, char *argv[])
 #else
         adios2::ADIOS adios;
 #endif
-        std::cout << "\n from processor" << rank << "\n";
+
         /*** IO class object: settings and factory of Settings: Variables,
          * Parameters, Transports, and Execution: Engines */
         adios2::IO bpIO = adios.DeclareIO("BPFile_N2N");
@@ -158,37 +57,25 @@ int main(int argc, char *argv[])
         /** global array : name, { shape (total) }, { start (local) }, {
          * count
          * (local) }, all are constant dimensions */
+        adios2::Variable<float> bpFloats = bpIO.DefineVariable<float>(
+            "bpFloats", {size * Nx}, {rank * Nx}, {Nx}, adios2::ConstantDims);
 
-        adios2::Variable<float> xOut = bpIO.DefineVariable<float>("x", {size * len}, {rank * len},
-                                                                  {len}, adios2::ConstantDims);
+        adios2::Variable<int> bpInts = bpIO.DefineVariable<int>("bpInts", {size * Nx}, {rank * Nx},
+                                                                {Nx}, adios2::ConstantDims);
 
-        adios2::Variable<float> yOut = bpIO.DefineVariable<float>("y", {size * len}, {rank * len},
-                                                                  {len}, adios2::ConstantDims);
+        adios2::Variable<std::string> bpString = bpIO.DefineVariable<std::string>("bpString");
+        (void)bpString; // For the sake of the example we create an unused
+                        // variable
 
-        adios2::Variable<float> derivOut = bpIO.DefineVariable<float>(
-            "DFDX", {size * len}, {rank * len}, {len}, adios2::ConstantDims);
-
-        adios2::Variable<float> derivOut4 = bpIO.DefineVariable<float>(
-            "DFDX4", {size * len}, {rank * len}, {len}, adios2::ConstantDims);
-
-        adios2::Variable<float> derivfor = bpIO.DefineVariable<float>(
-            "DFDX2F", {size * len}, {rank * len}, {len}, adios2::ConstantDims);
-
-        adios2::Variable<float> derivbac = bpIO.DefineVariable<float>(
-            "DFDX2B", {size * len}, {rank * len}, {len}, adios2::ConstantDims);
-
+        std::string filename = "myVector_cpp.bp";
         /** Engine derived class, spawned to start IO operations */
         adios2::Engine bpWriter = bpIO.Open(filename, adios2::Mode::Write);
 
         bpWriter.BeginStep();
         /** Put variables for buffering, template type is optional */
-        bpWriter.Put(xOut, x);
-        bpWriter.Put(yOut, F);
-        bpWriter.Put(derivOut, DFDX);
-        bpWriter.Put(derivOut4, DFDX4);
-        bpWriter.Put(derivfor, DFDX2F);
-        bpWriter.Put(derivbac, DFDX2B);
-
+        bpWriter.Put(bpFloats, myFloats.data());
+        bpWriter.Put(bpInts, myInts.data());
+        // bpWriter.Put(bpString, myString);
         bpWriter.EndStep();
 
         /** Create bp file, engine becomes unreachable after this*/

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -419,6 +419,7 @@ struct HostConfig
     std::string endpoint = "";
     std::string awsProfile = "default"; // profile name in ~/.aws/credentials
     bool isAWS_EC2 = false;
+    bool recheckMetadata = true;
 
     int verbose = 0;
 };

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -21,6 +21,7 @@
 #include <complex>
 #include <limits>
 #include <map>
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <utility> //std::pair
@@ -383,6 +384,44 @@ struct UserOptions
     Campaign campaign;
     SST sst;
 };
+
+/** Host access protocols */
+enum class HostAccessProtocol
+{
+    Invalid,
+    SSH,
+    XRootD,
+    S3
+};
+
+/** Host authentication protocols */
+enum class HostAuthProtocol
+{
+    Invalid,
+    Password,
+    X509
+};
+
+struct HostConfig
+{
+    std::string name; // Connection Option name
+    HostAccessProtocol protocol = HostAccessProtocol::Invalid;
+
+    /* ssh and xrootd parameters */
+    uint16_t port = 0;
+    std::string hostname = "";
+    std::string username = "";
+    std::string remoteServerPath = "";
+    HostAuthProtocol authentication = HostAuthProtocol::Invalid;
+
+    /* s3 parameters */
+    std::string endpoint = "";
+    std::string awsProfile = "default"; // profile name in ~/.aws/credentials
+    bool isAWS_EC2 = false;
+};
+
+/** HostOptions holds all user options from ~/.config/adios2/hosts.yaml */
+using HostOptions = std::map<std::string, std::vector<HostConfig>>;
 
 /**
  * os << [adios2_type] enables output of adios2 enums/classes directly

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -409,6 +409,7 @@ struct HostConfig
 
     /* ssh and xrootd parameters */
     uint16_t port = 0;
+    uint16_t localPort = 0;
     std::string hostname = "";
     std::string username = "";
     std::string remoteServerPath = "";
@@ -418,6 +419,8 @@ struct HostConfig
     std::string endpoint = "";
     std::string awsProfile = "default"; // profile name in ~/.aws/credentials
     bool isAWS_EC2 = false;
+
+    int verbose = 0;
 };
 
 /** HostOptions holds all user options from ~/.config/adios2/hosts.yaml */

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -110,6 +110,9 @@ static std::atomic_uint adios_count(0);    // total adios objects during runtime
 /** User defined options from ~/.config/adios2/adios2.yaml if it exists */
 const adios2::UserOptions &ADIOS::GetUserOptions() { return m_UserOptions; };
 
+/** A constant reference to the host options from ~/.config/adios2/hosts.yaml */
+const adios2::HostOptions &ADIOS::GetHostOptions() { return m_HostOptions; };
+
 ADIOS::ADIOS(const std::string configFile, helper::Comm comm, const std::string hostLanguage)
 : m_HostLanguage(hostLanguage), m_Comm(std::move(comm)), m_ConfigFile(configFile),
   m_CampaignManager(m_Comm)
@@ -129,6 +132,7 @@ ADIOS::ADIOS(const std::string configFile, helper::Comm comm, const std::string 
     }
 #endif
     ProcessUserConfig();
+    ProcessHostConfig();
     if (!configFile.empty())
     {
         if (!adios2sys::SystemTools::FileExists(configFile))
@@ -208,6 +212,22 @@ void ADIOS::ProcessUserConfig()
     if (adios2sys::SystemTools::FileExists(cfgFile))
     {
         helper::ParseUserOptionsFile(m_Comm, cfgFile, m_UserOptions, homePath);
+    }
+}
+
+void ADIOS::ProcessHostConfig()
+{
+    // read config parameters from config file
+    std::string homePath;
+#ifdef _WIN32
+    homePath = getenv("HOMEPATH");
+#else
+    homePath = getenv("HOME");
+#endif
+    const std::string cfgFile = homePath + "/.config/adios2/hosts.yaml";
+    if (adios2sys::SystemTools::FileExists(cfgFile))
+    {
+        helper::ParseHostOptionsFile(m_Comm, cfgFile, m_HostOptions, homePath);
     }
 }
 

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -167,6 +167,9 @@ public:
     /** A constant reference to the user options from ~/.config/adios2/adios2.yaml */
     const adios2::UserOptions &GetUserOptions();
 
+    /** A constant reference to the host options from ~/.config/adios2/hosts.yaml */
+    const adios2::HostOptions &GetHostOptions();
+
 private:
     /** Communicator given to parallel constructor. */
     helper::Comm m_Comm;
@@ -208,8 +211,11 @@ private:
                     core::IO &io);
 
     adios2::UserOptions m_UserOptions;
+    adios2::HostOptions m_HostOptions;
+    adios2::HostConfig m_Test;
     void SetUserOptionDefaults();
     void ProcessUserConfig();
+    void ProcessHostConfig();
 
 private:
     /* Global services that we want to initialize at most once and shutdown

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -24,7 +24,7 @@ namespace core
 Engine::Engine(const std::string engineType, IO &io, const std::string &name, const Mode openMode,
                helper::Comm comm)
 : m_EngineType(engineType), m_IO(io), m_Name(name), m_OpenMode(openMode), m_Comm(std::move(comm)),
-  m_UserOptions(io.m_ADIOS.GetUserOptions())
+  m_UserOptions(io.m_ADIOS.GetUserOptions()), m_HostOptions(io.m_ADIOS.GetHostOptions())
 {
     m_FailVerbose = (m_Comm.Rank() == 0);
 }

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -508,6 +508,9 @@ protected:
     /** User options parsed by the ADIOS object, here just for easy reference */
     const UserOptions &m_UserOptions;
 
+    /** Host options parsed by the ADIOS object, here just for easy reference */
+    const HostOptions &m_HostOptions;
+
     /** keeps track of current advance status */
     StepStatus m_AdvanceStatus = StepStatus::OK;
 

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -245,26 +245,28 @@ void CampaignReader::InitTransports()
                     p.emplace("cache", m_Options.cachepath + PathSeparator +
                                            m_CampaignData.hosts[ds.hostIdx].hostname +
                                            PathSeparator + m_Name);
-                    p.emplace("verbose", "0");
+                    p.emplace("verbose", std::to_string(ho.verbose));
                     io.AddTransport("File", p);
                     io.SetEngine("BP5");
                     localPath = m_CampaignData.hosts[ds.hostIdx].directory[ds.dirIdx] +
                                 PathSeparator + ds.name;
                     if (ho.isAWS_EC2)
                     {
-                        setenv("AWS_EC2_METADATA_DISABLED", "false", (int)true);
+                        adios2sys::SystemTools::PutEnv("AWS_EC2_METADATA_DISABLED=false");
                     }
                     else
                     {
-                        setenv("AWS_EC2_METADATA_DISABLED", "true", (int)true);
+                        adios2sys::SystemTools::PutEnv("AWS_EC2_METADATA_DISABLED=true");
                     }
+
                     if (ho.awsProfile.empty())
                     {
-                        setenv("AWS_PROFILE", "default", (int)true);
+                        adios2sys::SystemTools::PutEnv("AWS_PROFILE=default");
                     }
                     else
                     {
-                        setenv("AWS_PROFILE", ho.awsProfile.c_str(), (int)true);
+                        std::string es = "AWS_PROFILE=" + ho.awsProfile;
+                        adios2sys::SystemTools::PutEnv(es);
                     }
 
                     done = true;

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -246,6 +246,7 @@ void CampaignReader::InitTransports()
                                            m_CampaignData.hosts[ds.hostIdx].hostname +
                                            PathSeparator + m_Name);
                     p.emplace("verbose", std::to_string(ho.verbose));
+                    p.emplace("recheck_metadata", (ho.recheckMetadata ? "true" : "false"));
                     io.AddTransport("File", p);
                     io.SetEngine("BP5");
                     localPath = m_CampaignData.hosts[ds.hostIdx].directory[ds.dirIdx] +

--- a/source/adios2/helper/adiosYAML.cpp
+++ b/source/adios2/helper/adiosYAML.cpp
@@ -400,6 +400,7 @@ void ParseHostOptionsFile(Comm &comm, const std::string &configFileYAML, HostOpt
                         ": each entry in the list must be a YAML Map, " + hint);
             }
 
+            SetOption(hc.verbose, "verbose", hostmap, hint);
             std::string protocolStr;
             SetOption(protocolStr, "protocol", hostmap, hint, isMandatory);
             hc.protocol = GetHostAccessProtocol(protocolStr);
@@ -410,9 +411,10 @@ void ParseHostOptionsFile(Comm &comm, const std::string &configFileYAML, HostOpt
                 SetOption(authStr, "authentication", hostmap, hint, isMandatory);
                 hc.authentication = GetHostAuthProtocol(authStr);
                 SetOption(hc.hostname, "host", hostmap, hint, isMandatory);
-                SetOption(hc.username, "user", hostmap, hint, isNotMandatory);
+                SetOption(hc.username, "user", hostmap, hint);
                 SetOption(hc.remoteServerPath, "serverpath", hostmap, hint, isMandatory);
-                SetOption(hc.port, "port", hostmap, hint, isNotMandatory);
+                SetOption(hc.port, "port", hostmap, hint);
+                SetOption(hc.localPort, "local_port", hostmap, hint);
                 break;
             }
             case HostAccessProtocol::XRootD: {
@@ -420,15 +422,15 @@ void ParseHostOptionsFile(Comm &comm, const std::string &configFileYAML, HostOpt
                 SetOption(authStr, "authentication", hostmap, hint, isMandatory);
                 hc.authentication = GetHostAuthProtocol(authStr);
                 SetOption(hc.hostname, "host", hostmap, hint, isMandatory);
-                SetOption(hc.username, "user", hostmap, hint, isNotMandatory);
-                SetOption(hc.remoteServerPath, "serverpath", hostmap, hint, isNotMandatory);
-                SetOption(hc.port, "port", hostmap, hint, isNotMandatory);
+                SetOption(hc.username, "user", hostmap, hint);
+                SetOption(hc.remoteServerPath, "serverpath", hostmap, hint);
+                SetOption(hc.port, "port", hostmap, hint);
                 break;
             }
             case HostAccessProtocol::S3: {
-                SetOption(hc.awsProfile, "profile", hostmap, hint, isNotMandatory);
+                SetOption(hc.awsProfile, "profile", hostmap, hint);
                 SetOption(hc.endpoint, "endpoint", hostmap, hint, isMandatory);
-                SetOption(hc.isAWS_EC2, "aws_ec2_metadata", hostmap, hint, isNotMandatory);
+                SetOption(hc.isAWS_EC2, "aws_ec2_metadata", hostmap, hint);
                 break;
             }
             default:

--- a/source/adios2/helper/adiosYAML.cpp
+++ b/source/adios2/helper/adiosYAML.cpp
@@ -431,6 +431,7 @@ void ParseHostOptionsFile(Comm &comm, const std::string &configFileYAML, HostOpt
                 SetOption(hc.awsProfile, "profile", hostmap, hint);
                 SetOption(hc.endpoint, "endpoint", hostmap, hint, isMandatory);
                 SetOption(hc.isAWS_EC2, "aws_ec2_metadata", hostmap, hint);
+                SetOption(hc.recheckMetadata, "recheck_metadata", hostmap, hint);
                 break;
             }
             default:

--- a/source/adios2/helper/adiosYAML.h
+++ b/source/adios2/helper/adiosYAML.h
@@ -35,6 +35,9 @@ std::string ParseConfigYAML(core::ADIOS &adios, const std::string &configFileYAM
 void ParseUserOptionsFile(Comm &comm, const std::string &configFileYAML, UserOptions &options,
                           std::string &homePath);
 
+void ParseHostOptionsFile(Comm &comm, const std::string &configFileYAML, HostOptions &hosts,
+                          std::string &homePath);
+
 } // end namespace helper
 } // end namespace adios2
 

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
@@ -370,6 +370,7 @@ void FileAWSSDK::Read(char *buffer, size_t size, size_t start)
         if (m_CachingThisFile)
         {
             m_CacheFileWrite->Write(buffer, size, m_SeekPos);
+            m_CacheFileWrite->Flush();
             if (m_Verbose > 0)
             {
                 std::cout << "FileAWSSDK::Read: Written to cache " << m_CacheFileWrite->m_Name

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
@@ -71,6 +71,10 @@ void FileAWSSDK::SetParameters(const Params &params)
 
     helper::SetParameterValueInt("verbose", params, m_Verbose, "");
 
+    std::string recheckStr = "true";
+    helper::SetParameterValue("recheck_metadata", params, recheckStr);
+    m_RecheckMetadata = helper::StringTo<bool>(recheckStr, "");
+
     core::ADIOS::Global_init_AWS_API();
 
     s3ClientConfig = new Aws::S3::S3ClientConfiguration;
@@ -82,7 +86,8 @@ void FileAWSSDK::SetParameters(const Params &params)
     if (m_Verbose > 0)
     {
         std::cout << "FileAWSSDK::SetParameters: AWS Transport created with endpoint = '"
-                  << m_Endpoint << "'" << std::endl;
+                  << m_Endpoint << "'"
+                  << " recheck_metadata = " << m_RecheckMetadata << std::endl;
     }
 }
 
@@ -114,31 +119,58 @@ void FileAWSSDK::SetUpCache()
     if (m_CachingThisFile)
     {
         std::string const ep = std::regex_replace(m_Endpoint, std::regex("/|:"), "_");
-
-        m_CacheFileWrite = new FileFStream(m_Comm);
         const std::string path(m_CachePath + PathSeparator + ep + PathSeparator + m_BucketName +
                                PathSeparator + m_ObjectName);
         m_CacheFilePath = path;
-        const auto lastPathSeparator(path.find_last_of(PathSeparator));
-        if (lastPathSeparator != std::string::npos)
+        if (!m_RecheckMetadata)
         {
-            const std::string dirpath(path.substr(0, lastPathSeparator));
-            helper::CreateDirectory(dirpath);
+            m_CacheFileRead = new FileFStream(m_Comm);
+            try
+            {
+                m_CacheFileRead->Open(path, Mode::Read);
+                m_Size = m_CacheFileRead->GetSize();
+                m_IsCached = true;
+                m_CachingThisFile = false;
+                if (m_Verbose > 0)
+                {
+                    std::cout << "FileAWSSDK::SetUpCache: Already cached " << path
+                              << ", size = " << m_Size << std::endl;
+                }
+            }
+            catch (std::ios_base::failure &)
+            {
+                delete m_CacheFileRead;
+                m_IsCached = false;
+            }
         }
+    }
+}
 
+void FileAWSSDK::CheckCache(const size_t fileSize)
+{
+    if (m_CachingThisFile)
+    {
+        /* Check if cache file exists and size equals the cloud version*/
         m_CacheFileRead = new FileFStream(m_Comm);
         try
         {
-            m_CacheFileRead->Open(path, Mode::Read);
-            if (m_CacheFileRead->GetSize() == m_Size)
+            m_CacheFileRead->Open(m_CacheFilePath, Mode::Read);
+            size_t cacheSize = m_CacheFileRead->GetSize();
+            if (cacheSize == fileSize)
             {
                 m_IsCached = true;
                 m_CachingThisFile = false;
-                delete m_CacheFileWrite;
                 if (m_Verbose > 0)
                 {
-                    std::cout << "FileAWSSDK::SetUpCache: Already cached " << path << std::endl;
+                    std::cout << "FileAWSSDK::CheckCache: Already cached " << m_CacheFilePath
+                              << ", full size = " << cacheSize << std::endl;
                 }
+            }
+            else
+            {
+                std::cout << "FileAWSSDK::CheckCache: Partially cached " << m_CacheFilePath
+                          << ", cached size = " << cacheSize << " full size = " << fileSize
+                          << std::endl;
             }
         }
         catch (std::ios_base::failure &)
@@ -148,10 +180,19 @@ void FileAWSSDK::SetUpCache()
 
         if (m_CachingThisFile)
         {
-            m_CacheFileWrite->Open(path, Mode::Write);
+            /* Create output file for caching this data later */
+            const auto lastPathSeparator(m_CacheFilePath.find_last_of(PathSeparator));
+            if (lastPathSeparator != std::string::npos)
+            {
+                const std::string dirpath(m_CacheFilePath.substr(0, lastPathSeparator));
+                helper::CreateDirectory(dirpath);
+            }
+            m_CacheFileWrite = new FileFStream(m_Comm);
+            m_CacheFileWrite->Open(m_CacheFilePath, Mode::Write);
             if (m_Verbose > 0)
             {
-                std::cout << "FileAWSSDK::SetUpCache: Caching turn on for " << path << std::endl;
+                std::cout << "FileAWSSDK::CheckCache: Caching turn on for " << m_CacheFilePath
+                          << std::endl;
             }
         }
     }
@@ -184,31 +225,42 @@ void FileAWSSDK::Open(const std::string &name, const Mode openMode, const bool a
     case Mode::Read: {
         ProfilerStart("open");
         errno = 0;
-        Aws::S3::Model::HeadObjectRequest head_object_request;
-        head_object_request.SetBucket(m_BucketName);
-        head_object_request.SetKey(m_ObjectName);
 
-        if (m_Verbose > 0)
-        {
-            std::cout << "FileAWSSDK::Open: S3 HeadObjectRequests bucket='"
-                      << head_object_request.GetBucket() << "'  object = '"
-                      << head_object_request.GetKey() << "'" << std::endl;
-        }
-        head_object = s3Client->HeadObject(head_object_request);
-        if (!head_object.IsSuccess())
-        {
-            helper::Throw<std::invalid_argument>("Toolkit", "transport::file::FileAWSSDK", "Open",
-                                                 "'bucket/object'  " + m_Name + " does not exist ");
-        }
-        else
-        {
-            m_Size = head_object.GetResult().GetContentLength();
+        SetUpCache();
+        // m_IsCached=true if already found in cache and m_RecheckMetadata=false
+        // m_CachingThisFile=true if we want caching and m_IsCached=false
+        // m_CacheFilePath is the path to the local file in cache
 
-            /* Cache: check if we want to cache this file (metadata files) */
-            SetUpCache();
-        }
+        if (!m_IsCached)
+        {
+            Aws::S3::Model::HeadObjectRequest head_object_request;
+            head_object_request.SetBucket(m_BucketName);
+            head_object_request.SetKey(m_ObjectName);
 
-        m_Errno = errno;
+            if (m_Verbose > 0)
+            {
+                std::cout << "FileAWSSDK::Open: S3 HeadObjectRequests bucket='"
+                          << head_object_request.GetBucket() << "'  object = '"
+                          << head_object_request.GetKey() << "'" << std::endl;
+            }
+            head_object = s3Client->HeadObject(head_object_request);
+            if (!head_object.IsSuccess())
+            {
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "transport::file::FileAWSSDK", "Open",
+                    "'bucket/object'  " + m_Name + " does not exist ");
+            }
+            else
+            {
+                m_Size = head_object.GetResult().GetContentLength();
+                /* Cache: check if we want to cache this file (metadata files)
+                   and if we already have it fully in the cache
+                */
+                CheckCache(m_Size);
+            }
+
+            m_Errno = errno;
+        }
         ProfilerStop("open");
         break;
     }
@@ -369,10 +421,12 @@ void FileAWSSDK::Close()
     if (m_CachingThisFile)
     {
         m_CacheFileWrite->Close();
+        delete m_CacheFileWrite;
     }
     if (m_IsCached)
     {
         m_CacheFileRead->Close();
+        delete m_CacheFileRead;
     }
 
     m_IsOpen = false;
@@ -391,7 +445,7 @@ void FileAWSSDK::Delete()
 
 void FileAWSSDK::CheckFile(const std::string hint) const
 {
-    if (!head_object.IsSuccess())
+    if (!m_IsCached && !head_object.IsSuccess())
     {
         helper::Throw<std::ios_base::failure>("Toolkit", "transport::file::FileAWSSDK", "CheckFile",
                                               hint);

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.h
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.h
@@ -95,6 +95,7 @@ private:
     std::future<int> m_OpenFuture;
     size_t m_SeekPos = 0;
     size_t m_Size = 0;
+    int m_Verbose = 0;
 
     void SetUpCache();
     std::string m_CachePath;        // local cache directory

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.h
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.h
@@ -96,8 +96,10 @@ private:
     size_t m_SeekPos = 0;
     size_t m_Size = 0;
     int m_Verbose = 0;
+    bool m_RecheckMetadata = true; // always check if cached metadata is complete
 
     void SetUpCache();
+    void CheckCache(const size_t fileSize);
     std::string m_CachePath;        // local cache directory
     bool m_CachingThisFile = false; // save content to local cache
     FileFStream *m_CacheFileWrite;

--- a/source/utils/adios_campaign_manager/adios2_campaign_manager.py
+++ b/source/utils/adios_campaign_manager/adios2_campaign_manager.py
@@ -98,6 +98,7 @@ def SetupArgs():
             args.campaign_store = args.campaign_store[:-1]
 
     args.remote_data = False
+    args.s3_endpoint = None
     if args.hostname is None:
         args.hostname = args.user_options.hostname
     elif args.hostname in args.host_options and args.hostname != args.user_options.hostname:

--- a/source/utils/adios_campaign_manager/adios2_campaign_manager.py
+++ b/source/utils/adios_campaign_manager/adios2_campaign_manager.py
@@ -119,9 +119,9 @@ def SetupArgs():
         if not args.campaign.endswith(".aca"):
             args.CampaignFileName += ".aca"
         if (
-            not exists(args.CampaignFileName)
-            and not args.CampaignFileName.startswith("/")
-            and args.campaign_store is not None
+            not exists(args.CampaignFileName) and
+            not args.CampaignFileName.startswith("/") and
+            args.campaign_store is not None
         ):
             args.CampaignFileName = args.campaign_store + "/" + args.CampaignFileName
 
@@ -145,9 +145,9 @@ def CheckCampaignStore(args):
 def CheckLocalCampaignDir(args):
     if not isdir(args.LocalCampaignDir):
         print(
-            "ERROR: Shot campaign data '"
-            + args.LocalCampaignDir
-            + "' does not exist. Run this command where the code was executed.",
+            "ERROR: Shot campaign data '" +
+            args.LocalCampaignDir +
+            "' does not exist. Run this command where the code was executed.",
             flush=True,
         )
         exit(1)
@@ -383,15 +383,15 @@ def Create(args: dict, cur: sqlite3.Cursor):
     cur.execute("create table host" + "(hostname TEXT PRIMARY KEY, longhostname TEXT)")
     cur.execute("create table directory" + "(hostid INT, name TEXT, PRIMARY KEY (hostid, name))")
     cur.execute(
-        "create table bpdataset"
-        + "(hostid INT, dirid INT, name TEXT, ctime INT"
-        + ", PRIMARY KEY (hostid, dirid, name))"
+        "create table bpdataset" +
+        "(hostid INT, dirid INT, name TEXT, ctime INT" +
+        ", PRIMARY KEY (hostid, dirid, name))"
     )
     cur.execute(
-        "create table bpfile"
-        + "(bpdatasetid INT, name TEXT, compression INT, lenorig INT"
-        + ", lencompressed INT, ctime INT, data BLOB"
-        + ", PRIMARY KEY (bpdatasetid, name))"
+        "create table bpfile" +
+        "(bpdatasetid INT, name TEXT, compression INT, lenorig INT" +
+        ", lencompressed INT, ctime INT, data BLOB" +
+        ", PRIMARY KEY (bpdatasetid, name))"
     )
     Update(args, cur)
 
@@ -425,11 +425,11 @@ def Info(args: dict, cur: sqlite3.Cursor):
         for dir in dirs:
             print(f"    dir = {dir[1]}")
             res3 = cur.execute(
-                'select rowid, name, ctime from bpdataset where hostid = "'
-                + str(host[0])
-                + '" and dirid = "'
-                + str(dir[0])
-                + '"'
+                'select rowid, name, ctime from bpdataset where hostid = "' +
+                str(host[0]) +
+                '" and dirid = "' +
+                str(dir[0]) +
+                '"'
             )
             bpdatasets = res3.fetchall()
             for bpdataset in bpdatasets:

--- a/source/utils/adios_campaign_manager/adios2_campaign_manager.py
+++ b/source/utils/adios_campaign_manager/adios2_campaign_manager.py
@@ -7,6 +7,7 @@ import zlib
 import yaml
 from dataclasses import dataclass
 from datetime import datetime
+from dateutil.parser import parse
 from os import chdir, getcwd, remove, stat
 from os.path import exists, isdir, expanduser
 from re import sub
@@ -16,6 +17,7 @@ from time import time_ns
 # from adios2.adios2_campaign_manager import *
 
 ADIOS_ACA_VERSION = "0.1"
+
 
 @dataclass
 class UserOption:
@@ -45,6 +47,17 @@ def ReadUserConfig():
     return opts
 
 
+def ReadHostConfig() -> dict:
+    path = expanduser("~/.config/adios2/hosts.yaml")
+    doc = {}
+    try:
+        with open(path) as f:
+            doc = yaml.safe_load(f)
+    except FileNotFoundError:
+        None
+    return doc
+
+
 def SetupArgs():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -60,11 +73,19 @@ def SetupArgs():
         "--campaign_store", "-s", help="Path to local campaign store", default=None
     )
     parser.add_argument("--hostname", "-n", help="Host name unique for hosts in a campaign")
+    parser.add_argument("--s3_bucket", "-b", help="Bucket on S3 server", default=None)
+    parser.add_argument(
+        "--s3_datetime",
+        "-t",
+        help="Datetime of data on S3 server in " "'2024-04-19 10:20:15 -0400' format",
+        default=None,
+    )
     parser.add_argument("-f", "--files", nargs="+", help="Add ADIOS files manually")
     args = parser.parse_args()
 
     # default values
     args.user_options = ReadUserConfig()
+    args.host_options = ReadHostConfig()
 
     if args.verbose == 0:
         args.verbose = args.user_options.verbose
@@ -76,16 +97,32 @@ def SetupArgs():
         while args.campaign_store[-1] == "/":
             args.campaign_store = args.campaign_store[:-1]
 
+    args.remote_data = False
     if args.hostname is None:
         args.hostname = args.user_options.hostname
+    elif args.hostname in args.host_options and args.hostname != args.user_options.hostname:
+        args.remote_data = True
+        hostopt = args.host_options.get(args.hostname)
+        if hostopt is not None:
+            optID = next(iter(hostopt))
+            if hostopt[optID]["protocol"].casefold() == "s3":
+                args.s3_endpoint = hostopt[optID]["endpoint"]
+                if args.s3_bucket is None:
+                    print("ERROR: Remote option for an S3 server requires --s3_bucket")
+                    exit(1)
+                if args.s3_datetime is None:
+                    print("ERROR: Remote option for an S3 server requires --s3_datetime")
+                    exit(1)
 
     args.CampaignFileName = args.campaign
     if args.campaign is not None:
         if not args.campaign.endswith(".aca"):
             args.CampaignFileName += ".aca"
-        if (not exists(args.CampaignFileName) and
-                not args.CampaignFileName.startswith("/") and
-                args.campaign_store is not None):
+        if (
+            not exists(args.CampaignFileName)
+            and not args.CampaignFileName.startswith("/")
+            and args.campaign_store is not None
+        ):
             args.CampaignFileName = args.campaign_store + "/" + args.CampaignFileName
 
     if args.files is None:
@@ -108,12 +145,19 @@ def CheckCampaignStore(args):
 def CheckLocalCampaignDir(args):
     if not isdir(args.LocalCampaignDir):
         print(
-            "ERROR: Shot campaign data '" +
-            args.LocalCampaignDir +
-            "' does not exist. Run this command where the code was executed.",
+            "ERROR: Shot campaign data '"
+            + args.LocalCampaignDir
+            + "' does not exist. Run this command where the code was executed.",
             flush=True,
         )
         exit(1)
+
+
+def parse_date_to_utc(date, fmt=None):
+    if fmt is None:
+        fmt = "%Y-%m-%d %H:%M:%S %z"  # Defaults to : 2022-08-31 07:47:30 -0000
+    get_date_obj = parse(str(date))
+    return get_date_obj.timestamp()
 
 
 def IsADIOSDataset(dataset):
@@ -187,9 +231,9 @@ def AddFileToArchive(args: dict, filename: str, cur: sqlite3.Cursor, dsID: int):
     )
 
 
-def AddDatasetToArchive(hostID: int, dirID: int, dataset: str, cur: sqlite3.Cursor) -> int:
-    statres = stat(dataset)
-    ct = statres.st_ctime_ns
+def AddDatasetToArchive(
+    args: dict, hostID: int, dirID: int, dataset: str, cur: sqlite3.Cursor
+) -> int:
     select_cmd = (
         "select rowid from bpdataset "
         f"where hostid = {hostID} and dirid = {dirID} and name = '{dataset}'"
@@ -204,6 +248,15 @@ def AddDatasetToArchive(hostID: int, dirID: int, dataset: str, cur: sqlite3.Curs
         )
     else:
         print(f"Add dataset {dataset} to archive")
+        if args.remote_data:
+            if args.s3_datetime:
+                ct = parse_date_to_utc(args.s3_datetime)
+            else:
+                ct = 0
+        else:
+            statres = stat(dataset)
+            ct = statres.st_ctime_ns
+
         curDS = cur.execute(
             "insert into bpdataset (hostid, dirid, name, ctime) values (?, ?, ?, ?)",
             (hostID, dirID, dataset, ct),
@@ -221,8 +274,10 @@ def ProcessFiles(args: dict, cur: sqlite3.Cursor, hostID: int, dirID: int):
         print(f"Process entry {entry}:")
         dsID = 0
         dataset = entry
-        if IsADIOSDataset(dataset):
-            dsID = AddDatasetToArchive(hostID, dirID, dataset, cur)
+        if args.remote_data:
+            dsID = AddDatasetToArchive(args, hostID, dirID, dataset, cur)
+        elif IsADIOSDataset(dataset):
+            dsID = AddDatasetToArchive(args, hostID, dirID, dataset, cur)
             cwd = getcwd()
             chdir(dataset)
             mdFileList = glob.glob("*md.*")
@@ -236,16 +291,20 @@ def ProcessFiles(args: dict, cur: sqlite3.Cursor, hostID: int, dirID: int):
 
 
 def GetHostName():
-    host = getfqdn()
-    if host.startswith("login"):
-        host = sub("^login[0-9]*\\.", "", host)
-    if host.startswith("batch"):
-        host = sub("^batch[0-9]*\\.", "", host)
-    if args.hostname is None:
-        shorthost = host.split(".")[0]
+    if args.s3_endpoint:
+        longhost = args.s3_endpoint
     else:
-        shorthost = args.user_options.hostname
-    return host, shorthost
+        longhost = getfqdn()
+        if longhost.startswith("login"):
+            longhost = sub("^login[0-9]*\\.", "", longhost)
+        if longhost.startswith("batch"):
+            longhost = sub("^batch[0-9]*\\.", "", longhost)
+
+    if args.hostname is None:
+        shorthost = longhost.split(".")[0]
+    else:
+        shorthost = args.hostname
+    return longhost, shorthost
 
 
 def AddHostName(longHostName, shortHostName):
@@ -302,7 +361,10 @@ def Update(args: dict, cur: sqlite3.Cursor):
 
     hostID = AddHostName(longHostName, shortHostName)
 
-    rootdir = getcwd()
+    if args.remote_data and args.s3_bucket is not None:
+        rootdir = args.s3_bucket
+    else:
+        rootdir = getcwd()
     dirID = AddDirectory(hostID, rootdir)
     con.commit()
 
@@ -321,15 +383,15 @@ def Create(args: dict, cur: sqlite3.Cursor):
     cur.execute("create table host" + "(hostname TEXT PRIMARY KEY, longhostname TEXT)")
     cur.execute("create table directory" + "(hostid INT, name TEXT, PRIMARY KEY (hostid, name))")
     cur.execute(
-        "create table bpdataset" +
-        "(hostid INT, dirid INT, name TEXT, ctime INT" +
-        ", PRIMARY KEY (hostid, dirid, name))"
+        "create table bpdataset"
+        + "(hostid INT, dirid INT, name TEXT, ctime INT"
+        + ", PRIMARY KEY (hostid, dirid, name))"
     )
     cur.execute(
-        "create table bpfile" +
-        "(bpdatasetid INT, name TEXT, compression INT, lenorig INT" +
-        ", lencompressed INT, ctime INT, data BLOB" +
-        ", PRIMARY KEY (bpdatasetid, name))"
+        "create table bpfile"
+        + "(bpdatasetid INT, name TEXT, compression INT, lenorig INT"
+        + ", lencompressed INT, ctime INT, data BLOB"
+        + ", PRIMARY KEY (bpdatasetid, name))"
     )
     Update(args, cur)
 
@@ -363,11 +425,11 @@ def Info(args: dict, cur: sqlite3.Cursor):
         for dir in dirs:
             print(f"    dir = {dir[1]}")
             res3 = cur.execute(
-                'select rowid, name, ctime from bpdataset where hostid = "' +
-                str(host[0]) +
-                '" and dirid = "' +
-                str(dir[0]) +
-                '"'
+                'select rowid, name, ctime from bpdataset where hostid = "'
+                + str(host[0])
+                + '" and dirid = "'
+                + str(dir[0])
+                + '"'
             )
             bpdatasets = res3.fetchall()
             for bpdataset in bpdatasets:


### PR DESCRIPTION
- Parse ~/.config/adios2/hosts.yaml and build HostOptions dictionary. S3 protocol well defined, SSH and XRootD needs testing and fixing
- Enable creating a remote campaign with S3 location in adios2_campaign_manager
- CampaignReader handles S3 hosts and launches BP5 with AWSSDK transport library

Usage:
adios2_campaign_manager -v create MAST/30466 -n STFC-S3 --s3_bucket mast/test/adios/mini --s3_datetime "2024-04-19 10:20:15 -0400" -f 30466.bp
