### PR TITLE
Basic script to compare two BP files given a tolerance

### DIFF
--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -36,7 +36,7 @@ file(GENERATE
 )
 
 # BPCMP
-if(ADIOS2_HAVE_Python AND Python_Interpreter_FOUND)
+if(ADIOS2_HAVE_Python)
   add_subdirectory(bpcmp)
 
   configure_file(

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -36,18 +36,19 @@ file(GENERATE
 )
 
 # BPCMP
-if(Python_Interpreter_FOUND)
+if(ADIOS2_HAVE_Python AND Python_Interpreter_FOUND)
   add_subdirectory(bpcmp)
+
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/bpcmp/bpcmp.cmake.gen.in
+    ${PROJECT_BINARY_DIR}/bpcmp.cmake.gen
+    @ONLY
+  )
+  file(GENERATE
+    OUTPUT ${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake
+    INPUT ${PROJECT_BINARY_DIR}/bpcmp.cmake.gen
+  )
 endif()
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/bpcmp/bpcmp.cmake.gen.in
-  ${PROJECT_BINARY_DIR}/bpcmp.cmake.gen
-  @ONLY
-)
-file(GENERATE
-  OUTPUT ${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake
-  INPUT ${PROJECT_BINARY_DIR}/bpcmp.cmake.gen
-)
 
 # BPSPLIT
 #add_executable(bpsplit ./bpsplit/bpsplit.cpp)

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -35,6 +35,19 @@ file(GENERATE
   INPUT ${PROJECT_BINARY_DIR}/bpls.cmake.gen
 )
 
+# BPCMP
+if(Python_Interpreter_FOUND)
+  add_subdirectory(bpcmp)
+endif()
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/bpcmp/bpcmp.cmake.gen.in
+  ${PROJECT_BINARY_DIR}/bpcmp.cmake.gen
+  @ONLY
+)
+file(GENERATE
+  OUTPUT ${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake
+  INPUT ${PROJECT_BINARY_DIR}/bpcmp.cmake.gen
+)
 
 # BPSPLIT
 #add_executable(bpsplit ./bpsplit/bpsplit.cpp)

--- a/source/utils/bpcmp/CMakeLists.txt
+++ b/source/utils/bpcmp/CMakeLists.txt
@@ -1,0 +1,7 @@
+configure_file(bpcmp.py ${PROJECT_BINARY_DIR}/bin/bpcmp.py COPYONLY)
+
+install(PROGRAMS bpcmp.py
+  RENAME bpcmp
+  DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_scripts-runtime
+  ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
+)

--- a/source/utils/bpcmp/bpcmp.cmake.gen.in
+++ b/source/utils/bpcmp/bpcmp.cmake.gen.in
@@ -6,6 +6,12 @@ endif()
 if(ERROR_FILE)
   set(error_arg ERROR_FILE "${ERROR_FILE}")
 endif()
+if(NOT INPUT_FILE1)
+  set(error_arg INPUT_FILE1 "${INPUT_FILE1}")
+endif()
+if(NOT INPUT_FILE2)
+  set(error_arg INPUT_FILE2 "${INPUT_FILE2}")
+endif()
 
 execute_process(
   COMMAND ${Python_EXECUTABLE} ${PROJECT_BINARY_DIR}/bin/bpcmp.py ${INPUT_FILE1} ${INPUT_FILE2} ${ARG1} ${ARG2} ${ARG3}

--- a/source/utils/bpcmp/bpcmp.cmake.gen.in
+++ b/source/utils/bpcmp/bpcmp.cmake.gen.in
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.6)
+
+if(OUTPUT_FILE)
+  set(output_arg OUTPUT_FILE "${OUTPUT_FILE}")
+endif()
+if(ERROR_FILE)
+  set(error_arg ERROR_FILE "${ERROR_FILE}")
+endif()
+
+execute_process(
+  COMMAND ${Python_EXECUTABLE} ${PROJECT_BINARY_DIR}/bin/bpcmp.py ${INPUT_FILE1} ${INPUT_FILE2} ${ARG1} ${ARG2} ${ARG3}
+  RESULT_VARIABLE result
+  ${output_arg}
+  ${error_arg}
+)
+
+if(NOT result EQUAL 0)
+  message(FATAL_ERROR "result: ${result}")
+endif()

--- a/source/utils/bpcmp/bpcmp.py
+++ b/source/utils/bpcmp/bpcmp.py
@@ -1,0 +1,177 @@
+import numpy as np
+import sys
+import argparse
+from adios2 import Stream
+import itertools
+
+verbose = False
+
+# Function to detect the mismatch between two values
+# Input: val1, val2 - type T scalars
+#        tolerance - tolerance value for comparison
+#        tolperc - tolerance percentage between the two values
+# Output: true (if there is a mismatch), false otherwise
+def DetectMismatch(val1, val2, tolerance, tolperc):
+    mismatch = True
+    if val1 == val2:
+        return False
+    if tolerance > 0:
+        mismatch = (np.abs(val1 - val2) > tolerance)
+    if tolperc > 0:
+        if val1 == 0 and val2 != 0:
+            mismatch = True
+        else:
+            mismatch = (np.abs(val1 - val2) / val1 > tolperc)
+    if tolerance == 0 and tolperc == 0:
+        mismatch = (val1 != val2)
+    return mismatch
+
+# Function to detect the mismatch between two N dim arrays
+# Input: array1, array2 - N dimensional arrays
+#        tolerance - tolerance value for comparison
+#        tolperc - tolerance percentage between the two values
+# Output: a list of mismatch values in the array: (index, value1, value2)
+def CompareValues(array1, array2, tolerance, tolperc):
+    mismatch = []
+    dimensions = array1.shape
+    for idx in itertools.product(*[range(s) for s in dimensions]):
+        if DetectMismatch(array1[idx], array2[idx], tolerance, tolperc):
+            mismatch.append((idx, array1[idx], array2[idx]))
+    return mismatch
+
+# Function to detect the mismatch between two BP files
+# Input: filename1, filename2 - BP file name
+#        tolerance - tolerance value for comparison
+#        tolperc - tolerance percentage between the two values
+#        stats - boolean that constrols if stats or values are compared
+# Output: total number of mismatches between the two files
+def CompareFiles(filename1, filename2, tolerance, tolperc, stats=False):
+    err = 0
+    with Stream(filename1, 'rra') as s1, Stream(filename2, 'rra') as s2:
+        # compare total number of steps
+        num_steps = s1.num_steps()
+        if num_steps != s2.num_steps():
+            print("DIFFER : NUM_STEPS : " + str(num_steps) + " <> " + str(s2.num_steps()) +
+                  " : " + filename1 + " : " + filename2)
+            num_steps = min(num_steps, s2.num_steps())
+            err += 1
+
+        varInfoS1 = s1.available_variables()
+        varInfoS2 = s2.available_variables()
+        notinS1 = np.setdiff1d(list(varInfoS2.keys()), list(varInfoS1.keys()))
+        notinS2 = np.setdiff1d(list(varInfoS1.keys()), list(varInfoS2.keys()))
+        # compare total number of written variables
+        if len(notinS1) > 0 or len(notinS1) > 0:
+            print("DIFFER : AVAIL_VARS : " + str(notinS1) + " <> " + str(notinS2) + " : " +
+                  filename1 + " : " + filename2)
+            err += 1
+
+        # compare each common variable
+        for varName in np.intersect1d(list(varInfoS1.keys()), list(varInfoS2.keys())):
+            # compare number of steps
+            varSteps = int(varInfoS1[varName]["AvailableStepsCount"])
+            if varSteps != int(varInfoS2[varName]["AvailableStepsCount"]):
+                print("DIFFER : VARIABLE : " + varName + " : NUM_STEPS : " +
+                      str(varInfoS1[varName]["AvailableStepsCount"]) + " <> " +
+                      str(varInfoS2[varName]["AvailableStepsCount"]) + " : " + filename1 + " : " +
+                      filename2)
+                varSteps = min(varSteps, int(varInfoS2[varName]["AvailableStepsCount"]))
+                err += 1
+
+            # compare types
+            if varInfoS1[varName]["Type"] != varInfoS2[varName]["Type"]:
+                print("DIFFER : VARIABLE : " + varName + " : TYPE : " +
+                      str(varInfoS1[varName]["Type"]) + " <> " + str(varInfoS2[varName]["Type"]) +
+                      " : " + filename1 + " : " + filename2)
+                err += 1
+
+            # compare dimensions (single value and shape)
+            if varInfoS1[varName]["SingleValue"] != varInfoS2[varName]["SingleValue"]:
+                print("DIFFER : VARIABLE : " + varName + " : SINGLE_VALUE : " +
+                      str(varInfoS1[varName]["SingleValue"]) + " <> " +
+                      str(varInfoS2[varName]["SingleValue"]) + " : " + filename1 + " : " +
+                      filename2)
+                err += 1
+                # no point in comparing values if there is a difference in shape
+                continue
+
+            if varInfoS1[varName]["Shape"] != varInfoS2[varName]["Shape"]:
+                print("DIFFER : VARIABLE : " + varName + " : SHAPE : " +
+                      str(varInfoS1[varName]["Shape"]) + " <> " +
+                      str(varInfoS2[varName]["Shape"]) + " : " + filename1 + " : " + filename2)
+                err += 1
+                # no point in comparing values if there is a difference in shape
+                continue
+
+            if stats:
+                # compare min/max
+                if DetectMismatch(float(varInfoS1[varName]["Min"]),
+                                  float(varInfoS2[varName]["Min"]),
+                                  tolerance, tolperc):
+                    print("DIFFER : VARIABLE : " + varName + " : MIN : " +
+                          str(varInfoS1[varName]["Min"]) + " <> " +
+                          str(varInfoS2[varName]["Min"]) + " : " + filename1 + " : " + filename2)
+                    err += 1
+                if DetectMismatch(float(varInfoS1[varName]["Max"]),
+                                  float(varInfoS2[varName]["Max"]),
+                                  tolerance, tolperc):
+                    print("DIFFER : VARIABLE : " + varName + " : MAX : " +
+                          str(varInfoS1[varName]["Max"]) + " <> " +
+                          str(varInfoS2[varName]["Max"]) + " : " + filename1 + " : " + filename2)
+                    err += 1
+            # compare values
+            for step in range(varSteps):
+                values1 = s1.read(varName, step_selection=[step, 1])
+                values2 = s2.read(varName, step_selection=[step, 1])
+                ret = CompareValues(values1, values2, tolerance, tolperc)
+                if len(ret) == 0:
+                    continue
+                err += len(ret)
+                if verbose:
+                    for (idx, value1, value2) in ret:
+                        print("DIFFER : VARIABLE : " + varName + " : STEP : " + str(step) +
+                              " : POSITION : " + str(idx) + " : VALUE : " + str(value1) +
+                              " <> " + str(value2) + " : " + filename1 + " : " + filename2)
+                else:
+                    print("DIFFER : VARIABLE : " + varName + " : STEP : " + str(step) +
+                          " : VALUES_SUMMARY : " + str(len(ret)) + " : " + filename1 +
+                          " : " + filename2)
+
+    return err
+
+
+if __name__ == '__main__':
+    description = 'Utility code to compare the data within BP files'
+    epilog = 'If more than two files are provided, all files are compared to the first'
+    parser = argparse.ArgumentParser(prog="bpcmp", description=description, epilog=epilog)
+
+    parser.add_argument('bpfiles', metavar='file.bp', nargs='+',
+                        help='list of BP files to be compared')
+    parser.add_argument('-t', '--tolerance', dest='tolerance', type=float, default=0,
+                        help='tolerance for comparing values (default: 0)')
+    parser.add_argument('-p', '--perc-tolerance', dest='tolperc', type=float, default=0,
+                        help='tolerance as percentage of values (default: 0)')
+    parser.add_argument('-s', '--stats', action='store_true',
+                        help='compare stats (min/max) and not values')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='all different values are printed, not just a summary')
+
+    args = parser.parse_args()
+    if len(args.bpfiles) < 2:
+        print("WARNING : At least two files need to be provided for any comparison")
+        exit()
+
+    verbose = args.verbose
+
+    diff_found = 0
+    for i in range(1, len(args.bpfiles)):
+        print("COMPARE : FILE :", args.bpfiles[0], ": FILE :", args.bpfiles[i])
+        diff_file = CompareFiles(args.bpfiles[0], args.bpfiles[i], args.tolerance, args.tolperc,
+                                 args.stats)
+        if diff_file > 0:
+            print("TOTAL_DIFFERENCES : " + str(diff_file) + " : FILE :", args.bpfiles[0],
+                  ": FILE :", args.bpfiles[i])
+            diff_found += 1
+
+    if diff_found == 0:
+        print("DONE : Files have the same content")

