### PR TITLE
Draft: Add ZSTD operator with threading support

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -206,6 +206,16 @@ if(PNG_FOUND)
   set(ADIOS2_HAVE_PNG TRUE)
 endif()
 
+# ZSTD
+if(ADIOS2_USE_ZSTD STREQUAL AUTO)
+  find_package(ZSTD)
+elseif(ADIOS2_USE_ZSTD)
+  find_package(ZSTD REQUIRED)
+endif()
+if(ZSTD_FOUND)
+  set(ADIOS2_HAVE_ZSTD TRUE)
+endif()
+
 set(mpi_find_components C)
 
 if(ADIOS2_USE_Derived_Variable)

--- a/cmake/FindZSTD.cmake
+++ b/cmake/FindZSTD.cmake
@@ -1,0 +1,67 @@
+#------------------------------------------------------------------------------#
+# Distributed under the OSI-approved Apache License, Version 2.0.  See
+# accompanying file Copyright.txt for details.
+#------------------------------------------------------------------------------#
+#
+# FindZSTD
+# -----------
+#
+# Try to find the ZSTD library
+#
+# This module defines the following variables:
+#
+#   ZSTD_FOUND        - System has ZSTD
+#   ZSTD_INCLUDE_DIRS - The ZSTD include directory
+#   ZSTD_LIBRARIES    - Link these to use ZSTD
+#
+# and the following imported targets:
+#   ZSTD::ZSTD - The ZSTD compression library target
+#
+# You can also set the following variable to help guide the search:
+#   ZSTD_ROOT - The install prefix for ZSTD containing the
+#              include and lib folders
+#              Note: this can be set as a CMake variable or an
+#                    environment variable.  If specified as a CMake
+#                    variable, it will override any ZSTD_ROOT set in the
+#                    environment.
+
+if(NOT ZSTD_FOUND)
+  if(NOT ZSTD_ROOT)
+    if(NOT "$ENV{ZSTD_ROOT}" STREQUAL "")
+      set(ZSTD_ROOT "$ENV{ZSTD_ROOT}")
+    endif()
+  endif()
+
+  # Try to find the header
+  find_path(ZSTD_INCLUDE_DIR zstd.h
+    HINTS ${ZSTD_ROOT}
+    PATH_SUFFIXES include
+  )
+
+  # Try to find the library
+  find_library(ZSTD_LIBRARY zstd
+    HINTS ${ZSTD_ROOT}
+    PATH_SUFFIXES lib lib64
+  )
+
+  # Handle the QUIETLY and REQUIRED arguments and set ZSTD_FOUND to TRUE if all listed variables are TRUE.
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(ZSTD
+    FOUND_VAR ZSTD_FOUND
+    REQUIRED_VARS ZSTD_LIBRARY ZSTD_INCLUDE_DIR
+  )
+
+  if(ZSTD_FOUND)
+    set(ZSTD_INCLUDE_DIRS ${ZSTD_INCLUDE_DIR})
+    set(ZSTD_LIBRARIES ${ZSTD_LIBRARY})
+    if(NOT TARGET ZSTD::ZSTD)
+      add_library(ZSTD::ZSTD UNKNOWN IMPORTED)
+      set_target_properties(ZSTD::ZSTD PROPERTIES
+        IMPORTED_LOCATION "${ZSTD_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIR}"
+      )
+    endif()
+  endif()
+
+  mark_as_advanced(ZSTD_INCLUDE_DIR ZSTD_LIBRARY)
+endif()

