### PR TITLE
[Bug fix] Switch from `ROCM_VERSION_MAJOR` to `HIP_VERSION_MAJOR`

### DIFF
--- a/source/adios2/helper/kokkos/adiosKokkos.cpp
+++ b/source/adios2/helper/kokkos/adiosKokkos.cpp
@@ -85,7 +85,7 @@ bool IsGPUbuffer(const void *ptr)
     hipError_t ret;
     hipPointerAttribute_t attr;
     ret = hipPointerGetAttributes(&attr, ptr);
-#if defined(ROCM_VERSION_MAJOR) && ROCM_VERSION_MAJOR < 6
+#if defined(HIP_VERSION_MAJOR) && HIP_VERSION_MAJOR < 6
     if (ret == hipSuccess && attr.memoryType == hipMemoryTypeDevice)
 #else
     if (ret == hipSuccess && attr.type == hipMemoryTypeDevice)


### PR DESCRIPTION
Bug introduced in #4214 (PR solving the problem in ROCM API change for hipPointerAttribute_t:

ROCM 5.3: https://rocm.docs.amd.com/projects/HIP/en/docs-5.3.3/doxygen/html/structhip_pointer_attribute__t.html
ROCM 6.1: https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/structhip_pointer_attribute__t.html

@pnorbert this needs to be part of the latest release/patch or the GPU support on Frontier will give compile errors