### PR TITLE
Setting the memory space for Spans to Host

### DIFF
--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -815,6 +815,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
     else
     {
         MemorySpace MemSpace = VB->GetMemorySpace(Data);
+        MemorySpace spanMemSpace = MemSpace;
         MetaArrayRec *MetaEntry = (MetaArrayRec *)((char *)(MetadataBuf) + Rec->MetaOffset);
         size_t ElemCount = CalcSize(DimCount, Count);
         size_t DataOffset = 0;
@@ -884,6 +885,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
         {
             *Span = CurDataBuffer->Allocate(ElemCount * ElemSize, ElemSize);
             DataOffset = m_PriorDataBufferSizeTotal + Span->globalPos;
+            spanMemSpace = MemorySpace::Host;
         }
 
         if (!AlreadyWritten)
@@ -919,7 +921,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
                 }
                 else
                 {
-                    lf_QueueSpanMinMax(*Span, ElemCount, (DataType)Rec->Type, MemSpace,
+                    lf_QueueSpanMinMax(*Span, ElemCount, (DataType)Rec->Type, spanMemSpace,
                                        Rec->MetaOffset, Rec->MinMaxOffset, 0 /*BlockNum*/);
                 }
             }
@@ -963,7 +965,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
                 }
                 else
                 {
-                    lf_QueueSpanMinMax(*Span, ElemCount, (DataType)Rec->Type, MemSpace,
+                    lf_QueueSpanMinMax(*Span, ElemCount, (DataType)Rec->Type, spanMemSpace,
                                        Rec->MetaOffset, Rec->MinMaxOffset,
                                        MetaEntry->BlockCount - 1 /*BlockNum*/);
                 }


### PR DESCRIPTION
Memory selections when GPU pointers are used for BP5 copies the data to internal buffers before min/max is applied. I am updating the memory space for spans to Host when data is moved to temp buffers.