### PR TITLE
Bindings for cuPy pointers

### DIFF
--- a/bindings/Python/py11Engine.h
+++ b/bindings/Python/py11Engine.h
@@ -53,6 +53,9 @@ public:
              const Mode launch = Mode::Deferred);
     void Put(Variable variable, const std::vector<double> &doubles,
              const Mode launch = Mode::Deferred);
+#ifdef ADIOS2_HAVE_CUDA
+    void Put(Variable variable, long array, const Mode launch = Mode::Deferred);
+#endif
     void Put(Variable variable, const std::vector<std::complex<double>> &complexes,
              const Mode launch = Mode::Deferred);
     void Put(Variable variable, const std::string &string);
@@ -60,6 +63,9 @@ public:
     void PerformDataWrite();
 
     void Get(Variable variable, pybind11::array &array, const Mode launch = Mode::Deferred);
+#ifdef ADIOS2_HAVE_CUDA
+    void Get(Variable variable, long array, const Mode launch = Mode::Deferred);
+#endif
     std::string Get(Variable variable, const Mode launch = Mode::Deferred);
 
     void PerformGets();

--- a/bindings/Python/py11Variable.cpp
+++ b/bindings/Python/py11Variable.cpp
@@ -149,7 +149,7 @@ adios2::ShapeID Variable::ShapeID() const
     return m_VariableBase->m_ShapeID;
 }
 
-Dims Variable::Shape(const size_t step)
+Dims Variable::Shape(const size_t step) const
 {
     helper::CheckForNullptr(m_VariableBase, "in call to Variable::Shape");
 
@@ -179,7 +179,7 @@ void Variable::SetMemorySpace(const MemorySpace memSpace)
     m_VariableBase->SetMemorySpace(memSpace);
 }
 
