### PR TITLE
Fix errors and warning related to derived variables

### DIFF
--- a/source/adios2/toolkit/derived/Expression.cpp
+++ b/source/adios2/toolkit/derived/Expression.cpp
@@ -235,7 +235,7 @@ std::string ExpressionTree::toStringExpr()
             if (!detail.indices.empty())
             {
                 result += "[ ";
-                for (std::tuple<int, int, int> idx : detail.indices)
+                for (std::tuple<size_t, size_t, size_t> idx : detail.indices)
                 {
                     result += (std::get<0>(idx) < 0 ? "" : std::to_string(std::get<0>(idx))) + ":";
                     result += (std::get<1>(idx) < 0 ? "" : std::to_string(std::get<1>(idx))) + ":";

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -44,13 +44,13 @@ T *ApplyCurl(const T *input1, const T *input2, const T *input3, const size_t dim
     size_t dataSize = dims[0] * dims[1] * dims[2];
     T *data = (T *)malloc(dataSize * sizeof(float) * 3);
     size_t index = 0;
-    for (int i = 0; i < dims[0]; ++i)
+    for (int i = 0; i < (int)dims[0]; ++i)
     {
         size_t prev_i = std::max(0, i - 1), next_i = std::min((int)dims[0] - 1, i + 1);
-        for (int j = 0; j < dims[1]; ++j)
+        for (int j = 0; j < (int)dims[1]; ++j)
         {
             size_t prev_j = std::max(0, j - 1), next_j = std::min((int)dims[1] - 1, j + 1);
-            for (int k = 0; k < dims[2]; ++k)
+            for (int k = 0; k < (int)dims[2]; ++k)
             {
                 size_t prev_k = std::max(0, k - 1), next_k = std::min((int)dims[2] - 1, k + 1);
                 // curl[0] = dv3 / dy - dv2 / dz

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -81,20 +81,6 @@ T *ApplyCurl(const T *input1, const T *input2, const T *input3, const size_t dim
     return data;
 }
 
-// types not supported for curl
-std::complex<float> *ApplyCurl(const std::complex<float> * /*input 1*/,
-                               const std::complex<float> * /*input 2*/,
-                               const std::complex<float> * /*input 3*/, const size_t[3] /*dims*/)
-{
-    return NULL;
-}
-
-std::complex<double> *ApplyCurl(const std::complex<double> * /*input 1*/,
-                                const std::complex<double> * /*input 2*/,
-                                const std::complex<double> * /*input 3*/, const size_t[3] /*dims*/)
-{
-    return NULL;
-}
 }
 
 namespace derived
@@ -112,7 +98,7 @@ DerivedData AddFunc(std::vector<DerivedData> inputData, DataType type)
                                                 [](T a, T b) { return a + b; });                   \
         return DerivedData({(void *)addValues, inputData[0].Start, inputData[0].Count});           \
     }
-    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type_add)
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_add)
     helper::Throw<std::invalid_argument>("Derived", "Function", "AddFunc",
                                          "Invalid variable types");
     return DerivedData();
@@ -134,7 +120,7 @@ DerivedData SubtractFunc(std::vector<DerivedData> inputData, DataType type)
                 *(reinterpret_cast<T *>(inputData[0].Data) + i) - subtractValues[i];               \
         return DerivedData({(void *)subtractValues, inputData[0].Start, inputData[0].Count});      \
     }
-    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type_subtract)
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_subtract)
     helper::Throw<std::invalid_argument>("Derived", "Function", "SubtractFunc",
                                          "Invalid variable types");
     return DerivedData();
@@ -156,7 +142,7 @@ DerivedData MagnitudeFunc(std::vector<DerivedData> inputData, DataType type)
         }                                                                                          \
         return DerivedData({(void *)magValues, inputData[0].Start, inputData[0].Count});           \
     }
-    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type_mag)
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_mag)
     helper::Throw<std::invalid_argument>("Derived", "Function", "MagnitudeFunc",
                                          "Invalid variable types");
     return DerivedData();
@@ -196,7 +182,7 @@ DerivedData Curl3DFunc(const std::vector<DerivedData> inputData, DataType type)
         curl.Data = detail::ApplyCurl(input1, input2, input3, dims);                               \
         return curl;                                                                               \
     }
-    ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(declare_type_curl)
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_curl)
     helper::Throw<std::invalid_argument>("Derived", "Function", "Curl3DFunc",
                                          "Invalid variable types");
     return DerivedData();

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -2046,7 +2046,6 @@ void BP5Deserializer::FinalizeDerivedGets(std::vector<ReadRequest> &Reads)
         auto nameToVarInfo = Req.DerivedInputMap;
         auto DerivedBlockData = derivedVar->ApplyExpression(*nameToVarInfo);
 
-        auto entry = nameToVarInfo->begin();
         for (size_t i = 0; i < DerivedBlockData.size(); i++)
         {
             auto &DBlock = DerivedBlockData[i];

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1730,16 +1730,16 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
                                 for (auto varBase : derivedVarInputVarList)
                                 {
                                     ReadRequest RR;
-                                    BP5VarRec *VarRec = VarByName.at(varBase->m_Name);
+                                    BP5VarRec *VarPrimaryRec = VarByName.at(varBase->m_Name);
                                     MetaArrayRecOperator *writer_meta_base_input =
-                                        (MetaArrayRecOperator *)GetMetadataBase(VarRec, Step,
+                                        (MetaArrayRecOperator *)GetMetadataBase(VarPrimaryRec, Step,
                                                                                 WriterRank);
                                     RR.Timestep = Step;
                                     RR.WriterRank = WriterRank;
                                     RR.StartOffset = writer_meta_base_input->DataBlockLocation[0];
-                                    RR.ReadLength =
-                                        helper::GetDataTypeSize(VarRec->Type) *
-                                        CalcBlockLength(VarRec->DimCount, varBase->m_Count.data());
+                                    RR.ReadLength = helper::GetDataTypeSize(VarPrimaryRec->Type) *
+                                                    CalcBlockLength(VarPrimaryRec->DimCount,
+                                                                    varBase->m_Count.data());
                                     RR.DestinationAddr = (char *)malloc(RR.ReadLength);
                                     RR.DirectToAppMemory = false;
                                     RR.ReqIndex = ReqIndex;

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1739,7 +1739,7 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
                                     RR.StartOffset = writer_meta_base_input->DataBlockLocation[0];
                                     RR.ReadLength =
                                         helper::GetDataTypeSize(VarRec->Type) *
-                                        CalcBlockLength(VarRec->DimCount, Req->Count.data());
+                                        CalcBlockLength(VarRec->DimCount, varBase->m_Count.data());
                                     RR.DestinationAddr = (char *)malloc(RR.ReadLength);
                                     RR.DirectToAppMemory = false;
                                     RR.ReqIndex = ReqIndex;


### PR DESCRIPTION
PR to fix errors and warnings related to derived variables (except the lexer related warnings since @lizdulac is opening a PR on fixing lexer issues)

## Error

**Mismatch in reading count when reading variables that are part of a derived variable**

`Req->Count.data()` are the dimensions of the derived variable in the current request

`VarRec->DimCount` are the total dimensions of one of the variables used by the derived variable.

In all ecause Curl adds one dimension at the end).

However, I am adding now an aggregated operator that will have a lower dimension than the composing variables, so this line seg faults.