### PR TITLE
Open file with in-memory metadata 

### DIFF
--- a/bindings/C/adios2/c/adios2_c_engine.cpp
+++ b/bindings/C/adios2/c/adios2_c_engine.cpp
@@ -186,6 +186,24 @@ adios2_error adios2_engine_openmode(adios2_mode *mode, const adios2_engine *engi
     }
 }
 
+adios2_error adios2_engine_get_metadata(adios2_engine *engine, char **md, size_t *size)
+{
+    try
+    {
+        adios2::helper::CheckForNullptr(engine,
+                                        "for const adios2_engine, in call to adios2_get_metadata");
+
+        adios2::core::Engine *engineCpp = reinterpret_cast<adios2::core::Engine *>(engine);
+
+        engineCpp->GetMetadata(md, size);
+        return adios2_error_none;
+    }
+    catch (...)
+    {
+        return static_cast<adios2_error>(adios2::helper::ExceptionToError("adios2_get_metadata"));
+    }
+}
+
 adios2_error adios2_begin_step(adios2_engine *engine, const adios2_step_mode mode,
                                const float timeout_seconds, adios2_step_status *status)
 {

--- a/bindings/C/adios2/c/adios2_c_engine.h
+++ b/bindings/C/adios2/c/adios2_c_engine.h
@@ -59,8 +59,7 @@ adios2_error adios2_engine_openmode(adios2_mode *mode, const adios2_engine *engi
  * @return metadata (pointer to allocated memory) and size of metadata
  * the pointer must be deallocated by user using free()
  */
-adios2_error adios2_engine_get_metadata(adios2_engine *engine, char **md,
-                                        size_t *size);
+adios2_error adios2_engine_get_metadata(adios2_engine *engine, char **md, size_t *size);
 
 /**
  * @brief Begin a logical adios2 step stream

--- a/bindings/C/adios2/c/adios2_c_engine.h
+++ b/bindings/C/adios2/c/adios2_c_engine.h
@@ -53,6 +53,15 @@ adios2_error adios2_engine_get_type(char *type, size_t *size, const adios2_engin
  */
 adios2_error adios2_engine_openmode(adios2_mode *mode, const adios2_engine *engine);
 
+/** Serialize all metadata right after engine is created, which can be
+ * delivered to other processes to open the same file for reading without
+ * opening and reading in metadata again.
+ * @return metadata (pointer to allocated memory) and size of metadata
+ * the pointer must be deallocated by user using free()
+ */
+adios2_error adios2_engine_get_metadata(adios2_engine *engine, char **md,
+                                        size_t *size);
+
 /**
  * @brief Begin a logical adios2 step stream
  * Check each engine documentation for MPI collective/non-collective

--- a/bindings/C/adios2/c/adios2_c_io.cpp
+++ b/bindings/C/adios2/c/adios2_c_io.cpp
@@ -913,6 +913,24 @@ adios2_engine *adios2_open(adios2_io *io, const char *name, const adios2_mode mo
     return engine;
 }
 
+adios2_engine *adios2_open_with_metadata(adios2_io *io, const char *name,
+                                         const char *md, const size_t mdsize)
+{
+    adios2_engine *engine = nullptr;
+    try
+    {
+        adios2::helper::CheckForNullptr(
+            io, "for adios2_io, in call to adios2_open_with_metadata");
+        engine = reinterpret_cast<adios2_engine *>(
+            &reinterpret_cast<adios2::core::IO *>(io)->Open(name, md, mdsize));
+    }
+    catch (...)
+    {
+        adios2::helper::ExceptionToError("adios2_open_with_metadata");
+    }
+    return engine;
+}
+
 adios2_error adios2_flush_all_engines(adios2_io *io)
 {
     try

--- a/bindings/C/adios2/c/adios2_c_io.cpp
+++ b/bindings/C/adios2/c/adios2_c_io.cpp
@@ -913,14 +913,13 @@ adios2_engine *adios2_open(adios2_io *io, const char *name, const adios2_mode mo
     return engine;
 }
 
-adios2_engine *adios2_open_with_metadata(adios2_io *io, const char *name,
-                                         const char *md, const size_t mdsize)
+adios2_engine *adios2_open_with_metadata(adios2_io *io, const char *name, const char *md,
+                                         const size_t mdsize)
 {
     adios2_engine *engine = nullptr;
     try
     {
-        adios2::helper::CheckForNullptr(
-            io, "for adios2_io, in call to adios2_open_with_metadata");
+        adios2::helper::CheckForNullptr(io, "for adios2_io, in call to adios2_open_with_metadata");
         engine = reinterpret_cast<adios2_engine *>(
             &reinterpret_cast<adios2::core::IO *>(io)->Open(name, md, mdsize));
     }

--- a/bindings/C/adios2/c/adios2_c_io.h
+++ b/bindings/C/adios2/c/adios2_c_io.h
@@ -346,8 +346,8 @@ adios2_engine *adios2_open(adios2_io *io, const char *name, const adios2_mode mo
  * @param md file metadata residing in memory
  * @return success: handler, failure: NULL
  */
-adios2_engine *adios2_open_with_metadata(adios2_io *io, const char *name,
-                                         const char *md, const size_t mdsize);
+adios2_engine *adios2_open_with_metadata(adios2_io *io, const char *name, const char *md,
+                                         const size_t mdsize);
 
 #if ADIOS2_USE_MPI
 /**

--- a/bindings/C/adios2/c/adios2_c_io.h
+++ b/bindings/C/adios2/c/adios2_c_io.h
@@ -335,6 +335,20 @@ adios2_error adios2_remove_all_attributes(adios2_io *io);
  */
 adios2_engine *adios2_open(adios2_io *io, const char *name, const adios2_mode mode);
 
+/**
+ * Open an Engine to start heavy-weight input/output operations.
+ * This function is for opening a file (not stream) with ReadRandomAccess mode
+ * and supplying the metadata already in memory. The metadata should be
+ * retrieved by another program calling adios2_engine_get_metadata() after
+ * opening the file.
+ * @param io engine owner
+ * @param name unique engine identifier
+ * @param md file metadata residing in memory
+ * @return success: handler, failure: NULL
+ */
+adios2_engine *adios2_open_with_metadata(adios2_io *io, const char *name,
+                                         const char *md, const size_t mdsize);
+
 #if ADIOS2_USE_MPI
 /**
  * Open an Engine to start heavy-weight input/output operations.

--- a/bindings/CXX11/adios2/cxx11/Engine.cpp
+++ b/bindings/CXX11/adios2/cxx11/Engine.cpp
@@ -45,6 +45,12 @@ Mode Engine::OpenMode() const
     return m_Engine->OpenMode();
 }
 
+void Engine::GetMetadata(char **md, size_t *size) const
+{
+    helper::CheckForNullptr(m_Engine, "in call to Engine::GetMetadata");
+    m_Engine->GetMetadata(md, size);
+}
+
 StepStatus Engine::BeginStep()
 {
     helper::CheckForNullptr(m_Engine, "in call to Engine::BeginStep");

--- a/bindings/CXX11/adios2/cxx11/Engine.h
+++ b/bindings/CXX11/adios2/cxx11/Engine.h
@@ -71,6 +71,14 @@ public:
      */
     Mode OpenMode() const;
 
+    /** Serialize all metadata right after engine is created, which can be
+     * delivered to other processes to open the same file for reading without
+     * opening and reading in metadata again.
+     * @return metadata (pointer to allocated memory) and size of metadata
+     * the pointer must be deallocated by user using free()
+     */
+    void GetMetadata(char **md, size_t *size) const;
+
     /**
      * Begin a logical adios2 step, overloaded version with timeoutSeconds = 0
      * and mode = Read

--- a/bindings/CXX11/adios2/cxx11/IO.cpp
+++ b/bindings/CXX11/adios2/cxx11/IO.cpp
@@ -108,6 +108,13 @@ Engine IO::Open(const std::string &name, const Mode mode)
     helper::CheckForNullptr(m_IO, "for engine " + name + ", in call to IO::Open");
     return Engine(&m_IO->Open(name, mode));
 }
+
+Engine IO::Open(const std::string &name, const char *md, const size_t mdsize)
+{
+    helper::CheckForNullptr(m_IO, "for engine " + name + ", in call to IO::Open");
+    return Engine(&m_IO->Open(name, md, mdsize));
+}
+
 Group IO::InquireGroup(char delimiter) { return Group(&m_IO->CreateGroup(delimiter)); };
 void IO::FlushAll()
 {

--- a/bindings/CXX11/adios2/cxx11/IO.h
+++ b/bindings/CXX11/adios2/cxx11/IO.h
@@ -310,6 +310,21 @@ public:
     Engine Open(const std::string &name, const Mode mode, MPI_Comm comm);
 #endif
 
+    /**
+     * Overloaded version that is specifically for a serial program
+     * opening a file (not stream) with ReadRandomAccess mode and
+     * supplying the metadata already in memory. The metadata
+     * should be retrieved by another program calling engine.GetMetadata()
+     * after opening the file.
+     * @param name unique engine identifier within IO object
+     * (file name in case of File transports)
+     * @param md file metadata residing in memory
+     * @return a reference to a derived object of the Engine class
+     * @exception std::invalid_argument if Engine with unique name is already
+     * created with another Open
+     */
+    Engine Open(const std::string &name, const char *md, const size_t mdsize);
+
     /** Flushes all engines created with this IO with the Open function */
     void FlushAll();
 

--- a/examples/useCases/CMakeLists.txt
+++ b/examples/useCases/CMakeLists.txt
@@ -5,3 +5,5 @@
 
 add_subdirectory(fidesOneCell)
 add_subdirectory(insituGlobalArrays)
+add_subdirectory(ensembleRead)
+

--- a/examples/useCases/ensembleRead/CMakeLists.txt
+++ b/examples/useCases/ensembleRead/CMakeLists.txt
@@ -1,0 +1,9 @@
+#------------------------------------------------------------------------------#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#------------------------------------------------------------------------------#
+
+if(ADIOS2_HAVE_MPI)
+  add_executable(adios2_useCases_ensembleRead ensembleRead.cpp)
+  target_link_libraries(adios2_useCases_ensembleRead adios2::cxx11_mpi MPI::MPI_C)
+endif()

--- a/examples/useCases/ensembleRead/ensembleRead.cpp
+++ b/examples/useCases/ensembleRead/ensembleRead.cpp
@@ -1,0 +1,229 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * A Use Case for reading metadata by one process only, then distribute that
+ * among other processes/applications, which can "open" the dataset faster
+ * by processing metadata from memory.
+ *
+ * Data is still read from disk by each process/application.
+ *
+ * This is an MPI application but every process acts as a separate entity as far as
+ * reading with ADIOS goes.
+ *
+ * Created on: Aug 20, 2024
+ *      Author: pnorbert
+ */
+
+#include <algorithm> // std::transform
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <numeric> //std::accumulate
+#include <thread>  // sleep_for
+#include <vector>
+
+#include <adios2.h>
+
+#include <mpi.h>
+
+typedef std::chrono::duration<double> Seconds;
+typedef std::chrono::time_point<std::chrono::steady_clock,
+                                std::chrono::duration<double, std::chrono::steady_clock::period>>
+    TimePoint;
+
+inline TimePoint Now() { return std::chrono::steady_clock::now(); }
+
+struct VarInfo
+{
+    std::string varName;
+    std::string type;
+    adios2::Dims shape;
+    adios2::ShapeID shapeID;
+    size_t nSteps;
+    std::vector<char> data;
+    VarInfo(const std::string &name, const std::string &type, const adios2::Dims shape,
+            const adios2::ShapeID shapeID, const size_t nsteps)
+    : varName(name), type(type), shape(shape), shapeID(shapeID), nSteps(nsteps){};
+};
+
+std::string DimsToString(adios2::Dims &dims)
+{
+    std::string s = "";
+    for (size_t i = 0; i < dims.size(); i++)
+    {
+        if (i > 0)
+        {
+            s += "x";
+        }
+        s += std::to_string(dims[i]);
+    }
+    s += "";
+    return s;
+}
+
+size_t GetTotalSize(adios2::Dims &dimensions, size_t elementSize = 1)
+{
+    return std::accumulate(dimensions.begin(), dimensions.end(), elementSize,
+                           std::multiplies<size_t>());
+}
+
+template <class T>
+void ReadVariable(int rank, const std::string &name, const std::string &type,
+                  adios2::Engine &reader, adios2::IO &io, std::vector<VarInfo> &varinfos)
+{
+    adios2::Variable<T> variable = io.InquireVariable<T>(name);
+    varinfos.push_back(VarInfo(name, type, variable.Shape(), variable.ShapeID(), 1));
+    auto vit = varinfos.rbegin();
+    vit->nSteps = variable.Steps();
+    if (vit->shapeID == adios2::ShapeID::GlobalArray)
+    {
+        size_t n = vit->nSteps * GetTotalSize(vit->shape, sizeof(T));
+        vit->data.resize(n);
+        adios2::Dims start(vit->shape.size());
+        variable.SetSelection({start, vit->shape});
+        variable.SetStepSelection({0, vit->nSteps});
+        T *dataptr = reinterpret_cast<T *>(vit->data.data());
+        reader.Get(variable, dataptr);
+    }
+    else if (vit->shapeID == adios2::ShapeID::GlobalValue)
+    {
+        size_t n = vit->nSteps * sizeof(T);
+        vit->data.resize(n);
+        variable.SetStepSelection({0, vit->nSteps});
+        T *dataptr = reinterpret_cast<T *>(vit->data.data());
+        reader.Get(variable, dataptr);
+    }
+}
+
+std::vector<VarInfo> ReadFileContent(int rank, adios2::Engine &reader, adios2::IO &io)
+{
+    std::map<std::string, adios2::Params> varNameList = io.AvailableVariables();
+    std::vector<VarInfo> varinfos;
+    for (auto &var : varNameList)
+    {
+        const std::string &name(var.first);
+        auto it = var.second.find("Type");
+        const std::string &type = it->second;
+        if (type == "struct")
+        {
+            // not supported
+        }
+#define declare_template_instantiation(T)                                                          \
+    else if (type == adios2::GetType<T>())                                                         \
+    {                                                                                              \
+        ReadVariable<T>(rank, name, type, reader, io, varinfos);                                   \
+    }
+        ADIOS2_FOREACH_STDTYPE_1ARG(declare_template_instantiation)
+#undef declare_template_instantiation
+    }
+
+    reader.PerformGets();
+    return varinfos;
+}
+
+void ProcessFile(int rank, adios2::Engine &reader, adios2::IO &io, Seconds opentime)
+{
+    auto now = Now();
+    std::vector<VarInfo> varinfos = ReadFileContent(rank, reader, io);
+    Seconds readtime = Now() - now;
+
+    std::cout << "File info on rank " << rank << ":" << std::endl;
+    std::cout << "  Open time:   " << opentime.count() << "s" << std::endl;
+    std::cout << "  Read time:   " << readtime.count() << "s" << std::endl;
+    std::cout << "  Steps in file:   " << reader.Steps() << std::endl;
+    std::cout << "  Total number of variables = " << varinfos.size() << std::endl;
+    for (auto &vi : varinfos)
+    {
+        std::cout << "       Name: " << vi.varName << " dimensions = " << DimsToString(vi.shape)
+                  << " steps = " << vi.nSteps << " size = " << vi.data.size() << " bytes"
+                  << std::endl;
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2)
+    {
+        std::cout << "Usage: " << argv[0] << " BP-file" << std::endl;
+        return -1;
+    }
+    std::string fname = argv[1];
+
+    int rank = 0, nproc = 1;
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+
+    /* Each process is acting as a serial program */
+    adios2::ADIOS adios; // independent ADIOS object for each single process
+
+    adios2::IO io = adios.DeclareIO("Input");
+    char *fileMetadata;
+    size_t fileMetadataSize;
+
+    if (!rank)
+    {
+        std::cout << "First process opens file " << fname << std::endl;
+        adios2::Engine reader;
+        auto now = Now();
+        reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+        Seconds opentime = Now() - now;
+        reader.GetMetadata(&fileMetadata, &fileMetadataSize);
+        std::cout << "Serialized metadata size = " << fileMetadataSize << std::endl;
+        ProcessFile(rank, reader, io, opentime);
+        reader.Close();
+        std::cout << "\n=====  End of first process file processing =====\n" << std::endl;
+    }
+
+    /* Send metadata to all processes via MPI
+     * (Note limitation to 2GB due MPI int)
+     */
+    MPI_Bcast(&fileMetadataSize, 1, MPI_INT64_T, 0, MPI_COMM_WORLD);
+    if (fileMetadataSize > (size_t)std::numeric_limits<std::int32_t>::max())
+    {
+        if (!rank)
+            std::cout << "ERROR: metadata size is >2GB, not supported by "
+                         "MPI_BCast"
+                      << std::endl;
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    if (rank)
+    {
+        fileMetadata = (char *)malloc(fileMetadataSize);
+    }
+    int mdsize = (int)fileMetadataSize;
+    MPI_Bcast(fileMetadata, mdsize, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+    /* "Open" data by passing metadata to the adios engine */
+    auto now = Now();
+    adios2::Engine reader = io.Open(fname, fileMetadata, fileMetadataSize);
+    Seconds opentime = Now() - now;
+    free(fileMetadata);
+
+    /* Process file in a sequentialized order only for pretty printing */
+    MPI_Status status;
+    int token = 0;
+    if (rank > 0)
+    {
+        MPI_Recv(&token, 1, MPI_INT, rank - 1, 0, MPI_COMM_WORLD, &status);
+    }
+
+    ProcessFile(rank, reader, io, opentime);
+
+    if (rank < nproc - 1)
+    {
+        std::chrono::milliseconds timespan(100);
+        std::this_thread::sleep_for(timespan);
+        MPI_Send(&token, 1, MPI_INT, rank + 1, 0, MPI_COMM_WORLD);
+    }
+
+    // Called once: indicate that we are done with this output for the run
+    reader.Close();
+
+    MPI_Finalize();
+    return 0;
+}

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -29,6 +29,14 @@ Engine::Engine(const std::string engineType, IO &io, const std::string &name, co
     m_FailVerbose = (m_Comm.Rank() == 0);
 }
 
+Engine::Engine(const std::string engineType, IO &io, const std::string &name, const Mode openMode,
+               helper::Comm comm, const char *md, const size_t mdsize)
+: m_EngineType(engineType), m_IO(io), m_Name(name), m_OpenMode(openMode), m_Comm(std::move(comm)),
+  m_UserOptions(io.m_ADIOS.GetUserOptions()), m_HostOptions(io.m_ADIOS.GetHostOptions())
+{
+    ThrowUp("Engine with metadata in memory");
+}
+
 Engine::~Engine()
 {
     if (m_IsOpen)
@@ -42,6 +50,13 @@ Engine::operator bool() const noexcept { return !m_IsClosed; }
 IO &Engine::GetIO() noexcept { return m_IO; }
 
 Mode Engine::OpenMode() const noexcept { return m_OpenMode; }
+
+void Engine::GetMetadata(char **md, size_t *size)
+{
+    ThrowUp("GetMetadata");
+    *md = nullptr;
+    *size = 0;
+}
 
 StepStatus Engine::BeginStep()
 {

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -70,6 +70,19 @@ public:
     Engine(const std::string engineType, IO &io, const std::string &name, const Mode mode,
            helper::Comm comm);
 
+    /**
+     * Unique Base class constructor
+     * @param engineType derived class identifier
+     * @param io object that generates this Engine
+     * @param name unique engine name within IO class object
+     * @param mode  open mode from ADIOSTypes.h Mode
+     * @param comm  communicator passed at Open or from ADIOS class
+     * @param md Metadata already in memory
+     */
+    Engine(const std::string engineType, IO &io, const std::string &name,
+           const Mode mode, helper::Comm comm, const char *md,
+           const size_t mdsize);
+
     virtual ~Engine();
 
     explicit operator bool() const noexcept;
@@ -85,6 +98,14 @@ public:
      * @return
      */
     Mode OpenMode() const noexcept;
+
+    /** Serialize all metadata right after engine is created, which can be
+     * delivered to other processes to open the same file for reading without
+     * opening and reading in metadata again.
+     * @return metadata (pointer to allocated memory) and size of metadata
+     * the pointer must be deallocated by user using free()
+     */
+    virtual void GetMetadata(char **md, size_t *size);
 
     StepStatus BeginStep();
 

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -79,9 +79,8 @@ public:
      * @param comm  communicator passed at Open or from ADIOS class
      * @param md Metadata already in memory
      */
-    Engine(const std::string engineType, IO &io, const std::string &name,
-           const Mode mode, helper::Comm comm, const char *md,
-           const size_t mdsize);
+    Engine(const std::string engineType, IO &io, const std::string &name, const Mode mode,
+           helper::Comm comm, const char *md, const size_t mdsize);
 
     virtual ~Engine();
 

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -35,6 +35,7 @@
 #include "adios2/engine/skeleton/SkeletonWriter.h"
 
 #include "adios2/helper/adiosComm.h"
+#include "adios2/helper/adiosCommDummy.h"
 #include "adios2/helper/adiosFunctions.h" //BuildParametersMap
 #include "adios2/helper/adiosString.h"
 #include <adios2sys/SystemTools.hxx> // FileIsDirectory()
@@ -70,7 +71,15 @@ namespace
 std::unordered_map<std::string, IO::EngineFactoryEntry> Factory = {
     {"bp3", {IO::MakeEngine<engine::BP3Reader>, IO::MakeEngine<engine::BP3Writer>}},
     {"bp4", {IO::MakeEngine<engine::BP4Reader>, IO::MakeEngine<engine::BP4Writer>}},
-    {"bp5", {IO::MakeEngine<engine::BP5Reader>, IO::MakeEngine<engine::BP5Writer>}},
+    {"bp5",
+#ifdef ADIOS2_HAVE_BP5
+     {IO::MakeEngine<engine::BP5Reader>, IO::MakeEngine<engine::BP5Writer>,
+      IO::MakeEngineWithMD<engine::BP5Reader>}
+#else
+     IO::NoEngineEntry("ERROR: this version didn't compile with "
+                       "BP5 library, can't use BP5 engine\n")
+#endif
+    },
     {"dataman",
 #ifdef ADIOS2_HAVE_DATAMAN
      {IO::MakeEngine<engine::DataManReader>, IO::MakeEngine<engine::DataManWriter>}
@@ -520,7 +529,8 @@ void IO::AddOperation(const std::string &variable, const std::string &operatorTy
     m_VarOpsPlaceholder[variable].push_back({operatorType, parameters});
 }
 
-Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
+Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm, const char *md,
+                 const size_t mdsize)
 {
     PERFSTUBS_SCOPED_TIMER("IO::Open");
     auto itEngineFound = m_Engines.find(name);
@@ -687,7 +697,12 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm)
     auto f = FactoryLookup(engineTypeLC);
     if (f != Factory.end())
     {
-        if ((mode_to_use == Mode::Read) || (mode_to_use == Mode::ReadRandomAccess))
+        if (md && mode_to_use == Mode::ReadRandomAccess)
+        {
+            engine =
+                f->second.MakeReaderWithMD(*this, name, mode_to_use, std::move(comm), md, mdsize);
+        }
+        else if ((mode_to_use == Mode::Read) || (mode_to_use == Mode::ReadRandomAccess))
         {
             engine = f->second.MakeReader(*this, name, mode_to_use, std::move(comm));
         }
@@ -717,6 +732,15 @@ Engine &IO::Open(const std::string &name, const Mode mode)
 {
     return Open(name, mode, m_ADIOS.GetComm().Duplicate());
 }
+
+Engine &IO::Open(const std::string &name, const char *md, const size_t mdsize)
+{
+    const Mode mode = Mode::ReadRandomAccess;
+    // helper::Comm comm;
+    // std::cout << "Open comm rank = " << comm.Rank();
+    return Open(name, mode, helper::CommDummy(), md, mdsize);
+}
+
 Group &IO::CreateGroup(char delimiter)
 {
     m_Gr = std::make_shared<Group>("", delimiter, *this);

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -38,7 +38,12 @@ public:
      */
     BP4Reader(IO &io, const std::string &name, const Mode mode, helper::Comm comm);
 
+    BP4Reader(IO &io, const std::string &name, const Mode mode, helper::Comm comm, const char *md,
+              const size_t mdsize);
+
     virtual ~BP4Reader();
+
+    void GetMetadata(char **md, size_t *size) final;
 
     StepStatus BeginStep(StepMode mode = StepMode::Read, const float timeoutSeconds = -1.0) final;
 
@@ -87,8 +92,11 @@ private:
 
     int m_Verbosity = 0;
 
+    bool readMetadataFromFile = true;
+
     void Init();
     void InitTransports();
+    void ProcessMetadataFromMemory(const char *md);
 
     /* Sleep up to pollSeconds time if we have not reached timeoutInstant.
      * Return true if slept

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -45,8 +45,12 @@ public:
      */
     BP5Reader(IO &io, const std::string &name, const Mode mode, helper::Comm comm);
 
+    BP5Reader(IO &io, const std::string &name, const Mode mode, helper::Comm comm, const char *md,
+              const size_t mdsize);
+
     ~BP5Reader();
 
+    void GetMetadata(char **md, size_t *size) final;
     StepStatus BeginStep(StepMode mode = StepMode::Read, const float timeoutSeconds = -1.0) final;
 
     size_t CurrentStep() const final;
@@ -126,10 +130,12 @@ private:
     Minifooter m_Minifooter;
 
     bool m_InitialWriterActiveCheckDone = false;
+    bool m_ReadMetadataFromFile = true;
 
     void Init();
     void InitParameters();
     void InitTransports();
+    void ProcessMetadataFromMemory(const char *md);
 
     /* Sleep up to pollSeconds time if we have not reached timeoutInstant.
      * Return true if slept

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -144,6 +144,8 @@ public:
 
     virtual void Seek(const size_t start = MaxSizeT) = 0;
 
+    virtual size_t CurrentPos() = 0;
+
     virtual void Truncate(const size_t length) = 0;
 
     virtual void MkDir(const std::string &fileName) = 0;

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.h
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.h
@@ -74,6 +74,8 @@ public:
 
     void Seek(const size_t start = MaxSizeT) final;
 
+    size_t CurrentPos() final { return m_SeekPos; };
+
     void Truncate(const size_t length) final;
 
     void MkDir(const std::string &fileName) final;

--- a/source/adios2/toolkit/transport/file/FileDaos.h
+++ b/source/adios2/toolkit/transport/file/FileDaos.h
@@ -58,6 +58,8 @@ public:
 
     void Seek(const size_t start = MaxSizeT) final;
 
+    size_t CurrentPos() final { return m_GlobalOffset; };
+
     void Truncate(const size_t length) final;
 
     void MkDir(const std::string &fileName) final;

--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -334,6 +334,18 @@ void FileFStream::Seek(const size_t start)
     }
 }
 
+size_t FileFStream::CurrentPos()
+{
+    if (m_OpenMode == Mode::Write || m_OpenMode == Mode::Append)
+    {
+        return static_cast<size_t>(m_FileStream.tellp());
+    }
+    else
+    {
+        return static_cast<size_t>(m_FileStream.tellg());
+    }
+}
+
 void FileFStream::Truncate(const size_t length)
 {
 #if __cplusplus >= 201703L

--- a/source/adios2/toolkit/transport/file/FileFStream.h
+++ b/source/adios2/toolkit/transport/file/FileFStream.h
@@ -59,6 +59,8 @@ public:
 
     void Seek(const size_t start = MaxSizeT) final;
 
+    size_t CurrentPos() final;
+
     void Truncate(const size_t length) final;
 
     void MkDir(const std::string &fileName) final;

--- a/source/adios2/toolkit/transport/file/FileHTTP.h
+++ b/source/adios2/toolkit/transport/file/FileHTTP.h
@@ -81,6 +81,8 @@ public:
 
     void Seek(const size_t start = MaxSizeT) final;
 
+    size_t CurrentPos() final { return 0; };
+
     void Truncate(const size_t length) final;
 
     void MkDir(const std::string &fileName) final;

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -337,6 +337,12 @@ void FileIME::Seek(const size_t start)
     }
 }
 
+size_t FileIME::CurrentPos()
+{
+    return static_cast<size_t>(
+        ime_client_native2_lseek(m_FileDescriptor, 0, SEEK_CUR));
+}
+
 void FileIME::Truncate(const size_t length)
 {
     helper::Throw<std::ios_base::failure>("Toolkit", "transport::file::FileIME", "Truncate",

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -339,8 +339,7 @@ void FileIME::Seek(const size_t start)
 
 size_t FileIME::CurrentPos()
 {
-    return static_cast<size_t>(
-        ime_client_native2_lseek(m_FileDescriptor, 0, SEEK_CUR));
+    return static_cast<size_t>(ime_client_native2_lseek(m_FileDescriptor, 0, SEEK_CUR));
 }
 
 void FileIME::Truncate(const size_t length)

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -59,6 +59,8 @@ public:
 
     void Seek(const size_t start = MaxSizeT) final;
 
+    size_t CurrentPos() final;
+
     void Truncate(const size_t length) final;
 
     void MkDir(const std::string &fileName) final;

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -624,10 +624,7 @@ void FilePOSIX::Seek(const size_t start)
     }
 }
 
-size_t FilePOSIX::CurrentPos()
-{
-    return static_cast<size_t>(lseek(m_FileDescriptor, 0, SEEK_CUR));
-}
+size_t FilePOSIX::CurrentPos() { return static_cast<size_t>(lseek(m_FileDescriptor, 0, SEEK_CUR)); }
 
 void FilePOSIX::Truncate(const size_t length)
 {

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -624,6 +624,11 @@ void FilePOSIX::Seek(const size_t start)
     }
 }
 
+size_t FilePOSIX::CurrentPos()
+{
+    return static_cast<size_t>(lseek(m_FileDescriptor, 0, SEEK_CUR));
+}
+
 void FilePOSIX::Truncate(const size_t length)
 {
     WaitForOpen();

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -62,6 +62,8 @@ public:
 
     void Seek(const size_t start = MaxSizeT) final;
 
+    size_t CurrentPos() final;
+
     void Truncate(const size_t length) final;
 
     void MkDir(const std::string &fileName) final;

--- a/source/adios2/toolkit/transport/file/FileRemote.h
+++ b/source/adios2/toolkit/transport/file/FileRemote.h
@@ -64,6 +64,8 @@ public:
 
     void Seek(const size_t start = MaxSizeT) final;
 
+    size_t CurrentPos() final { return m_SeekPos; };
+
     void Truncate(const size_t length) final;
 
     void MkDir(const std::string &fileName) final;

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -424,6 +424,11 @@ void FileStdio::Seek(const size_t start)
     }
 }
 
+size_t FileStdio::CurrentPos()
+{
+    return static_cast<size_t>(std::ftell(m_File));
+}
+
 #ifdef _WIN32
 void FileStdio::Truncate(const size_t length)
 {

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -424,10 +424,7 @@ void FileStdio::Seek(const size_t start)
     }
 }
 
-size_t FileStdio::CurrentPos()
-{
-    return static_cast<size_t>(std::ftell(m_File));
-}
+size_t FileStdio::CurrentPos() { return static_cast<size_t>(std::ftell(m_File)); }
 
 #ifdef _WIN32
 void FileStdio::Truncate(const size_t length)

--- a/source/adios2/toolkit/transport/file/FileStdio.h
+++ b/source/adios2/toolkit/transport/file/FileStdio.h
@@ -61,6 +61,8 @@ public:
 
     void Seek(const size_t start) final;
 
+    size_t CurrentPos() final;
+
     void Truncate(const size_t length) final;
 
     void MkDir(const std::string &fileName) final;

--- a/source/adios2/toolkit/transport/null/NullTransport.h
+++ b/source/adios2/toolkit/transport/null/NullTransport.h
@@ -57,6 +57,8 @@ public:
 
     void Seek(const size_t start = MaxSizeT) override;
 
+    size_t CurrentPos() override { return 0; };
+
     void Truncate(const size_t length) override;
 
 protected:

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.h
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.h
@@ -53,6 +53,8 @@ public:
 
     void Seek(const size_t start = MaxSizeT) final;
 
+    size_t CurrentPos() final { return 0; };
+
     void MkDir(const std::string &fileName) final;
 
 private:

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -375,8 +375,7 @@ void TransportMan::SeekTo(const size_t start, const int transportIndex)
 size_t TransportMan::CurrentPos(const int transportIndex)
 {
     auto itTransport = m_Transports.find(transportIndex);
-    CheckFile(itTransport, ", in call to CurrentPos with index " +
-                               std::to_string(transportIndex));
+    CheckFile(itTransport, ", in call to CurrentPos with index " + std::to_string(transportIndex));
     return itTransport->second->CurrentPos();
 }
 

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -372,6 +372,14 @@ void TransportMan::SeekTo(const size_t start, const int transportIndex)
     }
 }
 
+size_t TransportMan::CurrentPos(const int transportIndex)
+{
+    auto itTransport = m_Transports.find(transportIndex);
+    CheckFile(itTransport, ", in call to CurrentPos with index " +
+                               std::to_string(transportIndex));
+    return itTransport->second->CurrentPos();
+}
+
 void TransportMan::Truncate(const size_t length, const int transportIndex)
 {
     if (transportIndex == -1)

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -198,6 +198,8 @@ public:
 
     void SeekTo(const size_t start, const int transportIndex = -1);
 
+    size_t CurrentPos(const int transportIndex);
+
     void Truncate(const size_t length, const int transportIndex = -1);
 
     /**

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -235,6 +235,7 @@ gtest_add_tests_helper(WriteNull MPI_ALLOW BP Engine.BP. .BP3
 # BP4 and BP5 but NOT BP3
 bp4_bp5_gtest_add_tests_helper(WriteAppendReadADIOS2 MPI_ALLOW)
 bp4_bp5_gtest_add_tests_helper(JoinedArray MPI_ALLOW)
+bp4_bp5_gtest_add_tests_helper(OpenWithMetadata MPI_NONE)
 
 # BP4 only for now
 # gtest_add_tests_helper(WriteAppendReadADIOS2 MPI_ALLOW BP Engine.BP. .BP4

--- a/testing/adios2/engine/bp/TestBPOpenWithMetadata.cpp
+++ b/testing/adios2/engine/bp/TestBPOpenWithMetadata.cpp
@@ -1,0 +1,203 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <numeric> //std::iota
+#include <stdexcept>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#include "../SmallTestData.h"
+
+std::string engineName;       // comes from command line
+std::string engineParameters; // comes from command line
+
+class BPOpenWithMetadata : public ::testing::Test
+{
+public:
+    BPOpenWithMetadata() = default;
+
+    SmallTestData m_TestData;
+};
+
+//******************************************************************************
+// Create an output
+// Open normally
+// Get metadata
+// Open again with metadata
+//******************************************************************************
+
+// ADIOS2 BP write and read 1D arrays
+TEST_F(BPOpenWithMetadata, ADIOS2BPOpenWithMetadata)
+{
+    const std::string fname("ADIOS2BPOpenWithMetadata.bp");
+    const size_t Nx = 6;
+    const size_t NSteps = 3;
+
+    adios2::ADIOS adios;
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+        const adios2::Dims shape{Nx};
+        const adios2::Dims start{0};
+        const adios2::Dims count{Nx};
+        auto v = io.DefineVariable<double>("r64", shape, start, count);
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+        if (!engineParameters.empty())
+        {
+            io.SetParameters(engineParameters);
+        }
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+        EXPECT_EQ(bpWriter.OpenMode(), adios2::Mode::Write);
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            // Generate test data for each process uniquely
+            SmallTestData currentTestData = generateNewSmallTestData(
+                m_TestData, static_cast<int>(step), 0, 1);
+
+            bpWriter.BeginStep();
+            bpWriter.Put(v, currentTestData.R64.data());
+            bpWriter.EndStep();
+        }
+        bpWriter.Close();
+    }
+
+    char *md;
+    size_t mdsize;
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        if (!engineParameters.empty())
+        {
+            io.SetParameters(engineParameters);
+        }
+
+        adios2::Engine bpReader =
+            io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        bpReader.GetMetadata(&md, &mdsize);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Steps(), NSteps);
+        ASSERT_EQ(var_r64.Shape()[0], Nx);
+
+        SmallTestData testData;
+        std::array<double, Nx> R64;
+
+        const adios2::Dims start{0};
+        const adios2::Dims count{Nx};
+        const adios2::Box<adios2::Dims> sel(start, count);
+
+        var_r64.SetSelection(sel);
+
+        for (size_t t = 0; t < NSteps; ++t)
+        {
+            var_r64.SetStepSelection({t, 1});
+
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, static_cast<int>(t), 0, 1);
+
+            bpReader.Get(var_r64, R64.data(), adios2::Mode::Sync);
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i;
+                std::string msg = ss.str();
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+            }
+        }
+        bpReader.Close();
+    }
+
+    /* Open again with metadata */
+    {
+        adios2::IO io = adios.DeclareIO("ReadIOMD");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        if (!engineParameters.empty())
+        {
+            io.SetParameters(engineParameters);
+        }
+
+        adios2::Engine bpReader = io.Open(fname, md, mdsize);
+
+        auto var_r64 = io.InquireVariable<double>("r64");
+        EXPECT_TRUE(var_r64);
+        ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+        ASSERT_EQ(var_r64.Steps(), NSteps);
+        ASSERT_EQ(var_r64.Shape()[0], Nx);
+
+        SmallTestData testData;
+        std::array<double, Nx> R64;
+
+        const adios2::Dims start{0};
+        const adios2::Dims count{Nx};
+        const adios2::Box<adios2::Dims> sel(start, count);
+
+        var_r64.SetSelection(sel);
+
+        for (size_t t = 0; t < NSteps; ++t)
+        {
+            var_r64.SetStepSelection({t, 1});
+
+            // Generate test data for each rank uniquely
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, static_cast<int>(t), 0, 1);
+
+            bpReader.Get(var_r64, R64.data(), adios2::Mode::Sync);
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i;
+                std::string msg = ss.str();
+                EXPECT_EQ(R64[i], currentTestData.R64[i]) << msg;
+            }
+        }
+        bpReader.Close();
+    }
+}
+
+//******************************************************************************
+// main
+//******************************************************************************
+
+int main(int argc, char **argv)
+{
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+    if (argc > 2)
+    {
+        engineParameters = std::string(argv[2]);
+    }
+    result = RUN_ALL_TESTS();
+    return result;
+}

--- a/testing/adios2/engine/bp/TestBPOpenWithMetadata.cpp
+++ b/testing/adios2/engine/bp/TestBPOpenWithMetadata.cpp
@@ -77,8 +77,8 @@ TEST_F(BPOpenWithMetadata, ADIOS2BPOpenWithMetadata)
         bpWriter.Close();
     }
 
-    char *md;
-    size_t mdsize;
+    char *md = nullptr;
+    size_t mdsize = 0;
 
     {
         adios2::IO io = adios.DeclareIO("ReadIO");
@@ -177,6 +177,11 @@ TEST_F(BPOpenWithMetadata, ADIOS2BPOpenWithMetadata)
             }
         }
         bpReader.Close();
+    }
+
+    if (md)
+    {
+        free(md);
     }
 }
 

--- a/testing/adios2/engine/bp/TestBPOpenWithMetadata.cpp
+++ b/testing/adios2/engine/bp/TestBPOpenWithMetadata.cpp
@@ -67,8 +67,8 @@ TEST_F(BPOpenWithMetadata, ADIOS2BPOpenWithMetadata)
         for (size_t step = 0; step < NSteps; ++step)
         {
             // Generate test data for each process uniquely
-            SmallTestData currentTestData = generateNewSmallTestData(
-                m_TestData, static_cast<int>(step), 0, 1);
+            SmallTestData currentTestData =
+                generateNewSmallTestData(m_TestData, static_cast<int>(step), 0, 1);
 
             bpWriter.BeginStep();
             bpWriter.Put(v, currentTestData.R64.data());
@@ -91,8 +91,7 @@ TEST_F(BPOpenWithMetadata, ADIOS2BPOpenWithMetadata)
             io.SetParameters(engineParameters);
         }
 
-        adios2::Engine bpReader =
-            io.Open(fname, adios2::Mode::ReadRandomAccess);
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::ReadRandomAccess);
 
         bpReader.GetMetadata(&md, &mdsize);
 


### PR DESCRIPTION
* Add a new functionality to an Engine, to serialize metadata in memory after Open(ReadRandomAccess), to send over to another programs that can then use this metadata to open the same dataset with an accelerated function (using metadata from memory instead of retrieving from disk). BP4 and BP5 engine supports this new function.

  Program 1:  reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
              char *md;
              size_t mdsize;
              reader.GetMetadata(&md, &mdsize);
  Program 2:  reader = io.Open(fname, md, mdsize);

* Added Transport::CurrentPos() to get the current seek position

This is code rebased and fixed from PR #3651 
Solves Issue #4311 