### PR TITLE
Fix argument ordering in FLEX_TARGET

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -150,8 +150,8 @@ if (ADIOS2_HAVE_Derived_Variable)
       DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/parser.h)
     FLEX_TARGET(MyScanner
       toolkit/derived/parser/lexer.l
-      COMPILE_FLAGS "-o lexer.cpp --header-file=lexer.h" 
       ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp
+      COMPILE_FLAGS "--header-file=lexer.h" 
       DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/lexer.h)
     ADD_FLEX_BISON_DEPENDENCY(MyScanner MyParser)
   endif()

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -151,7 +151,7 @@ if (ADIOS2_HAVE_Derived_Variable)
     FLEX_TARGET(MyScanner
       toolkit/derived/parser/lexer.l
       ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp
-      COMPILE_FLAGS "--header-file=lexer.h" 
+      COMPILE_FLAGS "-o lexer.cpp --header-file=lexer.h" 
       DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/lexer.h)
     ADD_FLEX_BISON_DEPENDENCY(MyScanner MyParser)
   endif()


### PR DESCRIPTION
The output file is the third item in the FLEX_TARGET macro.  Fixed the ordering