### PR TITLE
Backport #3759 to Release 2.10 branch. 

### DIFF
--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -203,6 +203,11 @@ private:
     helper::Comm *DataWritingComm; // processes that write the same data file
     // aggregators only (valid if m_Aggregator->m_Comm.Rank() == 0)
     helper::Comm m_CommAggregators;
+
+    /* two-level metadata aggregation */
+    aggregator::MPIChain m_AggregatorMetadata; // first level
+    helper::Comm m_CommMetadataAggregators;    // second level
+
     adios2::profiling::JSONProfiler m_Profiler;
 
 protected:


### PR DESCRIPTION
(cherry-picked from master branch #4340)

Organize the processes into groups so that the two steps of metadata aggregation has more or less the same number or participants. This replaces in-node aggregation in first step. The new strategy balances the size of metadata gathered in the two steps.