### PR TITLE
Overload NdCopy instead of adding a new argument for the 2.10 release

### DIFF
--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -252,7 +252,18 @@ int NdCopy(const char *in, const CoreDims &inStart, const CoreDims &inCount,
            const bool outIsLittleEndian, const int typeSize, const CoreDims &inMemStart,
            const CoreDims &inMemCount, const CoreDims &outMemStart, const CoreDims &outMemCount,
            const bool safeMode, MemorySpace MemSpace)
+{
+    return NdCopy(in, inStart, inCount, inIsRowMajor, inIsLittleEndian, out, outStart, outCount,
+                  outIsRowMajor, outIsLittleEndian, typeSize, inMemStart, inMemCount, outMemStart,
+                  outMemCount, safeMode, MemSpace, false);
+}
 
+int NdCopy(const char *in, const CoreDims &inStart, const CoreDims &inCount,
+           const bool inIsRowMajor, const bool inIsLittleEndian, char *out,
+           const CoreDims &outStart, const CoreDims &outCount, const bool outIsRowMajor,
+           const bool outIsLittleEndian, const int typeSize, const CoreDims &inMemStart,
+           const CoreDims &inMemCount, const CoreDims &outMemStart, const CoreDims &outMemCount,
+           const bool safeMode, const MemorySpace MemSpace, const bool duringWrite)
 {
 
     // use values of ioStart and ioCount if ioMemStart and ioMemCount are

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -242,6 +242,13 @@ int NdCopy(const char *in, const CoreDims &inStart, const CoreDims &inCount,
            const CoreDims &outMemStart = CoreDims(), const CoreDims &outMemCount = CoreDims(),
            const bool safeMode = false, MemorySpace MemSpace = MemorySpace::Host);
 
+int NdCopy(const char *in, const CoreDims &inStart, const CoreDims &inCount,
+           const bool inIsRowMajor, const bool inIsLittleEndian, char *out,
+           const CoreDims &outStart, const CoreDims &outCount, const bool outIsRowMajor,
+           const bool outIsLittleEndian, const int typeSize, const CoreDims &inMemStart,
+           const CoreDims &inMemCount, const CoreDims &outMemStart, const CoreDims &outMemCount,
+           const bool safeMode, const MemorySpace MemSpace, const bool duringWrite);
+
 template <class T>
 size_t PayloadSize(const T *data, const Dims &count) noexcept;
 


### PR DESCRIPTION
I am not sure how to add this only in the release and not master. I don't think we want this in 2.11

Required so that we can include #4359 in the 2.10 release without breaking the ABI.