### PR TITLE
Make adios2_remote_server multithreaded and compress responses using …

### DIFF
--- a/bindings/Python/py11Variable.cpp
+++ b/bindings/Python/py11Variable.cpp
@@ -75,6 +75,24 @@ size_t Variable::SelectionSize() const
     return size;
 }
 
+void Variable::SetAccuracy(const adios2::Accuracy &a)
+{
+    helper::CheckForNullptr(m_VariableBase, "in call to Variable::SetAccuracy");
+    m_VariableBase->SetAccuracy(a);
+}
+
+adios2::Accuracy Variable::GetAccuracy() const
+{
+    helper::CheckForNullptr(m_VariableBase, "in call to Variable::GetAccuracy");
+    return m_VariableBase->GetAccuracy();
+}
+
+adios2::Accuracy Variable::GetAccuracyRequested() const
+{
+    helper::CheckForNullptr(m_VariableBase, "in call to Variable::GetAccuracyRequested");
+    return m_VariableBase->GetAccuracyRequested();
+}
+
 size_t Variable::AddOperation(const Operator op, const Params &parameters)
 {
     helper::CheckForNullptr(m_VariableBase, "in call to Variable::AddOperation");

--- a/bindings/Python/py11Variable.h
+++ b/bindings/Python/py11Variable.h
@@ -49,6 +49,10 @@ public:
 
     size_t SelectionSize() const;
 
+    void SetAccuracy(const adios2::Accuracy &a);
+    adios2::Accuracy GetAccuracy() const;
+    adios2::Accuracy GetAccuracyRequested() const;
+
     std::string Name() const;
 
     std::string Type() const;

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -94,6 +94,9 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
     m.attr("is_built_with_mpi") = false;
 #endif
 
+    m.attr("L2_norm") = adios2::L2_norm;
+    m.attr("Linf_norm") = adios2::Linf_norm;
+
     // enum classes
     pybind11::enum_<adios2::Mode>(m, "Mode")
         .value("Write", adios2::Mode::Write)
@@ -130,6 +133,18 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
         .value("ExpressionString", adios2::DerivedVarType::ExpressionString)
         .value("StoreData", adios2::DerivedVarType::StoreData)
         .export_values();
+
+    pybind11::class_<adios2::Accuracy>(m, "Accuracy")
+        .def(pybind11::init<double, double, bool>())
+        .def_readwrite("error", &adios2::Accuracy::error)
+        .def_readwrite("norm", &adios2::Accuracy::norm)
+        .def_readwrite("relative", &adios2::Accuracy::relative)
+
+        .def("__repr__", [](const adios2::Accuracy &self) {
+            std::ostringstream _stream;
+            _stream << "(" << self.error << ", " << self.norm << ", " << self.relative << ")";
+            return _stream.str();
+        });
 
     pybind11::class_<adios2::py11::ADIOS>(m, "ADIOS")
         // Python 2
@@ -373,6 +388,9 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
         .def("SetBlockSelection", &adios2::py11::Variable::SetBlockSelection)
         .def("SetSelection", &adios2::py11::Variable::SetSelection)
         .def("SetStepSelection", &adios2::py11::Variable::SetStepSelection)
+        .def("SetAccuracy", &adios2::py11::Variable::SetAccuracy)
+        .def("GetAccuracy", &adios2::py11::Variable::GetAccuracy)
+        .def("GetAccuracyRequested", &adios2::py11::Variable::GetAccuracyRequested)
         .def("SelectionSize", &adios2::py11::Variable::SelectionSize)
         .def("Name", &adios2::py11::Variable::Name)
         .def("Type", &adios2::py11::Variable::Type)

--- a/python/adios2/variable.py
+++ b/python/adios2/variable.py
@@ -3,6 +3,7 @@
   accompanying file Copyright.txt for details.
 """
 
+from adios2 import bindings
 
 class Variable:
     """High level representation of the Variable class in the adios2.bindings"""
@@ -87,6 +88,18 @@ class Variable:
             step_selection (list): On the form of [start, count].
         """
         self.impl.SetStepSelection(step_selection)
+
+    def set_accuracy(self, error, norm, relative):
+        """
+        Set Accuracy for (remote) reading for this variable
+
+        Args:
+            error: floating point value
+            norm:  floating point value
+            relative: True or False
+        """
+        acc = bindings.Accuracy(error, norm, relative)
+        self.impl.SetAccuracy(acc)
 
     def shape(self, step=None):
         """
@@ -176,6 +189,15 @@ class Variable:
             str: Name of the Variable.
         """
         return self.impl.Name()
+
+    def get_accuracy(self):
+        """
+        Get the accuracy of the variable (of its last read)
+
+        Returns:
+            adios2.bindings.Accuracy struct (with error, norm and relative fields).
+        """
+        return self.impl.GetAccuracy()
 
     def add_operation_string(self, name, params={}):
         """

--- a/python/adios2/variable.py
+++ b/python/adios2/variable.py
@@ -5,6 +5,7 @@
 
 from adios2 import bindings
 
+
 class Variable:
     """High level representation of the Variable class in the adios2.bindings"""
 

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -83,6 +83,10 @@ void CampaignReader::PerformGets()
     {
         std::cout << "Campaign Reader " << m_ReaderRank << "     PerformGets()\n";
     }
+    for (auto ep : m_Engines)
+    {
+        ep->PerformGets();
+    }
     m_NeedPerformGets = false;
 }
 
@@ -451,10 +455,8 @@ std::string CampaignReader::VariableExprStr(const VariableBase &Var)
     void CampaignReader::DoGetDeferred(Variable<T> &variable, T *data)                             \
     {                                                                                              \
         PERFSTUBS_SCOPED_TIMER("CampaignReader::Get");                                             \
-        auto it = m_VarInternalInfo.find(variable.m_Name);                                         \
-        Variable<T> *v = reinterpret_cast<Variable<T> *>(it->second.originalVar);                  \
-        Engine *e = m_Engines[it->second.engineIdx];                                               \
-        e->Get(*v, data, adios2::Mode::Deferred);                                                  \
+        auto p = TranslateToActualVariable(variable);                                              \
+        p.second->Get(*p.first, data, adios2::Mode::Deferred);                                     \
     }                                                                                              \
                                                                                                    \
     std::map<size_t, std::vector<typename Variable<T>::BPInfo>>                                    \

--- a/source/adios2/engine/campaign/CampaignReader.tcc
+++ b/source/adios2/engine/campaign/CampaignReader.tcc
@@ -45,6 +45,8 @@ inline Variable<T> CampaignReader::DuplicateVariable(Variable<T> *variable, IO &
     v.m_StepsCount = variable->m_StepsCount;
     v.m_Start = variable->m_Start;
     v.m_Count = variable->m_Count;
+    v.m_AccuracyRequested = variable->m_AccuracyRequested;
+    v.m_AccuracyProvided = variable->m_AccuracyProvided;
 
     v.m_Engine = this; // Variable::Shape() uses this member to call engine
     vii.originalVar = static_cast<void *>(variable);
@@ -81,6 +83,7 @@ CampaignReader::TranslateToActualVariable(Variable<T> &variable)
     v->m_MemoryStart = variable.m_MemoryStart;
     v->m_MemoryCount = variable.m_MemoryCount;
     v->m_MemSpace = variable.m_MemSpace;
+    v->m_AccuracyRequested = variable.m_AccuracyRequested;
     return std::make_pair(v, e);
 }
 

--- a/source/adios2/operator/compress/CompressMGARD.cpp
+++ b/source/adios2/operator/compress/CompressMGARD.cpp
@@ -159,7 +159,6 @@ size_t CompressMGARD::Operate(const char *dataIn, const Dims &blockStart, const 
     mgard_x::compress(mgardDim, mgardType, mgardCount, tolerance, s, errorBoundType, dataIn,
                       compressedData, sizeOut, config, true);
     bufferOutOffset += sizeOut;
-
     return bufferOutOffset;
 }
 

--- a/source/adios2/operator/refactor/RefactorMDR.cpp
+++ b/source/adios2/operator/refactor/RefactorMDR.cpp
@@ -36,7 +36,7 @@ RefactorMDR::RefactorMDR(const Params &parameters)
     // config.block_size = 64;
 
     config.dev_type = mgard_x::device_type::AUTO;
-    config.prefetch = false;
+    // config.prefetch = false;
     // config.max_memory_footprint = max_memory_footprint;
 
     config.lossless = mgard_x::lossless_type::Huffman_Zstd;

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -6,9 +6,12 @@
 #include "EVPathRemote.h"
 #include "Remote.h"
 #include "adios2/core/ADIOS.h"
+#include "adios2/core/Operator.h"
 #include "adios2/helper/adiosLog.h"
 #include "adios2/helper/adiosString.h"
 #include "adios2/helper/adiosSystem.h"
+#include "adios2/operator/OperatorFactory.h"
+
 #ifdef _MSC_VER
 #define strdup(x) _strdup(x)
 #endif
@@ -60,7 +63,32 @@ void ReadResponseHandler(CManager cm, CMConnection conn, void *vevent, void *cli
 {
     EVPathRemoteCommon::ReadResponseMsg read_response_msg =
         static_cast<EVPathRemoteCommon::ReadResponseMsg>(vevent);
-    memcpy(read_response_msg->Dest, read_response_msg->ReadData, read_response_msg->Size);
+
+    switch (read_response_msg->OperatorType)
+    {
+    case adios2::core::Operator::OperatorType::COMPRESS_MGARD: {
+        auto op = adios2::core::MakeOperator("mgard", {});
+        op->InverseOperate(read_response_msg->ReadData, read_response_msg->Size,
+                           (char *)read_response_msg->Dest);
+        break;
+    }
+
+    case adios2::core::Operator::OperatorType::COMPRESS_ZFP: {
+        auto op = adios2::core::MakeOperator("zfp", {});
+        op->InverseOperate(read_response_msg->ReadData, read_response_msg->Size,
+                           (char *)read_response_msg->Dest);
+        break;
+    }
+
+    case adios2::core::Operator::OperatorType::COMPRESS_NULL:
+        memcpy(read_response_msg->Dest, read_response_msg->ReadData, read_response_msg->Size);
+        break;
+    default:
+        helper::Throw<std::invalid_argument>("Remote", "EVPathRemote", "ReadResponseHandler",
+                                             "Invalid operator type " +
+                                                 std::to_string(read_response_msg->OperatorType) +
+                                                 " received in response");
+    }
     CMCondition_signal(cm, read_response_msg->ReadResponseCondition);
     return;
 };
@@ -157,7 +185,7 @@ void EVPathRemote::OpenSimpleFile(const std::string hostname, const int32_t port
 }
 
 EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count,
-                                          Dims &Start, void *dest)
+                                          Dims &Start, Accuracy &accuracy, void *dest)
 {
     EVPathRemoteCommon::_GetRequestMsg GetMsg;
     memset(&GetMsg, 0, sizeof(GetMsg));
@@ -169,6 +197,9 @@ EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t Blo
     GetMsg.DimCount = (int)Count.size();
     GetMsg.Count = Count.data();
     GetMsg.Start = Start.data();
+    GetMsg.Error = accuracy.error;
+    GetMsg.Norm = accuracy.norm;
+    GetMsg.Relative = accuracy.relative;
     GetMsg.Dest = dest;
     CMwrite(m_conn, ev_state.GetRequestFormat, &GetMsg);
     return (Remote::GetHandle)(intptr_t)GetMsg.GetResponseCondition;
@@ -190,7 +221,9 @@ EVPathRemote::GetHandle EVPathRemote::Read(size_t Start, size_t Size, void *Dest
 
 bool EVPathRemote::WaitForGet(GetHandle handle)
 {
-    return CMCondition_wait(ev_state.cm, (int)(intptr_t)handle);
+    int result = CMCondition_wait(ev_state.cm, (int)(intptr_t)handle);
+
+    return result;
 }
 #else
 

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -43,7 +43,8 @@ public:
 
     void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename);
 
-    GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start, void *dest);
+    GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
+                  Accuracy &accuracy, void *dest);
 
     bool WaitForGet(GetHandle handle);
 

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -36,7 +36,7 @@ void Remote::OpenSimpleFile(const std::string hostname, const int32_t port,
 };
 
 Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
-                              void *dest)
+                              Accuracy &accuracy, void *dest)
 {
     ThrowUp("RemoteGet");
     return (Remote::GetHandle)(intptr_t)0;

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -40,7 +40,7 @@ public:
     typedef void *GetHandle;
 
     virtual GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
-                          void *dest);
+                          Accuracy &accuracy, void *dest);
 
     virtual bool WaitForGet(GetHandle handle);
 

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -334,7 +334,7 @@ bool XrootdRemote::WaitForGet(GetHandle handle)
 }
 
 Remote::GetHandle XrootdRemote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count,
-                                    Dims &Start, void *dest)
+                                    Dims &Start, Accuracy &accuracy, void *dest)
 {
 #ifdef ADIOS2_HAVE_XROOTD
     char rName[512] = "/etc";

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -100,7 +100,8 @@ public:
     void Open(const std::string hostname, const int32_t port, const std::string filename,
               const Mode mode, bool RowMajorOrdering);
 
-    GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start, void *dest);
+    GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
+                  Accuracy &accuracy, void *dest);
 
     GetHandle Read(size_t Start, size_t Size, void *Dest);
     bool WaitForGet(GetHandle handle);

--- a/source/adios2/toolkit/remote/remote_common.cpp
+++ b/source/adios2/toolkit/remote/remote_common.cpp
@@ -61,6 +61,9 @@ FMField GetRequestList[] = {
     {"DimCount", "integer", sizeof(size_t), FMOffset(GetRequestMsg, DimCount)},
     {"Count", "integer[DimCount]", sizeof(size_t), FMOffset(GetRequestMsg, Count)},
     {"Start", "integer[DimCount]", sizeof(size_t), FMOffset(GetRequestMsg, Start)},
+    {"Error", "double", sizeof(double), FMOffset(GetRequestMsg, Error)},
+    {"Norm", "double", sizeof(double), FMOffset(GetRequestMsg, Norm)},
+    {"Relative", "integer", sizeof(uint8_t), FMOffset(GetRequestMsg, Relative)},
     {"Dest", "integer", sizeof(size_t), FMOffset(GetRequestMsg, Dest)},
     {NULL, NULL, 0, 0}};
 
@@ -83,6 +86,7 @@ FMField ReadResponseList[] = {
     {"ReadResponseCondition", "integer", sizeof(long),
      FMOffset(ReadResponseMsg, ReadResponseCondition)},
     {"Dest", "integer", sizeof(void *), FMOffset(ReadResponseMsg, Dest)},
+    {"OperatorType", "integer", sizeof(uint8_t), FMOffset(ReadResponseMsg, OperatorType)},
     {"Size", "integer", sizeof(size_t), FMOffset(ReadResponseMsg, Size)},
     {"ReadData", "char[Size]", sizeof(char), FMOffset(ReadResponseMsg, ReadData)},
     {NULL, NULL, 0, 0}};

--- a/source/adios2/toolkit/remote/remote_common.h
+++ b/source/adios2/toolkit/remote/remote_common.h
@@ -59,6 +59,9 @@ typedef struct _GetRequestMsg
     int DimCount;
     size_t *Count;
     size_t *Start;
+    double Error;     // Requested error bound
+    double Norm;      // Requested error bound in this norm
+    uint8_t Relative; // relative or absolute error
     void *Dest;
 } *GetRequestMsg;
 
@@ -81,6 +84,7 @@ typedef struct _ReadResponseMsg
 {
     int ReadResponseCondition;
     void *Dest;
+    uint8_t OperatorType;
     size_t Size;
     char *ReadData;
 } *ReadResponseMsg;

--- a/source/adios2/toolkit/remote/remote_server.cpp
+++ b/source/adios2/toolkit/remote/remote_server.cpp
@@ -488,6 +488,7 @@ static void ReadRequestHandler(CManager cm, CMConnection conn, void *vevent, voi
     Response.ReadData = (char *)tmp;
     Response.ReadResponseCondition = ReadMsg->ReadResponseCondition;
     Response.Dest = ReadMsg->Dest;
+    Response.OperatorType = Operator::OperatorType::COMPRESS_NULL;
     if (verbose >= 2)
         std::cout << "Returning " << readable_size(Response.Size) << " for Read " << std::endl;
     f->m_BytesSent += Response.Size;

--- a/source/adios2/toolkit/remote/remote_server.cpp
+++ b/source/adios2/toolkit/remote/remote_server.cpp
@@ -9,6 +9,8 @@
 #include "adios2/core/IO.h"
 #include "adios2/core/Variable.h"
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2/helper/adiosNetwork.h"
+#include "adios2/operator/OperatorFactory.h"
 #include <evpath.h>
 
 #include <cstdio>  // remove
@@ -21,6 +23,8 @@
 #include <sys/stat.h>  // open, fstat
 #include <sys/types.h> // open
 #ifndef _MSC_VER
+#include <mutex>
+#include <thread>
 #include <unistd.h> // write, close, ftruncate
 
 static int fd_is_valid(int fd) { return fcntl(fd, F_GETFD) != -1 || errno != EBADF; }
@@ -58,6 +62,31 @@ size_t ADIOSFilesOpened = 0;
 static int report_port_selection = 0;
 int parent_pid;
 uint64_t random_cookie = 0;
+
+/* Threading for compressing responses of Gets */
+size_t maxThreads = 8;
+size_t nThreads = 0;
+std::mutex mutex_nThreads;
+void WaitForAvailableThread()
+{
+    // std::cout << "WaitForAvailableThread(): enter " << std::endl;
+    auto d = std::chrono::milliseconds(1000);
+    while (true)
+    {
+        {
+            std::lock_guard<std::mutex> lockGuard(mutex_nThreads);
+            if (nThreads < maxThreads)
+            {
+                ++nThreads;
+                // std::cout << "WaitForAvailableThread(): exit with threads = " << nThreads
+                //           << std::endl;
+                break;
+            }
+        }
+        // std::cout << "WaitForAvailableThread(): sleep = " << nThreads << std::endl;
+        std::this_thread::sleep_for(d);
+    }
+};
 
 std::string readable_size(uint64_t size)
 {
@@ -235,6 +264,142 @@ static void OpenSimpleHandler(CManager cm, CMConnection conn, void *vevent, void
     last_service_time = std::chrono::steady_clock::now();
 }
 
+template <class T>
+void ReturnResponseThread(CMConnection conn, CMFormat ReadResponseFormat, AnonADIOSFile *f,
+                          size_t readSize, T *RawData, void *Dest, int GetResponseCondition,
+                          Accuracy acc, std::string name, adios2::DataType vartype,
+                          adios2::Dims count, adios2::Dims start, size_t blockid, bool boxselection)
+{
+    _ReadResponseMsg Response;
+    memset(&Response, 0, sizeof(Response));
+    Response.Size = readSize;
+    Response.ReadResponseCondition = GetResponseCondition;
+    Response.Dest = Dest; /* final data destination in client memory space */
+    Response.OperatorType = Operator::OperatorType::COMPRESS_NULL;
+
+    if (acc.error > 0.0)
+    {
+#if defined(ADIOS2_HAVE_MGARD) || defined(ADIOS2_HAVE_ZFP)
+#if defined(ADIOS2_HAVE_MGARD)
+        Params p = {{"accuracy", std::to_string(acc.error)},
+                    {"s", std::to_string(acc.norm)},
+                    {"mode", (acc.relative ? "REL" : "ABS")}};
+        auto op = MakeOperator("mgard", p);
+#elif defined(ADIOS2_HAVE_ZFP)
+        Params p = {{"accuracy", std::to_string(acc.error)}};
+        auto op = MakeOperator("zfp", p);
+#endif
+        // TODO: would be nicer:
+        // op.SetAccuracy(Accuracy(GetMsg->error, GetMsg->norm, GetMsg->relative));
+        T *CompressedData = (T *)malloc(Response.Size);
+        size_t result = op->Operate((char *)RawData, {}, count, vartype, (char *)CompressedData);
+        if (result == 0)
+        {
+            Response.ReadData = (char *)RawData;
+            free(CompressedData);
+        }
+        else
+        {
+            Response.ReadData = (char *)CompressedData;
+            Response.Size = result;
+            Response.OperatorType = op->m_TypeEnum;
+            free(RawData);
+        }
+#else
+        Response.ReadData = (char *)RawData;
+#endif
+    }
+    else
+    {
+        Response.ReadData = (char *)RawData;
+    }
+
+    if (verbose >= 2)
+    {
+        if (boxselection)
+        {
+            std::cout << "Returning " << readable_size(Response.Size) << " for Get<" << vartype
+                      << ">(" << name << ") start = " << start << " count = " << count << std::endl;
+        }
+        else
+        {
+            std::cout << "Returning " << readable_size(Response.Size) << " for Get<" << vartype
+                      << ">(" << name << ") block = " << blockid << std::endl;
+        }
+    }
+    // std::cout << "-- start sending response --" << std::endl;
+    CMwrite(conn, ReadResponseFormat, &Response);
+    free(Response.ReadData);
+    // std::cout << "-- sent response --" << std::endl;
+    {
+        // std::cout << "-- get lock --" << std::endl;
+        std::lock_guard<std::mutex> lockGuard(mutex_nThreads);
+        // std::cout << "-- lock acquired --" << std::endl;
+        f->m_BytesSent += Response.Size;
+        f->m_OperationCount++;
+        TotalGetBytesSent += Response.Size;
+        TotalGets++;
+        --nThreads;
+    }
+    // std::cout << "-- done --" << std::endl;
+}
+
+template <class T>
+void PrepareResponseForGet(CMConnection conn, struct Remote_evpath_state *ev_state,
+                           GetRequestMsg &GetMsg, std::string &VarName, adios2::DataType TypeOfVar,
+                           AnonADIOSFile *f)
+{
+    // This part cannot be threaded as ADIOS InquireVariable/Get are not thread-safe
+    Variable<T> *var = f->m_io->InquireVariable<T>(VarName);
+    if (f->m_mode == RemoteOpenRandomAccess)
+        var->SetStepSelection({GetMsg->Step, 1});
+    if (GetMsg->BlockID != -1)
+        var->SetBlockSelection(GetMsg->BlockID);
+    if (GetMsg->Start)
+    {
+        Box<Dims> b;
+        if (GetMsg->Count)
+        {
+            for (int i = 0; i < GetMsg->DimCount; i++)
+            {
+                b.first.push_back(GetMsg->Start[i]);
+                b.second.push_back(GetMsg->Count[i]);
+            }
+        }
+        var->SetSelection(b);
+    }
+    std::cout << "Reading var " << VarName << " with "
+              << (GetMsg->Relative ? "relative" : "absolute") << " error " << GetMsg->Error
+              << " in norm " << GetMsg->Norm << std::endl;
+    size_t readSize = var->SelectionSize() * sizeof(T);
+    T *RawData = (T *)malloc(readSize);
+    f->m_engine->Get(*var, RawData, Mode::Sync);
+
+    WaitForAvailableThread(); /* blocking here until we can launch a thread */
+
+    // Handle returning data in a separate thread so that we can serve another read operation in the
+    // meantime. Compress data if possible and if requested.
+    // Note: Can't pass Variable object to thread as other response will modify its content
+    Accuracy acc = {GetMsg->Error, GetMsg->Norm, (bool)GetMsg->Relative};
+    std::thread{ReturnResponseThread<T>,
+                conn,
+                ev_state->ReadResponseFormat,
+                f,
+                readSize,
+                RawData,
+                GetMsg->Dest,
+                GetMsg->GetResponseCondition,
+                acc,
+                var->m_Name,
+                var->m_Type,
+                var->Count(), // correct for block selection too
+                var->m_Start,
+                var->m_BlockID,
+                (var->m_SelectionType == SelectionType::BoundingBox)}
+        .detach();
+    return;
+}
+
 static void GetRequestHandler(CManager cm, CMConnection conn, void *vevent, void *client_data,
                               attr_list attrs)
 {
@@ -261,15 +426,6 @@ static void GetRequestHandler(CManager cm, CMConnection conn, void *vevent, void
 
     std::string VarName = std::string(GetMsg->VarName);
     adios2::DataType TypeOfVar = f->m_io->InquireVariableType(VarName);
-    Box<Dims> b;
-    if (GetMsg->Count)
-    {
-        for (int i = 0; i < GetMsg->DimCount; i++)
-        {
-            b.first.push_back(GetMsg->Start[i]);
-            b.second.push_back(GetMsg->Count[i]);
-        }
-    }
 
     try
     {
@@ -279,30 +435,8 @@ static void GetRequestHandler(CManager cm, CMConnection conn, void *vevent, void
 #define GET(T)                                                                                     \
     else if (TypeOfVar == helper::GetDataType<T>())                                                \
     {                                                                                              \
-        _ReadResponseMsg Response;                                                                 \
-        memset(&Response, 0, sizeof(Response));                                                    \
-        auto var = f->m_io->InquireVariable<T>(VarName);                                           \
-        if (f->m_mode == RemoteOpenRandomAccess)                                                   \
-            var->SetStepSelection({GetMsg->Step, 1});                                              \
-        if (GetMsg->BlockID != -1)                                                                 \
-            var->SetBlockSelection(GetMsg->BlockID);                                               \
-        if (GetMsg->Start)                                                                         \
-            var->SetSelection(b);                                                                  \
-        Response.Size = var->SelectionSize() * sizeof(T);                                          \
-        T *RetData = (T *)malloc(Response.Size);                                                   \
-        f->m_engine->Get(*var, RetData, Mode::Sync);                                               \
-        Response.ReadData = (char *)RetData;                                                       \
-        Response.ReadResponseCondition = GetMsg->GetResponseCondition;                             \
-        Response.Dest = GetMsg->Dest; /* final data destination in client memory space */          \
-        if (verbose >= 2)                                                                          \
-            std::cout << "Returning " << readable_size(Response.Size) << " for Get<" << TypeOfVar  \
-                      << ">(" << VarName << ")" << b << std::endl;                                 \
-        f->m_BytesSent += Response.Size;                                                           \
-        f->m_OperationCount++;                                                                     \
-        TotalGetBytesSent += Response.Size;                                                        \
-        TotalGets++;                                                                               \
-        CMwrite(conn, ev_state->ReadResponseFormat, &Response);                                    \
-        free(RetData);                                                                             \
+        PrepareResponseForGet<T>(conn, ev_state, std::ref(GetMsg), std::ref(VarName), TypeOfVar,   \
+                                 f);                                                               \
     }
         ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(GET)
 #undef GET
@@ -502,7 +636,7 @@ static bool server_timeout(void *CMvoid, int time_since_service)
     CManager cm = (CManager)CMvoid;
     if (verbose && (time_since_service > 90))
         std::cout << time_since_service << " seconds since last service.\n";
-    if (time_since_service > 600)
+    if (time_since_service > 6000)
     {
         if (verbose)
             std::cout << "Timing out remote server" << std::endl;
@@ -542,6 +676,9 @@ static void timer_start(void *param, unsigned int interval)
         }
     }).detach();
 }
+
+const char usage[] = "Usage:  adios2_remote_server [-background] [-kill_server] [-no_timeout] "
+                     "[-status] [-v] [-q] [-l logfile] [-t nthreads]\n";
 
 int main(int argc, char **argv)
 {
@@ -589,9 +726,7 @@ int main(int argc, char **argv)
             if (argc <= i)
             {
                 fprintf(stderr, "Flag -l requires an argument\n");
-                fprintf(stderr,
-                        "Usage:  adios2_remote_server [-background] [-kill_server] [-no_timeout] "
-                        "[-status] [-v] [-q] [-l logfile]\n");
+                fprintf(stderr, usage);
                 exit(1);
             }
             char *filename = argv[i];
@@ -602,12 +737,21 @@ int main(int argc, char **argv)
             // Redirecting cout to write to logfile
             std::cout.rdbuf(fileOut.rdbuf());
         }
+        else if (strcmp(argv[i], "-t") == 0)
+        {
+            i++;
+            if (argc <= i)
+            {
+                fprintf(stderr, "Flag -t requires an argument\n");
+                fprintf(stderr, usage);
+                exit(1);
+            }
+            maxThreads = strtol(argv[i], nullptr, 10);
+        }
         else
         {
             fprintf(stderr, "Unknown argument \"%s\"\n", argv[i]);
-            fprintf(stderr,
-                    "Usage:  adios2_remote_server [-background] [-kill_server] [-no_timeout] "
-                    "[-status] [-v] [-q] [-l logfile]\n");
+            fprintf(stderr, usage);
             exit(1);
         }
     }
@@ -685,13 +829,12 @@ int main(int argc, char **argv)
             close(2);
             exit(0);
         }
-        /* I'm the child, close IO FDs so that ctest continues.  No verbosity here */
-        verbose = 0;
 
         //  Why close a bunch of FDs here?  Well, if we've linked with XRootD, stderr might have
-        //  been dup()'d in library initialization.  We don't need those FDs and we have to close
-        //  them to make sure we disassociate from the CTest parent (or else fixture startup hangs).
-        //  It doesn't seem to work to close them before the fork, so we close them afterwards.
+        //  been dup()'d in library initialization.  We don't need those FDs and we have to
+        //  close them to make sure we disassociate from the CTest parent (or else fixture
+        //  startup hangs). It doesn't seem to work to close them before the fork, so we close
+        //  them afterwards.
         for (int fd = 0; fd <= 16; fd++)
         {
             if (fd_is_valid(fd))
@@ -699,9 +842,9 @@ int main(int argc, char **argv)
                 // OK, fd is valid, should we close it?
                 if ((lseek(fd, 0, SEEK_CUR) == -1) && (errno == ESPIPE))
                 {
-                    // In the circumstances we care about (running under CTest), we want to close
-                    // FDs that are pipes.  The condition above tests for that and we should get
-                    // here only if it's a pipe.
+                    // In the circumstances we care about (running under CTest), we want to
+                    // close FDs that are pipes.  The condition above tests for that and we
+                    // should get here only if it's a pipe.
                     close(fd);
                 }
             }
@@ -741,6 +884,7 @@ int main(int argc, char **argv)
         rename(filename, final_filename);
     }
 
+    std::cout << "Hostname = " << helper::GetFQDN() << std::endl;
     attr_list contact_list = CMget_contact_list(cm);
     if (contact_list)
     {
@@ -749,6 +893,7 @@ int main(int argc, char **argv)
         std::cout << "Listening on Port " << Port << std::endl;
     }
     ev_state.cm = cm;
+    std::cout << "Max threads = " << maxThreads << std::endl;
 
     RegisterFormats(ev_state);
 


### PR DESCRIPTION
…MGARD or ZFP (preference in this order) when an accuracy is set by user.
- added "-t nThreads" option, default is 8
- Use threads to compress responsesi and to return data to client. Adios Get() is still done in main thread because that is not thread-safe.

updates to Campaign engine:
- Call PerformGets() in Campaign engine
- Pass accuracy between CampaignReader and BP5 variables

update to Python API
- added python `bindings.Accuracy` struct, and `SetAccuracy()`/`GetAccuracy()` to bindings, and `variable.set_accuracy()` and `variable.get_accuracy()` to python API.