--- a/source/utils/bpcmp/bpcmp.py
+++ b/source/utils/bpcmp/bpcmp.py
@@ -1,17 +1,25 @@
 import numpy as np
 import sys
+import errno
 import argparse
 from adios2 import Stream
 import itertools
 
 verbose = False
 
-# Function to detect the mismatch between two values
-# Input: val1, val2 - type T scalars
-#        tolerance - tolerance value for comparison
-#        tolperc - tolerance percentage between the two values
-# Output: true (if there is a mismatch), false otherwise
 def DetectMismatch(val1, val2, tolerance, tolperc):
+    """
+    Detects the mismatch between two scalar of any comparable type.
+
+    Args:
+        val1 : Any type scalar
+        val2 : Any type scalar
+        tolerance (float) : Tolerance used by the comparison
+        tolperc (float) : Accepted tolerance between the two values as percentage
+
+    Returns:
+        bool: true (if there is a mismatch), false otherwise
+    """
     mismatch = True
     if val1 == val2:
         return False
@@ -26,12 +34,19 @@ def DetectMismatch(val1, val2, tolerance, tolperc):
         mismatch = (val1 != val2)
     return mismatch
 
-# Function to detect the mismatch between two N dim arrays
-# Input: array1, array2 - N dimensional arrays
-#        tolerance - tolerance value for comparison
-#        tolperc - tolerance percentage between the two values
-# Output: a list of mismatch values in the array: (index, value1, value2)
 def CompareValues(array1, array2, tolerance, tolperc):
