### PR TITLE
Cache data blocks larger than 1MB in files.

### DIFF
--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -169,6 +169,7 @@ public:
     MACRO(IgnoreFlattenSteps, Bool, bool, false)                                                   \
     MACRO(RemoteDataPath, String, std::string, "")                                                 \
     MACRO(RemoteHost, String, std::string, "")                                                     \
+    MACRO(UUID, String, std::string, "")                                                           \
     MACRO(MaxOpenFilesAtOnce, UInt, unsigned int, UINT_MAX)
 
     struct BP5Params

--- a/source/adios2/engine/campaign/CampaignData.cpp
+++ b/source/adios2/engine/campaign/CampaignData.cpp
@@ -115,6 +115,10 @@ static int sqlcb_bpdataset(void *p, int argc, char **argv, char **azColName)
         cds.hasKey = (keyid); // keyid == 0 means there is no key used
         cds.keyIdx = size_t(keyid - 1);
     }
+    if (cdp->version.version >= 0.3)
+    {
+        cds.uuid = std::string(argv[5]);
+    }
     cdp->bpdatasets[dsid] = cds;
     return 0;
 };
@@ -192,7 +196,11 @@ void ReadCampaignData(sqlite3 *db, CampaignData &cd)
         sqlite3_free(zErrMsg);
     }
 
-    if (cd.version.version >= 0.2)
+    if (cd.version.version >= 0.3)
+    {
+        sqlcmd = "SELECT rowid, hostid, dirid, name, keyid, uuid FROM bpdataset";
+    }
+    else if (cd.version.version >= 0.2)
     {
         sqlcmd = "SELECT rowid, hostid, dirid, name, keyid FROM bpdataset";
     }

--- a/source/adios2/engine/campaign/CampaignData.h
+++ b/source/adios2/engine/campaign/CampaignData.h
@@ -53,6 +53,7 @@ struct CampaignBPFile
 
 struct CampaignBPDataset
 {
+    std::string uuid;
     std::string name;
     size_t hostIdx;
     size_t dirIdx;

--- a/source/adios2/toolkit/kvcache/KVCacheCommon.cpp
+++ b/source/adios2/toolkit/kvcache/KVCacheCommon.cpp
@@ -6,6 +6,8 @@
 
 #include "KVCacheCommon.h"
 
+#include <cstring>
+
 namespace adios2
 {
 namespace kvcache
@@ -36,6 +38,16 @@ void KVCacheCommon::CloseConnection()
         m_redisContext = nullptr;
         std::cout << "KVCache connection closed" << std::endl;
     }
+    if (m_CacheFile.is_open())
+    {
+        m_CacheFile.close();
+    }
+}
+
+void KVCacheCommon::SetLocalCacheFile(const std::string localCacheFilePath)
+{
+    m_LocalCacheFilePath = localCacheFilePath;
+    // open/create file only when required
 }
 
 void KVCacheCommon::Set(const char *key, size_t size, void *data)
@@ -66,23 +78,108 @@ void KVCacheCommon::Get(const char *key, size_t size, void *data)
     }
 }
 
-void KVCacheCommon::AppendCommandInBatch(const char *key, size_t mode, size_t size, void *data)
+constexpr size_t MAX_SIZE_INSIDE_KV = 1024 * 1024;
+
+void KVCacheCommon::AppendSetCommandInBatch(const char *key, size_t size, void *data)
 {
-    if (mode == 0)
+    // Write data to cache (reply in ExecuteBatch)
+    if (size > MAX_SIZE_INSIDE_KV)
+    {
+        // save data to file and add reference in key-value
+        if (!m_CacheFile.is_open())
+        {
+            m_CacheFile.open(m_LocalCacheFilePath, std::ios::in | std::ios::out | std::ios::app);
+        }
+        m_CacheFile.seekp(0, std::ios_base::end);
+        const std::streampos offset = m_CacheFile.tellp();
+        m_CacheFile.write(static_cast<char *>(data), static_cast<std::streamsize>(size));
+        std::string value =
+            "fileblock:offset=" + std::to_string(offset) + ":size=" + std::to_string(size);
+        redisAppendCommand(m_redisContext, "SET %s %b", key, value.c_str(), value.size());
+    }
+    else
     {
         redisAppendCommand(m_redisContext, "SET %s %b", key, data, size);
     }
-    else if (mode == 1)
-    {
-        redisAppendCommand(m_redisContext, "GET %s", key);
-    }
 }
 
