### PR TITLE
Remove <T> from constructor/destructor declarations. 

### DIFF
--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -92,10 +92,10 @@ public:
      * m_BlocksInfo index (BP4 ONLY) */
     std::map<size_t, Span> m_BlocksSpan;
 
-    Variable<T>(const std::string &name, const Dims &shape, const Dims &start, const Dims &count,
+    Variable(const std::string &name, const Dims &shape, const Dims &start, const Dims &count,
                 const bool constantShape);
 
-    ~Variable<T>() = default;
+    ~Variable() = default;
 
     BPInfo &SetBlockInfo(const T *data, const size_t stepsStart,
                          const size_t stepsCount = 1) noexcept;

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -93,7 +93,7 @@ public:
     std::map<size_t, Span> m_BlocksSpan;
 
     Variable(const std::string &name, const Dims &shape, const Dims &start, const Dims &count,
-                const bool constantShape);
+             const bool constantShape);
 
     ~Variable() = default;
 

--- a/source/adios2/toolkit/query/BlockIndex.h
+++ b/source/adios2/toolkit/query/BlockIndex.h
@@ -13,8 +13,7 @@ template <class T>
 class BlockIndex
 {
 public:
-    BlockIndex(adios2::core::Variable<T> *var, adios2::core::IO &io,
-                  adios2::core::Engine &reader)
+    BlockIndex(adios2::core::Variable<T> *var, adios2::core::IO &io, adios2::core::Engine &reader)
     : m_VarPtr(var), m_IdxIO(io), m_IdxReader(reader)
     {
     }

--- a/source/adios2/toolkit/query/BlockIndex.h
+++ b/source/adios2/toolkit/query/BlockIndex.h
@@ -13,7 +13,7 @@ template <class T>
 class BlockIndex
 {
 public:
-    BlockIndex<T>(adios2::core::Variable<T> *var, adios2::core::IO &io,
+    BlockIndex(adios2::core::Variable<T> *var, adios2::core::IO &io,
                   adios2::core::Engine &reader)
     : m_VarPtr(var), m_IdxIO(io), m_IdxReader(reader)
     {

--- a/source/adios2/toolkit/shm/TokenChain.h
+++ b/source/adios2/toolkit/shm/TokenChain.h
@@ -70,7 +70,7 @@ class TokenChain
     };
 
 public:
-    TokenChain<T>(helper::Comm *comm)
+    TokenChain(helper::Comm *comm)
     : m_NodeComm(comm), m_Rank(comm->Rank()), m_nProc(comm->Size())
     {
         if (m_nProc > 1)

--- a/source/adios2/toolkit/shm/TokenChain.h
+++ b/source/adios2/toolkit/shm/TokenChain.h
@@ -70,8 +70,7 @@ class TokenChain
     };
 
 public:
-    TokenChain(helper::Comm *comm)
-    : m_NodeComm(comm), m_Rank(comm->Rank()), m_nProc(comm->Size())
+    TokenChain(helper::Comm *comm) : m_NodeComm(comm), m_Rank(comm->Rank()), m_nProc(comm->Size())
     {
         if (m_nProc > 1)
         {


### PR DESCRIPTION
Required by C++20 standard.

How to test: in CMakeLists.txt:109 change CMAKE_CXX_STANDARD to 20 or 23 from 11

Fixes #4414
