### PR TITLE
Update the script to build adios with Kokkos for Frontier

### DIFF
--- a/scripts/build_scripts/build-adios2-kokkos-frontier.sh
+++ b/scripts/build_scripts/build-adios2-kokkos-frontier.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 # shellcheck disable=SC2191
 
-module load rocm/5.4.0
-module load gcc/11.2.0
+module load PrgEnv-gnu-amd/8.5.0
 module load cmake/3.23.2
-module load craype-accel-amd-gfx90a
 
 ######## User Configurations ########
 Kokkos_HOME=$HOME/kokkos/kokkos

--- a/scripts/build_scripts/build-adios2-kokkos-frontier.sh
+++ b/scripts/build_scripts/build-adios2-kokkos-frontier.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC2191
 
 module load PrgEnv-gnu-amd/8.5.0
+module load craype-accel-amd-gfx90a
 module load cmake/3.23.2
 
 ######## User Configurations ########


### PR DESCRIPTION
The gcc and cray modules on Frontier used in the build scripts have been deprecated as of July 2024:

```
gcc/11.2.0:
   As of July 16, 2024, the 'gcc' module name is deprecated and has been replaced by 'gcc-native'. Running 'module load gcc' from a
   default login shell has undefined behavior due to this name change. Please use 'module load PrgEnv-gnu gcc', or optionally 'module
   load PrgEnv-gnu cpe/23.09' to load older versions of the GNU toolchain. See
   https://docs.olcf.ornl.gov/software/software-news.html#frontier-system-software-update-july-16-2024 for more information.
```