### PR TITLE
FFS tweaks

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -2002,6 +2002,7 @@ BP5Deserializer::BP5Deserializer(bool WriterIsRowMajor, bool ReaderIsRowMajor,
   m_RandomAccessMode{RandomAccessMode}, m_FlattenSteps{FlattenSteps}
 {
     FMContext Tmp = create_local_FMcontext();
+    set_ignore_default_values_FMcontext(Tmp);
     ReaderFFSContext = create_FFSContext_FM(Tmp);
     free_FMcontext(Tmp);
 }

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -72,6 +72,7 @@ void BP5Serializer::Init()
     Info.MetaFieldCount = 0;
     Info.MetaFields = NULL;
     Info.LocalFMContext = create_local_FMcontext();
+    set_ignore_default_values_FMcontext(Info.LocalFMContext);
     AddSimpleField(&Info.MetaFields, &Info.MetaFieldCount, "BitFieldCount", "integer",
                    sizeof(size_t));
     AddSimpleField(&Info.MetaFields, &Info.MetaFieldCount, "BitField", "integer[BitFieldCount]",

--- a/testing/adios2/engine/staging-common/TestCommonRead.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonRead.cpp
@@ -143,7 +143,7 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
             ASSERT_EQ(var_i16.Shape()[0], writerSize * Nx);
         }
 
-        auto var_i32 = io.InquireVariable<int32_t>("i32(bob)");
+        auto var_i32 = io.InquireVariable<int32_t>("i32(testparen)");
         if (NoData)
         {
             EXPECT_FALSE(var_time);

--- a/testing/adios2/engine/staging-common/TestCommonRead.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonRead.cpp
@@ -143,7 +143,7 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
             ASSERT_EQ(var_i16.Shape()[0], writerSize * Nx);
         }
 
-        auto var_i32 = io.InquireVariable<int32_t>("i32");
+        auto var_i32 = io.InquireVariable<int32_t>("i32(bob)");
         if (NoData)
         {
             EXPECT_FALSE(var_time);

--- a/testing/adios2/engine/staging-common/TestCommonReadF.F90
+++ b/testing/adios2/engine/staging-common/TestCommonReadF.F90
@@ -153,22 +153,22 @@ program TestSstRead
     end if
     deallocate(shape_in)
 
-    call adios2_inquire_variable(variables(3), ioRead, "i32", ierr)
-    if (variables(3)%name /= 'i32') then
-       write(*,*) 'i32 not recognized'
+    call adios2_inquire_variable(variables(3), ioRead, "i32(testparen)", ierr)
+    if (variables(3)%name /= 'i32(testparen)') then
+       write(*,*) 'i32(testparen) not recognized'
        stop 1
     end if
     if (variables(3)%type /= adios2_type_integer4) then
-       write(*,*) 'i32 type not recognized'
+       write(*,*) 'i32(testparen) type not recognized'
        stop 1
     end if
     call adios2_variable_shape(shape_in, ndims, variables(3), ierr)
     if (ndims /= 1) then
-       write(*,*) 'i32 ndims is not 1'
+       write(*,*) 'i32(testparen) ndims is not 1'
        stop 1
     end if
     if (shape_in(1) /= nx*writerSize) then
-       write(*,*) 'i32 shape_in read failed'
+       write(*,*) 'i32(testparen) shape_in read failed'
        stop 1
     end if
     deallocate(shape_in)

--- a/testing/adios2/engine/staging-common/TestCommonWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWrite.cpp
@@ -93,7 +93,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         (void)io.DefineVariable<double>("scalar_r64");
         (void)io.DefineVariable<int8_t>("i8", shape, start, count);
         (void)io.DefineVariable<int16_t>("i16", shape, start, count);
-        (void)io.DefineVariable<int32_t>("i32", shape, start, count);
+        (void)io.DefineVariable<int32_t>("i32(bob)", shape, start, count);
         (void)io.DefineVariable<int64_t>("i64", shape, start, count);
         auto var_r32 = io.DefineVariable<float>("r32", shape, start, count);
         auto var_r64 = io.DefineVariable<double>("r64", shape, start_r64, count_r64);
@@ -128,7 +128,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         auto scalar_r64 = io.InquireVariable<double>("scalar_r64");
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         auto var_i16 = io.InquireVariable<int16_t>("i16");
-        auto var_i32 = io.InquireVariable<int32_t>("i32");
+        auto var_i32 = io.InquireVariable<int32_t>("i32(bob)");
         auto var_i64 = io.InquireVariable<int64_t>("i64");
         auto var_r32 = io.InquireVariable<float>("r32");
         auto var_r64 = io.InquireVariable<double>("r64");

--- a/testing/adios2/engine/staging-common/TestCommonWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWrite.cpp
@@ -93,7 +93,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         (void)io.DefineVariable<double>("scalar_r64");
         (void)io.DefineVariable<int8_t>("i8", shape, start, count);
         (void)io.DefineVariable<int16_t>("i16", shape, start, count);
-        (void)io.DefineVariable<int32_t>("i32(bob)", shape, start, count);
+        (void)io.DefineVariable<int32_t>("i32(testparen)", shape, start, count);
         (void)io.DefineVariable<int64_t>("i64", shape, start, count);
         auto var_r32 = io.DefineVariable<float>("r32", shape, start, count);
         auto var_r64 = io.DefineVariable<double>("r64", shape, start_r64, count_r64);
@@ -128,7 +128,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         auto scalar_r64 = io.InquireVariable<double>("scalar_r64");
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         auto var_i16 = io.InquireVariable<int16_t>("i16");
-        auto var_i32 = io.InquireVariable<int32_t>("i32(bob)");
+        auto var_i32 = io.InquireVariable<int32_t>("i32(testparen)");
         auto var_i64 = io.InquireVariable<int64_t>("i64");
         auto var_r32 = io.InquireVariable<float>("r32");
         auto var_r64 = io.InquireVariable<double>("r64");

--- a/testing/adios2/engine/staging-common/TestCommonWriteF.F90
+++ b/testing/adios2/engine/staging-common/TestCommonWriteF.F90
@@ -135,7 +135,7 @@ program TestSstWrite
        shape_dims, start_dims, count_dims, &
        adios2_constant_dims, ierr)
 
-  call adios2_define_variable(variables(3), ioWrite, "i32", &
+  call adios2_define_variable(variables(3), ioWrite, "i32(testparen)", &
        adios2_type_integer4, 1, &
        shape_dims, start_dims, count_dims, &
        adios2_constant_dims, ierr)

--- a/testing/adios2/engine/staging-common/TestShapeChangingWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestShapeChangingWrite.cpp
@@ -97,7 +97,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         (void)io.DefineVariable<double>("scalar_r64");
         (void)io.DefineVariable<int8_t>("i8", shape, start, count);
         (void)io.DefineVariable<int16_t>("i16", shape, start, count);
-        (void)io.DefineVariable<int32_t>("i32", first_shape, start,
+        (void)io.DefineVariable<int32_t>("i32(testparen)", first_shape, start,
                                          first_count); // changing
         (void)io.DefineVariable<int64_t>("i64", shape, start, count);
         auto var_r32 = io.DefineVariable<float>("r32", shape, start, count);
@@ -133,7 +133,7 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
         auto scalar_r64 = io.InquireVariable<double>("scalar_r64");
         auto var_i8 = io.InquireVariable<int8_t>("i8");
         auto var_i16 = io.InquireVariable<int16_t>("i16");
-        auto var_i32 = io.InquireVariable<int32_t>("i32");
+        auto var_i32 = io.InquireVariable<int32_t>("i32(testparen)");
         auto var_i64 = io.InquireVariable<int64_t>("i64");
         auto var_r32 = io.InquireVariable<float>("r32");
         auto var_r64 = io.InquireVariable<double>("r64");

--- a/thirdparty/ffs/ffs/ffs/ffs_conv.c
+++ b/thirdparty/ffs/ffs/ffs/ffs_conv.c
@@ -370,7 +370,7 @@ create_conversion(FFSTypeHandle src_ioformat, FMFieldList target_field_list, int
 	 */
 	input_index = 0;
 	
-	if (strchr(nfl_sort[i].field_name, '(') == NULL) {
+	if ((strchr(nfl_sort[i].field_name, '(') == NULL) || conv_ptr->context->fmc->ignore_default_values) {
 	    /* no default value */
 	    search_name = (char *) nfl_sort[i].field_name;
 	} else {

--- a/thirdparty/ffs/ffs/fm/fm.h
+++ b/thirdparty/ffs/ffs/fm/fm.h
@@ -11,6 +11,7 @@ typedef struct _FMContextStruct *FMContext;
 
 extern FMContext create_FMcontext();
 extern FMContext create_local_FMcontext();
+extern void set_ignore_default_values_FMcontext(FMContext c);
 extern void free_FMcontext(FMContext c);
 extern void add_ref_FMcontext(FMContext c);
 extern void FMcontext_allow_self_formats(FMContext fmc);

--- a/thirdparty/ffs/ffs/fm/fm_formats.c
+++ b/thirdparty/ffs/ffs/fm/fm_formats.c
@@ -1600,7 +1600,7 @@ validate_and_copy_field_list(FMFieldList field_list, FMFormat fmformat)
 					    field_size);
 	new_field_list[field].field_name = strdup(field_list[field].field_name);
 	if  (fmformat->context->ignore_default_values) {
-	    new_field_list[field].field_name = strdup(new_field_list[field].field_name);
+	    new_field_list[field].field_name = new_field_list[field].field_name;
 	} else {
 	    field_name_strip_default((char *)new_field_list[field].field_name);
 	}

--- a/thirdparty/ffs/ffs/fm/fm_formats.c
+++ b/thirdparty/ffs/ffs/fm/fm_formats.c
@@ -181,6 +181,7 @@ new_FMContext()
     c->native_column_major_arrays = 0;
     c->native_pointer_size = sizeof(char*);
     c->errno_val = 0;
+    c->ignore_default_values = 0;
     c->result = NULL;
     
     c->self_server = 0;
@@ -191,6 +192,11 @@ new_FMContext()
     c->master_context = NULL;
 
     return (c);
+}
+
+extern void set_ignore_default_values_FMcontext(FMContext c)
+{
+    c->ignore_default_values = 1;
 }
 
 extern
@@ -1593,7 +1599,11 @@ validate_and_copy_field_list(FMFieldList field_list, FMFormat fmformat)
 					 field_list[field].field_offset +
 					    field_size);
 	new_field_list[field].field_name = strdup(field_list[field].field_name);
-	field_name_strip_default((char *)new_field_list[field].field_name);
+	if  (fmformat->context->ignore_default_values) {
+	    new_field_list[field].field_name = strdup(new_field_list[field].field_name);
+	} else {
+	    field_name_strip_default((char *)new_field_list[field].field_name);
+	}
 	new_field_list[field].field_type = strdup(field_list[field].field_type);
 	new_field_list[field].field_size = field_list[field].field_size;
 	if (simple_string) {

--- a/thirdparty/ffs/ffs/fm/fm_internal.h
+++ b/thirdparty/ffs/ffs/fm/fm_internal.h
@@ -129,6 +129,7 @@ typedef struct _FMContextStruct {
     int server_pid;
     int format_server_identifier;
     int server_byte_reversal;
+    int ignore_default_values;
 
     int format_list_size;
     FMFormat *format_list;


### PR DESCRIPTION
FFS has a feature where you can specify a default value for incoming structures (messages).  This is useful in an environment where different actors in a distributed system might be running different versions of software and helps let new systems accept old messages (if the "old" incoming message is missing a "new" field, that field is filled in with the default value and the message still be processed by new code, allowing a measure of transparent interoperability).  However, this feature is not useful in BP5 marshaling and the mechanism through which the default value is specified (enclosed in parens in the field name) restricts the set of ADIOS variable names to those that don't include an open paren.  This patch selectively disbles this feature of FFS for the FFS contexts that manage BP5 metadata handling while leaving it active in other situations (EVPath message handling).  This should address issue #4202.
