### PR TITLE
Catch Shape.size() change

### DIFF
--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -166,6 +166,12 @@ void VariableBase::SetShape(const adios2::Dims &shape)
                                                  m_Name + ", in call to SetShape");
     }
 
+    if (m_Shape.size() != shape.size())
+    {
+        helper::Throw<std::invalid_argument>("Core", "VariableBase", "SetShape",
+                                             "can't assign change dimension count on variable " +
+                                                 m_Name + ", in call to SetShape");
+    }
     m_Shape = shape;
 #if defined(ADIOS2_HAVE_KOKKOS) || defined(ADIOS2_HAVE_GPU_SUPPORT)
     UpdateLayout(m_Shape);


### PR DESCRIPTION
ADIOS' intent was always for variables to have a fixed dimension count (I.E. 2D, 3D, 4D, etc.) with possibly changing dimensions.  But we didn't check for changing dimension count.  This PR adds that check in SetShape.

Closes #4474 