### PR TITLE
Uniquify filenames in HeatTransfer tests

### DIFF
--- a/testing/examples/heatTransfer/TestBPFileMx1.cmake
+++ b/testing/examples/heatTransfer/TestBPFileMx1.cmake
@@ -10,7 +10,7 @@ add_test(NAME HeatTransfer.BP3.Mx1.Write
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp3.xml
-        Write.bp 2 2 10 10 10 10
+        WriteBPFileMx1.bp 2 2 10 10 10 10
 )
 set_tests_properties(HeatTransfer.BP3.Mx1.Write PROPERTIES PROCESSORS 4)
 
@@ -19,21 +19,21 @@ add_test(NAME HeatTransfer.BP3.Mx1.Read
     ${MPIEXEC_NUMPROC_FLAG} 1
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp3.xml
-        Write.bp Read.bp 1 1
+        WriteBPFileMx1.bp ReadBPFileMx1.bp 1 1
 )
 
 add_test(NAME HeatTransfer.BP3.Mx1.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadBPFileMx1.bp
+    -DOUTPUT_FILE=DumpBPFileMx1.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.BP3.Mx1.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpBPFileMx1.txt
 )
 
 SetupTestPipeline(HeatTransfer.BP3.Mx1 "Write;Read;Dump;Validate" TRUE)
@@ -45,7 +45,7 @@ add_test(NAME HeatTransfer.BP4.Mx1.Write
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp4.xml
-        Write.bp 2 2 10 10 10 10
+        WriteBPFileMx1.bp 2 2 10 10 10 10
 )
 set_tests_properties(HeatTransfer.BP4.Mx1.Write PROPERTIES PROCESSORS 4)
 
