### PR TITLE
Extend Expressions: 3D Cross product

### DIFF
--- a/source/adios2/toolkit/derived/Expression.cpp
+++ b/source/adios2/toolkit/derived/Expression.cpp
@@ -36,27 +36,28 @@ const std::map<ExpressionOperator, OperatorProperty> op_property = {
     {ExpressionOperator::OP_ASIN, {"ASIN", false}},
     {ExpressionOperator::OP_ACOS, {"ACOS", false}},
     {ExpressionOperator::OP_ATAN, {"ATAN", false}},
-    {ExpressionOperator::OP_CURL, {"CURL", false}},
-    {ExpressionOperator::OP_MAGN, {"MAGNITUDE", false}}};
+    {ExpressionOperator::OP_MAGN, {"MAGNITUDE", false}},
+    {ExpressionOperator::OP_CROSS, {"CROSS", false}},
+    {ExpressionOperator::OP_CURL, {"CURL", false}}};
 
 const std::map<std::string, ExpressionOperator> string_to_op = {
     {"ALIAS", ExpressionOperator::OP_ALIAS}, /* Parser-use only */
     {"PATH", ExpressionOperator::OP_PATH},   /* Parser-use only */
     {"NUM", ExpressionOperator::OP_NUM},     /* Parser-use only */
-    {"INDEX", ExpressionOperator::OP_INDEX},   {"+", ExpressionOperator::OP_ADD},
-    {"add", ExpressionOperator::OP_ADD},       {"ADD", ExpressionOperator::OP_ADD},
-    {"-", ExpressionOperator::OP_SUBTRACT},    {"SUBTRACT", ExpressionOperator::OP_SUBTRACT},
-    {"/", ExpressionOperator::OP_DIV},         {"divide", ExpressionOperator::OP_DIV},
-    {"DIVIDE", ExpressionOperator::OP_DIV},    {"*", ExpressionOperator::OP_MULT},
-    {"multiply", ExpressionOperator::OP_MULT}, {"MULTIPLY", ExpressionOperator::OP_MULT},
-    {"SQRT", ExpressionOperator::OP_SQRT},     {"sqrt", ExpressionOperator::OP_SQRT},
-    {"pow", ExpressionOperator::OP_POW},       {"POW", ExpressionOperator::OP_POW},
-    {"sin", ExpressionOperator::OP_SIN},       {"cos", ExpressionOperator::OP_COS},
-    {"tan", ExpressionOperator::OP_TAN},       {"asin", ExpressionOperator::OP_ASIN},
-    {"acos", ExpressionOperator::OP_ACOS},     {"atan", ExpressionOperator::OP_ATAN},
-    {"^", ExpressionOperator::OP_POW},         {"CURL", ExpressionOperator::OP_CURL},
-    {"curl", ExpressionOperator::OP_CURL},     {"MAGNITUDE", ExpressionOperator::OP_MAGN},
-    {"magnitude", ExpressionOperator::OP_MAGN}};
+    {"INDEX", ExpressionOperator::OP_INDEX},    {"+", ExpressionOperator::OP_ADD},
+    {"add", ExpressionOperator::OP_ADD},        {"ADD", ExpressionOperator::OP_ADD},
+    {"-", ExpressionOperator::OP_SUBTRACT},     {"SUBTRACT", ExpressionOperator::OP_SUBTRACT},
+    {"/", ExpressionOperator::OP_DIV},          {"divide", ExpressionOperator::OP_DIV},
+    {"DIVIDE", ExpressionOperator::OP_DIV},     {"*", ExpressionOperator::OP_MULT},
+    {"multiply", ExpressionOperator::OP_MULT},  {"MULTIPLY", ExpressionOperator::OP_MULT},
+    {"SQRT", ExpressionOperator::OP_SQRT},      {"sqrt", ExpressionOperator::OP_SQRT},
+    {"pow", ExpressionOperator::OP_POW},        {"POW", ExpressionOperator::OP_POW},
+    {"sin", ExpressionOperator::OP_SIN},        {"cos", ExpressionOperator::OP_COS},
+    {"tan", ExpressionOperator::OP_TAN},        {"asin", ExpressionOperator::OP_ASIN},
+    {"acos", ExpressionOperator::OP_ACOS},      {"atan", ExpressionOperator::OP_ATAN},
+    {"^", ExpressionOperator::OP_POW},          {"magnitude", ExpressionOperator::OP_MAGN},
+    {"MAGNITUDE", ExpressionOperator::OP_MAGN}, {"cross", ExpressionOperator::OP_CROSS},
+    {"curl", ExpressionOperator::OP_CURL},      {"CURL", ExpressionOperator::OP_CURL}};
 
 inline std::string get_op_name(ExpressionOperator op) { return op_property.at(op).name; }
 
