### PR TITLE
Fix the Kokkos testing compilation error on Frontier

### DIFF
--- a/.gitlab/gitlab-ci-frontier.yml
+++ b/.gitlab/gitlab-ci-frontier.yml
@@ -101,7 +101,7 @@ stages:
       PrgEnv-gnu
       gcc-native/12
       craype-accel-amd-gfx90a
-      rocm/5.4.3
+      rocm/5.7.1
       cmake
       git
       ninja
@@ -111,10 +111,10 @@ stages:
 
 setup:frontier-kokkos-hip:
   variables:
-    KOKKOS_VER: 3.7.01
+    KOKKOS_VER: 4.4.01
     KOKKOS_OPTS: >-
       -DCMAKE_INSTALL_PREFIX:PATH=$Kokkos_DIR
-      -DCMAKE_CXX_COMPILER:FILEPATH=/opt/rocm-5.4.3/hip/bin/hipcc
+      -DCMAKE_CXX_COMPILER:FILEPATH=/opt/rocm-5.7.1/hip/bin/hipcc
       -DKokkos_ARCH_VEGA90A:BOOL=ON
       -DKokkos_ENABLE_HIP:BOOL=ON
       -DKokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE:BOOL=OFF

--- a/testing/adios2/CMakeLists.txt
+++ b/testing/adios2/CMakeLists.txt
@@ -21,3 +21,7 @@ endif()
 if (ADIOS2_HAVE_Python)
 add_subdirectory(python)
 endif()
+
+if(ADIOS2_HAVE_Kokkos)
+add_subdirectory(gpu-backend)
+endif()

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -278,17 +278,3 @@ gtest_add_tests_helper(StepsInSituGlobalArray MPI_ALLOW BP Engine.BP. .FileStrea
 gtest_add_tests_helper(StepsInSituLocalArray MPI_ALLOW BP Engine.BP. .FileStream
   WORKING_DIRECTORY ${FS_DIR} EXTRA_ARGS "FileStream"
 )
-
-if(ADIOS2_HAVE_Kokkos)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_COMPILER "${Kokkos_CXX_COMPILER}")
-
-    gtest_add_tests_helper(WriteReadKokkos MPI_ALLOW BP Engine.BP. .BP5
-    WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
-  )
-
-  foreach(tgt ${Test.Engine.BP.WriteReadKokkos-TARGETS})
-    target_link_libraries(${tgt} Kokkos::kokkos)
-  endforeach()
-endif()

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -280,6 +280,10 @@ gtest_add_tests_helper(StepsInSituLocalArray MPI_ALLOW BP Engine.BP. .FileStream
 )
 
 if(ADIOS2_HAVE_Kokkos)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_COMPILER "${Kokkos_CXX_COMPILER}")
+
     gtest_add_tests_helper(WriteReadKokkos MPI_ALLOW BP Engine.BP. .BP5
     WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
   )

--- a/testing/adios2/engine/bp/TestBPWriteReadKokkos.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadKokkos.cpp
@@ -367,8 +367,9 @@ bool compareSelection2D(
             if (b(x, y) != a(start_0 + x, start_1 + y))
             {
                 lmatch++;
-                Kokkos::printf("   Non-match at pos = (%d %d) : input = %f : output = %f\n", x, y,
-                               a(start_0 + x, start_1 + y), b(x, y));
+                // Add lines back when using Kokkos 4.2
+                // Kokkos::printf("   Non-match at pos = (%d %d) : input = %f : output = %f\n", x,
+                //               y, a(start_0 + x, start_1 + y), b(x, y));
             }
         },
         match);

--- a/testing/adios2/gpu-backend/CMakeLists.txt
+++ b/testing/adios2/gpu-backend/CMakeLists.txt
@@ -1,0 +1,19 @@
+# ------------------------------------------------------------------------------#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+# ------------------------------------------------------------------------------#
+include(ADIOSFunctions)
+
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  if(DEFINED Kokkos_CXX_COMPILER)
+    set(CMAKE_CXX_COMPILER "${Kokkos_CXX_COMPILER}")
+  endif()
+
+  gtest_add_tests_helper(WriteReadKokkos MPI_ALLOW BP Engine.BP. .BP5
+    WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
+  )
+
+  foreach(tgt ${Test.Engine.BP.WriteReadKokkos-TARGETS})
+    target_link_libraries(${tgt} Kokkos::kokkos)
+  endforeach()

--- a/testing/adios2/gpu-backend/CMakeLists.txt
+++ b/testing/adios2/gpu-backend/CMakeLists.txt
@@ -2,18 +2,16 @@
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.
 # ------------------------------------------------------------------------------#
-include(ADIOSFunctions)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(DEFINED Kokkos_CXX_COMPILER)
+  set(CMAKE_CXX_COMPILER "${Kokkos_CXX_COMPILER}")
+endif()
 
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  if(DEFINED Kokkos_CXX_COMPILER)
-    set(CMAKE_CXX_COMPILER "${Kokkos_CXX_COMPILER}")
-  endif()
+gtest_add_tests_helper(WriteReadKokkos MPI_ALLOW BP Engine.BP. .BP5
+  WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
+)
 
-  gtest_add_tests_helper(WriteReadKokkos MPI_ALLOW BP Engine.BP. .BP5
-    WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
-  )
-
-  foreach(tgt ${Test.Engine.BP.WriteReadKokkos-TARGETS})
-    target_link_libraries(${tgt} Kokkos::kokkos)
-  endforeach()
+foreach(tgt ${Test.Engine.BP.WriteReadKokkos-TARGETS})
+  target_link_libraries(${tgt} Kokkos::kokkos)
+endforeach()

--- a/testing/adios2/gpu-backend/TestBPWriteReadKokkos.cpp
+++ b/testing/adios2/gpu-backend/TestBPWriteReadKokkos.cpp
@@ -367,9 +367,6 @@ bool compareSelection2D(
             if (b(x, y) != a(start_0 + x, start_1 + y))
             {
                 lmatch++;
-                // Add lines back when using Kokkos 4.2
-                // Kokkos::printf("   Non-match at pos = (%d %d) : input = %f : output = %f\n", x,
-                //               y, a(start_0 + x, start_1 + y), b(x, y));
             }
         },
         match);

--- a/testing/adios2/gpu-backend/TestBPWriteReadKokkos.cpp
+++ b/testing/adios2/gpu-backend/TestBPWriteReadKokkos.cpp
@@ -521,6 +521,7 @@ int main(int argc, char **argv)
     // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
     MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
 #endif
+    Kokkos::initialize(argc, argv);
 
     int result;
     ::testing::InitGoogleTest(&argc, argv);
@@ -530,6 +531,7 @@ int main(int argc, char **argv)
     }
     result = RUN_ALL_TESTS();
 
+    Kokkos::finalize();
 #if ADIOS2_USE_MPI
     MPI_Finalize();
 #endif


### PR DESCRIPTION
Reopening #4358 (closing it was a mistake)

If hipcc is used as the CXX compiler there is no error, but the CI is using g++ so we need to manually set the CXX compiler to whatever was used to build Kokkos.

The rocm version had to be updated to rocm/5.7.1 in the frontier CI due to an incompatibility between the g++ version in PrgEnv-gnu/8.5.0 and the hipcc version in rocm/5.4.3

The Kokkos version had to be updated to > 4.0.0 due to a warning with 3.7.01 and newer rocm compilers.

@vicentebolea thank you for catching the mistake.