### PR TITLE
Add the VariableExprStr function in the CampaignReader

### DIFF
--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -429,6 +429,18 @@ bool CampaignReader::VariableMinMax(const VariableBase &Var, const size_t Step,
     return false;
 }
 
+std::string CampaignReader::VariableExprStr(const VariableBase &Var)
+{
+    auto it = m_VarInternalInfo.find(Var.m_Name);
+    if (it != m_VarInternalInfo.end())
+    {
+        VariableBase *vb = reinterpret_cast<VariableBase *>(it->second.originalVar);
+        Engine *e = m_Engines[it->second.engineIdx];
+        return e->VariableExprStr(*vb);
+    }
+    return "";
+}
+
 #define declare_type(T)                                                                            \
     void CampaignReader::DoGetSync(Variable<T> &variable, T *data)                                 \
     {                                                                                              \

--- a/source/adios2/engine/campaign/CampaignReader.h
+++ b/source/adios2/engine/campaign/CampaignReader.h
@@ -52,6 +52,7 @@ public:
     MinVarInfo *MinBlocksInfo(const VariableBase &, const size_t Step) const;
     bool VarShape(const VariableBase &Var, const size_t Step, Dims &Shape) const;
     bool VariableMinMax(const VariableBase &, const size_t Step, MinMaxStruct &MinMax);
+    std::string VariableExprStr(const VariableBase &Var);
 
 private:
     UserOptions::Campaign m_Options;


### PR DESCRIPTION
so that bpls can show the derived expression when applied to `aca` files.

With this PR:

```
$ ./bin/bpls -l gray-scott-derived-run1.aca --show-derived
  double   gs-derived.bp/U              200*{128, 128, 128} = 0.0813067 / 1
  double   gs-derived.bp/V              200*{128, 128, 128} = 0 / 0.674805
  double   gs-derived.bp/derived/sumUV  200*{128, 128, 128} = 0.306159 / 1
    Derived variable with expression: ADD({U},{V})
  int32_t  gs-derived.bp/step           200*scalar = 10 / 2000
```

Before this PR:

```
$ ./bin/bpls -l gray-scott-derived-run1.aca --show-derived
  double   gs-derived.bp/U              200*{128, 128, 128} = 0.0813067 / 1
  double   gs-derived.bp/V              200*{128, 128, 128} = 0 / 0.674805
  double   gs-derived.bp/derived/sumUV  200*{128, 128, 128} = 0.306159 / 1
  int32_t  gs-derived.bp/step           200*scalar = 10 / 2000
```