### PR TITLE
Relaxing the restriction of the derived variables to have the same type as the operands

### DIFF
--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -890,8 +890,8 @@ VariableDerived &IO::DefineDerivedVariable(const std::string &name, const std::s
 
     derived::Expression derived_exp(exp_string);
     std::vector<std::string> var_list = derived_exp.VariableNameList();
-    DataType expressionType = DataType::None;
     bool isConstant = true;
+    std::map<std::string, DataType> name_to_type;
     std::map<std::string, std::tuple<Dims, Dims, Dims>> name_to_dims;
     // check correctness for the variable names and types within the expression
     for (auto var_name : var_list)
@@ -902,20 +902,15 @@ VariableDerived &IO::DefineDerivedVariable(const std::string &name, const std::s
                                                  "using undefine variable " + var_name +
                                                      " in defining the derived variable " + name);
         DataType var_type = InquireVariableType(var_name);
-        if (expressionType == DataType::None)
-            expressionType = var_type;
-        if (expressionType != var_type)
-            helper::Throw<std::invalid_argument>("Core", "IO", "DefineDerivedVariable",
-                                                 "all variables within a derived variable "
-                                                 " must have the same type ");
+        name_to_type.insert({var_name, var_type});
         if ((itVariable->second)->IsConstantDims() == false)
             isConstant = false;
         name_to_dims.insert({var_name,
                              {(itVariable->second)->m_Start, (itVariable->second)->m_Count,
                               (itVariable->second)->m_Shape}});
     }
-    // std::cout << "Derived variable " << name << ": PASS : variables exist and have the same type"
-    //          << std::endl;
+    // set the type of the expression and check correcness
+    DataType expressionType = derived_exp.GetType(name_to_type);
     // set the initial shape of the expression and check correcness
     derived_exp.SetDims(name_to_dims);
     // std::cout << "Derived variable " << name << ": PASS : initial variable dimensions are valid"

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -918,8 +918,8 @@ VariableDerived &IO::DefineDerivedVariable(const std::string &name, const std::s
 
     // create derived variable with the expression
     auto itVariablePair = m_VariablesDerived.emplace(
-        name, std::unique_ptr<VariableBase>(
-                  new VariableDerived(name, derived_exp, expressionType, isConstant, varType)));
+        name, std::unique_ptr<VariableBase>(new VariableDerived(
+                  name, derived_exp, expressionType, isConstant, varType, name_to_type)));
     VariableDerived &variable = static_cast<VariableDerived &>(*itVariablePair.first->second);
 
     // check IO placeholder for variable operations

--- a/source/adios2/core/VariableDerived.cpp
+++ b/source/adios2/core/VariableDerived.cpp
@@ -8,10 +8,11 @@ namespace core
 
 VariableDerived::VariableDerived(const std::string &name, adios2::derived::Expression expr,
                                  const DataType exprType, const bool isConstant,
-                                 const DerivedVarType varType)
+                                 const DerivedVarType varType,
+                                 const std::map<std::string, DataType> nameToType)
 : VariableBase(name, exprType, helper::GetDataTypeSize(exprType), expr.GetShape(), expr.GetStart(),
                expr.GetCount(), isConstant),
-  m_DerivedType(varType), m_Expr(expr)
+  m_DerivedType(varType), m_NameToType(nameToType), m_Expr(expr)
 {
 }
 
@@ -52,13 +53,14 @@ VariableDerived::ApplyExpression(std::map<std::string, std::unique_ptr<MinVarInf
         {
             Dims start;
             Dims count;
+            DataType type = m_NameToType[variable.first];
             for (int d = 0; d < variable.second->Dims; d++)
             {
                 start.push_back(variable.second->BlocksInfo[i].Start[d]);
                 count.push_back(variable.second->BlocksInfo[i].Count[d]);
             }
             varData.push_back(adios2::derived::DerivedData(
-                {variable.second->BlocksInfo[i].BufferP, start, count}));
+                {variable.second->BlocksInfo[i].BufferP, start, count, type}));
         }
         inputData.insert({variable.first, varData});
     }

--- a/source/adios2/core/VariableDerived.h
+++ b/source/adios2/core/VariableDerived.h
@@ -15,11 +15,13 @@ namespace core
 class VariableDerived : public VariableBase
 {
     DerivedVarType m_DerivedType;
+    std::map<std::string, DataType> m_NameToType;
 
 public:
     adios2::derived::Expression m_Expr;
     VariableDerived(const std::string &name, adios2::derived::Expression expr,
-                    const DataType exprType, const bool isConstant, const DerivedVarType varType);
+                    const DataType exprType, const bool isConstant, const DerivedVarType varType,
+                    const std::map<std::string, DataType> nameToType);
     ~VariableDerived() = default;
 
     DerivedVarType GetDerivedType();

--- a/source/adios2/toolkit/derived/DerivedData.h
+++ b/source/adios2/toolkit/derived/DerivedData.h
@@ -12,6 +12,7 @@ struct DerivedData
     void *Data;
     Dims Start;
     Dims Count;
+    DataType Type;
 };
 }
 }

--- a/source/adios2/toolkit/derived/Expression.h
+++ b/source/adios2/toolkit/derived/Expression.h
@@ -66,6 +66,7 @@ public:
 
     std::vector<std::string> VariableNameList();
     Dims GetDims(std::map<std::string, Dims> NameToDims);
+    DataType GetType(std::map<std::string, DataType> NameToType);
     std::vector<DerivedData>
     ApplyExpression(DataType type, size_t numBlocks,
                     std::map<std::string, std::vector<DerivedData>> nameToData);
@@ -90,6 +91,7 @@ public:
     Dims GetShape();
     Dims GetStart();
     Dims GetCount();
+    DataType GetType(std::map<std::string, DataType> NameToType);
     std::string toStringExpr();
     void SetDims(std::map<std::string, std::tuple<Dims, Dims, Dims>> NameToDims);
     std::vector<std::string> VariableNameList();

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -223,6 +223,16 @@ Dims CurlDimsFunc(std::vector<Dims> input)
     return output;
 }
 
+DataType SameTypeFunc(DataType input) { return input; }
+
+DataType FloatTypeFunc(DataType input)
+{
+    if ((input == DataType::Double) || (input == DataType::LongDouble))
+        return input;
+    if ((input == DataType::FloatComplex) || (input == DataType::DoubleComplex))
+        return input;
+    return DataType::Float;
+}
 }
 } // namespace adios2
 #endif

--- a/source/adios2/toolkit/derived/Function.h
+++ b/source/adios2/toolkit/derived/Function.h
@@ -14,6 +14,9 @@ DerivedData Curl3DFunc(std::vector<DerivedData> input, DataType type);
 
 Dims SameDimsFunc(std::vector<Dims> input);
 Dims CurlDimsFunc(std::vector<Dims> input);
+
+DataType SameTypeFunc(DataType input);
+DataType FloatTypeFunc(DataType input);
 }
 }
 #endif


### PR DESCRIPTION
For derived operations that do not have the same input and output type, e.g. `float sqrt(int)`

DerivedData contains now in addition to the data pointer and the start and count Dims, the type of each input operand. The derived functions will have the following signature:
```
struct DerivedData
{
    void *Data;
    Dims Start;
    Dims Count;
    DataType Type;
};
    std::function<DerivedData(std::vector<DerivedData>, DataType)> ComputeFct;
```

The second argument `DataType` is the output type. 