### PR TITLE
Introducing aggregated derived operators 

### DIFF
--- a/source/adios2/toolkit/derived/Expression.cpp
+++ b/source/adios2/toolkit/derived/Expression.cpp
@@ -139,7 +139,7 @@ struct OperatorFunctions
 };
 
 std::map<adios2::detail::ExpressionOperator, OperatorFunctions> OpFunctions = {
-    {adios2::detail::ExpressionOperator::OP_ADD, {AddFunc, SameDimsFunc, SameTypeFunc}},
+    {adios2::detail::ExpressionOperator::OP_ADD, {AddFunc, SameDimsWithAgrFunc, SameTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_SUBTRACT, {SubtractFunc, SameDimsFunc, SameTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_MULT, {MultFunc, SameDimsFunc, SameTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_DIV, {DivFunc, SameDimsFunc, SameTypeFunc}},
@@ -152,7 +152,7 @@ std::map<adios2::detail::ExpressionOperator, OperatorFunctions> OpFunctions = {
     {adios2::detail::ExpressionOperator::OP_ACOS, {AcosFunc, SameDimsFunc, FloatTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_ATAN, {AtanFunc, SameDimsFunc, FloatTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_CURL, {Curl3DFunc, CurlDimsFunc, SameTypeFunc}},
-    {adios2::detail::ExpressionOperator::OP_MAGN, {MagnitudeFunc, SameDimsFunc, SameTypeFunc}}};
+    {adios2::detail::ExpressionOperator::OP_MAGN, {MagnitudeFunc, SameDimsWithAgrFunc, SameTypeFunc}}};
 
 Expression::Expression(std::string string_exp)
 : m_Shape({0}), m_Start({0}), m_Count({0}), ExprString(string_exp)

--- a/source/adios2/toolkit/derived/Expression.cpp
+++ b/source/adios2/toolkit/derived/Expression.cpp
@@ -152,7 +152,8 @@ std::map<adios2::detail::ExpressionOperator, OperatorFunctions> OpFunctions = {
     {adios2::detail::ExpressionOperator::OP_ACOS, {AcosFunc, SameDimsFunc, FloatTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_ATAN, {AtanFunc, SameDimsFunc, FloatTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_CURL, {Curl3DFunc, CurlDimsFunc, SameTypeFunc}},
-    {adios2::detail::ExpressionOperator::OP_MAGN, {MagnitudeFunc, SameDimsWithAgrFunc, SameTypeFunc}}};
+    {adios2::detail::ExpressionOperator::OP_MAGN,
+     {MagnitudeFunc, SameDimsWithAgrFunc, SameTypeFunc}}};
 
 Expression::Expression(std::string string_exp)
 : m_Shape({0}), m_Start({0}), m_Count({0}), ExprString(string_exp)

--- a/source/adios2/toolkit/derived/Function.h
+++ b/source/adios2/toolkit/derived/Function.h
@@ -23,6 +23,7 @@ DerivedData MagnitudeFunc(std::vector<DerivedData> input, DataType type);
 DerivedData Curl3DFunc(std::vector<DerivedData> input, DataType type);
 
 std::tuple<Dims, Dims, Dims> SameDimsFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
+std::tuple<Dims, Dims, Dims> SameDimsWithAgrFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
 std::tuple<Dims, Dims, Dims> CurlDimsFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
 
 DataType SameTypeFunc(DataType input);

--- a/testing/adios2/derived/TestBPDerivedCorrectness.cpp
+++ b/testing/adios2/derived/TestBPDerivedCorrectness.cpp
@@ -618,8 +618,8 @@ TEST_P(DerivedCorrectnessP, MagCurlCorrectnessTest)
     bpFileReader.Get(varmag, readMag);
     bpFileReader.EndStep();
 
-    float curl_x, curl_y, curl_z, mag_curl;
-    float err;
+    float curl_x, curl_y, curl_z;
+    double err;
     for (size_t i = 0; i < Nx; ++i)
     {
         for (size_t j = 0; j < Ny; ++j)
@@ -633,7 +633,7 @@ TEST_P(DerivedCorrectnessP, MagCurlCorrectnessTest)
                 curl_x = -(2 * x);
                 curl_y = 7 - (2 * y);
                 curl_z = (4 * z) - (6 * x);
-                mag_curl = sqrt(pow(curl_x, 2) + pow(curl_y, 2) + pow(curl_z, 2));
+                auto mag_curl = sqrt(pow(curl_x, 2) + pow(curl_y, 2) + pow(curl_z, 2));
                 if (fabs(mag_curl) < 1)
                 {
                     err = fabs(mag_curl - readMag[idx]) / (1 + fabs(mag_curl));


### PR DESCRIPTION
The changes will allow `ADD` and `MAG` to work on a single variable and apply the operation as an aggregation on the last dimension.

e.g. for a 2D variable with dimensions (4, 2) with values:
```
1 2
3 4
5 6
7 8
```
`add(variable)` will return a 1D array with dimension (4) and values [3 7 11 15]

Since `CURL` is returning a single variable containing all 3 vectors x, y, z this PR will allow us to create a derived variable for magnitude of curl.

The PR is a different solution from #4208 that was splitting variable into corresponding subarrays. In the previous example, #4208 creates 4 1D arrays of dimension 2 and applies normal add over them. We need this functionality as well but this PR reduces the number of temporary variables used inside adios.