+    """
+    Detects the mismatch between two N dim arrays
+
+    Args:
+        array1 : N dimensional array
+        array2 : N dimensional array
+        tolerance (float) : Tolerance used by the comparison
+        tolperc (float) : Accepted tolerance between the two values as percentage
+
+    Returns:
+        list(tuple): a list of mismatch values in the array: (index, value1, value2)
+    """
     mismatch = []
     dimensions = array1.shape
     for idx in itertools.product(*[range(s) for s in dimensions]):
@@ -39,20 +54,27 @@ def CompareValues(array1, array2, tolerance, tolperc):
             mismatch.append((idx, array1[idx], array2[idx]))
     return mismatch
 
-# Function to detect the mismatch between two BP files
-# Input: filename1, filename2 - BP file name
-#        tolerance - tolerance value for comparison
-#        tolperc - tolerance percentage between the two values
-#        stats - boolean that constrols if stats or values are compared
-# Output: total number of mismatches between the two files
 def CompareFiles(filename1, filename2, tolerance, tolperc, stats=False):
+    """
+    Detects the mismatch between two BP files
+
+    Args:
+        filename1 : BP file name
+        filename2 : BP file name
+        tolerance (float) : Tolerance used by the comparison
+        tolperc (float) : Accepted tolerance between the two values as percentage
+        stats (bool) : boolean that constrols if stats are compared or not
+
+    Returns:
+        int: total number of mismatches between the two files
+    """
     err = 0
     with Stream(filename1, 'rra') as s1, Stream(filename2, 'rra') as s2:
         # compare total number of steps
         num_steps = s1.num_steps()
         if num_steps != s2.num_steps():
-            print("DIFFER : NUM_STEPS : " + str(num_steps) + " <> " + str(s2.num_steps()) +
-                  " : " + filename1 + " : " + filename2)
+            print(f"DIFFER : NUM_STEPS : {num_steps} <> {s2.num_steps()} : {filename1}"
+                  f" : {filename2}")
             num_steps = min(num_steps, s2.num_steps())
             err += 1
 
@@ -62,8 +84,7 @@ def CompareFiles(filename1, filename2, tolerance, tolperc, stats=False):
         notinS2 = np.setdiff1d(list(varInfoS1.keys()), list(varInfoS2.keys()))
         # compare total number of written variables
         if len(notinS1) > 0 or len(notinS1) > 0:
-            print("DIFFER : AVAIL_VARS : " + str(notinS1) + " <> " + str(notinS2) + " : " +
-                  filename1 + " : " + filename2)
+            print(f"DIFFER : AVAIL_VARS : {notinS1} <> {notinS2} : {filename1} : {filename2}")
             err += 1
 
         # compare each common variable
