### PR TITLE
Connect to tunnel server to launch remote server

### DIFF
--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -102,7 +102,8 @@ public:
 };
 
 ADIOS::GlobalServices ADIOS::m_GlobalServices;
-adios2::HostOptions *ADIOS::m_StaticHostOptions = nullptr;
+
+std::atomic<adios2::HostOptions *> m_StaticHostOptions = nullptr;
 
 std::mutex PerfStubsMutex;
 static std::atomic_uint adios_refcount(0); // adios objects at the same time

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -102,6 +102,7 @@ public:
 };
 
 ADIOS::GlobalServices ADIOS::m_GlobalServices;
+adios2::HostOptions *ADIOS::m_StaticHostOptions = nullptr;
 
 std::mutex PerfStubsMutex;
 static std::atomic_uint adios_refcount(0); // adios objects at the same time
@@ -112,6 +113,8 @@ const adios2::UserOptions &ADIOS::GetUserOptions() { return m_UserOptions; };
 
 /** A constant reference to the host options from ~/.config/adios2/hosts.yaml */
 const adios2::HostOptions &ADIOS::GetHostOptions() { return m_HostOptions; };
+/** A constant reference to the host options from ~/.config/adios2/hosts.yaml */
+const adios2::HostOptions &ADIOS::StaticGetHostOptions() { return *m_StaticHostOptions; };
 
 ADIOS::ADIOS(const std::string configFile, helper::Comm comm, const std::string hostLanguage)
 : m_HostLanguage(hostLanguage), m_Comm(std::move(comm)), m_ConfigFile(configFile),
@@ -229,6 +232,7 @@ void ADIOS::ProcessHostConfig()
     {
         helper::ParseHostOptionsFile(m_Comm, cfgFile, m_HostOptions, homePath);
     }
+    m_StaticHostOptions = &m_HostOptions;
 }
 
 IO &ADIOS::DeclareIO(const std::string name, const ArrayOrdering ArrayOrder)

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -226,9 +226,15 @@ private:
     class GlobalServices;
     static class GlobalServices m_GlobalServices;
 
+    // a class pointer to one of the active ADIOS object's host options
+    // to make it accessible everwhere within a process
+    static adios2::HostOptions *m_StaticHostOptions;
+
 public:
     /** Global service AWS SDK initialization */
     static void Global_init_AWS_API();
+
+    static const adios2::HostOptions &StaticGetHostOptions();
 };
 
 } // end namespace core

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -226,10 +226,6 @@ private:
     class GlobalServices;
     static class GlobalServices m_GlobalServices;
 
-    // a class pointer to one of the active ADIOS object's host options
-    // to make it accessible everwhere within a process
-    static adios2::HostOptions *m_StaticHostOptions;
-
 public:
     /** Global service AWS SDK initialization */
     static void Global_init_AWS_API();

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -175,6 +175,7 @@ public:
     MACRO(FlattenSteps, Bool, bool, false)                                                         \
     MACRO(IgnoreFlattenSteps, Bool, bool, false)                                                   \
     MACRO(RemoteDataPath, String, std::string, "")                                                 \
+    MACRO(RemoteHost, String, std::string, "")                                                     \
     MACRO(MaxOpenFilesAtOnce, UInt, unsigned int, UINT_MAX)
 
     struct BP5Params

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -299,17 +299,17 @@ void BP5Reader::PerformGets()
 #ifdef ADIOS2_HAVE_XROOTD
         if (getenv("DoXRootD"))
         {
-            m_Remote = std::unique_ptr<XrootdRemote>(new XrootdRemote());
+            m_Remote = std::unique_ptr<XrootdRemote>(new XrootdRemote(m_HostOptions));
             m_Remote->Open("localhost", 1094, m_Name, m_OpenMode, RowMajorOrdering);
         }
         else
 #endif
 #ifdef ADIOS2_HAVE_SST
