### PR TITLE
ci(frontier): revert to use Core/24.00

### DIFF
--- a/.gitlab/gitlab-ci-frontier.yml
+++ b/.gitlab/gitlab-ci-frontier.yml
@@ -95,7 +95,9 @@ stages:
     LD_LIBRARY_PATH: "$Kokkos_DIR/lib64/:$LD_LIBRARY_PATH"
     # Order matters
     JOB_MODULES: >-
-      DefApps
+      Core/24.00
+      lfs-wrapper
+      hsi
       PrgEnv-gnu
       gcc-native/12
       craype-accel-amd-gfx90a


### PR DESCRIPTION
The update to Core/24.07 does not provide the packages: libffi and zstd.