### PR TITLE
Cleanup CMake a bit

### DIFF
--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -527,12 +527,12 @@ endif()
 find_package(DAOS)
 if(DAOS_FOUND)
   set(ADIOS2_HAVE_DAOS TRUE)
-endif()
 
-# Caliper
-find_package(Caliper)
-if(Caliper_FOUND)
-  set(ADIOS2_HAVE_Caliper TRUE)
+  # Caliper  (currently on needed by DAOS code)
+  find_package(Caliper REQUIRED)
+  if(Caliper_FOUND)
+     set(ADIOS2_HAVE_Caliper TRUE)
+  endif()
 endif()
 
 #SysV IPC

--- a/thirdparty/enet/enet/CMakeLists.txt
+++ b/thirdparty/enet/enet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
 project(ENET VERSION 1.3.14 LANGUAGES C)
 


### PR DESCRIPTION
Only try to find Caliper if DAOS is found, because it's not used by non-DAOS code.  Pull in new version of enet with increased minimum CMake version to avoid warnings.