### PR TITLE
cmake: add ADIOS2_LIBADIOS_MODE flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ adios_option(Derived_Variable    "Enable support for derived variables" OFF)
 adios_option(PIP        "Enable support for pip packaging" OFF)
 adios_option(XRootD     "Enable support for XRootD" AUTO)
 
+option(ADIOS2_LIBADIOS_MODE "Install only C/C++ library components" OFF)
+mark_as_advanced(ADIOS2_LIBADIOS_MODE)
 option(ADIOS2_Blosc2_PREFER_SHARED "Prefer shared Blosc2 libraries" ON)
 mark_as_advanced(ADIOS2_Blosc2_PREFER_SHARED)
 mark_as_advanced(ADIOS2_USE_PIP)
@@ -314,6 +316,10 @@ if(MSVC AND BUILD_SHARED_LIBS AND ADIOS2_HAVE_HDF5)
   # See note about building with visual studio and shared libs, here:
   #     https://github.com/HDFGroup/hdf5/blob/develop/release_docs/USING_HDF5_VS.txt
   add_definitions(-DH5_BUILT_AS_DYNAMIC_LIB=1)
+endif()
+
+if (ADIOS2_LIBADIOS_MODE)
+  set(ADIOS2_MAYBE_EXCLUDE_FROM_ALL "EXCLUDE_FROM_ALL")
 endif()
 
 #------------------------------------------------------------------------------#

--- a/bindings/Python/CMakeLists.txt
+++ b/bindings/Python/CMakeLists.txt
@@ -60,12 +60,15 @@ endif()
 install(TARGETS adios2_py
   DESTINATION ${install_location}/bindings
   COMPONENT adios2_python-python
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )
 install(FILES ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/adios2/bindings/__init__.py
   DESTINATION ${install_location}/bindings
   COMPONENT adios2_python-python
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test
   DESTINATION ${install_location}
   COMPONENT adios2_python-python
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -15,4 +15,5 @@ endif()
 install(DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/adios2/
   DESTINATION ${install_location}
   COMPONENT adios2_python-python
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )

--- a/source/adios2/toolkit/remote/CMakeLists.txt
+++ b/source/adios2/toolkit/remote/CMakeLists.txt
@@ -15,5 +15,6 @@ if (NOT ADIOS2_USE_PIP)
   set_property(TARGET adios2_remote_server PROPERTY OUTPUT_NAME adios2_remote_server${ADIOS2_EXECUTABLE_SUFFIX})
   install(TARGETS adios2_remote_server EXPORT adios2
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_tools-runtime
+    ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
   )
 endif ()

--- a/source/adios2/toolkit/sst/util/CMakeLists.txt
+++ b/source/adios2/toolkit/sst/util/CMakeLists.txt
@@ -24,4 +24,5 @@ target_include_directories(sst_conn_tool PRIVATE .. ../cp )
 
 install(TARGETS sst_conn_tool EXPORT adios2
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_tools-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -23,6 +23,7 @@ target_include_directories(bpls PRIVATE
 set_property(TARGET bpls PROPERTY OUTPUT_NAME bpls${ADIOS2_EXECUTABLE_SUFFIX})
 install(TARGETS bpls EXPORT adios2
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_tools-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/bpls/bpls.cmake.gen.in
@@ -70,6 +71,7 @@ install(TARGETS adios_reorganize
   ${maybe_adios_reorganize_mpi}
   EXPORT adios2
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_tools-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )
 
 if(ADIOS2_HAVE_MPI)
@@ -83,13 +85,17 @@ if(Python_Interpreter_FOUND)
   install(PROGRAMS adios2_json_pp.py
     RENAME adios2_json_pp
     DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT adios2_scripts-runtime)
+    COMPONENT adios2_scripts-runtime
+    ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
+  )
 endif()
 
 install(PROGRAMS adios2_deactivate_bp
   RENAME adios2_deactivate_bp
   DESTINATION ${CMAKE_INSTALL_BINDIR}
-  COMPONENT adios2_scripts-runtime)
+  COMPONENT adios2_scripts-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
+)
 
 # Simplified wrappers for adios2_reorganize
 configure_file(

--- a/source/utils/adios_campaign_manager/CMakeLists.txt
+++ b/source/utils/adios_campaign_manager/CMakeLists.txt
@@ -1,6 +1,7 @@
 install(PROGRAMS adios2_campaign_manager.py
   RENAME adios2_campaign_manager
   DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_scripts-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )
 #install(
 #  FILES

--- a/source/utils/adios_iotest/CMakeLists.txt
+++ b/source/utils/adios_iotest/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 
 install(TARGETS adios_iotest EXPORT adios2
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_tools-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )
 
 install(DIRECTORY iotest-config/

--- a/source/utils/bp4dbg/CMakeLists.txt
+++ b/source/utils/bp4dbg/CMakeLists.txt
@@ -1,6 +1,7 @@
 install(PROGRAMS bp4dbg.py
   RENAME bp4dbg
   DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_scripts-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )
 install(
   FILES
@@ -10,4 +11,5 @@ install(
     adios2/bp4dbg/metadata.py
     adios2/bp4dbg/idxtable.py
   DESTINATION ${CMAKE_INSTALL_PYTHONDIR}/adios2/bp4dbg COMPONENT adios2_scripts-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )

--- a/source/utils/bp5dbg/CMakeLists.txt
+++ b/source/utils/bp5dbg/CMakeLists.txt
@@ -1,6 +1,7 @@
 install(PROGRAMS bp5dbg.py
   RENAME bp5dbg
   DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_scripts-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )
 install(
   FILES
@@ -10,4 +11,5 @@ install(
     adios2/bp5dbg/metametadata.py
     adios2/bp5dbg/idxtable.py
   DESTINATION ${CMAKE_INSTALL_PYTHONDIR}/adios2/bp5dbg COMPONENT adios2_scripts-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )


### PR DESCRIPTION
We need this for package managers where we first need to install c/c++ components for the first package (libadios2) and later for the adios python/adios binaries package we need to install the remaining components.