@@ -71,34 +92,30 @@ def CompareFiles(filename1, filename2, tolerance, tolperc, stats=False):
             # compare number of steps
             varSteps = int(varInfoS1[varName]["AvailableStepsCount"])
             if varSteps != int(varInfoS2[varName]["AvailableStepsCount"]):
-                print("DIFFER : VARIABLE : " + varName + " : NUM_STEPS : " +
-                      str(varInfoS1[varName]["AvailableStepsCount"]) + " <> " +
-                      str(varInfoS2[varName]["AvailableStepsCount"]) + " : " + filename1 + " : " +
-                      filename2)
+                print(f"DIFFER : VARIABLE : {varName} : NUM_STEPS: "
+                      f"{varInfoS1[varName]['AvailableStepsCount']} <> "
+                      f"{varInfoS2[varName]['AvailableStepsCount']} : {filename1} : {filename2}")
                 varSteps = min(varSteps, int(varInfoS2[varName]["AvailableStepsCount"]))
                 err += 1
 
             # compare types
             if varInfoS1[varName]["Type"] != varInfoS2[varName]["Type"]:
-                print("DIFFER : VARIABLE : " + varName + " : TYPE : " +
-                      str(varInfoS1[varName]["Type"]) + " <> " + str(varInfoS2[varName]["Type"]) +
-                      " : " + filename1 + " : " + filename2)
+                print(f"DIFFER : VARIABLE : {varName} : TYPE : {varInfoS1[varName]['Type']}"
+                      f" <> {varInfoS2[varName]['Type']} : {filename1} : {filename2}")
                 err += 1
 
             # compare dimensions (single value and shape)
             if varInfoS1[varName]["SingleValue"] != varInfoS2[varName]["SingleValue"]:
-                print("DIFFER : VARIABLE : " + varName + " : SINGLE_VALUE : " +
-                      str(varInfoS1[varName]["SingleValue"]) + " <> " +
-                      str(varInfoS2[varName]["SingleValue"]) + " : " + filename1 + " : " +
-                      filename2)
+                print(f"DIFFER : VARIABLE : {varName} : SINGLE_VALUE : "
+                      f"{varInfoS1[varName]['SingleValue']} <> "
+                      f"{varInfoS2[varName]['SingleValue']} : {filename1} : {filename2}")
                 err += 1
                 # no point in comparing values if there is a difference in shape
                 continue
 
             if varInfoS1[varName]["Shape"] != varInfoS2[varName]["Shape"]:
-                print("DIFFER : VARIABLE : " + varName + " : SHAPE : " +
-                      str(varInfoS1[varName]["Shape"]) + " <> " +
-                      str(varInfoS2[varName]["Shape"]) + " : " + filename1 + " : " + filename2)
+                print(f"DIFFER : VARIABLE : {varName} : SHAPE : {varInfoS1[varName]['Shape']}"
+                      f" <> {varInfoS2[varName]['Shape']} : {filename1} : {filename2}")
                 err += 1
                 # no point in comparing values if there is a difference in shape
                 continue
@@ -108,16 +125,14 @@ def CompareFiles(filename1, filename2, tolerance, tolperc, stats=False):
                 if DetectMismatch(float(varInfoS1[varName]["Min"]),
                                   float(varInfoS2[varName]["Min"]),
                                   tolerance, tolperc):
-                    print("DIFFER : VARIABLE : " + varName + " : MIN : " +
-                          str(varInfoS1[varName]["Min"]) + " <> " +
-                          str(varInfoS2[varName]["Min"]) + " : " + filename1 + " : " + filename2)
+                    print(f"DIFFER : VARIABLE : {varName} : MIN : {varInfoS1[varName]['Min']}"
+                          f" <> {varInfoS2[varName]['Min']} : {filename1} : {filename2}")
                     err += 1
                 if DetectMismatch(float(varInfoS1[varName]["Max"]),
                                   float(varInfoS2[varName]["Max"]),
                                   tolerance, tolperc):
-                    print("DIFFER : VARIABLE : " + varName + " : MAX : " +
-                          str(varInfoS1[varName]["Max"]) + " <> " +
-                          str(varInfoS2[varName]["Max"]) + " : " + filename1 + " : " + filename2)
+                    print(f"DIFFER : VARIABLE : {varName} : MAX : {varInfoS1[varName]['Max']}"
+                          f" <> {varInfoS2[varName]['Max']} : {filename1} : {filename2}")
                     err += 1
             # compare values
             for step in range(varSteps):
@@ -129,13 +144,11 @@ def CompareFiles(filename1, filename2, tolerance, tolperc, stats=False):
                 err += len(ret)
                 if verbose:
                     for (idx, value1, value2) in ret:
-                        print("DIFFER : VARIABLE : " + varName + " : STEP : " + str(step) +
-                              " : POSITION : " + str(idx) + " : VALUE : " + str(value1) +
-                              " <> " + str(value2) + " : " + filename1 + " : " + filename2)
+                        print(f"DIFFER : VARIABLE : {varName} : STEP : {step} : POSITION : "
+                              f"{idx} : VALUE : {value1} <> {value2} : {filename1} : {filename2}")
                 else:
-                    print("DIFFER : VARIABLE : " + varName + " : STEP : " + str(step) +
-                          " : VALUES_SUMMARY : " + str(len(ret)) + " : " + filename1 +
-                          " : " + filename2)
+                    print(f"DIFFER : VARIABLE : {varName} : STEP : {step} : VALUES_SUMMARY : "
+                          f"{len(ret)} : {filename1} : {filename2}")
 
     return err
 
