### PR TITLE
[Bug fix] Read side computation of derived variables should not be triggered when data is stored

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -592,7 +592,8 @@ BP5Serializer::BP5WriterRec BP5Serializer::CreateWriterRec(void *Variable, const
         // and Offsets matching _MetaArrayRec
         const char *ExprString = NULL;
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
-        ExprString = VD ? VD->m_Expr.ExprString.c_str() : NULL;
+        if (VD && (VD->GetDerivedType() != DerivedVarType::StoreData))
+            ExprString = VD->m_Expr.ExprString.c_str();
 #endif
         char *LongName =
             BuildLongName(Name, VB->m_ShapeID, (int)Type, ElemSize, TextStructID, ExprString);


### PR DESCRIPTION
Before this PR, adios2 calls `ApplyExpression` every time there is a derived variable (which is identified by the expression string we encode in the name). However, for variables where we store data we do not want to recompute the values. The easiest fix is to not store the expression string for these variables (since in essence they are no longer derived variables). 