### PR TITLE
Modify remote requests to include step count in a single request ...

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -265,7 +265,7 @@ if(ADIOS2_HAVE_Campaign)
   target_link_libraries(adios2_core PRIVATE SQLite::SQLite3 ZLIB::ZLIB)
   if(ADIOS2_HAVE_Sodium)
     target_link_libraries(adios2_core PRIVATE sodium)
-  endif(ADIOS2_HAVE_SODIUM)
+  endif(ADIOS2_HAVE_Sodium)
 endif(ADIOS2_HAVE_Campaign)
 
 if(ADIOS2_HAVE_DAOS)

--- a/source/adios2/engine/bp5/BP5Reader.tcc
+++ b/source/adios2/engine/bp5/BP5Reader.tcc
@@ -24,14 +24,14 @@ namespace engine
 
 inline void BP5Reader::GetSyncCommon(VariableBase &variable, void *data)
 {
-    bool need_sync = m_BP5Deserializer->QueueGet(variable, data);
+    bool need_sync = m_BP5Deserializer->QueueGet(variable, data, m_dataIsRemote);
     if (need_sync)
         PerformGets();
 }
 
 void BP5Reader::GetDeferredCommon(VariableBase &variable, void *data)
 {
-    (void)m_BP5Deserializer->QueueGet(variable, data);
+    (void)m_BP5Deserializer->QueueGet(variable, data, m_dataIsRemote);
 }
 
 } // end namespace engine

--- a/source/adios2/helper/adiosType.cpp
+++ b/source/adios2/helper/adiosType.cpp
@@ -290,5 +290,20 @@ std::string OpenModeToString(const Mode openMode, const bool oneLetter) noexcept
     return openModeString;
 }
 
+adios2::Dims DimsWithStep(size_t firstElement, adios2::Dims &dimsWithoutSteps) noexcept
+{
+    // Start/Count in cache includes steps as first dimension
+    adios2::Dims d = {firstElement};
+    d.insert(d.end(), dimsWithoutSteps.begin(), dimsWithoutSteps.end());
+    return d;
+}
+
+std::tuple<size_t, adios2::Dims> DimsWithoutStep(adios2::Dims &dimsWithSteps) noexcept
+{
+    size_t step = dimsWithSteps[0];
+    adios2::Dims d = {dimsWithSteps.begin() + 1, dimsWithSteps.end()};
+    return std::tuple<size_t, adios2::Dims>(step, d);
+}
+
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/helper/adiosType.h
+++ b/source/adios2/helper/adiosType.h
@@ -188,6 +188,19 @@ public:
 };
 
 /**
+ * Make an adios2::Dims vector from steps + another Dims vector
+ * @return adios2::Dims vector, first element is 'firstElement', rest is input vector
+ */
+adios2::Dims DimsWithStep(size_t firstElement, adios2::Dims &dimsWithoutSteps) noexcept;
+
+/**
+ * Separate adios2::Dims vector with step
+ * @return tuple of first element, and an adios2::Dims vector without first element of input
+ * vector.
+ */
+std::tuple<size_t, adios2::Dims> DimsWithoutStep(adios2::Dims &dimsWithSteps) noexcept;
+
+/**
  * Gets type from template parameter T
  * @return DataType enumeration value
  */

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -61,9 +61,11 @@ public:
 
     void SetupForStep(size_t Step, size_t WriterCount);
     // return from QueueGet is true if a sync is needed to fill the data
-    bool QueueGet(core::VariableBase &variable, void *DestData);
+    bool QueueGet(core::VariableBase &variable, void *DestData, bool dataIsRemote = false);
     bool QueueGetSingle(core::VariableBase &variable, void *DestData, size_t AbsStep,
                         size_t RelStep);