@@ -159,18 +172,18 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if len(args.bpfiles) < 2:
         print("WARNING : At least two files need to be provided for any comparison")
-        exit()
+        exit(errno.ENOEXEC)
 
     verbose = args.verbose
 
     diff_found = 0
     for i in range(1, len(args.bpfiles)):
-        print("COMPARE : FILE :", args.bpfiles[0], ": FILE :", args.bpfiles[i])
+        print(f"COMPARE : FILE : {args.bpfiles[0]} : FILE : {args.bpfiles[i]}")
         diff_file = CompareFiles(args.bpfiles[0], args.bpfiles[i], args.tolerance, args.tolperc,
                                  args.stats)
         if diff_file > 0:
-            print("TOTAL_DIFFERENCES : " + str(diff_file) + " : FILE :", args.bpfiles[0],
-                  ": FILE :", args.bpfiles[i])
+            print(f"TOTAL_DIFFERENCES : {diff_file} : FILE : {args.bpfiles[0]} : FILE : "
+                  f"{args.bpfiles[i]}")
             diff_found += 1
 
     if diff_found == 0:

--- a/testing/utils/CMakeLists.txt
+++ b/testing/utils/CMakeLists.txt
@@ -10,6 +10,10 @@ else()
   set(MPIEXEC_COMMAND)
 endif()
 
+if(Python_Interpreter_FOUND)
+  add_subdirectory(bpcmp)
+endif()
+
 add_subdirectory(cwriter)
 add_subdirectory(changingshape)
 

--- a/testing/utils/CMakeLists.txt
+++ b/testing/utils/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
   set(MPIEXEC_COMMAND)
 endif()
 
-if(ADIOS2_HAVE_Python AND Python_Interpreter_FOUND)
+if(ADIOS2_HAVE_Python)
   add_subdirectory(bpcmp)
 endif()
 

--- a/testing/utils/CMakeLists.txt
+++ b/testing/utils/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
   set(MPIEXEC_COMMAND)
 endif()
 
-if(Python_Interpreter_FOUND)
+if(ADIOS2_HAVE_Python AND Python_Interpreter_FOUND)
   add_subdirectory(bpcmp)
 endif()
 

--- a/testing/utils/bpcmp/CMakeLists.txt
+++ b/testing/utils/bpcmp/CMakeLists.txt
@@ -1,0 +1,55 @@
+include(ADIOSFunctions)
+
+add_executable(Test.Utils.BPcmp TestUtilsBPcmp.cpp)
+
+target_link_libraries(Test.Utils.BPcmp adios2::c adios2::cxx11)
+set(cmd_executor)
+
+add_test(NAME Utils.BPcmp
+  COMMAND ${cmd_executor} $<TARGET_FILE:Test.Utils.BPcmp>
+)
+# This test produces TestBPcmp_set1.bp and TestBPcmp_set2.bp
+
+########################################
+# bpcmp --stats
+########################################
+add_test(NAME Utils.BPcmp.Stats.Dump
+  COMMAND ${CMAKE_COMMAND}
+    -DARG1=--stats
+    -DINPUT_FILE1=TestBPcmp_set1.bp
+    -DINPUT_FILE2=TestBPcmp_set2.bp
+    -DOUTPUT_FILE=TestUtilsBPcmp.stats.result.txt
+    -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
+    -DPython_EXECUTABLE=${Python_EXECUTABLE}
+    -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake"
+)
+
+add_test(NAME Utils.BPcmp.Stats.Validate
+  COMMAND ${DIFF_COMMAND} -u -w
+  ${CMAKE_CURRENT_SOURCE_DIR}/TestUtilsBPcmp.stats.expected.txt
+    TestUtilsBPcmp.stats.result.txt
+)
+
+SetupTestPipeline(Utils.BPcmp ";Stats.Dump;Stats.Validate" TRUE)
+
+########################################
+# bpcmp --verbose
+########################################
+add_test(NAME Utils.BPcmp.Verbose.Dump
+  COMMAND ${CMAKE_COMMAND}
+    -DARG1=--verbose
+    -DINPUT_FILE1=TestBPcmp_set1.bp
+    -DINPUT_FILE2=TestBPcmp_set2.bp
+    -DOUTPUT_FILE=TestUtilsBPcmp.verbose.result.txt
+    -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
+    -DPython_EXECUTABLE=${Python_EXECUTABLE}
+    -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake"
+)
+
+add_test(NAME Utils.BPcmp.Verbose.Validate
+  COMMAND ${DIFF_COMMAND} -u -w
+  ${CMAKE_CURRENT_SOURCE_DIR}/TestUtilsBPcmp.verbose.expected.txt
+    TestUtilsBPcmp.verbose.result.txt
+)
+
+SetupTestPipeline(Utils.BPcmp ";Verbose.Dump;Verbose.Validate" FALSE)

--- a/testing/utils/bpcmp/CMakeLists.txt
+++ b/testing/utils/bpcmp/CMakeLists.txt
@@ -1,12 +1,9 @@
-include(ADIOSFunctions)
-
 add_executable(Test.Utils.BPcmp TestUtilsBPcmp.cpp)
 
-target_link_libraries(Test.Utils.BPcmp adios2::c adios2::cxx11)
-set(cmd_executor)
+target_link_libraries(Test.Utils.BPcmp adios2::cxx11)
 
 add_test(NAME Utils.BPcmp
-  COMMAND ${cmd_executor} $<TARGET_FILE:Test.Utils.BPcmp>
+  COMMAND $<TARGET_FILE:Test.Utils.BPcmp>
 )
 # This test produces TestBPcmp_set1.bp and TestBPcmp_set2.bp
 

