### PR TITLE
Remove reference to xarray backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,6 @@ Documentation = "https://adios2.readthedocs.io/"
 Discussions = "https://github.com/ornladios/ADIOS2/discussions"
 Changelog = "https://github.com/ornladios/ADIOS2/releases"
 
-[project.entry-points."xarray.backends"]
-adios = "adios2.xarraybackend:AdiosBackendEntrypoint"
-
 [tool.cibuildwheel]
 # Trigger an install of the package, and run a basic test
 test-command = "python -m unittest adios2.test.simple_read_write.TestSimpleReadWrite"


### PR DESCRIPTION
The deleted entry causes the generation of an entry_points.txt file with the following content:
```
[xarray.backends]
adios = adios2.xarraybackend:AdiosBackendEntrypoint
```
When [xarray](https://docs.xarray.dev/en/stable/index.html) and ADIOS 2 are both installed with e.g. pip, xarray finds this file and tries to load the `adios2.xarraybackend` module. I assume this module exists somewhere locally, but it doesn't seem to be in this repo, and xarray generates a warning when loading this module fails.

As far as I know, the only ways to make this warning go away are a) remove the reference to the missing xarray backend, or b) implement said backend. This PR obviously does the former, but I'm very curious about the state of progress towards the latter option!