+    bool QueueGetSingleRemote(core::VariableBase &variable, void *DestData, size_t RelStep,
+                              size_t StepCount);
 
     /* generate read requests. return vector of requests AND the size of
      * the largest allocation block necessary for reading.
@@ -105,8 +107,9 @@ public:
         void *VarRec = NULL;
         char *VarName;
         enum RequestTypeEnum RequestType;
-        size_t Step;    // local operations use absolute steps
-        size_t RelStep; // preserve Relative Step for remote
+        size_t Step;      // local operations use absolute steps
+        size_t RelStep;   // preserve Relative Step for remote
+        size_t StepCount; // =1 for local, can be >1 for remote
         size_t BlockID;
         Dims Start;
         Dims Count;

--- a/source/adios2/toolkit/kvcache/QueryBox.h
+++ b/source/adios2/toolkit/kvcache/QueryBox.h
@@ -54,7 +54,7 @@ public:
     // ToString
     std::string toString() const
     {
-        std::string str = "|Start_";
+        std::string str = "Start_";
         for (size_t i = 0; i < Start.size(); ++i)
         {
             str += std::to_string(Start[i]);
@@ -101,17 +101,17 @@ public:
     }
 
     // convert helper::DimsArray to std::vector<size_t>
-    void StartToVector(std::vector<size_t> &vec) const
+    void StartToVector(std::vector<size_t> &vec, size_t startPos = 0) const
     {
-        for (size_t i = 0; i < Start.size(); ++i)
+        for (size_t i = startPos; i < Start.size(); ++i)
         {
             vec.push_back(Start[i]);
         }
     }
 
-    void CountToVector(std::vector<size_t> &vec) const
+    void CountToVector(std::vector<size_t> &vec, size_t startPos = 0) const
     {
-        for (size_t i = 0; i < Count.size(); ++i)
+        for (size_t i = startPos; i < Count.size(); ++i)
         {
             vec.push_back(Count[i]);
         }
@@ -260,7 +260,9 @@ public:
         for (auto &key : samePrefixKeys)
         {
             // Initialize the box from the key
-            size_t DimCount = std::count(key.begin(), key.end(), '_') / 2;
+            auto sp = key.find("|Start");
+            auto cp = key.find("|Count");
+            size_t DimCount = std::count(key.begin() + sp, key.begin() + cp, '_');
             QueryBox box(DimCount);
             lf_ExtractDimensions(key, "|Start_", box.Start);
             lf_ExtractDimensions(key, "|Count_", box.Count);

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -184,8 +184,9 @@ void EVPathRemote::OpenSimpleFile(const std::string hostname, const int32_t port
     m_Active = true;
 }
 
-EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count,
-                                          Dims &Start, Accuracy &accuracy, void *dest)
+EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t StepCount,
+                                          size_t BlockID, Dims &Count, Dims &Start,
+                                          Accuracy &accuracy, void *dest)
 {
     EVPathRemoteCommon::_GetRequestMsg GetMsg;
     memset(&GetMsg, 0, sizeof(GetMsg));
@@ -193,6 +194,7 @@ EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t Blo
     GetMsg.FileHandle = m_ID;
     GetMsg.VarName = VarName;
     GetMsg.Step = Step;
+    GetMsg.StepCount = StepCount;
     GetMsg.BlockID = BlockID;
     GetMsg.DimCount = (int)Count.size();
     GetMsg.Count = Count.data();

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -43,8 +43,8 @@ public:
 
     void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename);
 
-    GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
-                  Accuracy &accuracy, void *dest);
+    GetHandle Get(char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
+                  Dims &Start, Accuracy &accuracy, void *dest);
 
     bool WaitForGet(GetHandle handle);
 

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -35,8 +35,8 @@ void Remote::OpenSimpleFile(const std::string hostname, const int32_t port,
     ThrowUp("RemoteSimpleOpen");
 };
 
-Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
-                              Accuracy &accuracy, void *dest)
+Remote::GetHandle Remote::Get(char *VarName, size_t Step, size_t StepCount, size_t BlockID,
+                              Dims &Count, Dims &Start, Accuracy &accuracy, void *dest)
 {
     ThrowUp("RemoteGet");
     return (Remote::GetHandle)(intptr_t)0;

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -43,8 +43,8 @@ public:
 
     typedef void *GetHandle;
 
-    virtual GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
-                          Accuracy &accuracy, void *dest);
+    virtual GetHandle Get(char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
+                          Dims &Start, Accuracy &accuracy, void *dest);
 
     virtual bool WaitForGet(GetHandle handle);
 

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -333,9 +333,10 @@ bool XrootdRemote::WaitForGet(GetHandle handle)
     return true;
 }
 
-Remote::GetHandle XrootdRemote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count,
-                                    Dims &Start, Accuracy &accuracy, void *dest)
+Remote::GetHandle XrootdRemote::Get(char *VarName, size_t Step, size_t StepCount, size_t BlockID,
+                                    Dims &Count, Dims &Start, Accuracy &accuracy, void *dest)
 {
+// FIXME: StepCount is not implemented here yet
 #ifdef ADIOS2_HAVE_XROOTD
     char rName[512] = "/etc";
     XrdSsiResource rSpec((std::string)rName);

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -344,7 +344,8 @@ Remote::GetHandle XrootdRemote::Get(char *VarName, size_t Step, size_t StepCount
     std::string reqData = "get Filename=" + std::string(m_Filename) + std::string("&RMOrder=") +
                           std::to_string(m_RowMajorOrdering) + std::string("&Varname=") +
                           std::string(VarName);
-    reqData += "&Step=" + std::to_string(Step);
+    reqData += "&StepStart=" + std::to_string(Step);
+    reqData += "&StepCount=" + std::to_string(StepCount);
     reqData += "&Block=" + std::to_string(BlockID);
     reqData += "&Dims=" + std::to_string(Count.size());
 

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -100,8 +100,8 @@ public:
     void Open(const std::string hostname, const int32_t port, const std::string filename,
               const Mode mode, bool RowMajorOrdering);
 
-    GetHandle Get(char *VarName, size_t Step, size_t BlockID, Dims &Count, Dims &Start,
-                  Accuracy &accuracy, void *dest);
+    GetHandle Get(char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
+                  Dims &Start, Accuracy &accuracy, void *dest);
 
     GetHandle Read(size_t Start, size_t Size, void *Dest);
     bool WaitForGet(GetHandle handle);

--- a/source/adios2/toolkit/remote/remote_common.cpp
+++ b/source/adios2/toolkit/remote/remote_common.cpp
@@ -56,6 +56,7 @@ FMField GetRequestList[] = {
     {"FileHandle", "integer", sizeof(int64_t), FMOffset(GetRequestMsg, FileHandle)},
     {"RequestType", "integer", sizeof(int), FMOffset(GetRequestMsg, RequestType)},
     {"Step", "integer", sizeof(size_t), FMOffset(GetRequestMsg, Step)},
+    {"StepCount", "integer", sizeof(size_t), FMOffset(GetRequestMsg, StepCount)},
     {"VarName", "string", sizeof(char *), FMOffset(GetRequestMsg, VarName)},
     {"BlockID", "integer", sizeof(int64_t), FMOffset(GetRequestMsg, BlockID)},
     {"DimCount", "integer", sizeof(size_t), FMOffset(GetRequestMsg, DimCount)},

--- a/source/adios2/toolkit/remote/remote_common.h
+++ b/source/adios2/toolkit/remote/remote_common.h
@@ -55,6 +55,7 @@ typedef struct _GetRequestMsg
     int64_t FileHandle;
     char *VarName;
     size_t Step;
+    size_t StepCount;
     int64_t BlockID;
     int DimCount;
     size_t *Count;

--- a/source/utils/xrootd-plugin/XrdSsiSvService.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvService.cpp
@@ -424,7 +424,8 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
         std::string Filename;
         std::string VarName;
         adios2::Dims Start, Count;
-        size_t BlockID, DimCount, Step;
+        size_t BlockID, DimCount, StepStart;
+        size_t StepCount = 1;
         bool ArrayOrder;
         std::vector<std::string> requestParams = split(reqArgs, '&');
         for (auto &param : requestParams)
@@ -453,11 +454,17 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
                 std::stringstream sstream(param.substr(pos));
                 sstream >> DimCount;
             }
-            else if (HasPrefix(param, "Step="))
+            else if (HasPrefix(param, "StepCount="))
             {
                 std::size_t pos = param.find("=") + 1;
                 std::stringstream sstream(param.substr(pos));
-                sstream >> Step;
+                sstream >> StepCount;
+            }
+            else if (HasPrefix(param, "StepStart="))
+            {
+                std::size_t pos = param.find("=") + 1;
+                std::stringstream sstream(param.substr(pos));
+                sstream >> StepStart;
             }
             else if (HasPrefix(param, "Block="))
             {
@@ -507,7 +514,7 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
         adios2::Variable<T> var = io.InquireVariable<T>(VarName);                                  \
         if (BlockID != (size_t)-1)                                                                 \
             var.SetBlockSelection(BlockID);                                                        \
-        var.SetStepSelection({Step, 1});                                                           \
+        var.SetStepSelection({StepStart, StepCount});                                              \
         if (Start.size())                                                                          \
             var.SetSelection(varSel);                                                              \
         m_responseBufferSize = var.SelectionSize() * sizeof(T);                                    \


### PR DESCRIPTION
instead of splitting them into many single step requests. Modify cache using steps as part of dimensions.

 - keyPrefix should have ending '|' to distinguish variables with inclusive prefix like 'psi' and 'psi_surf'.