--- a/scripts/ci/scripts/run-check-locally.bash
+++ b/scripts/ci/scripts/run-check-locally.bash
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -x
+
+readonly DOCKER_IMG=ghcr.io/ornladios/adios2:ci-formatting
+readonly PODMAN_CMD=(podman run -v .:/data -w /data -it "${DOCKER_IMG}")
+
+read -r -d '' HELP_MSG << EOS
+  run-check-locally.bash <action>
+    -c    clang-format
+    -p    pylint
+    -k    shellcheck
+EOS
+
+if (( "$#" == 0 ))
+then
+  echo "error: action not given"
+  echo "${HELP_MSG}"
+  exit 1
+fi
+
+while getopts "cps" o
+do
+  case "${o}" in
+    c)
+      "${PODMAN_CMD[@]}" "./scripts/ci/scripts/run-clang-format.sh"
+      ;;
+    p)
+      "${PODMAN_CMD[@]}" "./scripts/ci/scripts/run-pylint.sh"
+      ;;
+    s)
+      "${PODMAN_CMD[@]}" "./scripts/ci/scripts/run-shellcheck.sh"
+      ;;
+    *)
+      echo "error: action not recognized"
+      echo "${HELP_MSG}"
+      exit 2
+      ;;
+  esac
+done

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -407,6 +407,11 @@ if(ADIOS2_HAVE_PNG)
   target_link_libraries(adios2_core PRIVATE PNG::PNG)
 endif()
 
+if(ADIOS2_HAVE_ZSTD)
+  target_sources(adios2_core PRIVATE operator/compress/CompressZSTD.cpp)
+  target_link_libraries(adios2_core PRIVATE ZSTD::ZSTD)
+endif()
+
 if(ADIOS2_HAVE_MHS)
 target_sources(adios2_core PRIVATE operator/compress/CompressSirius.cpp)
 endif()

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -656,6 +656,38 @@ constexpr char doshuffle_bitshuffle[] = "BLOSC_BITSHUFFLE";
 
 #endif
 
+// ZSTD PARAMETERS
+#ifdef ADIOS2_HAVE_ZSTD
+
+constexpr char LosslessZSTD[] = "zstd";
+
+namespace zstd
+{
+
+namespace key
+{
+constexpr char compressionLevel[] = "compressionLevel";
+constexpr char nThreads[] = "nThreads";
+}
+
+namespace value
+{
+constexpr char compressionLevel_1[] = "1";
+constexpr char compressionLevel_2[] = "2";
+constexpr char compressionLevel_3[] = "3";
+constexpr char compressionLevel_5[] = "5";
+constexpr char compressionLevel_7[] = "7";
+constexpr char compressionLevel_9[] = "9";
+constexpr char compressionLevel_12[] = "12";
+constexpr char compressionLevel_15[] = "15";
+constexpr char compressionLevel_19[] = "19";
+constexpr char compressionLevel_22[] = "22";
+} // end namespace value
+
+} // end namespace zstd
+
+#endif
+
 } // end namespace ops
 
 } // end namespace adios2

--- a/source/adios2/core/Operator.h
+++ b/source/adios2/core/Operator.h
@@ -38,6 +38,7 @@ public:
         COMPRESS_ZFP = 7,
         COMPRESS_MGARDPLUS = 8,
         COMPRESS_BIGWHOOP = 9,
+        COMPRESS_ZSTD = 10,
         REFACTOR_MDR = 41,
         CALLBACK_SIGNATURE1 = 51,
         CALLBACK_SIGNATURE2 = 52,

--- a/source/adios2/operator/OperatorFactory.cpp
+++ b/source/adios2/operator/OperatorFactory.cpp
@@ -55,6 +55,10 @@
 #include "adios2/operator/compress/CompressZFP.h"
 #endif
 
