### PR TITLE
Remote server test fix

### DIFF
--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -438,7 +438,7 @@ void BP5Reader::PerformGets()
                 "Remote file " + m_Name +
                     " cannot be opened. Possible server or file specification error.");
         }
-        if (!m_Remote)
+        if (!(*m_Remote)) // evaluate validity of object, not just that the pointer is non-NULL
         {
             helper::Throw<std::ios_base::failure>(
                 "Engine", "BP5Reader", "OpenFiles",

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -321,6 +321,7 @@ void XrootdRemote::Open(const std::string hostname, const int32_t port, const st
         fprintf(XrdSsiCl::outErr, "Unable to get service object for %s; %s\n", clUI.contact,
                 eInfo.Get().c_str());
     }
+    m_OpenSuccess = true;
 #endif
     return;
 }

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -93,9 +93,12 @@ public:
     std::string m_Filename;
     Mode m_Mode;
     bool m_RowMajorOrdering;
+    bool m_OpenSuccess = false;
 
     XrootdRemote(const adios2::HostOptions &hostOptions);
     ~XrootdRemote();
+
+    explicit operator bool() const { return m_OpenSuccess; }
 
     void Open(const std::string hostname, const int32_t port, const std::string filename,
               const Mode mode, bool RowMajorOrdering);


### PR DESCRIPTION
The test (!m_Remote) was intended as a test to see if the objected pointed to by the m_Remote pointer was valid, but that syntax should have been (!(*m_Remote)).  Fixing this, and maybe this will get a better error for the Remote test failures we sometimes see in CI.