### PR TITLE
ci: set ubuntu host to be ubuntu22.04

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -112,7 +112,7 @@ jobs:
     needs: [format, git_checks]
     if: needs.git_checks.outputs.num_code_changes > 0
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/ornladios/adios2:ci-spack-${{ matrix.os }}-${{ matrix.compiler }}
       options: --shm-size=1g


### PR DESCRIPTION
Github is phasing out ubuntu 20.04 machines