### PR TITLE
Fixing the GPU examples for the Fortran and C bindings

### DIFF
--- a/examples/hello/bpStepsWriteReadCuda/CMakeLists.txt
+++ b/examples/hello/bpStepsWriteReadCuda/CMakeLists.txt
@@ -18,6 +18,11 @@ if(NOT TARGET adios2_core)
 endif()
 
 if(ADIOS2_HAVE_CUDA OR ADIOS2_HAVE_Kokkos_CUDA)
+  add_executable(adios2_hello_bpStepsWriteReadCuda_c bpStepsWriteReadCBindings.cu)
+  target_link_libraries(adios2_hello_bpStepsWriteReadCuda_c PUBLIC adios2::c CUDA::cudart)
+  set_target_properties(adios2_hello_bpStepsWriteReadCuda_c PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+  install(TARGETS adios2_hello_bpStepsWriteReadCuda_c RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
   add_executable(adios2_hello_bpStepsWriteReadCuda bpStepsWriteReadCuda.cu)
   target_link_libraries(adios2_hello_bpStepsWriteReadCuda PUBLIC adios2::cxx11 CUDA::cudart)
   set_target_properties(adios2_hello_bpStepsWriteReadCuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON)

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCBindings.cu
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCBindings.cu
@@ -1,0 +1,100 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * bpStepsWriteReadCBindings.cu  Simple example of writing and reading data through ADIOS2 BP engine
+ * with multiple simulations steps for every IO step using CUDA (using the C bindings)
+ */
+
+#include <adios2_c.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+
+__global__ void update_array(float *vect, int val) { vect[blockIdx.x] += val; }
+
+void writer(adios2_adios *adios, const char *fname, const size_t Nx, unsigned int nSteps)
+{
+    // Initialize the simulation data
+    float *gpuSimData;
+    cudaMalloc(&gpuSimData, Nx * sizeof(float));
+    cudaMemset(gpuSimData, 0, Nx);
+
+    // Set up the ADIOS structures
+    adios2_io *bpIO = adios2_declare_io(adios, "WriteIO");
+
+    size_t shape[1];
+    size_t start[1];
+    size_t count[1];
+    shape[0] = Nx;
+    start[0] = 0;
+    count[0] = Nx;
+
+    adios2_variable *bpFloats = adios2_define_variable(
+        bpIO, "bpFloats", adios2_type_float, 1, shape, start, count, adios2_constant_dims_true);
+
+    adios2_engine *bpWriter = adios2_open(bpIO, fname, adios2_mode_write);
+
+    adios2_step_status err;
+    for (unsigned int step = 0; step < nSteps; ++step)
+    {
+        adios2_begin_step(bpWriter, adios2_step_mode_append, 0.0f, &err);
+        adios2_set_memory_space(bpFloats, adios2_memory_space_gpu);
+        adios2_put(bpWriter, bpFloats, gpuSimData, adios2_mode_sync);
+        adios2_end_step(bpWriter);
+
+        // Update values in the simulation data
+        update_array<<<Nx, 1>>>(gpuSimData, 10);
+    }
+
+    adios2_close(bpWriter);
+    cudaFree(gpuSimData);
+}
+
+void reader(adios2_adios *adios, const char *fname, const size_t Nx, unsigned int nSteps)
+{
+    adios2_step_status status;
+
+    adios2_io *bpIO = adios2_declare_io(adios, "ReadIO");
+
+    adios2_engine *bpReader = adios2_open(bpIO, fname, adios2_mode_read);
+
+    float *gpuSimData;
+    cudaMalloc(&gpuSimData, Nx * sizeof(float));
+    cudaMemset(gpuSimData, 0, Nx);
+
+    while (adios2_begin_step(bpReader, adios2_step_mode_read, -1., &status) == adios2_error_none)
+    {
+        if (status == adios2_step_status_end_of_stream)
+        {
+            break;
+        }
+
+        adios2_variable *bpFloats = adios2_inquire_variable(bpIO, "bpFloats");
+        size_t start[1];
+        size_t count[1];
+        start[0] = 0;
+        count[0] = Nx;
+        adios2_set_selection(bpFloats, 1, start, count);
+        adios2_set_memory_space(bpFloats, adios2_memory_space_gpu);
+        adios2_get(bpReader, bpFloats, gpuSimData, adios2_mode_sync);
+        adios2_end_step(bpReader);
+    }
+    adios2_close(bpReader);
+    cudaFree(gpuSimData);
+}
+
+int main(int argc, char **argv)
+{
+    const int device_id = 1;
+    cudaSetDevice(device_id);
+
+    const char filename[30] = "BPStepsWriteReadCBindings.bp";
+    const unsigned int nSteps = 2;
+    const unsigned int Nx = 3;
+
+    adios2_adios *adios = adios2_init_serial();
+    writer(adios, filename, Nx, nSteps);
+    reader(adios, filename, Nx, nSteps);
+
+    return 0;
+}

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCuda.cu
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCuda.cu
@@ -59,6 +59,7 @@ void writer(adios2::ADIOS &adios, const std::string &engine, const std::string &
     }
 
     bpWriter.Close();
+    cudaFree(gpuSimData);
 }
 
 void reader(adios2::ADIOS &adios, const std::string &engine, const std::string &fname,
@@ -101,6 +102,7 @@ void reader(adios2::ADIOS &adios, const std::string &engine, const std::string &
         }
     }
     bpReader.Close();
+    cudaFree(gpuSimData);
 }
 
 int main(int argc, char **argv)

