### PR TITLE
Backport 4305

### DIFF
--- a/scripts/ci/cmake/ci-macos-12-xcode13_4_1-static-serial.cmake
+++ b/scripts/ci/cmake/ci-macos-12-xcode13_4_1-static-serial.cmake
@@ -1,7 +1,7 @@
 # Client maintainer: vicente.bolea@kitware.com
 set(ENV{CC}  clang)
 set(ENV{CXX} clang++)
-set(ENV{FC}  gfortran-11)
+set(ENV{FC}  gfortran-12)
 
 set(dashboard_cache "
 BUILD_SHARED_LIBS=OFF


### PR DESCRIPTION
It fixes the macos 12 build. Still macos 11 will fail but something is better than nothing. Lets bring all the CI changes to this branch if we decided on doing another patch release.

x-ref: #4341 