--- a/testing/utils/bpcmp/CMakeLists.txt
+++ b/testing/utils/bpcmp/CMakeLists.txt
@@ -13,16 +13,31 @@ add_test(NAME Utils.BPcmp
 ########################################
 # bpcmp --stats
 ########################################
-add_test(NAME Utils.BPcmp.Stats.Dump
-  COMMAND ${CMAKE_COMMAND}
-    -DARG1=--stats
-    -DINPUT_FILE1=TestBPcmp_set1.bp
-    -DINPUT_FILE2=TestBPcmp_set2.bp
-    -DOUTPUT_FILE=TestUtilsBPcmp.stats.result.txt
-    -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
-    -DPython_EXECUTABLE=${Python_EXECUTABLE}
-    -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake"
-)
+  add_test(NAME Utils.BPcmp.Stats.Dump
+    COMMAND ${CMAKE_COMMAND}
+      -DARG1=--stats
+      -DINPUT_FILE1=TestBPcmp_set1.bp
+      -DINPUT_FILE2=TestBPcmp_set2.bp
+      -DOUTPUT_FILE=TestUtilsBPcmp.stats.result.txt
+      -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
+      -DPython_EXECUTABLE=$<TARGET_FILE:Python::Interpreter>
+      -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake"
+  )
+
+if(UNIX)
+  set_property(TEST Utils.BPcmp.Stats.Dump PROPERTY
+    ENVIRONMENT
+      "PYTHONPATH=${ADIOS2_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+      "PYTHONUSERBASE=${CMAKE_BINARY_DIR}"
+  )
+else()
+  set_property(TEST Utils.BPcmp.Stats.Dump PROPERTY
+    ENVIRONMENT
+      "PYTHONPATH=${ADIOS2_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR};$<SHELL_PATH:$<TARGET_FILE_DIR:adios2_py>>;$ENV{PYTHONPATH}"
+      "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:adios2_py>>;$<SHELL_PATH:$<TARGET_FILE_DIR:adios2_core>>;$ENV{PATH}"
+      "PYTHONUSERBASE=${CMAKE_BINARY_DIR}"
+  )
+endif()
 
 add_test(NAME Utils.BPcmp.Stats.Validate
   COMMAND ${DIFF_COMMAND} -u -w
@@ -36,15 +51,30 @@ SetupTestPipeline(Utils.BPcmp ";Stats.Dump;Stats.Validate" TRUE)
 # bpcmp --verbose
 ########################################
 add_test(NAME Utils.BPcmp.Verbose.Dump
-  COMMAND ${CMAKE_COMMAND}
-    -DARG1=--verbose
-    -DINPUT_FILE1=TestBPcmp_set1.bp
-    -DINPUT_FILE2=TestBPcmp_set2.bp
-    -DOUTPUT_FILE=TestUtilsBPcmp.verbose.result.txt
-    -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
-    -DPython_EXECUTABLE=${Python_EXECUTABLE}
-    -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake"
-)
+    COMMAND ${CMAKE_COMMAND}
+      -DARG1=--verbose
+      -DINPUT_FILE1=TestBPcmp_set1.bp
+      -DINPUT_FILE2=TestBPcmp_set2.bp
+      -DOUTPUT_FILE=TestUtilsBPcmp.verbose.result.txt
+      -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
+      -DPython_EXECUTABLE=$<TARGET_FILE:Python::Interpreter>
+      -P "${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake"
+  )
+
+if(UNIX)
+  set_property(TEST Utils.BPcmp.Verbose.Dump PROPERTY
+    ENVIRONMENT
+      "PYTHONPATH=${ADIOS2_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR}:$ENV{PYTHONPATH}"
+      "PYTHONUSERBASE=${CMAKE_BINARY_DIR}"
+  )
+else()
+  set_property(TEST Utils.BPcmp.Verbose.Dump PROPERTY
+    ENVIRONMENT
+      "PYTHONPATH=${ADIOS2_BINARY_DIR}/${CMAKE_INSTALL_PYTHONDIR};$<SHELL_PATH:$<TARGET_FILE_DIR:adios2_py>>;$ENV{PYTHONPATH}"
+      "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:adios2_py>>;$<SHELL_PATH:$<TARGET_FILE_DIR:adios2_core>>;$ENV{PATH}"
+      "PYTHONUSERBASE=${CMAKE_BINARY_DIR}"
+  )
+endif()
 
 add_test(NAME Utils.BPcmp.Verbose.Validate
   COMMAND ${DIFF_COMMAND} -u -w

--- a/testing/utils/bpcmp/TestUtilsBPcmp.cpp
+++ b/testing/utils/bpcmp/TestUtilsBPcmp.cpp
@@ -1,7 +1,7 @@
 #include <algorithm>
 #include <ios>
 #include <iostream>
-#include <random>
+#include <numeric>
 #include <stdexcept>
 #include <vector>
 
@@ -25,15 +25,8 @@ int main(int argc, char *argv[])
 
     const size_t Nx = 2, Ny = 3;
     const size_t steps = 2;
-    std::default_random_engine generator;
-    generator.seed(0);
-    std::uniform_real_distribution<float> distribution(0.0, 10.0);
-
     std::vector<float> commonArray(Nx * Ny);
-    for (size_t i = 0; i < Nx * Ny; ++i)
-    {
-        commonArray[i] = distribution(generator);
-    }
+    std::iota(commonArray.begin(), commonArray.end(), 4.0f);
 
 #if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);

--- a/testing/utils/bpcmp/TestUtilsBPcmp.cpp
+++ b/testing/utils/bpcmp/TestUtilsBPcmp.cpp
@@ -1,0 +1,101 @@
+#include <algorithm>
+#include <ios>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+#include <adios2.h>
+#if ADIOS2_USE_MPI
+#include <mpi.h>
+#endif
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+#if ADIOS2_USE_MPI
+    int provided;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+#else
+    rank = 0;
+    size = 1;
+#endif
+
+    const size_t Nx = 2, Ny = 3;
+    const size_t steps = 2;
+    std::default_random_engine generator;
+    generator.seed(0);
+    std::uniform_real_distribution<float> distribution(0.0, 10.0);
+
+    std::vector<float> commonArray(Nx * Ny);
+    for (size_t i = 0; i < Nx * Ny; ++i)
+    {
+        commonArray[i] = distribution(generator);
+    }
+
+#if ADIOS2_USE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+    adios2::ADIOS adios;
+#endif
+
+    /* PRIMARY file */
+    {
+        adios2::IO bpIO = adios.DeclareIO("BPcmp1");
+
+        auto bpFloats = bpIO.DefineVariable<float>("bpFloats", {size * Nx, Ny}, {rank * Nx, 0},
+                                                   {Nx, Ny}, adios2::ConstantDims);
+
+        auto bpStep = bpIO.DefineVariable<unsigned int>("bpStep");
+
+        // Create the raw file with the 2D raw array and step information
+        adios2::Engine bpWriter = bpIO.Open("TestBPcmp_set1.bp", adios2::Mode::Write);
+
+        for (size_t i = 0; i < steps; i++)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put(bpFloats, commonArray.data());
+            bpWriter.Put(bpStep, static_cast<unsigned int>(i));
+            bpWriter.EndStep();
+
+            std::transform(commonArray.begin(), commonArray.end(), commonArray.begin(),
+                           [](float &v) { return v + 1; });
+        }
+
+        bpWriter.Close();
+    }
+
+    /* SECONDARY file */
+    {
+        adios2::IO bpIO = adios.DeclareIO("BPcmp2");
+
+        auto bpFloats = bpIO.DefineVariable<float>("bpFloats", {size * Nx, Ny}, {rank * Nx, 0},
+                                                   {Nx, Ny}, adios2::ConstantDims);
+
+        auto bpStep = bpIO.DefineVariable<int>("bpStep", {1}, {0}, {1});
+
+        // Create the raw file with the 2D raw array and step information
+        adios2::Engine bpWriter = bpIO.Open("TestBPcmp_set2.bp", adios2::Mode::Write);
+
+        for (size_t i = 0; i < steps; i++)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put(bpFloats, commonArray.data());
+            bpWriter.Put(bpStep, static_cast<int>(i));
+            bpWriter.EndStep();
+        }
+        bpWriter.BeginStep();
+        bpWriter.Put(bpStep, static_cast<int>(steps));
+        bpWriter.EndStep();
+
+        bpWriter.Close();
+    }
+
+#if ADIOS2_USE_MPI
+    MPI_Finalize();
+#endif
+
+    return 0;
+}