@@ -151,9 +152,9 @@ std::map<adios2::detail::ExpressionOperator, OperatorFunctions> OpFunctions = {
     {adios2::detail::ExpressionOperator::OP_ASIN, {AsinFunc, SameDimsFunc, FloatTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_ACOS, {AcosFunc, SameDimsFunc, FloatTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_ATAN, {AtanFunc, SameDimsFunc, FloatTypeFunc}},
-    {adios2::detail::ExpressionOperator::OP_CURL, {Curl3DFunc, CurlDimsFunc, SameTypeFunc}},
-    {adios2::detail::ExpressionOperator::OP_MAGN,
-     {MagnitudeFunc, SameDimsWithAgrFunc, SameTypeFunc}}};
+    {adios2::detail::ExpressionOperator::OP_MAGN, {MagnitudeFunc, SameDimsFunc, SameTypeFunc}},
+    {adios2::detail::ExpressionOperator::OP_CROSS, {Cross3DFunc, Cross3DDimsFunc, SameTypeFunc}},
+    {adios2::detail::ExpressionOperator::OP_CURL, {Curl3DFunc, CurlDimsFunc, SameTypeFunc}}};
 
 Expression::Expression(std::string string_exp)
 : m_Shape({0}), m_Start({0}), m_Count({0}), ExprString(string_exp)

--- a/source/adios2/toolkit/derived/Expression.cpp
+++ b/source/adios2/toolkit/derived/Expression.cpp
@@ -152,7 +152,8 @@ std::map<adios2::detail::ExpressionOperator, OperatorFunctions> OpFunctions = {
     {adios2::detail::ExpressionOperator::OP_ASIN, {AsinFunc, SameDimsFunc, FloatTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_ACOS, {AcosFunc, SameDimsFunc, FloatTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_ATAN, {AtanFunc, SameDimsFunc, FloatTypeFunc}},
-    {adios2::detail::ExpressionOperator::OP_MAGN, {MagnitudeFunc, SameDimsFunc, SameTypeFunc}},
+    {adios2::detail::ExpressionOperator::OP_MAGN,
+     {MagnitudeFunc, SameDimsWithAgrFunc, SameTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_CROSS, {Cross3DFunc, Cross3DDimsFunc, SameTypeFunc}},
     {adios2::detail::ExpressionOperator::OP_CURL, {Curl3DFunc, CurlDimsFunc, SameTypeFunc}}};
 

--- a/source/adios2/toolkit/derived/Expression.h
+++ b/source/adios2/toolkit/derived/Expression.h
@@ -29,6 +29,7 @@ enum ExpressionOperator
     OP_ACOS,
     OP_ATAN,
     OP_MAGN,
+    OP_CROSS,
     OP_CURL
 };
 }

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -710,21 +710,24 @@ std::tuple<Dims, Dims, Dims> SameDimsWithAgrFunc(std::vector<std::tuple<Dims, Di
     return {outStart, outCount, outShape};
 }
 
-Dims Cross3DDimsFunc(std::vector<Dims> input)
+std::tuple<Dims, Dims, Dims> Cross3DDimsFunc(std::vector<std::tuple<Dims, Dims, Dims>> input)
 {
     // check that all dimenstions are the same
     if (input.size() > 1)
     {
-        Dims first_element = input[0];
-        bool dim_are_equal = std::all_of(input.begin() + 1, input.end(),
-                                         [&first_element](Dims x) { return x == first_element; });
+        auto first_element = input[0];
+        bool dim_are_equal = std::all_of(
+            input.begin() + 1, input.end(),
+            [&first_element](std::tuple<Dims, Dims, Dims> x) { return x == first_element; });
         if (!dim_are_equal)
             helper::Throw<std::invalid_argument>("Derived", "Function", "Cross3DDimsFunc",
                                                  "Invalid variable dimensions");
     }
     // return original dimensions with added dimension of number of inputs
-    Dims output = input[0];
-    output.push_back(3);
+    std::tuple<Dims, Dims, Dims> output = input[0];
+    std::get<0>(output).push_back(0);
+    std::get<1>(output).push_back(3);
+    std::get<2>(output).push_back(3);
     return output;
 }
 

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -71,7 +71,6 @@ T *ApplyCross3D(const T *Ax, const T *Ay, const T *Az, const T *Bx, const T *By,
                 const size_t dataSize)
 {
     T *data = (T *)malloc(dataSize * sizeof(T) * 3);
-    size_t index = 0;
     for (size_t i = 0; i < dataSize; ++i)
     {
         data[3 * i] = (Ay[i] * Bz[i]) - (Az[i] * By[i]);

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -67,6 +67,21 @@ inline size_t returnIndex(size_t x, size_t y, size_t z, const size_t dims[3])
 }
 
 template <class T>
+T *ApplyCross3D(const T *Ax, const T *Ay, const T *Az, const T *Bx, const T *By, const T *Bz,
+                const size_t dataSize)
+{
+    T *data = (T *)malloc(dataSize * sizeof(T) * 3);
+    size_t index = 0;
+    for (size_t i = 0; i < dataSize; ++i)
+    {
+        data[3 * i] = (Ay[i] * Bz[i]) - (Az[i] * By[i]);
+        data[3 * i + 1] = (Ax[i] * Bz[i]) - (Az[i] * Bx[i]);
+        data[3 * i + 2] = (Ax[i] * By[i]) - (Ay[i] * Bx[i]);
+    }
+    return data;
+}
+
+template <class T>
 T *ApplyCurl(const T *input1, const T *input2, const T *input3, const size_t dims[3])
 {
     size_t dataSize = dims[0] * dims[1] * dims[2];
@@ -196,8 +211,8 @@ DerivedData MultFunc(std::vector<DerivedData> inputData, DataType type)
 #define declare_type_mult(T)                                                                       \
     if (type == helper::GetDataType<T>())                                                          \
     {                                                                                              \
-        T *multValues = detail::ApplyOneToOne<T>(                                                  \
-            inputData.begin(), inputData.end(), dataSize, [](T a, T b) { return a * b; }, 1);      \
+        T *multValues = detail::ApplyOneToOne<T>(inputData.begin(), inputData.end(), dataSize,     \
+                                                 [](T a, T b) { return a * b; }, 1);               \
         return DerivedData({(void *)multValues, inputData[0].Start, inputData[0].Count});          \
     }
     ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_mult)
@@ -218,8 +233,8 @@ DerivedData DivFunc(std::vector<DerivedData> inputData, DataType type)
 #define declare_type_div(T)                                                                        \
     if (type == helper::GetDataType<T>())                                                          \
     {                                                                                              \
-        T *divValues = detail::ApplyOneToOne<T>(                                                   \
-            inputData.begin() + 1, inputData.end(), dataSize, [](T a, T b) { return a * b; }, 1);  \
+        T *divValues = detail::ApplyOneToOne<T>(inputData.begin() + 1, inputData.end(), dataSize,  \
+                                                [](T a, T b) { return a * b; }, 1);                \
         for (size_t i = 0; i < dataSize; i++)                                                      \
             divValues[i] = *(reinterpret_cast<T *>(inputData[0].Data) + i) / divValues[i];         \
         return DerivedData({(void *)divValues, inputData[0].Start, inputData[0].Count});           \
@@ -586,6 +601,41 @@ DerivedData MagnitudeFunc(std::vector<DerivedData> inputData, DataType type)
     return DerivedData();
 }
 
+DerivedData Cross3DFunc(const std::vector<DerivedData> inputData, DataType type)
+{
+    PERFSTUBS_SCOPED_TIMER("derived::Function::Cross3DFunc");
+    if (inputData.size() != 6)
+    {
+        helper::Throw<std::invalid_argument>("Derived", "Function", "Cross3DFunc",
+                                             "Invalid number of arguments passed to Cross3DFunc");
+    }
+    size_t dataSize = std::accumulate(std::begin(inputData[0].Count), std::end(inputData[0].Count),
+                                      1, std::multiplies<size_t>());
+
+    DerivedData cross;
+    cross.Start = inputData[0].Start;
+    cross.Start.push_back(0);
+    cross.Count = inputData[0].Count;
+    cross.Count.push_back(3);
+
+#define declare_type_cross(T)                                                                      \
+    if (type == helper::GetDataType<T>())                                                          \
+    {                                                                                              \
+        T *Ax = (T *)inputData[0].Data;                                                            \
+        T *Ay = (T *)inputData[1].Data;                                                            \
+        T *Az = (T *)inputData[2].Data;                                                            \
+        T *Bx = (T *)inputData[3].Data;                                                            \
+        T *By = (T *)inputData[4].Data;                                                            \
+        T *Bz = (T *)inputData[5].Data;                                                            \
+        cross.Data = detail::ApplyCross3D(Ax, Ay, Az, Bx, By, Bz, dataSize);                       \
+        return cross;                                                                              \
+    }
+    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_cross)
+    helper::Throw<std::invalid_argument>("Derived", "Function", "Cross3DFunc",
+                                         "Invalid variable types");
+    return DerivedData();
+}
+
 /*
  * Input: 3D vector field F(x,y,z)= {F1(x,y,z), F2(x,y,z), F3(x,y,z)}
  *
@@ -658,6 +708,24 @@ std::tuple<Dims, Dims, Dims> SameDimsWithAgrFunc(std::vector<std::tuple<Dims, Di
     std::copy(std::get<1>(input[0]).begin(), std::get<1>(input[0]).end() - 1, outCount.begin());
     std::copy(std::get<2>(input[0]).begin(), std::get<2>(input[0]).end() - 1, outShape.begin());
     return {outStart, outCount, outShape};
+}
+
+Dims Cross3DDimsFunc(std::vector<Dims> input)
+{
+    // check that all dimenstions are the same
+    if (input.size() > 1)
+    {
+        Dims first_element = input[0];
+        bool dim_are_equal = std::all_of(input.begin() + 1, input.end(),
+                                         [&first_element](Dims x) { return x == first_element; });
+        if (!dim_are_equal)
+            helper::Throw<std::invalid_argument>("Derived", "Function", "Cross3DDimsFunc",
+                                                 "Invalid variable dimensions");
+    }
+    // return original dimensions with added dimension of number of inputs
+    Dims output = input[0];
+    output.push_back(3);
+    return output;
 }
 
 // Input Dims are the same, output is combination of all inputs

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -211,8 +211,8 @@ DerivedData MultFunc(std::vector<DerivedData> inputData, DataType type)
 #define declare_type_mult(T)                                                                       \
     if (type == helper::GetDataType<T>())                                                          \
     {                                                                                              \
-        T *multValues = detail::ApplyOneToOne<T>(inputData.begin(), inputData.end(), dataSize,     \
-                                                 [](T a, T b) { return a * b; }, 1);               \
+        T *multValues = detail::ApplyOneToOne<T>(                                                  \
+            inputData.begin(), inputData.end(), dataSize, [](T a, T b) { return a * b; }, 1);      \
         return DerivedData({(void *)multValues, inputData[0].Start, inputData[0].Count});          \
     }
     ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_mult)
@@ -233,8 +233,8 @@ DerivedData DivFunc(std::vector<DerivedData> inputData, DataType type)
 #define declare_type_div(T)                                                                        \
     if (type == helper::GetDataType<T>())                                                          \
     {                                                                                              \
-        T *divValues = detail::ApplyOneToOne<T>(inputData.begin() + 1, inputData.end(), dataSize,  \
-                                                [](T a, T b) { return a * b; }, 1);                \
+        T *divValues = detail::ApplyOneToOne<T>(                                                   \
+            inputData.begin() + 1, inputData.end(), dataSize, [](T a, T b) { return a * b; }, 1);  \
         for (size_t i = 0; i < dataSize; i++)                                                      \
             divValues[i] = *(reinterpret_cast<T *>(inputData[0].Data) + i) / divValues[i];         \
         return DerivedData({(void *)divValues, inputData[0].Start, inputData[0].Count});           \

--- a/source/adios2/toolkit/derived/Function.h
+++ b/source/adios2/toolkit/derived/Function.h
@@ -20,10 +20,12 @@ DerivedData DivFunc(std::vector<DerivedData> input, DataType type);
 DerivedData SqrtFunc(std::vector<DerivedData> input, DataType type);
 DerivedData PowFunc(std::vector<DerivedData> input, DataType type);
 DerivedData MagnitudeFunc(std::vector<DerivedData> input, DataType type);
+DerivedData Cross3DFunc(std::vector<DerivedData> input, DataType type);
 DerivedData Curl3DFunc(std::vector<DerivedData> input, DataType type);
 
 std::tuple<Dims, Dims, Dims> SameDimsFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
 std::tuple<Dims, Dims, Dims> SameDimsWithAgrFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
+std::tuple<Dims, Dims, Dims> Cross3DDimsFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
 std::tuple<Dims, Dims, Dims> CurlDimsFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
 
 DataType SameTypeFunc(DataType input);


### PR DESCRIPTION
Create 3D cross product function that can be called in the format "cross(Ax, Ay, Az, Bx, By, Bz)"

For now, to compute AxB (A and B being 3D vectors), the components of the vector must be given individually as shown above.

"x" symbol operator not recognized in this pr (ie. AxB)