### PR TITLE
Replacing DefApps with Core/24.00 for the frontier-cray CI

### DIFF
--- a/.gitlab/gitlab-ci-frontier.yml
+++ b/.gitlab/gitlab-ci-frontier.yml
@@ -144,7 +144,7 @@ build:frontier-kokkos-hip:
   variables:
     # Order matters
     JOB_MODULES: >-
-      DefApps
+      Core/24.00
       PrgEnv-cray
       cmake
       git


### PR DESCRIPTION
The frontier cray CI was failing:
```
Lmod has detected the following error: The following module(s) are unknown:
"zstd" "libffi"
```
They both require the Core/24.00 module that is not compatible with DefApps

@vicentebolea please let me know if you think another fix will be better.