-            if (getenv("DoRemote"))
         {
-            m_Remote = std::unique_ptr<EVPathRemote>(new EVPathRemote());
-            m_Remote->Open("localhost", EVPathRemoteCommon::ServerPort, RemoteName, m_OpenMode,
-                           RowMajorOrdering);
+            m_Remote = std::unique_ptr<EVPathRemote>(new EVPathRemote(m_HostOptions));
+            int localPort =
+                m_Remote->LaunchRemoteServerViaConnectionManager(m_Parameters.RemoteHost);
+            m_Remote->Open("localhost", localPort, RemoteName, m_OpenMode, RowMajorOrdering);
         }
 #endif
 #ifdef ADIOS2_HAVE_KVCACHE

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -297,6 +297,7 @@ void CampaignReader::InitTransports()
                     SaveToFile(m_DB, localPath + PathSeparator + bpf.name, bpf);
                 }
                 io.SetParameter("RemoteDataPath", remotePath);
+                io.SetParameter("RemoteHost", m_CampaignData.hosts[ds.hostIdx].hostname);
             }
         }
         else

--- a/source/adios2/helper/adiosNetwork.h
+++ b/source/adios2/helper/adiosNetwork.h
@@ -13,6 +13,7 @@
 #define ADIOS2_HELPER_ADIOSNETWORK_H_
 
 /// \cond EXCLUDE_FROM_DOXYGEN
+#include <memory>
 #include <string>
 #include <vector>
 /// \endcond
