### PR TITLE
Update the memory selection layout when there is a layout mismatch

### DIFF
--- a/bindings/CXX11/adios2/cxx11/Engine.h
+++ b/bindings/CXX11/adios2/cxx11/Engine.h
@@ -218,9 +218,7 @@ public:
         auto bufferView = static_cast<AdiosView<U>>(data);
 #if defined(ADIOS2_HAVE_KOKKOS) || defined(ADIOS2_HAVE_GPU_SUPPORT)
         auto bufferMem = bufferView.memory_space();
-        auto bufferLayout = bufferView.layout();
         variable.SetMemorySpace(bufferMem);
-        variable.SetArrayLayout(bufferLayout);
 #endif
         Put(variable, bufferView.data(), launch);
     }
@@ -424,9 +422,7 @@ public:
         auto bufferView = static_cast<AdiosView<U>>(data);
 #if defined(ADIOS2_HAVE_KOKKOS) || defined(ADIOS2_HAVE_GPU_SUPPORT)
         auto bufferMem = bufferView.memory_space();
-        auto bufferLayout = bufferView.layout();
         variable.SetMemorySpace(bufferMem);
-        variable.SetArrayLayout(bufferLayout);
 #endif
         Get(variable, bufferView.data(), launch);
     }

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -57,6 +57,8 @@ void VariableBase::SetArrayLayout(const ArrayOrdering layout)
         UpdateLayout(m_Shape);
         UpdateLayout(m_Count);
         UpdateLayout(m_Start);
+        UpdateLayout(m_MemoryStart);
+        UpdateLayout(m_MemoryCount);
         return;
     }
     if (m_ArrayLayout != layout)
@@ -117,6 +119,8 @@ void VariableBase::SetMemorySpace(const MemorySpace mem)
                                                  ExistingMemSpace + " and cannot received a " +
                                                  NewMemSpace + " buffer");
     }
+    if (mem == MemorySpace::GPU && m_ArrayLayout == ArrayOrdering::Auto)
+        SetArrayLayout(ArrayOrdering::ColumnMajor);
 #endif
     m_MemSpace = mem;
 }

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -105,6 +105,9 @@ MemorySpace VariableBase::GetMemorySpace(const void *ptr)
 
 void VariableBase::SetMemorySpace(const MemorySpace mem)
 {
+#if defined(ADIOS2_HAVE_KOKKOS) || defined(ADIOS2_HAVE_GPU_SUPPORT)
+    ArrayOrdering layout = m_BaseLayout;
+#endif
 #ifdef ADIOS2_HAVE_GPU_SUPPORT
     if (m_MemSpace != MemorySpace::Detect && m_MemSpace != mem)
     {
@@ -119,8 +122,14 @@ void VariableBase::SetMemorySpace(const MemorySpace mem)
                                                  ExistingMemSpace + " and cannot received a " +
                                                  NewMemSpace + " buffer");
     }
-    if (mem == MemorySpace::GPU && m_ArrayLayout == ArrayOrdering::Auto)
-        SetArrayLayout(ArrayOrdering::ColumnMajor);
+    if (mem == MemorySpace::GPU)
+        layout = ArrayOrdering::ColumnMajor;
+#endif
+#if defined(ADIOS2_HAVE_KOKKOS) || defined(ADIOS2_HAVE_GPU_SUPPORT)
+    // set the layout based on the buffer memory space
+    // skipping throwing an exception for a mismatch
+    if (m_ArrayLayout == ArrayOrdering::Auto)
+        SetArrayLayout(layout);
 #endif
     m_MemSpace = mem;
 }


### PR DESCRIPTION
Since we set the memory space after we set all the variable shapes and selections, the memory selection needs to be updated together with the variable shape.

```c++
        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize), Ny};
        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank), 0};
        const adios2::Dims count{Nx, Ny};
        auto var = io.DefineVariable<float>("r32", shape, start, count);

        const adios2::Dims memoryStart = {ghostCells, ghostCells};
        const adios2::Dims memoryCount = {totalNx, totalNy};
        var.SetMemorySelection({memoryStart, memoryCount});

        var.SetMemorySpace(adios2::MemorySpace::GPU);
```

The `SetMemorySpace` call was updating the shape, start and count but not the memory selection.

@franzpoeschel this is why your code was writing the wrong data for your 2D array. Could you please double check?