--- a/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.F90
+++ b/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.F90
@@ -1,80 +1,97 @@
-program TestBPWriteReadHeatMap2D use mpi use adios2
-
+program TestBPWriteReadHeatMap2D
+    use mpi
+    use adios2
     implicit none
 
-        integer(kind = 8)::sum_i1,
-    sum_i2 type(adios2_adios)::adios type(adios2_io)::ioPut, ioGet type(adios2_engine)::bpWriter,
-    bpReader type(adios2_variable), dimension(1)::var_g,
-    var_gIn
+    integer(kind = 8) :: sum_i1, sum_i2
+    type(adios2_adios) :: adios
+    type(adios2_io) :: ioPut, ioGet
+    type(adios2_engine) :: bpWriter, bpReader
+    type(adios2_variable), dimension(1) :: var_g, var_gIn
 
-    integer(kind = 2),
-    dimension(
-        :,
-        :),
-    allocatable ::g, &sel_g integer(kind = 8),
-    dimension(2)::ishape, istart, icount integer(kind = 8),
-    dimension(2)::sel_start, sel_count integer ::ierr, irank, isize,
-    step_status integer ::in1, in2 integer ::i1,
-    i2
+    integer(kind = 2), dimension(:,:), allocatable :: g, sel_g
+    integer(kind = 8), dimension(2) :: ishape, istart, icount
+    integer(kind = 8), dimension(2) :: sel_start, sel_count
+    integer :: ierr, irank, isize, step_status
+    integer :: in1, in2
+    integer :: i1, i2
 
-    call MPI_INIT(ierr) call MPI_COMM_RANK(MPI_COMM_WORLD, irank, ierr) call
-    MPI_COMM_SIZE(MPI_COMM_WORLD, isize, ierr)
+    call MPI_Init(ierr)
+    call MPI_Comm_rank(MPI_COMM_WORLD, irank, ierr)
+    call MPI_Comm_size(MPI_COMM_WORLD, isize, ierr)
 
-        in1 = 3 in2 = 4 icount = (/ in1, in2 /) istart = (/ 0, in2 *irank /) ishape = (/ in1,
-                                                                                       in2 *isize /)
+    in1 = 3
+    in2 = 4
+    icount = (/ in1, in2 /)
+    istart = (/ 0, in2 *irank /)
+    ishape = (/ in1, in2 *isize /)
 
-            allocate(g(in1, in2)) do i2 = 1,
-        in2 do i1 = 1,
-        in1 g(i1, i2) = irank + i1 end do end do
+    allocate(g(in1, in2))
 
