### PR TITLE
Make filenames not conflict in TestForEOF

### DIFF
--- a/testing/adios2/unit/TestPosixTransport.cpp
+++ b/testing/adios2/unit/TestPosixTransport.cpp
@@ -40,7 +40,8 @@ TEST(FileTransport, FailOnEOF)
         w->Close();
     }
     {
-        std::vector<uint8_t> b(256);
+        // 2x the size of data which was written
+        std::vector<uint8_t> b(512);
         helper::Comm comm = helper::CommDummy();
         std::unique_ptr<transport::FilePOSIX> r =
             std::unique_ptr<transport::FilePOSIX>(new transport::FilePOSIX(comm));
@@ -48,7 +49,7 @@ TEST(FileTransport, FailOnEOF)
         r->Open("FailOnEOF", Mode::Read);
         Params p = {{"FailOnEOF", "true"}};
         r->SetParameters(p);
-        EXPECT_THROW(r->Read((char *)b.data(), b.size() * 2), std::ios_base::failure);
+        EXPECT_THROW(r->Read((char *)b.data(), b.size()), std::ios_base::failure);
         r->Close();
     }
 }
@@ -61,7 +62,7 @@ TEST(FileTransport, WaitForData)
     std::unique_ptr<transport::FilePOSIX> w =
         std::unique_ptr<transport::FilePOSIX>(new transport::FilePOSIX(comm));
 
-    w->Open("FailOnEOF", Mode::Write);
+    w->Open("FailOnEOF2", Mode::Write);
     w->Write((char *)b.data(), b.size());
     {
         auto lf_WriteMore = [&](const transport::FilePOSIX *) {
@@ -79,7 +80,7 @@ TEST(FileTransport, WaitForData)
         std::unique_ptr<transport::FilePOSIX> r =
             std::unique_ptr<transport::FilePOSIX>(new transport::FilePOSIX(comm));
 
-        r->Open("FailOnEOF", Mode::Read);
+        r->Open("FailOnEOF2", Mode::Read);
         r->Read((char *)b.data(), size * 2);
         ASSERT_EQ(b[0], 0xef);
         ASSERT_EQ(b[size], 0xfe);


### PR DESCRIPTION
This kills an inconsistent failure when running with NoTestReruns.  The test tries to verify if our Posix transport does indeed fail on EOF if we read more data than is in the file (when we're not in a mode where we're waiting for more data to be written).  The original test write 256 bytes, then tried to read 512 bytes.  For some reason this sometimes succeeds rather than fails with an exception.  Suspecting that this is because despite living in the same file, sometimes these tests are run concurrently and the first test writes a file of 512 bytes.  Change the names so this doesn't happen.