### PR TITLE
Handling compilation error with Fujitsu compilers on Fugaku

### DIFF
--- a/thirdparty/KWSys/adios2sys/Configure.hxx.in
+++ b/thirdparty/KWSys/adios2sys/Configure.hxx.in
@@ -17,7 +17,7 @@
 
 #if defined(__SUNPRO_CC) && __SUNPRO_CC > 0x5130 && defined(__has_attribute)
 #  define @KWSYS_NAMESPACE@_has_cpp_attribute(x) __has_attribute(x)
-#elif defined(__has_cpp_attribute)
+#elif defined(__clang__) && defined(__has_cpp_attribute)
 #  define @KWSYS_NAMESPACE@_has_cpp_attribute(x) __has_cpp_attribute(x)
 #else
 #  define @KWSYS_NAMESPACE@_has_cpp_attribute(x) 0


### PR DESCRIPTION
Hello,

This change is required when I compile the ADIOS2 on Fugaku@RIKEN with Fujitsu compilers.

- version fj@4.10.0 on linux-rhel8-a64fx

Thanks for considering it.