### PR TITLE
[BugFix] Set the correct dimensions and type for a derived expression

### DIFF
--- a/source/adios2/core/VariableDerived.cpp
+++ b/source/adios2/core/VariableDerived.cpp
@@ -71,7 +71,7 @@ VariableDerived::ApplyExpression(std::map<std::string, std::unique_ptr<MinVarInf
         inputData.insert({variable.first, varData});
     }
     std::vector<adios2::derived::DerivedData> outputData =
-        m_Expr.ApplyExpression(m_Type, numBlocks, inputData);
+        m_Expr.ApplyExpression(numBlocks, inputData);
 
     std::vector<std::tuple<void *, Dims, Dims>> blockData;
     for (size_t i = 0; i < numBlocks; i++)

--- a/source/adios2/toolkit/derived/Expression.cpp
+++ b/source/adios2/toolkit/derived/Expression.cpp
@@ -194,10 +194,10 @@ DataType Expression::GetType(std::map<std::string, DataType> NameToType)
 }
 
 std::vector<DerivedData>
-Expression::ApplyExpression(DataType type, size_t numBlocks,
+Expression::ApplyExpression(const size_t numBlocks,
                             std::map<std::string, std::vector<DerivedData>> nameToData)
 {
-    return m_Expr.ApplyExpression(type, numBlocks, nameToData);
+    return m_Expr.ApplyExpression(numBlocks, nameToData);
 }
 
 void ExpressionTree::set_base(double c) { detail.constant = c; }
@@ -340,7 +340,7 @@ DataType ExpressionTree::GetType(std::map<std::string, DataType> NameToType)
 }
 
 std::vector<DerivedData>
-ExpressionTree::ApplyExpression(DataType type, size_t numBlocks,
+ExpressionTree::ApplyExpression(const size_t numBlocks,
                                 std::map<std::string, std::vector<DerivedData>> nameToData)
 {
     // create operands for the computation function

--- a/source/adios2/toolkit/derived/Expression.h
+++ b/source/adios2/toolkit/derived/Expression.h
@@ -78,7 +78,7 @@ public:
     GetDims(std::map<std::string, std::tuple<Dims, Dims, Dims>> NameToDims);
     DataType GetType(std::map<std::string, DataType> NameToType);
     std::vector<DerivedData>
-    ApplyExpression(DataType type, size_t numBlocks,
+    ApplyExpression(const size_t numBlocks,
                     std::map<std::string, std::vector<DerivedData>> nameToData);
     void print();
     std::string toStringExpr();
@@ -108,7 +108,7 @@ public:
     void SetDims(std::map<std::string, std::tuple<Dims, Dims, Dims>> NameToDims);
     std::vector<std::string> VariableNameList();
     std::vector<DerivedData>
-    ApplyExpression(DataType type, size_t numBlocks,
+    ApplyExpression(const size_t numBlocks,
                     std::map<std::string, std::vector<DerivedData>> nameToData);
 };
 

--- a/testing/adios2/derived/TestBPDerivedCorrectness.cpp
+++ b/testing/adios2/derived/TestBPDerivedCorrectness.cpp
@@ -42,6 +42,7 @@ TEST_P(DerivedCorrectnessP, BasicCorrectnessTest)
         simArray1[i] = distribution(generator);
 
     auto U = bpOut.DefineVariable<float>("var1", {N}, {0}, {N});
+    EXPECT_TRUE(U); // needed to not have a warning for not using U
     auto V = bpOut.DefineVariable<float>("var2", {N}, {0}, {N});
     bpOut.DefineDerivedVariable("derived", "x= var1 \n sqrt(x)", mode);
     adios2::Engine bpFileWriter = bpOut.Open("BPNoData.bp", adios2::Mode::Write);


### PR DESCRIPTION
Setting the type and dimensions of a variable is currently done in two places using two different logics. One in the math expressions (the return `DerivedData` object has the dimensions set by the math function) and the second in the derived variable class (when defining the variable). This PR removes the logic inside the math function so we have consistent dimensions and types.

Before this PR if you defined a derived variable:
```
    bpIO.DefineDerivedVariable("derived/myderived",
                                "x = U \n"
                                "sqrt(pow(x))",
                                adios2::DerivedVarType::StatsOnly);
```
The result your error with the following message:
```
"x = U\n sqrt(pow(x))" -> <Derived> <Function> <SqrtFunc> : Invalid variable types
```

**I tested this with the derived variables on and the CI passes**