### PR TITLE
[Bug fix] Change the default expression string for derived variables

### DIFF
--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -509,7 +509,7 @@ public:
         return false;
     }
 
-    virtual std::string VariableExprStr(const VariableBase &) { return NULL; }
+    virtual std::string VariableExprStr(const VariableBase &) { return ""; }
 
     /** Notify the engine when a new attribute is defined. Called from IO.tcc
      */


### PR DESCRIPTION
When I try to bpls on an aca file (in Norbert's branch) I am getting seg fault
```
$ ./bin/bpls -l run-488.aca --show-derived
  double   ckpt.bp/U      {8, 66, 66, 66} = 0.0964156 / 1
Segmentation fault: 11
```
This is because bpls checks the length of the expression string to decide if a variable is derived or not:
```
std::string ExprStr = fp->VariableExprStr(*variable);
if (ExprStr.size() > 0)
     // do stuff
```

Normally we return an empty string so this is fine in most cases:
```c++
std::string BP5Reader::VariableExprStr(const VariableBase &Var)
{
    // check if this is a derived variable and return the correct string, else
    std::string noDerive("");
    return noDerive;
}
```

However, for some reason `aca` files use the default implementation in Engine.h which is wrongly returning a NULL pointer.