### PR TITLE
cmake,ci: disable kvcache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ adios_option(AWSSDK     "Enable support for S3 compatible storage using AWS SDK'
 adios_option(Derived_Variable    "Enable support for derived variables" OFF)
 adios_option(PIP        "Enable support for pip packaging" OFF)
 adios_option(XRootD     "Enable support for XRootD" AUTO)
-adios_option(KVCACHE    "Enable support for KVCache" AUTO)
+adios_option(KVCACHE    "Enable support for KVCache" OFF)
 
 option(ADIOS2_LIBADIOS_MODE "Install only C/C++ library components" OFF)
 mark_as_advanced(ADIOS2_LIBADIOS_MODE)

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -608,7 +608,7 @@ endif()
 
 # KVCache
 if(ADIOS2_USE_KVCACHE STREQUAL AUTO)
-    find_package(hiredis)
+    find_package(hiredis QUIET)
     if (hiredis_FOUND)
       message(STATUS "hiredis found. Turn on KVCache")
       set(ADIOS2_HAVE_KVCACHE TRUE)


### PR DESCRIPTION
#4250  broke the CI, the reason is that we did not test this kvcache enable in the corresponding CI due to a typo. 

Disabling kvcache until we resolve this