+#ifdef ADIOS2_HAVE_ZSTD
+#include "adios2/operator/compress/CompressZSTD.h"
+#endif
+
 namespace adios2
 {
 namespace core
@@ -84,6 +88,8 @@ std::string OperatorTypeToString(const Operator::OperatorType type)
         return "sz";
     case Operator::COMPRESS_ZFP:
         return "zfp";
+    case Operator::COMPRESS_ZSTD:
+        return "zstd";
     case Operator::REFACTOR_MDR:
         return "mdr";
     case Operator::PLUGIN_INTERFACE:
@@ -157,6 +163,12 @@ std::shared_ptr<Operator> MakeOperator(const std::string &type, const Params &pa
     {
 #ifdef ADIOS2_HAVE_ZFP
         ret = std::make_shared<compress::CompressZFP>(parameters);
+#endif
+    }
+    else if (typeLowerCase == "zstd")
+    {
+#ifdef ADIOS2_HAVE_ZSTD
+        ret = std::make_shared<compress::CompressZSTD>(parameters);
 #endif
     }
     else if (typeLowerCase == "mdr")

--- a/source/adios2/operator/compress/CompressZSTD.cpp
+++ b/source/adios2/operator/compress/CompressZSTD.cpp
@@ -1,0 +1,252 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * CompressZSTD.cpp
+ *
+ *  Created on: March 4, 2025
+ *      Author: Vicente Adolfo Bolea Sanchez
+ */
+
+#include "CompressZSTD.h"
+
+#include <cmath>     //std::ceil
+#include <ios>       //std::ios_base::failure
+#include <stdexcept> //std::invalid_argument
+
+extern "C" {
+#include <zstd.h>
+}
+
+#include "adios2/helper/adiosFunctions.h"
+
+namespace adios2
+{
+namespace core
+{
+namespace compress
+{
+
+CompressZSTD::CompressZSTD(const Params &parameters)
+: Operator("zstd", COMPRESS_ZSTD, "compress", parameters)
+{
+}
+
+size_t CompressZSTD::Operate(const char *dataIn, const Dims &blockStart, const Dims &blockCount,
+                             DataType type, char *bufferOut)
+{
+    const uint8_t bufferVersion = 1;
+    unsigned int destOffset = 0;
+
+    MakeCommonHeader(bufferOut, destOffset, bufferVersion);
+
+    const size_t sizeIn = helper::GetTotalSize(blockCount, helper::GetDataTypeSize(type));
+    const size_t batches = sizeIn / DefaultMaxFileBatchSize + 1;
+
+    // ZSTD V1 metadata
+    PutParameter(bufferOut, destOffset, sizeIn);
+    PutParameter(bufferOut, destOffset, batches);
+    // ZSTD V1 metadata end
+
+    int compressionLevel = 1; // Default zstd compression level (1-22)
+    int nThreads = 1;         // Default: single-threaded
+
+    if (!m_Parameters.empty())
+    {
+        const std::string hint(" in call to CompressZSTD Compress " + ToString(type) + "\n");
+        helper::SetParameterValueInt("compressionLevel", m_Parameters, compressionLevel, hint);
+        helper::SetParameterValueInt("nThreads", m_Parameters, nThreads, hint);
+        if (compressionLevel < 1 || compressionLevel > 22)
+        {
+            helper::Throw<std::invalid_argument>("Operator", "CompressZSTD", "Operate",
+                                                 "compressionLevel must be an "
+                                                 "integer between 1 (less "
+                                                 "compression, less memory) and 22 "
+                                                 "(more compression, more memory) inclusive, " +
+                                                     hint);
+        }
+        if (nThreads < 1)
+        {
+            helper::Throw<std::invalid_argument>("Operator", "CompressZSTD", "Operate",
+                                                 "nThreads must be greater than or equal to 1, " +
+                                                     hint);
+        }
+    }
+
+    unsigned int sourceOffset = 0;
+    unsigned int batchInfoOffset = destOffset;
+    destOffset += static_cast<unsigned int>(batches * 4 * sizeof(unsigned int));
+
+    for (size_t b = 0; b < batches; ++b)
+    {
+        char *source = const_cast<char *>(dataIn) + sourceOffset;
+
+        const size_t batchSize =
+            (b == batches - 1) ? sizeIn % DefaultMaxFileBatchSize : DefaultMaxFileBatchSize;
+        unsigned int sourceLen = static_cast<unsigned int>(batchSize);
+
+        char *dest = bufferOut + destOffset;
+
+        // Set up compression context based on nThreads
+        ZSTD_CCtx *cctx = ZSTD_createCCtx();
+        if (cctx == NULL)
+        {
+            helper::Throw<std::runtime_error>("Operator", "CompressZSTD", "Operate",
+                                              "Failed to create ZSTD compression context");
+        }
+
+        // Set parameters for the context
+        ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, compressionLevel);
+
+        if (nThreads > 1)
+        {
+            ZSTD_CCtx_setParameter(cctx, ZSTD_c_nbWorkers, nThreads);
+        }
+
+        // Calculate maximum compressed size
+        size_t maxDestSize = ZSTD_compressBound(sourceLen);
+
+        // Check if buffer has enough space for compression
+        if (maxDestSize > sourceLen)
+        {
+            helper::Throw<std::runtime_error>(
+                "Operator", "CompressZSTD", "Operate",
+                "Output buffer may not be large enough for compression");
+        }
+
+        // Compress data with context
+        size_t destLen =
+            ZSTD_compressCCtx(cctx, dest, maxDestSize, source, sourceLen, compressionLevel);
+
+        // Free the context
+        ZSTD_freeCCtx(cctx);
+
+        // Check for errors
+        if (ZSTD_isError(destLen))
+        {
+            CheckStatus(destLen,
+                        "in call to ADIOS2 ZSTD Compress batch " + std::to_string(b) + "\n");
+        }
+
+        // ZSTD V1 metadata
+        PutParameter(bufferOut, batchInfoOffset, sourceOffset);
+        PutParameter(bufferOut, batchInfoOffset, sourceLen);
+        PutParameter(bufferOut, batchInfoOffset, destOffset);
+        PutParameter(bufferOut, batchInfoOffset, static_cast<unsigned int>(destLen));
+        // ZSTD V1 metadata end
+
+        sourceOffset += sourceLen;
+        destOffset += static_cast<unsigned int>(destLen);
+    }
+
+    return destOffset;
+}
+
+size_t CompressZSTD::InverseOperate(const char *bufferIn, const size_t sizeIn, char *dataOut)
+{
+    size_t bufferInOffset = 1; // skip operator type
+    const uint8_t bufferVersion = GetParameter<uint8_t>(bufferIn, bufferInOffset);
+    bufferInOffset += 2; // skip two reserved bytes
+
+    if (bufferVersion == 1)
+    {
+        // pass in the whole buffer as there is absolute positions saved in the
+        // buffer to determine the offsets and lengths for batches
+        return DecompressV1(bufferIn, sizeIn, dataOut);
+    }
+    else if (bufferVersion == 2)
+    {
+        // TODO: if a Version 2 ZSTD buffer is being implemented, put it here
+        // and keep the DecompressV1 routine for backward compatibility
+    }
+    else
+    {
+        helper::Throw<std::runtime_error>("Operator", "CompressZSTD", "InverseOperate",
+                                          "invalid ZSTD buffer version");
+    }
+
+    return 0;
+}
+
+bool CompressZSTD::IsDataTypeValid(const DataType type) const { return true; }
+
+size_t CompressZSTD::DecompressV1(const char *bufferIn, const size_t sizeIn, char *dataOut)
+{
+    // Do NOT remove even if the buffer version is updated. Data might be still
+    // in legacy formats. This function must be kept for backward compatibility.
+    // If a newer buffer format is implemented, create another function, e.g.
+    // DecompressV2 and keep this function for decompressing legacy data.
+
+    size_t bufferInOffset = 4; // skip the first four bytes
+
+    size_t sizeOut = GetParameter<size_t, size_t>(bufferIn, bufferInOffset);
+    size_t batches = GetParameter<size_t, size_t>(bufferIn, bufferInOffset);
+
+    size_t expectedSizeOut = 0;
+
+    for (size_t b = 0; b < batches; ++b)
+    {
+        unsigned int destOffset = GetParameter<unsigned int>(bufferIn, bufferInOffset);
+
+        bufferInOffset += sizeof(unsigned int);
+
+        char *dest = dataOut + destOffset;
+
+        const size_t batchSize =
+            (b == batches - 1) ? sizeOut % DefaultMaxFileBatchSize : DefaultMaxFileBatchSize;
+
+        unsigned int destLen = static_cast<unsigned int>(batchSize);
+
+        unsigned int sourceOffset = GetParameter<unsigned int>(bufferIn, bufferInOffset);
+
+        char *source = const_cast<char *>(bufferIn) + sourceOffset;
+
+        unsigned int sourceLen = GetParameter<unsigned int>(bufferIn, bufferInOffset);
+
+        // Create a decompression context (optional for simple cases but allows for advanced
+        // settings)
+        ZSTD_DCtx *dctx = ZSTD_createDCtx();
+        if (dctx == NULL)
+        {
+            helper::Throw<std::runtime_error>("Operator", "CompressZSTD", "DecompressV1",
+                                              "Failed to create ZSTD decompression context");
+        }
+
+        // Decompress the data
+        size_t result = ZSTD_decompressDCtx(dctx, dest, destLen, source, sourceLen);
+
+        // Free the context
+        ZSTD_freeDCtx(dctx);
+
+        // Check for errors
+        if (ZSTD_isError(result))
+        {
+            CheckStatus(result,
+                        "in call to ADIOS2 ZSTD Decompress batch " + std::to_string(b) + "\n");
+        }
+
+        expectedSizeOut += static_cast<size_t>(result);
+    }
+
+    if (expectedSizeOut != sizeOut)
+    {
+        helper::Throw<std::runtime_error>("Operator", "CompressZSTD", "DecompressV1",
+                                          "corrupted ZSTD buffer");
+    }
+
+    return sizeOut;
+}
+
+void CompressZSTD::CheckStatus(const size_t status, const std::string hint) const
+{
+    if (ZSTD_isError(status))
+    {
+        helper::Throw<std::invalid_argument>("Operator", "CompressZSTD", "CheckStatus",
+                                             std::string("ZSTD error: ") +
+                                                 ZSTD_getErrorName(status) + " " + hint);
+    }
+}
+
+} // end namespace compress
+} // end namespace core
+} // end namespace adios2

--- a/source/adios2/operator/compress/CompressZSTD.h
+++ b/source/adios2/operator/compress/CompressZSTD.h
@@ -1,0 +1,79 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * CompressZSTD.h : wrapper to ZSTD compression library https://github.com/facebook/zstd
+ *
+ *  Created on: March 4, 2025
+ *      Author: Vicente Adolfo Bolea Sanchez
+ */
+
+#ifndef ADIOS2_OPERATOR_COMPRESS_COMPRESSZSTD_H_
+#define ADIOS2_OPERATOR_COMPRESS_COMPRESSZSTD_H_
+
+#include "adios2/core/Operator.h"
+
+namespace adios2
+{
+namespace core
+{
+namespace compress
+{
+
+class CompressZSTD : public Operator
+{
+
+public:
+    /**
+     * Unique constructor
+     */
+    CompressZSTD(const Params &parameters);
+
+    ~CompressZSTD() = default;
+
+    /**
+     * @param dataIn
+     * @param blockStart
+     * @param blockCount
+     * @param type
+     * @param bufferOut
+     * @return size of compressed buffer
+     */
+    size_t Operate(const char *dataIn, const Dims &blockStart, const Dims &blockCount,
+                   const DataType type, char *bufferOut) final;
+
+    /**
+     * @param bufferIn
+     * @param sizeIn
+     * @param dataOut
+     * @return size of decompressed buffer
+     */
+    size_t InverseOperate(const char *bufferIn, const size_t sizeIn, char *dataOut) final;
+
+    bool IsDataTypeValid(const DataType type) const final;
+
+private:
+    /**
+     * check status from ZSTD compression and decompression functions
+     * @param status returned by ZSTD library
+     * @param hint extra exception information
+     */
+    void CheckStatus(const size_t status, const std::string hint) const;
+
+    /**
+     * Decompress function for V1 buffer. Do NOT remove even if the buffer
+     * version is updated. Data might be still in lagacy formats. This function
+     * must be kept for backward compatibility
+     * @param bufferIn : compressed data buffer (V1 only)
+     * @param sizeIn : number of bytes in bufferIn
+     * @param dataOut : decompressed data buffer
+     * @return : number of bytes in dataOut
+     */
+    size_t DecompressV1(const char *bufferIn, const size_t sizeIn, char *dataOut);
+};
+
+} // end namespace compress
+} // end namespace core
+} // end namespace adios2
+
+#endif /* ADIOS2_OPERATOR_COMPRESS_COMPRESSZSTD_H_ */

--- a/testing/adios2/engine/bp/operations/CMakeLists.txt
+++ b/testing/adios2/engine/bp/operations/CMakeLists.txt
@@ -79,3 +79,7 @@ endif()
 if(ADIOS2_HAVE_Blosc2)
   bp_gtest_add_tests_helper(WriteReadBlosc2 MPI_ALLOW)
 endif()
+
+if(ADIOS2_HAVE_ZSTD)
+  bp_gtest_add_tests_helper(WriteReadZSTD MPI_ALLOW)
+endif()

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZSTD.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZSTD.cpp
@@ -1,0 +1,622 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <numeric> //std::iota
+#include <stdexcept>
+#include <tuple>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+std::string engineName; // comes from command line
+
+void ZSTDAccuracy1D(const std::string compressionLevel, const std::string nThreads)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 1000;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx);
+    std::vector<double> r64s(Nx);
+
+    // range 0 to 999
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+    const std::string fname("BPWR_ZSTD_1D_" + compressionLevel + "_" + nThreads + "_MPI.bp");
+#else
+    const std::string fname("BPWR_ZSTD_1D_" + compressionLevel + "_" + nThreads + ".bp");
+#endif
+
+#if ADIOS2_USE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+    adios2::ADIOS adios;
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize)};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
+        const adios2::Dims count{Nx};
+
+        adios2::Variable<float> var_r32 =
+            io.DefineVariable<float>("r32", shape, start, count, adios2::ConstantDims);
+        adios2::Variable<double> var_r64 =
+            io.DefineVariable<double>("r64", shape, start, count, adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator ZSTDOp = adios.DefineOperator("ZSTDCompressor", adios2::ops::LosslessZSTD);
+
+        var_r32.AddOperation(ZSTDOp, {{adios2::ops::zstd::key::compressionLevel, compressionLevel},
+                                      {adios2::ops::zstd::key::nThreads, nThreads}});
+        var_r64.AddOperation(ZSTDOp, {{adios2::ops::zstd::key::compressionLevel, compressionLevel},
+                                      {adios2::ops::zstd::key::nThreads, nThreads}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Steps(), NSteps);
+            ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(var_r64);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Steps(), NSteps);
+            ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+
+            const adios2::Dims start{mpiRank * Nx};
+            const adios2::Dims count{Nx};
+            const adios2::Box<adios2::Dims> sel(start, count);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[i]) << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+void ZSTDAccuracy2D(const std::string compressionLevel, const std::string nThreads)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 100;
+    const size_t Ny = 50;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx * Ny);
+    std::vector<double> r64s(Nx * Ny);
+
+    // range 0 to 100*50
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+    const std::string fname("BPWRZSTD2D_" + compressionLevel + "_" + nThreads + "_MPI.bp");
+#else
+    const std::string fname("BPWRZSTD2D_" + compressionLevel + "_" + nThreads + ".bp");
+#endif
+
+#if ADIOS2_USE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+    adios2::ADIOS adios;
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize), Ny};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank), 0};
+        const adios2::Dims count{Nx, Ny};
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count, adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count, adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator ZSTDOp = adios.DefineOperator("ZSTDCompressor", adios2::ops::LosslessZSTD);
+
+        var_r32.AddOperation(ZSTDOp, {{adios2::ops::zstd::key::compressionLevel, compressionLevel},
+                                      {adios2::ops::zstd::key::nThreads, nThreads}});
+        var_r64.AddOperation(ZSTDOp, {{adios2::ops::zstd::key::compressionLevel, compressionLevel},
+                                      {adios2::ops::zstd::key::nThreads, nThreads}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Steps(), NSteps);
+            ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+            ASSERT_EQ(var_r32.Shape()[1], Ny);
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(var_r64);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Steps(), NSteps);
+            ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+            ASSERT_EQ(var_r64.Shape()[1], Ny);
+
+            const adios2::Dims start{mpiRank * Nx, 0};
+            const adios2::Dims count{Nx, Ny};
+            const adios2::Box<adios2::Dims> sel(start, count);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx * Ny; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[i]) << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+void ZSTDAccuracy3D(const std::string compressionLevel, const std::string nThreads)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 10;
+    const size_t Ny = 20;
+    const size_t Nz = 15;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx * Ny * Nz);
+    std::vector<double> r64s(Nx * Ny * Nz);
+
+    // range 0 to 100*50
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+    const std::string fname("BPWRZSTD3D_" + compressionLevel + "_" + nThreads + "_MPI.bp");
+#else
+    const std::string fname("BPWRZSTD3D_" + compressionLevel + "_" + nThreads + ".bp");
+#endif
+
+#if ADIOS2_USE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+    adios2::ADIOS adios;
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize), Ny, Nz};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank), 0, 0};
+        const adios2::Dims count{Nx, Ny, Nz};
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count, adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count, adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator ZSTDOp = adios.DefineOperator("ZSTDCompressor", adios2::ops::LosslessZSTD);
+
+        var_r32.AddOperation(ZSTDOp, {{adios2::ops::zstd::key::compressionLevel, compressionLevel},
+                                      {adios2::ops::zstd::key::nThreads, nThreads}});
+        var_r64.AddOperation(ZSTDOp, {{adios2::ops::zstd::key::compressionLevel, compressionLevel},
+                                      {adios2::ops::zstd::key::nThreads, nThreads}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Steps(), NSteps);
+            ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+            ASSERT_EQ(var_r32.Shape()[1], Ny);
+            ASSERT_EQ(var_r32.Shape()[2], Nz);
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(var_r64);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Steps(), NSteps);
+            ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+            ASSERT_EQ(var_r64.Shape()[1], Ny);
+            ASSERT_EQ(var_r64.Shape()[2], Nz);
+
+            const adios2::Dims start{mpiRank * Nx, 0, 0};
+            const adios2::Dims count{Nx, Ny, Nz};
+            const adios2::Box<adios2::Dims> sel(start, count);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx * Ny * Nz; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[i]) << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+void ZSTDAccuracy1DSel(const std::string compressionLevel, const std::string nThreads)
+{
+    // Each process would write a 1x8 array and all processes would
+    // form a mpiSize * Nx 1D array
+    int mpiRank = 0, mpiSize = 1;
+    // Number of rows
+    const size_t Nx = 1000;
+
+    // Number of steps
+    const size_t NSteps = 1;
+
+    std::vector<float> r32s(Nx);
+    std::vector<double> r64s(Nx);
+
+    // range 0 to 999
+    std::iota(r32s.begin(), r32s.end(), 0.f);
+    std::iota(r64s.begin(), r64s.end(), 0.);
+
+#if ADIOS2_USE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+    const std::string fname("BPWRZSTD1DSel_" + compressionLevel + "_" + nThreads + "_MPI.bp");
+#else
+    const std::string fname("BPWRZSTD1DSel_" + compressionLevel + "_" + nThreads + ".bp");
+#endif
+
+#if ADIOS2_USE_MPI
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+#else
+    adios2::ADIOS adios;
+#endif
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        const adios2::Dims shape{static_cast<size_t>(Nx * mpiSize)};
+        const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
+        const adios2::Dims count{Nx};
+
+        auto var_r32 = io.DefineVariable<float>("r32", shape, start, count, adios2::ConstantDims);
+        auto var_r64 = io.DefineVariable<double>("r64", shape, start, count, adios2::ConstantDims);
+
+        // add operations
+        adios2::Operator ZSTDOp = adios.DefineOperator("ZSTDCompressor", adios2::ops::LosslessZSTD);
+
+        var_r32.AddOperation(ZSTDOp, {{adios2::ops::zstd::key::compressionLevel, compressionLevel},
+                                      {adios2::ops::zstd::key::nThreads, nThreads}});
+        var_r64.AddOperation(ZSTDOp, {{adios2::ops::zstd::key::compressionLevel, compressionLevel},
+                                      {adios2::ops::zstd::key::nThreads, nThreads}});
+
+        adios2::Engine bpWriter = io.Open(fname, adios2::Mode::Write);
+
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            bpWriter.BeginStep();
+            bpWriter.Put<float>("r32", r32s.data());
+            bpWriter.Put<double>("r64", r64s.data());
+            bpWriter.EndStep();
+        }
+
+        bpWriter.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+
+        adios2::Engine bpReader = io.Open(fname, adios2::Mode::Read);
+
+        unsigned int t = 0;
+        std::vector<float> decompressedR32s;
+        std::vector<double> decompressedR64s;
+
+        while (bpReader.BeginStep() == adios2::StepStatus::OK)
+        {
+            auto var_r32 = io.InquireVariable<float>("r32");
+            EXPECT_TRUE(var_r32);
+            ASSERT_EQ(var_r32.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r32.Steps(), NSteps);
+            ASSERT_EQ(var_r32.Shape()[0], mpiSize * Nx);
+
+            auto var_r64 = io.InquireVariable<double>("r64");
+            EXPECT_TRUE(var_r64);
+            ASSERT_EQ(var_r64.ShapeID(), adios2::ShapeID::GlobalArray);
+            ASSERT_EQ(var_r64.Steps(), NSteps);
+            ASSERT_EQ(var_r64.Shape()[0], mpiSize * Nx);
+
+            const adios2::Dims start{mpiRank * Nx + Nx / 2};
+            const adios2::Dims count{Nx / 2};
+            const adios2::Box<adios2::Dims> sel(start, count);
+            var_r32.SetSelection(sel);
+            var_r64.SetSelection(sel);
+
+            bpReader.Get(var_r32, decompressedR32s);
+            bpReader.Get(var_r64, decompressedR64s);
+            bpReader.EndStep();
+
+            for (size_t i = 0; i < Nx / 2; ++i)
+            {
+                std::stringstream ss;
+                ss << "t=" << t << " i=" << i << " rank=" << mpiRank;
+                std::string msg = ss.str();
+
+                ASSERT_EQ(decompressedR32s[i], r32s[Nx / 2 + i]) << msg;
+                ASSERT_EQ(decompressedR64s[i], r64s[Nx / 2 + i]) << msg;
+            }
+            ++t;
+        }
+
+        EXPECT_EQ(t, NSteps);
+
+        bpReader.Close();
+    }
+}
+
+class BPWriteReadZSTD : public ::testing::TestWithParam<std::tuple<std::string, std::string>>
+{
+public:
+    BPWriteReadZSTD() = default;
+    virtual void SetUp(){};
+    virtual void TearDown(){};
+};
+
+TEST_P(BPWriteReadZSTD, ADIOS2BPWriteReadZSTD1D)
+{
+    ZSTDAccuracy1D(std::get<0>(GetParam()), std::get<1>(GetParam()));
+}
+TEST_P(BPWriteReadZSTD, ADIOS2BPWriteReadZSTD2D)
+{
+    ZSTDAccuracy2D(std::get<0>(GetParam()), std::get<1>(GetParam()));
+}
+TEST_P(BPWriteReadZSTD, ADIOS2BPWriteReadZSTD3D)
+{
+    ZSTDAccuracy3D(std::get<0>(GetParam()), std::get<1>(GetParam()));
+}
+TEST_P(BPWriteReadZSTD, ADIOS2BPWriteReadZSTD1DSel)
+{
+    ZSTDAccuracy1DSel(std::get<0>(GetParam()), std::get<1>(GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(ZSTDAccuracy, BPWriteReadZSTD,
+                         ::testing::Combine(
+                             // test compression levels
+                             ::testing::Values(adios2::ops::zstd::value::compressionLevel_1,
+                                               adios2::ops::zstd::value::compressionLevel_3,
+                                               adios2::ops::zstd::value::compressionLevel_7,
+                                               adios2::ops::zstd::value::compressionLevel_9,
+                                               adios2::ops::zstd::value::compressionLevel_15,
+                                               adios2::ops::zstd::value::compressionLevel_22),
+                             // test threading
+                             ::testing::Values("1", "2", "4")));
+
+int main(int argc, char **argv)
+{
+#if ADIOS2_USE_MPI
+    int provided;
+
+    // MPI_THREAD_MULTIPLE is only required if you enable the SST MPI_DP
+    MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+    result = RUN_ALL_TESTS();
+
+#if ADIOS2_USE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}


### PR DESCRIPTION
This commit adds a new operator for ADIOS2 that uses the ZSTD compression library.

Features:
- Support for different compression levels (1-22)
- Multithreaded compression via nThreads parameter
- Added FindZSTD.cmake for CMake integration
- Added necessary CMake infrastructure

The operator can be configured with parameters:
- compressionLevel: 1 (fast) to 22 (high compression)
- nThreads: Number of threads for compression (default: 1)