### PR TITLE
ci: address gha warnings

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -65,7 +65,7 @@ jobs:
           ls -la *-changed-files.txt
           NUM_CHANGES=$(wc -l < filtered-changed-files.txt)
           echo "Number of files changed (filtered): ${NUM_CHANGES}"
-          echo "::set-output name=num_code_changes::${NUM_CHANGES}"
+          echo "num_code_changes=${NUM_CHANGES}" >> $GITHUB_OUTPUT
 
 #######################################
 # Formatting jobs
@@ -176,7 +176,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: source
       - name: Restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-cache
         with:
           path: .ccache
@@ -196,7 +196,7 @@ jobs:
       - name: Print ccache statistics
         run: ccache -s | tee $GITHUB_STEP_SUMMARY
       - name: Save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit != 'true' }}
         id: save-cache
         with:
@@ -241,7 +241,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: source
       - name: Restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-cache
         with:
           path: .ccache
@@ -261,7 +261,7 @@ jobs:
       - name: Print ccache statistics
         run: ccache -s
       - name: Save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit != 'true' }}
         id: save-cache
         with:
@@ -319,7 +319,7 @@ jobs:
       - name: Setup
         run: gha/scripts/ci/gh-actions/macos-setup.sh
       - name: Restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-cache
         with:
           path: .ccache
@@ -337,7 +337,7 @@ jobs:
       - name: Print ccache statistics
         run: ccache -s
       - name: Save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: ${{ github.ref_name == 'master' && steps.restore-cache.outputs.cache-hit != 'true' }}
         id: save-cache
         with:
@@ -444,7 +444,7 @@ jobs:
             docker save -o ci-docker.tar ornladios/adios2:ci-tmp
             ls -lah ci-docker.tar
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 1
           name: ci-docker ${{ matrix.baseos }} ${{ github.sha }}
@@ -501,7 +501,7 @@ jobs:
           ref: ${{ matrix.ref }}
           path: source
       - name: Download CI docker image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ci-docker ubuntu-bionic ${{ github.sha }}
       - name: Initialize containers
@@ -561,7 +561,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         path: source
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config: |
@@ -578,7 +578,7 @@ jobs:
     - name: Build
       run: gha/scripts/ci/gh-actions/run.sh build
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/pypackaging.yml
+++ b/.github/workflows/pypackaging.yml
@@ -34,9 +34,10 @@ jobs:
       - name: Build SDist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
+          overwrite: true
 
   build_wheels:
     name: Wheel on ${{ matrix.os }}
@@ -60,9 +61,10 @@ jobs:
           CIBW_BUILD: cp*-manylinux_x86_64
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl
+          overwrite: true
 
   upload_pypi:
     needs: [build_wheels, make_sdist]
@@ -77,7 +79,7 @@ jobs:
         github.event.action == 'published'
       )
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
@@ -94,7 +96,7 @@ jobs:
     # Upload to Test PyPI for every commit on main branch
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/scripts/ci/cmake/ci-win2019-vs2019-msmpi.cmake
+++ b/scripts/ci/cmake/ci-win2019-vs2019-msmpi.cmake
@@ -22,5 +22,9 @@ set(CTEST_CMAKE_GENERATOR "Visual Studio 16 2019")
 set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
 list(APPEND CTEST_UPDATE_NOTES_FILES "${CMAKE_CURRENT_LIST_FILE}")
 # https://github.com/ornladios/ADIOS2/issues/4276
-set(CTEST_TEST_ARGS EXCLUDE "Api.Python.FileReader|Api.Python.BPWriteTypesHighLevelAPI_HDF5")
+# https://github.com/ornladios/ADIOS2/issues/4279
+# https://github.com/ornladios/ADIOS2/issues/4278
+set(CTEST_TEST_ARGS
+    EXCLUDE "Api.Python.FileReader|Api.Python.BPWriteTypesHighLevelAPI_HDF5|Api.Python.BPWriteTypesHighLevelAPI.MPI"
+)
 include(${CMAKE_CURRENT_LIST_DIR}/ci-common.cmake)

--- a/scripts/ci/cmake/ci-win2022-vs2022-msmpi.cmake
+++ b/scripts/ci/cmake/ci-win2022-vs2022-msmpi.cmake
@@ -23,5 +23,9 @@ set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
 list(APPEND CTEST_UPDATE_NOTES_FILES "${CMAKE_CURRENT_LIST_FILE}")
 # https://github.com/ornladios/ADIOS2/issues/4276
-set(CTEST_TEST_ARGS EXCLUDE "Api.Python.FileReader|Api.Python.BPWriteTypesHighLevelAPI_HDF5")
+# https://github.com/ornladios/ADIOS2/issues/4279
+# https://github.com/ornladios/ADIOS2/issues/4278
+set(CTEST_TEST_ARGS
+    EXCLUDE "Api.Python.FileReader|Api.Python.BPWriteTypesHighLevelAPI_HDF5|Api.Python.BPWriteTypesHighLevelAPI.MPI"
+)
 include(${CMAKE_CURRENT_LIST_DIR}/ci-common.cmake)

--- a/scripts/ci/cmake/ci-win2022-vs2022-serial.cmake
+++ b/scripts/ci/cmake/ci-win2022-vs2022-serial.cmake
@@ -26,6 +26,7 @@ set(CTEST_CMAKE_GENERATOR "Visual Studio 17 2022")
 set(CTEST_CMAKE_GENERATOR_PLATFORM "x64")
 list(APPEND CTEST_UPDATE_NOTES_FILES "${CMAKE_CURRENT_LIST_FILE}")
 # https://github.com/ornladios/ADIOS2/issues/4276
+# https://github.com/ornladios/ADIOS2/issues/4279
 set(CTEST_TEST_ARGS EXCLUDE "Api.Python.FileReader|Api.Python.BPWriteTypesHighLevelAPI_HDF5")
 
 include(${CMAKE_CURRENT_LIST_DIR}/ci-common.cmake)


### PR DESCRIPTION
This will save us from future feature removals of current deprecations. Warnings are found at the bottom of the following link: https://github.com/ornladios/ADIOS2/actions/runs/10100803550