### PR TITLE
[Bug fix] SegFault when a variable that is part of a derived expression doesn't have data

### DIFF
--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -585,7 +585,7 @@ void BP5Writer::ComputeDerivedVariables()
             // extract the dimensions and data for each variable
             VariableBase *varBase = itVariable->second.get();
             auto mvi = WriterMinBlocksInfo(*varBase);
-            if (mvi->BlocksInfo.size() == 0)
+            if (!mvi || mvi->BlocksInfo.size() == 0)
             {
                 computeDerived = false;
                 break;

--- a/testing/adios2/derived/TestBPDerivedCorrectness.cpp
+++ b/testing/adios2/derived/TestBPDerivedCorrectness.cpp
@@ -25,6 +25,42 @@ protected:
     adios2::DerivedVarType GetThreads() { return GetParam(); };
 };
 
+TEST_P(DerivedCorrectnessP, BasicCorrectnessTest)
+{
+    adios2::DerivedVarType mode = GetParam();
+    adios2::ADIOS adios;
+    adios2::IO bpOut = adios.DeclareIO("BPNoData");
+    EXPECT_THROW(bpOut.DefineDerivedVariable("derived", "x= var1 \n sqrt(x)", mode),
+                 std::invalid_argument);
+
+    const size_t N = 10;
+    std::default_random_engine generator;
+    std::uniform_real_distribution<float> distribution(0.0, 10.0);
+    std::vector<float> simArray1(N);
+    std::vector<float> simArray2(N);
+    for (size_t i = 0; i < N; ++i)
+        simArray1[i] = distribution(generator);
+
+    auto U = bpOut.DefineVariable<float>("var1", {N}, {0}, {N});
+    auto V = bpOut.DefineVariable<float>("var2", {N}, {0}, {N});
+    bpOut.DefineDerivedVariable("derived", "x= var1 \n sqrt(x)", mode);
+    adios2::Engine bpFileWriter = bpOut.Open("BPNoData.bp", adios2::Mode::Write);
+
+    bpFileWriter.BeginStep();
+    bpFileWriter.Put(V, simArray1.data());
+    bpFileWriter.EndStep();
+    bpFileWriter.Close();
+
+    // check that no derived data was written
+    adios2::IO bpIn = adios.DeclareIO("BPReadExpression");
+    adios2::Engine bpFileReader = bpIn.Open("BPNoData.bp", adios2::Mode::Read);
+    bpFileReader.BeginStep();
+    auto derVar = bpIn.InquireVariable<float>("derived");
+    EXPECT_FALSE(derVar);
+    bpFileReader.EndStep();
+    bpFileReader.Close();
+}
+
 TEST_P(DerivedCorrectnessP, ScalarFunctionsCorrectnessTest)
 {
     const size_t Nx = 10, Ny = 3, Nz = 6;


### PR DESCRIPTION
We were checking if a variable was defined before allowing the derived variables to be defined but we were not checking correctly if there is data written in a given step for all the variables needed by the derived expression. Before this fix the code was seg faulting.

I added a test for what happens when we try to define a derived variable before we define the component variables and what happens when there's no data to compute the derived variable.

