### PR TITLE
issues: stale issues that have been open been inactive

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 2 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been 1 year with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          stale-pr-message: 'This PR is stale because it has been open 6 months with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity.'
+          days-before-issue-stale: 365
+          days-before-pr-stale: 180
+          days-before-issue-close: 30
+          days-before-pr-close: 30
+          exempt-issue-labels: 'evergreen'


### PR DESCRIPTION
Add daily check that goes through opened issues and set them as stale if open and inactive for over a year.

For issues that are stale, they will be closed a month later if still inactive. Re-opening the issue resets the timers.