### PR TITLE
Fix an issue when reading blocks in streaming mode

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1628,7 +1628,7 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
                     MetaArrayRecOperator *writer_meta_base =
                         (MetaArrayRecOperator *)GetMetadataBase((struct BP5VarRec *)Req->VarRec,
                                                                 Step, WriterRank);
-                    if (!writer_meta_base)
+                    if (!writer_meta_base || !writer_meta_base->BlockCount)
                     {
                         continue; // Not writen on this step
                     }


### PR DESCRIPTION
 when some producers did not write any block to output.

Issue could be reproduced before this fix by running localArray example with multiple processes. `v3` is not written by every process and in the third step, there is a "gap" meaning, rank N did not write, but rank N+1 did write a block. Then the following script would fail in reading the blocks from the third step.

```
#!/usr/bin/env python3
import numpy as np
import adios2

def process_var(f, varname):
    print("--------------------------")
    print(f"Process variable {varname}")
    v = f.inquire_variable(varname)
    # b = f.all_blocks_info(varname)
    for step in range(v.steps()):
        v.set_step_selection([step, 1])
        bs = f.engine.blocks_info(varname, step)
        for bid in range(len(bs)):   # could use here len(b[step])
            v.set_block_selection(bid)
            data = f.read(v)
            print(f"step {step} block {bid} count = {data.shape}")


with adios2.Stream("localArray.bp", "r") as f:
    for _ in f.steps():
        process_var(f, 'v3')
```