@@ -54,21 +54,21 @@ add_test(NAME HeatTransfer.BP4.Mx1.Read
     ${MPIEXEC_NUMPROC_FLAG} 1
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp4.xml
-        Write.bp Read.bp 1 1
+        WriteBPFileMx1.bp ReadBPFileMx1.bp 1 1
 )
 
 add_test(NAME HeatTransfer.BP4.Mx1.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadBPFileMx1.bp
+    -DOUTPUT_FILE=DumpBPFileMx1.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.BP4.Mx1.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpBPFileMx1.txt
 )
 
 SetupTestPipeline(HeatTransfer.BP4.Mx1 "Write;Read;Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestBPFileMx1_zfp.cmake
+++ b/testing/examples/heatTransfer/TestBPFileMx1_zfp.cmake
@@ -10,7 +10,7 @@ add_test(NAME HeatTransfer.BP3.zfp.Mx1.Write
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp3_zfp.xml
-        Write.bp 2 2 10 10 10 10
+        WriteBPFileMx1_zfp.bp 2 2 10 10 10 10
 )
 set_tests_properties(HeatTransfer.BP3.zfp.Mx1.Write PROPERTIES PROCESSORS 4)
 
@@ -19,14 +19,14 @@ add_test(NAME HeatTransfer.BP3.zfp.Mx1.Read
     ${MPIEXEC_NUMPROC_FLAG} 1
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp3.xml
-        Write.bp Read.bp 1 1
+        WriteBPFileMx1_zfp.bp ReadBPFileMx1_zfp.bp 1 1
 )
 
 add_test(NAME HeatTransfer.BP3.zfp.Mx1.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadBPFileMx1_zfp.bp
+    -DOUTPUT_FILE=DumpBPFileMx1_zfp.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
@@ -38,7 +38,7 @@ add_test(NAME HeatTransfer.BP4.zfp.Mx1.Write
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp4_zfp.xml
-        Write.bp 2 2 10 10 10 10
+        WriteBPFile4Mx1_zfp.bp 2 2 10 10 10 10
 )
 set_tests_properties(HeatTransfer.BP3.zfp.Mx1.Write PROPERTIES PROCESSORS 4)
 
@@ -47,14 +47,14 @@ add_test(NAME HeatTransfer.BP4.zfp.Mx1.Read
     ${MPIEXEC_NUMPROC_FLAG} 1
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp4.xml
-        Write.bp Read.bp 1 1
+        WriteBPFile4Mx1_zfp.bp ReadBPFile4Mx1_zfp.bp 1 1
 )
 
 add_test(NAME HeatTransfer.BP4.zfp.Mx1.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadBPFile4Mx1_zfp.bp
+    -DOUTPUT_FILE=DumpBPFile4Mx1_zfp.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 

--- a/testing/examples/heatTransfer/TestBPFileMxM.cmake
+++ b/testing/examples/heatTransfer/TestBPFileMxM.cmake
@@ -11,7 +11,7 @@ add_test(NAME HeatTransfer.BP3.MxM.Write
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp3.xml
-        Write.bp 2 2 10 10 10 10
+        WriteBPFileMxM.bp 2 2 10 10 10 10
 )
 set_tests_properties(HeatTransfer.BP3.MxM.Write PROPERTIES PROCESSORS 4)
 
@@ -20,22 +20,22 @@ add_test(NAME HeatTransfer.BP3.MxM.Read
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp3.xml
-        Write.bp Read.bp 2 2
+        WriteBPFileMxM.bp ReadBPFileMxM.bp 2 2
 )
 set_tests_properties(HeatTransfer.BP3.MxM.Read PROPERTIES PROCESSORS 4)
 
 add_test(NAME HeatTransfer.BP3.MxM.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadBPFileMxM.bp
+    -DOUTPUT_FILE=DumpBPFileMxM.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.BP3.MxM.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpBPFileMxM.txt
 )
 
 SetupTestPipeline(HeatTransfer.BP3.MxM "Write;Read;Dump;Validate" True)
@@ -46,7 +46,7 @@ add_test(NAME HeatTransfer.BP4.MxM.Write
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp4.xml
-        Write.bp 2 2 10 10 10 10
+        WriteBPFile4MxM.bp 2 2 10 10 10 10
 )
 set_tests_properties(HeatTransfer.BP4.MxM.Write PROPERTIES PROCESSORS 4)
 
@@ -55,22 +55,22 @@ add_test(NAME HeatTransfer.BP4.MxM.Read
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp4.xml
-        Write.bp Read.bp 2 2
+        WriteBPFile4MxM.bp ReadBPFile4MxM.bp 2 2
 )
 set_tests_properties(HeatTransfer.BP4.MxM.Read PROPERTIES PROCESSORS 4)
 
 add_test(NAME HeatTransfer.BP4.MxM.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadBPFile4MxM.bp
+    -DOUTPUT_FILE=DumpBPFile4MxM.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.BP4.MxM.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpBPFile4MxM.txt
 )
 
 SetupTestPipeline(HeatTransfer.BP4.MxM "Write;Read;Dump;Validate" True)

--- a/testing/examples/heatTransfer/TestBPFileMxN.cmake
+++ b/testing/examples/heatTransfer/TestBPFileMxN.cmake
@@ -11,7 +11,7 @@ add_test(NAME HeatTransfer.BP3.MxN.Write
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp3.xml
-        Write.bp 2 2 10 10 10 10
+        WriteBPFileMxN.bp 2 2 10 10 10 10
 )
 set_tests_properties(HeatTransfer.BP3.MxN.Write PROPERTIES PROCESSORS 4)
 
@@ -20,22 +20,22 @@ add_test(NAME HeatTransfer.BP3.MxN.Read
     ${MPIEXEC_NUMPROC_FLAG} 3
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp3.xml
-        Write.bp Read.bp 1 3
+        WriteBPFileMxN.bp ReadBPFileMxN.bp 1 3
 )
 set_tests_properties(HeatTransfer.BP3.MxN.Read PROPERTIES PROCESSORS 3)
 
 add_test(NAME HeatTransfer.BP3.MxN.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadBPFileMxN.bp
+    -DOUTPUT_FILE=DumpBPFileMxN.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.BP3.MxN.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpBPFileMxN.txt
 )
 
 SetupTestPipeline(HeatTransfer.BP3.MxN "Write;Read;Dump;Validate" True)
@@ -46,7 +46,7 @@ add_test(NAME HeatTransfer.BP4.MxN.Write
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp4.xml
-        Write.bp 2 2 10 10 10 10
+        WriteBPFile4MxN.bp 2 2 10 10 10 10
 )
 set_tests_properties(HeatTransfer.BP4.MxN.Write PROPERTIES PROCESSORS 4)
 
@@ -55,22 +55,22 @@ add_test(NAME HeatTransfer.BP4.MxN.Read
     ${MPIEXEC_NUMPROC_FLAG} 3
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_bp4.xml
-        Write.bp Read.bp 1 3
+        WriteBPFile4MxN.bp ReadBPFile4MxN.bp 1 3
 )
 set_tests_properties(HeatTransfer.BP4.MxN.Read PROPERTIES PROCESSORS 3)
 
 add_test(NAME HeatTransfer.BP4.MxN.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadBPFile4MxN.bp
+    -DOUTPUT_FILE=DumpBPFile4MxN.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.BP4.MxN.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpBPFile4MxN.txt
 )
 
 SetupTestPipeline(HeatTransfer.BP4.MxN "Write;Read;Dump;Validate" True)

--- a/testing/examples/heatTransfer/TestInlineMxM.cmake
+++ b/testing/examples/heatTransfer/TestInlineMxM.cmake
@@ -10,22 +10,24 @@ add_test(NAME HeatTransfer.Inline.MxM
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferInline>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_inline.xml
-        Read.bp 2 2 10 10 10 10
+        ReadInlineMxN.bp 2 2 10 10 10 10
 )
 set_tests_properties(HeatTransfer.Inline.MxM PROPERTIES PROCESSORS 8)
 
 add_test(NAME HeatTransfer.Inline.MxM.Dump
+  WORKING_DIRECTORY InlineMxN
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadInlineMxN.bp
+    -DOUTPUT_FILE=DumpInlineMxN.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.Inline.MxM.Validate
+  WORKING_DIRECTORY InlineMxN
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpInlineMxN.txt
 )
 
 SetupTestPipeline(HeatTransfer.Inline.MxM ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSCMx1.cmake
+++ b/testing/examples/heatTransfer/TestSSCMx1.cmake
@@ -10,27 +10,29 @@ add_test(NAME HeatTransfer.InsituMPI.Mx1
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_ssc.xml
-        Write.bp 2 2 10 10 10 10
+        WriteInsituMx1.bp 2 2 10 10 10 10
     :
     ${MPIEXEC_NUMPROC_FLAG} 1
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_ssc.xml
-        Write.bp Read.bp 1 1
+        WriteInsituMx1.bp ReadInsituMx1.bp 1 1
 )
 set_tests_properties(HeatTransfer.InsituMPI.Mx1 PROPERTIES PROCESSORS 5)
 
 add_test(NAME HeatTransfer.InsituMPI.Mx1.Dump
+  WORKING_DIRECTORY InsituMx1
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadInsituMx1.bp
+    -DOUTPUT_FILE=DumpInsituMx1.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.InsituMPI.Mx1.Validate
+  WORKING_DIRECTORY InsituMx1
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpInsituMx1.txt
 )
 
 SetupTestPipeline(HeatTransfer.InsituMPI.Mx1 ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSCMxM.cmake
+++ b/testing/examples/heatTransfer/TestSSCMxM.cmake
@@ -10,27 +10,29 @@ add_test(NAME HeatTransfer.SSC.MxM
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_ssc.xml
-        Write.bp 2 2 10 10 10 10
+        WriteSSCMxM.bp 2 2 10 10 10 10
     :
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_ssc.xml
-        Write.bp Read.bp 2 2
+        WriteSSCMxM.bp ReadSSCMxM.bp 2 2
 )
 set_tests_properties(HeatTransfer.SSC.MxM PROPERTIES PROCESSORS 8)
 
 add_test(NAME HeatTransfer.SSC.MxM.Dump
+  WORKING_DIRECTORY SSCMxM
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadSSCMxM.bp
+    -DOUTPUT_FILE=DumpSSCMxM.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.SSC.MxM.Validate
+  WORKING_DIRECTORY SSCMxM
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpSSCMxM.txt
 )
 
 SetupTestPipeline(HeatTransfer.SSC.MxM ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSCMxN.cmake
+++ b/testing/examples/heatTransfer/TestSSCMxN.cmake
@@ -10,27 +10,27 @@ add_test(NAME HeatTransfer.InsituMPI.MxN
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_ssc.xml
-        Write.bp 2 2 10 10 10 10
+        WriteSSCMxN.bp 2 2 10 10 10 10
     :
     ${MPIEXEC_NUMPROC_FLAG} 3
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_ssc.xml
-        Write.bp Read.bp 1 3
+        WriteSSCMxN.bp ReadSSCMxN.bp 1 3
 )
 set_tests_properties(HeatTransfer.InsituMPI.MxN PROPERTIES PROCESSORS 7)
 
 add_test(NAME HeatTransfer.InsituMPI.MxN.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadSSCMxN.bp
+    -DOUTPUT_FILE=DumpSSCMxN.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.InsituMPI.MxN.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpSSCMxN.txt
 )
 
 SetupTestPipeline(HeatTransfer.InsituMPI.MxN ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSTBPMx1.cmake
+++ b/testing/examples/heatTransfer/TestSSTBPMx1.cmake
@@ -10,27 +10,29 @@ add_test(NAME HeatTransfer.SST.BP.Mx1
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_bp.xml
-        Write.bp 2 2 10 10 10 10 SST
+        WriteSSTBPMx1.bp 2 2 10 10 10 10 SST
     :
     ${MPIEXEC_NUMPROC_FLAG} 1
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_bp.xml
-        Write.bp Read.bp 1 1 SST
+        WriteSSTBPMx1.bp ReadSSTBPMx1.bp 1 1 SST
 )
 set_tests_properties(HeatTransfer.SST.BP.Mx1 PROPERTIES PROCESSORS 5)
 
 add_test(NAME HeatTransfer.SST.BP.Mx1.Dump
+  WORKING_DIRECTORY SSTBPMx1
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadSSTBPMx1.bp
+    -DOUTPUT_FILE=DumpSSTBPMx1.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.SST.BP.Mx1.Validate
+  WORKING_DIRECTORY SSTBPMx1
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpSSTBPMx1.txt
 )
 
 SetupTestPipeline(HeatTransfer.SST.BP.Mx1 ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSTBPMxM.cmake
+++ b/testing/examples/heatTransfer/TestSSTBPMxM.cmake
@@ -10,27 +10,29 @@ add_test(NAME HeatTransfer.SST.BP.MxM
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_bp.xml
-        Write.bp 2 2 10 10 10 10 SST
+        WriteSSTBPMxM.bp 2 2 10 10 10 10 SST
     :
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_bp.xml
-        Write.bp Read.bp 2 2 SST
+        WriteSSTBPMxM.bp ReadSSTBPMxM.bp 2 2 SST
 )
 set_tests_properties(HeatTransfer.SST.BP.MxM PROPERTIES PROCESSORS 8)
 
 add_test(NAME HeatTransfer.SST.BP.MxM.Dump
+  WORKING_DIRECTORY SSTBPMxM
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadSSTBPMxM.bp
+    -DOUTPUT_FILE=DumpSSTBPMxM.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.SST.BP.MxM.Validate
+  WORKING_DIRECTORY SSTBPMxM
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpSSTBPMxM.txt
 )
 
 SetupTestPipeline(HeatTransfer.SST.BP.MxM ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSTBPMxN.cmake
+++ b/testing/examples/heatTransfer/TestSSTBPMxN.cmake
@@ -10,27 +10,29 @@ add_test(NAME HeatTransfer.SST.BP.MxN
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_bp.xml
-        Write.bp 2 2 10 10 10 10 SST
+        WriteSSTBPMxN.bp 2 2 10 10 10 10 SST
     :
     ${MPIEXEC_NUMPROC_FLAG} 3
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_bp.xml
-        Write.bp Read.bp 1 3 SST
+        WriteSSTBPMxN.bp ReadSSTBPMxN.bp 1 3 SST
 )
 set_tests_properties(HeatTransfer.SST.BP.MxN PROPERTIES PROCESSORS 7)
 
 add_test(NAME HeatTransfer.SST.BP.MxN.Dump
+  WORKING_DIRECTORY SSTBPMxN
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadSSTBPMxN.bp
+    -DOUTPUT_FILE=DumpSSTBPMxN.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.SST.BP.MxN.Validate
+  WORKING_DIRECTORY SSTBPMxN
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpSSTBPMxN.txt
 )
 
 SetupTestPipeline(HeatTransfer.SST.BP.MxN ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSTBPRDMAMxN.cmake
+++ b/testing/examples/heatTransfer/TestSSTBPRDMAMxN.cmake
@@ -10,27 +10,29 @@ add_test(NAME HeatTransfer.SST.BP.RDMA.MxN
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_bp_rdma.xml
-        Write.bp 2 2 10 10 10 10 SST
+        WriteSSTBPRDMAMxN.bp 2 2 10 10 10 10 SST
     :
     ${MPIEXEC_NUMPROC_FLAG} 3
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_bp_rdma.xml
-        Write.bp Read.bp 1 3 SST
+        WriteSSTBPRDMAMxN.bp ReadSSTBPRDMAMxN.bp 1 3 SST
 )
 set_tests_properties(HeatTransfer.SST.BP.RDMA.MxN PROPERTIES PROCESSORS 7)
 
 add_test(NAME HeatTransfer.SST.BP.RDMA.MxN.Dump
+  WORKING_DIRECTORY SSTBPRDMAMxN
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadSSTBPRDMAMxN.bp
+    -DOUTPUT_FILE=DumpSSTBPRDMAMxN.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.SST.BP.RDMA.MxN.Validate
+  WORKING_DIRECTORY SSTBPRDMAMxN
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpSSTBPRDMAMxN.txt
 )
 
 SetupTestPipeline(HeatTransfer.SST.BP.RDMA.MxN ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSTFFSMx1.cmake
+++ b/testing/examples/heatTransfer/TestSSTFFSMx1.cmake
@@ -10,27 +10,27 @@ add_test(NAME HeatTransfer.SST.FFS.Mx1
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_ffs.xml
-        Write.bp 2 2 10 10 10 10 SST
+        WriteSSTFFSMx1.bp 2 2 10 10 10 10 SST
     :
     ${MPIEXEC_NUMPROC_FLAG} 1
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_ffs.xml
-        Write.bp Read.bp 1 1 SST
+        WriteSSTFFSMx1.bp ReadSSTFFSMx1.bp 1 1 SST
 )
 set_tests_properties(HeatTransfer.SST.FFS.Mx1 PROPERTIES PROCESSORS 5)
 
 add_test(NAME HeatTransfer.SST.FFS.Mx1.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadSSTFFSMx1.bp
+    -DOUTPUT_FILE=DumpSSTFFSMx1.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.SST.FFS.Mx1.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpSSTFFSMx1.txt
 )
 
 SetupTestPipeline(HeatTransfer.SST.FFS.Mx1 ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSTFFSMxM.cmake
+++ b/testing/examples/heatTransfer/TestSSTFFSMxM.cmake
@@ -6,6 +6,7 @@
 include(ADIOSFunctions)
 
 add_test(NAME HeatTransfer.SST.FFS.MxM
+  WORKING_DIRECTORY SSTFFSMxM
   COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_EXTRA_FLAGS}
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
@@ -20,6 +21,7 @@ add_test(NAME HeatTransfer.SST.FFS.MxM
 set_tests_properties(HeatTransfer.SST.FFS.MxM PROPERTIES PROCESSORS 8)
 
 add_test(NAME HeatTransfer.SST.FFS.MxM.Dump
+  WORKING_DIRECTORY SSTFFSMxM
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
     -DINPUT_FILE=Read.bp
@@ -28,6 +30,7 @@ add_test(NAME HeatTransfer.SST.FFS.MxM.Dump
 )
 
 add_test(NAME HeatTransfer.SST.FFS.MxM.Validate
+  WORKING_DIRECTORY SSTFFSMxM
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
     Dump.txt

--- a/testing/examples/heatTransfer/TestSSTFFSMxN.cmake
+++ b/testing/examples/heatTransfer/TestSSTFFSMxN.cmake
@@ -10,27 +10,27 @@ add_test(NAME HeatTransfer.SST.FFS.MxN
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_ffs.xml
-        Write.bp 2 2 10 10 10 10 SST
+        WriteSSTFFSMxN.bp 2 2 10 10 10 10 SST
     :
     ${MPIEXEC_NUMPROC_FLAG} 3
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_ffs.xml
-        Write.bp Read.bp 1 3 SST
+        WriteSSTFFSMxN.bp ReadSSTFFSMxN.bp 1 3 SST
 )
 set_tests_properties(HeatTransfer.SST.FFS.MxN PROPERTIES PROCESSORS 7)
 
 add_test(NAME HeatTransfer.SST.FFS.MxN.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadSSTFFSMxN.bp
+    -DOUTPUT_FILE=DumpSSTFFSMxN.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.SST.FFS.MxN.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpSSTFFSMxN.txt
 )
 
 SetupTestPipeline(HeatTransfer.SST.FFS.MxN ";Dump;Validate" TRUE)

--- a/testing/examples/heatTransfer/TestSSTFFSRDMAMxN.cmake
+++ b/testing/examples/heatTransfer/TestSSTFFSRDMAMxN.cmake
@@ -10,27 +10,27 @@ add_test(NAME HeatTransfer.SST.FFS.MxN
     ${MPIEXEC_NUMPROC_FLAG} 4
       $<TARGET_FILE:adios2_simulations_heatTransferWrite>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_ffs_rdma.xml
-        Write.bp 2 2 10 10 10 10 SST
+        WriteSSTFFRDMASMxN.bp 2 2 10 10 10 10 SST
     :
     ${MPIEXEC_NUMPROC_FLAG} 3
       $<TARGET_FILE:adios2_simulations_heatTransferRead>
         ${PROJECT_SOURCE_DIR}/examples/simulations/heatTransfer/heat_sst_ffs_rdma.xml
-        Write.bp Read.bp 1 3 SST
+        WriteSSTFFRDMASMxN.bp ReadSSTFFRDMASMxN.bp 1 3 SST
 )
 set_tests_properties(HeatTransfer.SST.FFS.MxN PROPERTIES PROCESSORS 7)
 
 add_test(NAME HeatTransfer.SST.FFS.MxN.Dump
   COMMAND ${CMAKE_COMMAND}
     -DARG1=-d 
-    -DINPUT_FILE=Read.bp
-    -DOUTPUT_FILE=Dump.txt
+    -DINPUT_FILE=ReadSSTFFRDMASMxN.bp
+    -DOUTPUT_FILE=DumpSSTFFRDMASMxN.txt
     -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
 )
 
 add_test(NAME HeatTransfer.SST.FFS.MxN.Validate
   COMMAND ${DIFF_COMMAND} -u -w
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatTransfer.Dump.txt
-    Dump.txt
+    DumpSSTFFRDMASMxN.txt
 )
 
 SetupTestPipeline(HeatTransfer.SST.FFS.MxN ";Dump;Validate" TRUE)


### PR DESCRIPTION
Another stab at killing CI heisenbugs that might be related to concurrent test execution.