### PR TITLE
Add macro defines for BP3, BP4 and BP5

### DIFF
--- a/source/adios2/common/ADIOSConfig.h.in
+++ b/source/adios2/common/ADIOSConfig.h.in
@@ -31,7 +31,16 @@
 
 @ADIOS2_CONFIG_DEFINES@
 
-#define ADIOS2_FEATURE_LIST @ADIOS2_CONFIG_FEATURE_LIST@
+/*
+ * Constant defines: These are available unconditionally
+ * in the current version of ADIOS2.
+ */
+
+#define ADIOS2_HAVE_BP3
+#define ADIOS2_HAVE_BP4
+#define ADIOS2_HAVE_BP5
+
+#define ADIOS2_FEATURE_LIST "BP3" "BP4" "BP5" @ADIOS2_CONFIG_FEATURE_LIST@
 
 /* Everything between here and the note above is programatically generated */
 


### PR DESCRIPTION
For us, this concerns mostly BP5. 

In ADIOS2 v2.9, BP5 was an optional feature, so all our code targeting BP5 in openPMD is behind an `#ifdef ADIOS2_HAVE_BP5` check. 
With ADIOS2 v2.10, BP5 is available unconditionally, so it was removed from the feature list in `CMakeLists.txt`:
```cmake
set(ADIOS2_CONFIG_OPTS
    DataMan DataSpaces HDF5 HDF5_VOL MHS SST Fortran MPI Python PIP Blosc2 BZip2
    LIBPRESSIO MGARD MGARD_MDR PNG SZ ZFP DAOS IME O_DIRECT Sodium Catalyst SysVShMem UCX
    ZeroMQ Profiling Endian_Reverse Derived_Variable AWSSDK XRootD GPU_Support CUDA Kokkos
    Kokkos_CUDA Kokkos_HIP Kokkos_SYCL Campaign
)
```
This means that the `#define ADIOS2_HAVE_BP5` is no longer there in `ADIOSConfig.h`. In consequence, the current release of openPMD does not work very well together with BP5 in ADIOS2 v2.10 since it thinks BP5 is not there.

I'm unfortunately too late with this for the v2.10.1 patch release, but maybe there will be a v2.10.2. Otherwise, this situation will be resolved in a release on our end.