@@ -59,6 +60,24 @@ void HandshakeReader(Comm const &comm, size_t &appID, std::vector<std::string> &
 
 #endif // ADIOS2_HAVE_DATAMAN || ADIOS2_HAVE_TABLE
 #endif // _WIN32
+
+struct NetworkSocketData;
+
+class NetworkSocket
+{
+public:
+    NetworkSocket();
+    ~NetworkSocket();
+
+    bool valid() const;
+
+    void Connect(std::string hostname, uint16_t port, std::string protocol = "tcp");
+    void RequestResponse(const std::string &request, char *response, size_t maxResponseSize);
+    void Close();
+
+private:
+    NetworkSocketData *m_Data;
+};
 
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -21,7 +21,7 @@
 namespace adios2
 {
 
-EVPathRemote::EVPathRemote() {}
+EVPathRemote::EVPathRemote(const adios2::HostOptions &hostOptions) : Remote(hostOptions) {}
 
 #ifdef ADIOS2_HAVE_SST
 EVPathRemote::~EVPathRemote()

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -33,7 +33,7 @@ public:
      * @param type from derived class
      * @param comm passed to m_Comm
      */
-    EVPathRemote();
+    EVPathRemote(const adios2::HostOptions &hostOptions);
     ~EVPathRemote();
 
     explicit operator bool() const { return m_Active; }

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -7,10 +7,12 @@
 #include "EVPathRemote.h"
 #include "adios2/core/ADIOS.h"
 #include "adios2/helper/adiosLog.h"
+#include "adios2/helper/adiosNetwork.h"
 #include "adios2/helper/adiosString.h"
 #include "adios2/helper/adiosSystem.h"
 #ifdef _MSC_VER
 #define strdup(x) _strdup(x)
+#define strtok_r(str, delim, saveptr) strtok_s(str, delim, saveptr)
 #endif
 
 #define ThrowUp(x)                                                                                 \
@@ -52,6 +54,94 @@ Remote::GetHandle Remote::Read(size_t Start, size_t Size, void *Dest)
     return (Remote::GetHandle)0;
 };
 Remote::~Remote() {}
-Remote::Remote() {}
+Remote::Remote(const adios2::HostOptions &hostOptions)
+: m_HostOptions(std::make_shared<adios2::HostOptions>(hostOptions))
+{
+}
+
+int Remote::LaunchRemoteServerViaConnectionManager(const std::string remoteHost)
+{
+    if (remoteHost.empty() || remoteHost == "localhost")
+    {
+        // std::cout << "Remote::LaunchRemoteServerViaConnectionManager: Assume server is already "
+        //              "running at on localhost at port = "
+        //           << 26200 << std::endl;
+        return 26200;
+    }
+
+    helper::NetworkSocket socket;
+    socket.Connect("localhost", 30000);
+
+    struct adios2::HostConfig *hostconf = nullptr;
+
+    auto it = m_HostOptions->find(remoteHost);
+    if (it != m_HostOptions->end())
+    {
+        for (auto &ho : it->second)
+        {
+            if (ho.protocol == HostAccessProtocol::SSH)
+            {
+                hostconf = &ho;
+            }
+        }
+    }
+    if (!hostconf)
+    {
+        helper::Throw<std::invalid_argument>("Toolkit", "Remote", "EstablishConnection",
+                                             "No ssh configuration found for host " + remoteHost +
+                                                 ". Add config in ~/.config/adios2/hosts.yaml");
+    }
+
+    std::string request = "/run_service?group=" + remoteHost + "&service=" + hostconf->name;
+
+    char response[2048];
+    socket.RequestResponse(request, response, 2048);
+
+    // responses:
+    //   port:-1,msg:incomplete_service_definition
+    //   port:-1,msg:missing_service_in_request
+    //   port:26200,cookie:0xd93d91e3643c9869,msg:no_error
+
+    char *token;
+    char *rest = response;
+
+    int serverPort = -1;
+    std::string cookie;
+
+    // std::cout << "Response = \"" << response << "\"" << std::endl;
+    while ((token = strtok_r(rest, ",", &rest)))
+    {
+        char *key;
+        char *value = token;
+        key = strtok_r(value, ":", &value);
+        if (!strncmp(key, "port", 4))
+        {
+            serverPort = atoi(value);
+        }
+        else if (!strncmp(key, "cookie", 6))
+        {
+            cookie = std::string(value);
+        }
+        else if (!strncmp(key, "msg", 3))
+        {
+            if (strcmp(value, "no_error"))
+            {
+                helper::Throw<std::invalid_argument>("Toolkit", "Remote", "EstablishConnection",
+                                                     "Error response from connection manager: " +
+                                                         std::string(value));
+            }
+        }
+        else
+        {
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "Remote", "EstablishConnection",
+                "Invalid response from connection manager. Do not understand key " +
+                    std::string(key));
+        }
+    }
+
+    socket.Close();
+    return serverPort;
+}
 
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -22,8 +22,12 @@ class Remote
 {
 
 public:
-    Remote();
+    Remote(const adios2::HostOptions &hostOptions);
     virtual ~Remote();
+
+    // Talk to local connection manager and ask for an existing or new SSH connection
+    // to 'remoteHost'. Return the local port through which one can talk to the remote server
+    int LaunchRemoteServerViaConnectionManager(const std::string remoteHost);
 
     virtual explicit operator bool() const { return false; }
 
@@ -43,6 +47,9 @@ public:
     virtual GetHandle Read(size_t Start, size_t Size, void *Dest);
 
     size_t m_Size;
+
+private:
+    const std::shared_ptr<adios2::HostOptions> m_HostOptions;
 };
 
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -303,7 +303,7 @@ extern XrdSsiProvider *XrdSsiProviderClient;
 #endif
 namespace adios2
 {
-XrootdRemote::XrootdRemote() {}
+XrootdRemote::XrootdRemote(const adios2::HostOptions &hostOptions) : Remote(hostOptions) {}
 XrootdRemote::~XrootdRemote() {}
 void XrootdRemote::Open(const std::string hostname, const int32_t port, const std::string filename,
                         const Mode mode, bool RowMajorOrdering)

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -94,7 +94,7 @@ public:
     Mode m_Mode;
     bool m_RowMajorOrdering;
 
-    XrootdRemote();
+    XrootdRemote(const adios2::HostOptions &hostOptions);
     ~XrootdRemote();
 
     void Open(const std::string hostname, const int32_t port, const std::string filename,

--- a/source/adios2/toolkit/transport/file/FileRemote.h
+++ b/source/adios2/toolkit/transport/file/FileRemote.h
@@ -81,6 +81,7 @@ private:
     size_t m_Size = 0;
 
     void SetUpCache();
+    std::string m_Hostname; // name from hosts.yaml
     std::string m_FileName;
     std::string m_CachePath;        // local cache directory
     bool m_CachingThisFile = false; // save content to local cache


### PR DESCRIPTION
- Added function LaunchRemoteServerViaConnectionManager() to Remote class to talk to local tunnel server to establish a connection to remote host (and launch adios2_remote_server on remote host). Local tunnel server is looked for on fixed port 30000 for now. Remote server's port and local port forwarded to remote server's port are dynamic.

- Ugly hack: added to ADIOS a static Class-member (m_StaticHostOptions) and class-function (StaticGetHostOptions()) that contains one of the ADIOS object's HostOptions, in order to allow access to HostOptions from functions that has no access to any ADIOS objects (e.g. FileRemote transport).