### PR TITLE
extend DimsArray constructor with DimsArray and DimsArray & Count

### DIFF
--- a/source/adios2/helper/adiosType.h
+++ b/source/adios2/helper/adiosType.h
@@ -177,6 +177,16 @@ public:
     {
         std::copy(d1.begin(), d1.end(), &Dimensions[0]);
     }
+
+    DimsArray(const DimsArray &d1) : CoreDims(d1.size(), &Dimensions[0])
+    {
+        std::copy(d1.begin(), d1.end(), &Dimensions[0]);
+    }
+
+    DimsArray(const size_t count, const DimsArray &d1) : CoreDims(count, &Dimensions[0])
+    {
+        std::copy(d1.begin(), d1.end(), &Dimensions[0]);
+    }
 };
 
 /**


### PR DESCRIPTION
add two more DimsArray constructors

CoreDims is designed as a Span and does not own the corresponding memory, but DimsArray is designed to copy the dimension data. However, existing method `DimsArray(const CoreDims &d1)` fails to copy the data in `DimsArray dimsPointer3(dimsPointer2);`

My test script is available at: https://github.com/Change72/adios-test/blob/master/TestCoreDims.cpp

```c++
// will make a value copy of dimsPoint2
DimsArray dimsPointer3(reinterpret_cast<CoreDims&>(dimsPointer2));

// will only copy the pointer
DimsArray dimsPointer3(dimsPointer2);

dimsPointer3[1] = 50;
```

So the first added constructor is to fix this issue. As to the second one, when the dimension count is unknown during construction, one way to use `DimsArray` is to declare with `helper::Max_Dims` first, and save the corresponding count in a separate variable.

However, when passing DimsArray to another function, like `NdCopy`, it will copy the entire array with helper::Max_Dims. That's why we need count, which is not equal to d1.size(), to indicate the actual size.

```c++
        helper::DimsArray startArray(ReqInfo.ReqBox.DimCount, ReqInfo.ReqBox.Start);
        helper::DimsArray countArray(ReqInfo.ReqBox.DimCount, ReqInfo.ReqBox.Count);

        helper::NdCopy(reinterpret_cast<char *>(ReqInfo.Data), startArray, countArray, true, false, reinterpret_cast<char *>(Req.Data), Req.Start, Req.Count, true, false, ReqInfo.TypeSize);
```