--- a/testing/utils/bpcmp/TestUtilsBPcmp.stats.expected.txt
+++ b/testing/utils/bpcmp/TestUtilsBPcmp.stats.expected.txt
@@ -1,7 +1,7 @@
 COMPARE : FILE : TestBPcmp_set1.bp : FILE : TestBPcmp_set2.bp
 DIFFER : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : MIN : 0.000224775 <> 2.00022 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : MAX : 10.6796 <> 11.6796 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : MIN : 4 <> 6 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : MAX : 10 <> 11 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
 DIFFER : VARIABLE : bpFloats : STEP : 0 : VALUES_SUMMARY : 6 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
 DIFFER : VARIABLE : bpFloats : STEP : 1 : VALUES_SUMMARY : 6 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
 DIFFER : VARIABLE : bpStep : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp

--- a/testing/utils/bpcmp/TestUtilsBPcmp.stats.expected.txt
+++ b/testing/utils/bpcmp/TestUtilsBPcmp.stats.expected.txt
@@ -1,0 +1,10 @@
+COMPARE : FILE : TestBPcmp_set1.bp : FILE : TestBPcmp_set2.bp
+DIFFER : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : MIN : 0.000224775 <> 2.00022 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : MAX : 10.6796 <> 11.6796 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : VALUES_SUMMARY : 6 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : VALUES_SUMMARY : 6 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpStep : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpStep : TYPE : uint32_t <> int32_t : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpStep : SINGLE_VALUE : true <> false : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+TOTAL_DIFFERENCES : 18 : FILE : TestBPcmp_set1.bp : FILE : TestBPcmp_set2.bp