-void KVCacheCommon::ExecuteBatch(const char *key, size_t mode, size_t size, void *data)
+void KVCacheCommon::ExecuteSetBatch(const char *key)
 {
     if (redisGetReply(m_redisContext, (void **)&m_redisReply) == REDIS_OK)
     {
-        if (mode == 1)
+        freeReplyObject(m_redisReply);
+    }
+    else
+    {
+        std::cout << "Error to execute batch command: " << key << std::endl;
+    }
+}
+
+void KVCacheCommon::AppendGetCommandInBatch(const char *key)
+{
+    // Read data from cache (combo with ExecuteBatch)
+    redisAppendCommand(m_redisContext, "GET %s", key);
+}
+
+void KVCacheCommon::ExecuteGetBatch(const char *key, size_t size, void *data)
+{
+    if (redisGetReply(m_redisContext, (void **)&m_redisReply) == REDIS_OK)
+    {
+        if (!std::strncmp("fileblock:offset=", m_redisReply->str, 17))
+        {
+            size_t cOffset, cSize;
+
+            char *saveptr;
+            char *endptr;
+            char *token = strtok_r(m_redisReply->str, ":", &saveptr); // fileblock
+            // printf("  header = %s\n", token);
+
+            token = strtok_r(NULL, ":", &saveptr); // offset=%d
+            // printf("  offset token = %s\n", token);
+            cOffset = strtoull(token + 7, &endptr, 10);
+            std::cout << "  offset " << cOffset << std::endl;
+
+            token = strtok_r(NULL, ":", &saveptr); // size=%d
+            // printf("  size token = %s\n", token);
+            cSize = strtoull(token + 5, &endptr, 10);
+            std::cout << "  size = " << cSize << " expected size = " << size << std::endl;
+
+            token = strtok_r(NULL, ":", &saveptr);
+            std::cout << "  completed scan? = " << (token ? "No, something left" : "Yes")
+                      << std::endl;
+            // assert(token == NULL);
+
+            if (size != cSize)
+            {
+                std::cout << "Logical error in caching: expected block size = " << size
+                          << " but cache value says size = " << cSize;
+            }
+
+            // data is in the cache file
+            if (!m_CacheFile.is_open())
+            {
+                m_CacheFile.open(m_LocalCacheFilePath,
+                                 std::ios::in | std::ios::out | std::ios::app);
+                if (!m_CacheFile)
+                {
+                    std::cout << "Open Error details: " << strerror(errno) << std::endl;
+                }
+            }
+            m_CacheFile.seekg(cOffset, std::ios_base::beg);
+            if (!m_CacheFile)
+            {
+                std::cout << "Seek Error details: " << strerror(errno) << std::endl;
+            }
+            errno = 0;
+            m_CacheFile.read(static_cast<char *>(data), cSize);
+            if (m_CacheFile.fail())
+            {
+                std::cout << "Error when reading " << cSize << " bytes from cache file "
+                          << m_LocalCacheFilePath << " from offset " << cOffset
+                          << " error: " << strerror(errno) << std::endl;
+            }
+        }
+        else
         {
             memcpy(data, m_redisReply->str, size);
         }

--- a/source/adios2/toolkit/kvcache/KVCacheCommon.h
+++ b/source/adios2/toolkit/kvcache/KVCacheCommon.h
@@ -6,6 +6,7 @@
 #define ADIOS2_KVCACHECOMMON_H
 #include "QueryBox.h"
 #include <cstring> // For memcpy
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -35,20 +36,30 @@ public:
 
     void CloseConnection();
 
+    void SetLocalCacheFile(const std::string localCacheFilePath);
+
     void Set(const char *key, size_t size, void *data);
 
     void Get(const char *key, size_t size, void *data);
 
-    // Batch operations in pipeline, mode 0 for SET, 1 for GET
-    void AppendCommandInBatch(const char *key, size_t mode, size_t size, void *data);
+    // Batch operations in pipeline, SET operation
+    void AppendSetCommandInBatch(const char *key, size_t size, void *data);
+    void ExecuteSetBatch(const char *key);
 
-    void ExecuteBatch(const char *key, size_t mode, size_t size, void *data);
+    // Batch operations in pipeline, GET operation
+    void AppendGetCommandInBatch(const char *key);
+    void ExecuteGetBatch(const char *key, size_t size, void *data);
 
     bool Exists(std::string key);
 
     void KeyPrefixExistence(const std::string &key_prefix, std::unordered_set<std::string> &keys);
 
     void RemotePathHashMd5(const std::string &remotePath, std::string &result);
+
+private:
+    std::string m_LocalCacheFilePath;
+    std::fstream m_CacheFile;
+
 #else
 public:
     KVCacheCommon() = default;


### PR DESCRIPTION
- Cached data is saved in under the locally opened BP folder, instead of pushing into the KV store. Store the reference to the file as KV value instead.
- Use UUID of each dataset in campaign in kv-cache keys and in the cache filenames. Requires ACA >= 0.3 campaign files.
- Organize cache folders with XXX/XXXYYYYY, using first three letters of UUID to create a subfolder, to avoid creating too many folders in the root directory.