### PR TITLE
ci: only use conda-forge channel

### DIFF
--- a/scripts/ci/gh-actions/macos-setup.sh
+++ b/scripts/ci/gh-actions/macos-setup.sh
@@ -42,9 +42,10 @@ source "/Users/runner/miniconda3/bin/activate"
 
 # Canonical installation of Miniconda
 conda init --all
-conda update --all -y
+conda config --remove channels defaults
 conda config --add channels conda-forge
 conda config --set channel_priority strict
+conda update --all -y
 
 conda env create --verbose -f "gha/scripts/ci/gh-actions/conda-env-macos.yml"
 

--- a/scripts/ci/gh-actions/windows-setup.ps1
+++ b/scripts/ci/gh-actions/windows-setup.ps1
@@ -7,6 +7,10 @@ conda.bat init bash
 Write-Host "::endgroup::"
 
 Write-Host "::group::Installing common deps"
+conda.bat config --remove channels defaults
+conda.bat config --add channels conda-forge
+conda.bat config --set channel_priority strict
+conda.bat update --all -y
 conda.bat env create -f "gha\scripts\ci\gh-actions\conda-env-win.yml"
 Write-Host "::endgroup::"
 


### PR DESCRIPTION
Conda default channels requires a licence for organizations over 200 people, it is unclear whether this is ornl;github;kitware or just adios2 dev team. To play on the safe side, avoid using the defaults channel in conda.