-                        !Start adios2 Writer call adios2_init(adios, MPI_COMM_WORLD, ierr) call
-                        adios2_declare_io(ioPut, adios, 'WriteIO', ierr)
+    do i2 = 1, in2
+       do i1 = 1, in1
+          g(i1, i2) = irank + i1
+       end do
+    end do
 
-                            call adios2_define_variable(var_g(1), ioPut, &'bpFloats',
-                                                        adios2_type_integer2, &2, ishape, istart,
-                                                        icount, &adios2_constant_dims, ierr)
+    ! Start adios2 writer
+    call adios2_init(adios, MPI_COMM_WORLD, ierr)
+    call adios2_declare_io(ioPut, adios, 'WriteIO', ierr)
 
-                                call
-                        adios2_open(bpWriter, ioPut, 'BPFortranKokkos.bp', adios2_mode_write, &ierr)
+    call adios2_define_variable(var_g(1), ioPut, 'bpFloats', &
+       adios2_type_integer2, 2, &
+       ishape, istart, icount, &
+       adios2_constant_dims, ierr)
 
-                            call adios2_put(bpWriter, var_g(1), g, ierr)
+    call adios2_open(bpWriter, ioPut, 'BPFortranKokkos.bp', &
+       adios2_mode_write, ierr)
 
-                                call adios2_close(bpWriter, ierr)
+    call adios2_put(bpWriter, var_g(1), g, ierr)
 
-                                    if (allocated(g)) deallocate(g)
+    call adios2_close(bpWriter, ierr)
 
-                                        !Start adios2 Reader in rank 0 if (irank == 0) then
+    if (allocated(g)) then
+       deallocate(g)
+    end if
 
-                        call adios2_declare_io(ioGet, adios, 'ReadIO', ierr)
+    ! Start adios2 Reader in rank 0 if (irank == 0) then
 
-                            call adios2_open(bpReader, ioGet, 'BPFortranKokkos.bp',
-                                             &adios2_mode_read, MPI_COMM_SELF, ierr)
+    call adios2_declare_io(ioGet, adios, 'ReadIO', ierr)
 
-                                call
-                        adios2_begin_step(bpReader, adios2_step_mode_read, -1., &step_status, ierr)
+    call adios2_open(bpReader, ioGet, 'BPFortranKokkos.bp', &
+       adios2_mode_read, MPI_COMM_SELF, ierr)
 
-                            call adios2_inquire_variable(var_gIn(1), ioGet, &'bpFloats', ierr)
+    call adios2_begin_step(bpReader, adios2_step_mode_read, -1., &
+       step_status, ierr)
 
-                                sel_start = (/ 0, 0 /) sel_count = (/ ishape(1), ishape(2) /)
+    call adios2_inquire_variable(var_gIn(1), ioGet, &
+       'bpFloats', ierr)
 
-                            allocate(sel_g(ishape(1), ishape(2))) sel_g = 0
+    sel_start = (/ 0, 0 /)
+    sel_count = (/ ishape(1), ishape(2) /)
+    allocate(sel_g(ishape(1), ishape(2)))
+    sel_g = 0
 
-        call adios2_set_selection(var_gIn(1), 2, sel_start, sel_count, &ierr) call
-        adios2_get(bpReader, var_gIn(1), sel_g, ierr)
+    call adios2_set_selection(var_gIn(1), 2, sel_start, sel_count, &
+       ierr)
+   call adios2_get(bpReader, var_gIn(1), sel_g, ierr)
 
-            call adios2_end_step(bpReader, ierr)
+   call adios2_end_step(bpReader, ierr)
 
-                call adios2_close(bpReader, ierr)
+   call adios2_close(bpReader, ierr)
 
-                    do i2 = 1,
-        INT(sel_count(2), 4) do i1 = 1,
-        INT(sel_count(1), 4) write(6, "(i8)", advance = "no") sel_g(i1, i2) end do write(6, *) end
-    do
+    do i2 = 1, INT(sel_count(2), 4)
+       do i1 = 1, INT(sel_count(1), 4)
+          write(6, "(i8)", advance = "no") sel_g(i1, i2)
+       end do
+       write(6, *)
+    end do
 
