### PR TITLE
ci,frontier: do not load hdf5

### DIFF
--- a/.gitlab/gitlab-ci-frontier.yml
+++ b/.gitlab/gitlab-ci-frontier.yml
@@ -106,7 +106,6 @@ stages:
       git
       ninja
       libffi
-      hdf5
       zstd
 
 setup:frontier-kokkos-hip:


### PR DESCRIPTION
HDF5 is not needed since HDF5 adios2 support is already disabled at both: `scripts/ci/cmake/ci-frontier-cray.cmake` and `scripts/ci/cmake/ci-frontier-kokkos-hip.cmake`