--- a/testing/utils/bpcmp/TestUtilsBPcmp.verbose.expected.txt
+++ b/testing/utils/bpcmp/TestUtilsBPcmp.verbose.expected.txt
@@ -1,17 +1,17 @@
 COMPARE : FILE : TestBPcmp_set1.bp : FILE : TestBPcmp_set2.bp
 DIFFER : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (0, 0) : VALUE : 0.0002247747 <> 2.0002248 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (0, 1) : VALUE : 0.8503245 <> 2.8503246 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (0, 2) : VALUE : 6.0135264 <> 8.013527 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (1, 0) : VALUE : 8.916113 <> 10.916113 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (1, 1) : VALUE : 9.679557 <> 11.679557 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (1, 2) : VALUE : 1.8968977 <> 3.8968978 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (0, 0) : VALUE : 1.0002248 <> 2.0002248 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (0, 1) : VALUE : 1.8503245 <> 2.8503246 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (0, 2) : VALUE : 7.0135264 <> 8.013527 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (1, 0) : VALUE : 9.916113 <> 10.916113 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (1, 1) : VALUE : 10.679557 <> 11.679557 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (1, 2) : VALUE : 2.8968978 <> 3.8968978 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (0, 0) : VALUE : 4.0 <> 6.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (0, 1) : VALUE : 5.0 <> 7.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (0, 2) : VALUE : 6.0 <> 8.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (1, 0) : VALUE : 7.0 <> 9.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (1, 1) : VALUE : 8.0 <> 10.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (1, 2) : VALUE : 9.0 <> 11.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (0, 0) : VALUE : 5.0 <> 6.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (0, 1) : VALUE : 6.0 <> 7.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (0, 2) : VALUE : 7.0 <> 8.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (1, 0) : VALUE : 8.0 <> 9.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (1, 1) : VALUE : 9.0 <> 10.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (1, 2) : VALUE : 10.0 <> 11.0 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
 DIFFER : VARIABLE : bpStep : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
 DIFFER : VARIABLE : bpStep : TYPE : uint32_t <> int32_t : TestBPcmp_set1.bp : TestBPcmp_set2.bp
 DIFFER : VARIABLE : bpStep : SINGLE_VALUE : true <> false : TestBPcmp_set1.bp : TestBPcmp_set2.bp

--- a/testing/utils/bpcmp/TestUtilsBPcmp.verbose.expected.txt
+++ b/testing/utils/bpcmp/TestUtilsBPcmp.verbose.expected.txt
@@ -1,0 +1,18 @@
+COMPARE : FILE : TestBPcmp_set1.bp : FILE : TestBPcmp_set2.bp
+DIFFER : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (0, 0) : VALUE : 0.0002247747 <> 2.0002248 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (0, 1) : VALUE : 0.8503245 <> 2.8503246 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (0, 2) : VALUE : 6.0135264 <> 8.013527 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (1, 0) : VALUE : 8.916113 <> 10.916113 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (1, 1) : VALUE : 9.679557 <> 11.679557 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (1, 2) : VALUE : 1.8968977 <> 3.8968978 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (0, 0) : VALUE : 1.0002248 <> 2.0002248 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (0, 1) : VALUE : 1.8503245 <> 2.8503246 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (0, 2) : VALUE : 7.0135264 <> 8.013527 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (1, 0) : VALUE : 9.916113 <> 10.916113 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (1, 1) : VALUE : 10.679557 <> 11.679557 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (1, 2) : VALUE : 2.8968978 <> 3.8968978 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpStep : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpStep : TYPE : uint32_t <> int32_t : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpStep : SINGLE_VALUE : true <> false : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+TOTAL_DIFFERENCES : 16 : FILE : TestBPcmp_set1.bp : FILE : TestBPcmp_set2.bp


### PR DESCRIPTION
Based on a request from GX developers, this is the first version of a python script to compare the information in two BP files (given a certain tolerance). The functionality is kept similar to https://gitlab.com/remikz/nccmp 

Current differences detected:
- **Metadata** (number of steps, number of variables, type and dimension of each variable)
- **Stats** (min/max with a tolerance) - only if the `--stats` option is used
- **Values** (values on each position with a tolerance)

The tolerance can be absolute value or percentage. 

Example metadata differences:
```
$ python bpcmp.py BPFileStepsWriteRead.bp BPFileStepsWriteReadKokkos.bp
COMPARE : FILE : BPFileStepsWriteRead.bp : FILE : BPFileStepsWriteReadKokkos.bp
DIFFER : NUM_STEPS : 10 <> 1 : BPFileStepsWriteRead.bp : BPFileStepsWriteReadKokkos.bp
DIFFER : AVAIL_VARS : ['bpStep'] <> [] : BPFileStepsWriteRead.bp : BPFileStepsWriteReadKokkos.bp
DIFFER : VARIABLE : bpFloats : NUM_STEPS : 10 <> 1 : BPFileStepsWriteRead.bp : BPFileStepsWriteReadKokkos.bp
DIFFER : VARIABLE : bpFloats : SHAPE : 60000 <> 4, 3 : BPFileStepsWriteRead.bp : BPFileStepsWriteReadKokkos.bp

DIFFER : VARIABLE : bpType : TYPE :  uint32_t <> float : test1.bp : test2.bp
DIFFER : VARIABLE : bpSV : SINGLE_VALUE :  true <> false : test1.bp : test2.bp
```

Example min/max differences:
```
DIFFER : VARIABLE : bpFloats : MIN : 0 <> 1 : test1.bp : test2.bp
DIFFER : VARIABLE : bpFloats : MAX : 90 <> 60089 : BPFileStepsWriteRead.bp : BPFileStepsWriteReadHip.bp
```

Without verbose the script only plots a summary of the value difference
```
DIFFER : VARIABLE : bpFloats : VALUES_SUMMARY : 599990 : BPFileStepsWriteRead.bp : BPFileStepsWriteReadHip.bp
```

Using `--verbose` the script will plot every value difference
```
DIFFER : VARIABLE : bpFloats : STEP : 0 : POSITION : (5,0) : VALUE : 0.0 <> 5.0 : test1.bp : test2.bp
DIFFER : VARIABLE : bpFloats : STEP : 1 : POSITION : (6,10) : VALUE : 1.0 <> 6.0 : test1.bp : test2.bp
```

Things that still need to be added:
- Parallel execution (add MPI support)
- Specific variable inclusion or exclusion.
- Print data difference statistics (count, sum, absolute sum, min, max, range, mean, stdev) for numeric variables and compound fields.
- Per block comparison of min/max
- Do not read the entire values for each step to compare them. Comparing per blocks might allow multi-gigabyte files to only consume several megabytes of memory.
- Statistics about the difference between the values (min/max/avg/std)