-    if (allocated(sel_g)) deallocate(sel_g)
+    if (allocated(sel_g)) then
+       deallocate(sel_g)
+    end if
 
-        end if
+    call adios2_finalize(adios, ierr)
+    call MPI_Finalize(ierr)
 
-    call adios2_finalize(adios, ierr) call MPI_Finalize(ierr)
-
-        end program TestBPWriteReadHeatMap2D
+end program TestBPWriteReadHeatMap2D

--- a/examples/hello/bpStepsWriteReadKokkos/view-f.f90
+++ b/examples/hello/bpStepsWriteReadKokkos/view-f.f90
@@ -1,39 +1,51 @@
-module view_f_mod use, intrinsic ::iso_c_binding use,
-    intrinsic ::iso_fortran_env
+module view_f_mod
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
 
-            use ::flcl_mod
+    use :: flcl_mod
 
-                implicit none
+    implicit none
 
-        public
+    public
 
-        interface subroutine f_init_view(x, val) &
-        &bind(c, name = 'c_init_view') use,
-    intrinsic ::iso_c_binding use ::flcl_mod type(c_ptr), intent(in)::x integer(c_int),
-    intent(in)::val end subroutine f_init_view
+      interface
+        subroutine f_init_view(x, val) &
+          & bind(c, name = 'c_init_view')
+          use, intrinsic :: iso_c_binding
+          use :: flcl_mod
+          type(c_ptr), intent(in) :: x
+          integer(c_int), intent(in) :: val
+        end subroutine f_init_view
 
         subroutine f_print_view(x) &
-        &bind(c, name = 'c_print_view') use,
-    intrinsic ::iso_c_binding use ::flcl_mod type(c_ptr),
-    intent(in)::x end subroutine f_print_view end interface
+          & bind(c, name = 'c_print_view')
+          use, intrinsic :: iso_c_binding
+          use ::flcl_mod
+          type(c_ptr), intent(in) :: x
+        end subroutine f_print_view
+      end interface
 
     contains
 
-    subroutine init_view(x, val) use,
-    intrinsic ::iso_c_binding use ::flcl_mod implicit none type(view_i32_2d_t),
-    intent(inout)::x integer(c_int),
-    intent(in)::val
+        subroutine init_view(x, val)
+          use, intrinsic :: iso_c_binding
+          use :: flcl_mod
+          implicit none
+          type(view_i32_2d_t), intent(inout) :: x
+          integer(c_int), intent(in) :: val
 
-    call f_init_view(x % ptr(), val)
+          call f_init_view(x % ptr(), val)
 
         end subroutine init_view
 
-    subroutine print_view(x) use,
-    intrinsic ::iso_c_binding use ::flcl_mod implicit none type(view_i32_2d_t),
-    intent(in)::x
+        subroutine print_view(x)
+          use, intrinsic ::iso_c_binding
+          use ::flcl_mod
+          implicit none
+          type(view_i32_2d_t), intent(in)::x
 
-    call f_print_view(x % ptr())
+          call f_print_view(x % ptr())
 
         end subroutine print_view
 
-    end module view_f_mod
+end module view_f_mod


### PR DESCRIPTION
Fortran example using Kokkos and Fortran on Frontier (clang format messed the example so this PR fixes it):
```
$ ./bin/adios2_hello_bpStepsWriteReadKokkos_f
       1       2       3
       1       2       3
       1       2       3
       1       2       3
$ ./bin/bpls BPFortranKokkos.bp/ -d -n 3
  int16_t  bpFloats  {4, 3}
    (0,0)    1 2 3
    (1,0)    1 2 3
    (2,0)    1 2 3
    (3,0)    1 2 3
```

For the C bindings, I added an example uses CUDA on Perlmutter:
```
$ ./bin/adios2_hello_bpStepsWriteReadCuda_c
$ ./bin/bpls -d BPStepsWriteReadCBindings.bp/
  float    bpFloats  2*{3}
    (0,0)    0 0 0 10 10 10
```

There was a memory leak in the C++ CUDA example that is fixed now.