-Dims Variable::Shape(const MemorySpace memSpace, const size_t step)
+Dims Variable::Shape(const MemorySpace memSpace, const size_t step) const
 {
     helper::CheckForNullptr(m_VariableBase, "in call to Variable::Shape");
 

--- a/bindings/Python/py11Variable.h
+++ b/bindings/Python/py11Variable.h
@@ -73,7 +73,12 @@ public:
      * Inspects current shape
      * @return shape vector
      */
-    Dims Shape(const size_t step = adios2::EngineCurrentStep) const;
+    Dims Shape(const size_t step = adios2::EngineCurrentStep);
+#ifdef ADIOS2_HAVE_CUDA
+    Dims Shape(const MemorySpace memSpace, const size_t step = adios2::EngineCurrentStep);
+
+    void SetMemorySpace(const MemorySpace memSpace);
+#endif
 
     /**
      * Inspects current start point

--- a/bindings/Python/py11Variable.h
+++ b/bindings/Python/py11Variable.h
@@ -73,9 +73,9 @@ public:
      * Inspects current shape
      * @return shape vector
      */
-    Dims Shape(const size_t step = adios2::EngineCurrentStep);
+    Dims Shape(const size_t step = adios2::EngineCurrentStep) const;
 #ifdef ADIOS2_HAVE_CUDA
-    Dims Shape(const MemorySpace memSpace, const size_t step = adios2::EngineCurrentStep);
+    Dims Shape(const MemorySpace memSpace, const size_t step = adios2::EngineCurrentStep) const;
 
     void SetMemorySpace(const MemorySpace memSpace);
 #endif

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -134,6 +134,12 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
         .value("StoreData", adios2::DerivedVarType::StoreData)
         .export_values();
 
+#ifdef ADIOS2_HAVE_CUDA
+    pybind11::enum_<adios2::MemorySpace>(m, "MemorySpace")
+        .value("Host", adios2::MemorySpace::Host)
+        .value("GPU", adios2::MemorySpace::GPU);
+#endif
+
     pybind11::class_<adios2::Accuracy>(m, "Accuracy")
         .def(pybind11::init<double, double, bool>())
         .def_readwrite("error", &adios2::Accuracy::error)
@@ -396,8 +402,20 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
         .def("Type", &adios2::py11::Variable::Type)
         .def("Sizeof", &adios2::py11::Variable::Sizeof)
         .def("ShapeID", &adios2::py11::Variable::ShapeID)
-        .def("Shape", &adios2::py11::Variable::Shape,
+        .def("Shape",
+             (adios2::Dims(adios2::py11::Variable::*)(const size_t)) &
+                 adios2::py11::Variable::Shape,
              pybind11::arg("step") = adios2::EngineCurrentStep)
+#ifdef ADIOS2_HAVE_CUDA
+        .def("Shape",
+             (adios2::Dims(adios2::py11::Variable::*)(const adios2::MemorySpace, const size_t)) &
+                 adios2::py11::Variable::Shape,
+             pybind11::arg("memSpace"), pybind11::arg("step") = adios2::EngineCurrentStep)
+        .def("SetMemorySpace",
+             (void(adios2::py11::Variable::*)(const adios2::MemorySpace)) &
+                 adios2::py11::Variable::SetMemorySpace,
+             pybind11::arg("memSpace"))
+#endif
         .def("Start", &adios2::py11::Variable::Start)
         .def("Count", &adios2::py11::Variable::Count)
         .def("Steps", &adios2::py11::Variable::Steps)

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -495,6 +495,15 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
              pybind11::arg("variable"), pybind11::arg("floats"),
              pybind11::arg("launch") = adios2::Mode::Sync)
 
+#ifdef ADIOS2_HAVE_CUDA
+        .def("Put",
+             (void(adios2::py11::Engine::*)(adios2::py11::Variable variable, long,
+                                            const adios2::Mode launch)) &
+                 adios2::py11::Engine::Put,
+             pybind11::arg("variable"), pybind11::arg("cypyPointer"),
+             pybind11::arg("launch") = adios2::Mode::Sync)
+#endif
+
         .def("Put",
              (void(adios2::py11::Engine::*)(adios2::py11::Variable,
                                             const std::vector<std::complex<double>> &,
@@ -513,6 +522,15 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
                  adios2::py11::Engine::Get,
              pybind11::arg("variable"), pybind11::arg("array"),
              pybind11::arg("launch") = adios2::Mode::Deferred)
+
+#ifdef ADIOS2_HAVE_CUDA
+        .def("Get",
+             (void(adios2::py11::Engine::*)(adios2::py11::Variable variable, long,
+                                            const adios2::Mode launch)) &
+                 adios2::py11::Engine::Get,
+             pybind11::arg("variable"), pybind11::arg("cupyPointer"),
+             pybind11::arg("launch") = adios2::Mode::Sync)
+#endif
 
         .def("Get",
              (std::string(adios2::py11::Engine::*)(adios2::py11::Variable,

--- a/bindings/Python/py11glue.cpp
+++ b/bindings/Python/py11glue.cpp
@@ -403,12 +403,13 @@ PYBIND11_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
         .def("Sizeof", &adios2::py11::Variable::Sizeof)
         .def("ShapeID", &adios2::py11::Variable::ShapeID)
         .def("Shape",
-             (adios2::Dims(adios2::py11::Variable::*)(const size_t)) &
+             (adios2::Dims(adios2::py11::Variable::*)(const size_t) const) &
                  adios2::py11::Variable::Shape,
              pybind11::arg("step") = adios2::EngineCurrentStep)
 #ifdef ADIOS2_HAVE_CUDA
         .def("Shape",
-             (adios2::Dims(adios2::py11::Variable::*)(const adios2::MemorySpace, const size_t)) &
+             (adios2::Dims(adios2::py11::Variable::*)(const adios2::MemorySpace, const size_t)
+                  const) &
                  adios2::py11::Variable::Shape,
              pybind11::arg("memSpace"), pybind11::arg("step") = adios2::EngineCurrentStep)
         .def("SetMemorySpace",

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCuda.py
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCuda.py
@@ -1,0 +1,73 @@
+import numpy as np
+import cupy as cp
+from adios2 import FileReader
+import adios2.bindings as adios2
+
+def write_array(fileName, nSteps, gpuArray, cpuArray):
+    adios = adios2.ADIOS()
+    ioWriter = adios.DeclareIO("cupyWriter")
+    # define adios variables, the cpuArray is used for both variables to
+    # define the type of the variables (float32 in this case)
+    gpuVar = ioWriter.DefineVariable("gpuArray", cpuArray, gpuArray.shape,
+                                     [0] * len(gpuArray.shape), gpuArray.shape)
+    # optionally the memory space can be set to GPU
+    gpuVar.SetMemorySpace(adios2.MemorySpace.GPU)
+    cpuVar = ioWriter.DefineVariable("cpuArray", cpuArray, cpuArray.shape,
+                                     [0] * len(cpuArray.shape), cpuArray.shape)
+
+    # write both cpu and gpu arrays for each simulation step
+    wStream = ioWriter.Open(fileName, adios2.Mode.Write)
+    for step in range(nSteps):
+        # write buffers
+        wStream.BeginStep()
+        wStream.Put(cpuVar, cpuArray)
+        wStream.Put(gpuVar, gpuArray.data.ptr)
+        wStream.EndStep()
+        # update buffers
+        gpuArray = gpuArray * 2
+        cpuArray = cpuArray + 1
+    wStream.Close()
+    print("Write to file %s: %s data from GPU and %s data from CPU" % (
+        fileName, gpuArray.shape, cpuArray.shape))
+
+def read_array(fileName, nSteps):
+    adios = adios2.ADIOS()
+    ioReader = adios.DeclareIO("cupyReader")
+    rStream = ioReader.Open(fileName, adios2.Mode.Read)
+    for step in range(nSteps):
+        rStream.BeginStep()
+        # prepare input buffers
+        gpuVar = ioReader.InquireVariable("gpuArray")
+        cpuVar = ioReader.InquireVariable("cpuArray")
+        cpuBuffer = np.zeros(cpuVar.Shape(), dtype=np.float32)
+        gpuShape = gpuVar.Shape(adios2.MemorySpace.GPU)
+        gpuBuffer = cp.zeros(gpuShape, dtype=np.float32)
+        gpuVar.SetSelection([(0, 0), gpuShape])
+        # populate data
+        rStream.Get(gpuVar, gpuBuffer.data.ptr)
+        rStream.Get(cpuVar, cpuBuffer)
+        rStream.EndStep()
+        print("Step %d: read GPU data\n %s" % (step, gpuBuffer))
+        print("Step %d: read CPU data\n %s" % (step, cpuBuffer))
+    rStream.Close()
+
+
+if __name__ == '__main__':
+    # define simulation host data
+    cpuArray = np.array([[0, 1.0, 2.0], [3.0, 4.0, 5.0]], dtype=np.float32)
+    # copy the data on the device
+    gpuArray = cp.asarray(cpuArray)
+    print("Array allocation: ", gpuArray.device)
+
+    mempool = cp.get_default_memory_pool()
+    pinned_mempool = cp.get_default_pinned_memory_pool()
+    print("Bytes required to store the gpu array", gpuArray.nbytes)
+    print("Bytes allocated on the device memory pool", mempool.total_bytes())
+    print("Bytes used on the device memory pool", mempool.used_bytes())
+    print("Blocks allocated on the pinned memory pool (The allocated pinned"
+          " memory is released just after the transfer is complete)",
+          pinned_mempool.n_free_blocks())
+
+    nSteps = 2
+    write_array("StepsWriteReadCuPy.bp", nSteps, gpuArray, cpuArray)
+    read_array("StepsWriteReadCuPy.bp", nSteps)


### PR DESCRIPTION
**Allow python to feed GPU pointers to ADIOS.**

Writer side will have to provide the pointer to the cupy array in the call to Put.

Reader side can call Shape(adios2.MemorySpace.GPU) to receive the dimensions correctly for the GPU then will have to SetSelection to this shape and allocate memory on the GPU using these dimensions.

Example in  `examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCuda.py`

Running the examples:
```
 $ python examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCuda.py
Array allocation:  <CUDA Device 0>
Bytes required to store the gpu array 24
Bytes allocated on the device memory pool 512
Bytes used on the device memory pool 512
Blocks allocated on the pinned memory pool (The allocated pinned memory is released just after the transfer is complete) 1
Write to file StepsWriteReadCuPy.bp: (2, 3) data from GPU and (2, 3) data from CPU
Step 0: read GPU data
 [[0. 1. 2.]
 [3. 4. 5.]]
Step 0: read CPU data
 [[0. 1. 2.]
 [3. 4. 5.]]
Step 1: read GPU data
 [[ 0.  2.  4.]
 [ 6.  8. 10.]]
Step 1: read CPU data
 [[1. 2. 3.]
 [4. 5. 6.]]
```

If we bpls the ADIOS file created, the read is done on the CPU so the dimensions will be flipped for the GPU array:
```
$ bpls StepsWriteReadCuPy.bp/ -d gpuArray -n 2
  float    gpuArray  2*{3, 2}
    (0,0,0)    0 1
    (0,1,0)    2 3
    (0,2,0)    4 5
    (1,0,0)    0 2
    (1,1,0)    4 6
    (1,2,0)    8 10
```