### PR TITLE
Patch for xrootd with derived variables

### DIFF
--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -12,6 +12,10 @@ namespace adios2
 {
 namespace derived
 {
+std::map<adios2::detail::ExpressionOperator, OperatorFunctions> OpFunctions = {
+    {adios2::detail::ExpressionOperator::OP_ADD, {AddFunc, SameDimsFunc}},
+    {adios2::detail::ExpressionOperator::OP_CURL, {Curl3DFunc, CurlDimsFunc}},
+    {adios2::detail::ExpressionOperator::OP_MAGN, {MagnitudeFunc, SameDimsFunc}}};
 
 DerivedData AddFunc(std::vector<DerivedData> inputData, DataType type)
 {

--- a/source/adios2/toolkit/derived/Function.h
+++ b/source/adios2/toolkit/derived/Function.h
@@ -31,10 +31,7 @@ DerivedData Curl3DFunc(std::vector<DerivedData> input, DataType type);
 Dims SameDimsFunc(std::vector<Dims> input);
 Dims CurlDimsFunc(std::vector<Dims> input);
 
-const std::map<adios2::detail::ExpressionOperator, OperatorFunctions> OpFunctions = {
-    {adios2::detail::ExpressionOperator::OP_ADD, {AddFunc, SameDimsFunc}},
-    {adios2::detail::ExpressionOperator::OP_CURL, {Curl3DFunc, CurlDimsFunc}},
-    {adios2::detail::ExpressionOperator::OP_MAGN, {MagnitudeFunc, SameDimsFunc}}};
+extern std::map<adios2::detail::ExpressionOperator, OperatorFunctions> OpFunctions;
 
 template <class T>
 T *ApplyOneToOne(std::vector<DerivedData> inputData, size_t dataSize,


### PR DESCRIPTION
The error we are getting when both XRootD and the derived variables are both ON:

```
Undefined symbols for architecture arm64:
  "adios2::derived::Curl3DFunc(std::__1::vector<adios2::derived::DerivedData, std::__1::allocator<adios2::derived::DerivedData>>, adios2::DataType)", referenced from:
      __GLOBAL__sub_I_XrdSsiSvService.cpp in XrdSsiSvService.cpp.o
  "adios2::derived::CurlDimsFunc(std::__1::vector<std::__1::vector<unsigned long, std::__1::allocator<unsigned long>>, std::__1::allocator<std::__1::vector<unsigned long, std::__1::allocator<unsigned long>>>>)", referenced from:
      __GLOBAL__sub_I_XrdSsiSvService.cpp in XrdSsiSvService.cpp.o
  "adios2::derived::SameDimsFunc(std::__1::vector<std::__1::vector<unsigned long, std::__1::allocator<unsigned long>>, std::__1::allocator<std::__1::vector<unsigned long, std::__1::allocator<unsigned long>>>>)", referenced from:
      __GLOBAL__sub_I_XrdSsiSvService.cpp in XrdSsiSvService.cpp.o
  "adios2::derived::MagnitudeFunc(std::__1::vector<adios2::derived::DerivedData, std::__1::allocator<adios2::derived::DerivedData>>, adios2::DataType)", referenced from:
      __GLOBAL__sub_I_XrdSsiSvService.cpp in XrdSsiSvService.cpp.o
  "adios2::derived::AddFunc(std::__1::vector<adios2::derived::DerivedData, std::__1::allocator<adios2::derived::DerivedData>>, adios2::DataType)", referenced from:
      __GLOBAL__sub_I_XrdSsiSvService.cpp in XrdSsiSvService.cpp.o
ld: symbol(s) not found for architecture arm64
 
```