### PR TITLE
Implementing reader side derivation version 2

### DIFF
--- a/source/adios2/core/VariableDerived.cpp
+++ b/source/adios2/core/VariableDerived.cpp
@@ -95,14 +95,27 @@ std::vector<std::tuple<void *, Dims, Dims>> VariableDerived::GenerateDerivedDims
     std::vector<std::tuple<void *, Dims, Dims>> blockData;
     for (size_t i = 0; i < numBlocks; i++)
     {
-        auto &blockEntry = NameToVarInfo.begin()->second;
-        Dims Start(blockEntry->BlocksInfo[i].Start,
-                   blockEntry->BlocksInfo[i].Start + blockEntry->Dims);
-        Dims Count(blockEntry->BlocksInfo[i].Count,
-                   blockEntry->BlocksInfo[i].Count + blockEntry->Dims);
-        blockData.emplace_back((void *)NULL, Start, Count);
-    }
+        std::map<std::string, Dims> nameToCount;
+        std::map<std::string, Dims> nameToStart;
+        for (const auto &variable : NameToVarInfo)
+        {
+            Dims start;
+            Dims count;
+            for (int d = 0; d < variable.second->Dims; d++)
+            {
+                start.push_back(variable.second->BlocksInfo[i].Start[d]);
+                count.push_back(variable.second->BlocksInfo[i].Count[d]);
+            }
+            nameToCount.insert({variable.first, count});
+            nameToStart.insert({variable.first, start});
+        }
 
+        Dims outputCount = m_Expr.m_Expr.GetDims(nameToCount);
+        Dims outputStart = m_Expr.m_Expr.GetDims(nameToStart);
+
+        std::cout << "Get DetDimms returns " << outputCount << "    " << outputStart << std::endl;
+        blockData.push_back({nullptr, outputStart, outputCount});
+    }
     return blockData;
 }
 

--- a/source/adios2/core/VariableDerived.h
+++ b/source/adios2/core/VariableDerived.h
@@ -33,6 +33,8 @@ public:
                     std::map<std::string, std::tuple<Dims, Dims, Dims>> NameToDims);
     std::vector<std::tuple<void *, Dims, Dims>>
     ApplyExpression(std::map<std::string, std::unique_ptr<MinVarInfo>> &mvi);
+    std::vector<std::tuple<void *, Dims, Dims>>
+    GenerateDerivedDims(std::map<std::string, std::unique_ptr<MinVarInfo>> &NameToVarInfo);
 };
 
 } // end namespace core

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -550,6 +550,11 @@ void BP5Writer::ComputeDerivedVariables()
         {
             DerivedBlockData = derivedVar->ApplyExpression(nameToVarInfo);
         }
+        else
+        {
+            // for expressionString, just generate the blocksinfo
+            DerivedBlockData = derivedVar->GenerateDerivedDims(nameToVarInfo);
+        }
 
         // Send the derived variable to ADIOS2 internal logic
         for (auto derivedBlock : DerivedBlockData)
@@ -561,7 +566,8 @@ void BP5Writer::ComputeDerivedVariables()
                 (*it).second->m_Count = std::get<2>(derivedBlock);
             }
             PutCommon(*(*it).second.get(), std::get<0>(derivedBlock), true /* sync */);
-            free(std::get<0>(derivedBlock));
+            if (derivedVar->GetDerivedType() != DerivedVarType::ExpressionString)
+                free(std::get<0>(derivedBlock));
         }
     }
     m_Profiler.Stop("DeriveVars");

--- a/source/adios2/toolkit/derived/Expression.h
+++ b/source/adios2/toolkit/derived/Expression.h
@@ -78,13 +78,14 @@ public:
 
 class Expression
 {
-    ExpressionTree m_Expr;
 
     Dims m_Shape;
     Dims m_Start;
     Dims m_Count;
 
 public:
+    ExpressionTree m_Expr;
+
     Expression() = default;
     Expression(std::string expression);
 

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -111,8 +111,8 @@ public:
         Dims Start;
         Dims Count;
         MemorySpace MemSpace;
-        std::map<std::string, std::unique_ptr<MinVarInfo>> *DerivedInputMap;
-        void *Data;
+        std::map<std::string, std::unique_ptr<MinVarInfo>> *DerivedInputMap = NULL;
+        void *Data = NULL;
     };
     std::vector<BP5ArrayRequest> PendingGetRequests;
 

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -591,9 +591,12 @@ BP5Serializer::BP5WriterRec BP5Serializer::CreateWriterRec(void *Variable, const
         // Array field.  To Metadata, add FMFields for DimCount, Shape, Count
         // and Offsets matching _MetaArrayRec
         const char *ExprString = NULL;
+        bool NeverMinMax = false;
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
         if (VD && (VD->GetDerivedType() != DerivedVarType::StoreData))
             ExprString = VD->m_Expr.ExprString.c_str();
+        if (VD && (VD->GetDerivedType() == DerivedVarType::ExpressionString))
+            NeverMinMax = true;
 #endif
         char *LongName =
             BuildLongName(Name, VB->m_ShapeID, (int)Type, ElemSize, TextStructID, ExprString);
@@ -605,7 +608,7 @@ BP5Serializer::BP5WriterRec BP5Serializer::CreateWriterRec(void *Variable, const
             ArrayTypeName = "MetaArrayOp";
             FieldSize = sizeof(MetaArrayRecOperator);
         }
-        if (m_StatsLevel > 0)
+        if ((m_StatsLevel > 0) && !NeverMinMax)
         {
             char MMArrayName[40] = {0};
             strcat(MMArrayName, ArrayTypeName);

--- a/testing/adios2/derived/TestBPDerivedCorrectness.cpp
+++ b/testing/adios2/derived/TestBPDerivedCorrectness.cpp
@@ -401,8 +401,8 @@ TEST_P(DerivedCorrectnessP, CurlCorrectnessTest)
 
 INSTANTIATE_TEST_SUITE_P(DerivedCorrectness, DerivedCorrectnessP,
                          ::testing::Values(adios2::DerivedVarType::StatsOnly,
+                                           adios2::DerivedVarType::ExpressionString,
                                            adios2::DerivedVarType::StoreData));
-
 int main(int argc, char **argv)
 {
     int result;


### PR DESCRIPTION
 This PR takes a different approach to getting writer-side metadata for uncalculated variables than does #4249.  However, as currently written is is broken because Expression SetDims() doesn't handle Start correctly.