### PR TITLE
Support -D -d -t for BP5 files, i.e. dump a subset of each block of …

### DIFF
--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -3706,7 +3706,7 @@ void print_decomp_singlestep(core::Engine *fp, core::IO *io, core::Variable<T> *
 {
     /* Print block info */
     DataType adiosvartype = variable->m_Type;
-    const auto minBlocks = fp->MinBlocksInfo(*variable, fp->CurrentStep());
+    const adios2::MinVarInfo *minBlocks = fp->MinBlocksInfo(*variable, fp->CurrentStep());
 
     std::vector<typename core::Variable<T>::BPInfo> coreBlocks;
 
@@ -3882,14 +3882,16 @@ void print_decomp_singlestep(core::Engine *fp, core::IO *io, core::Variable<T> *
             fprintf(outf, "\n");
             if (dump)
             {
-                if (!minBlocks)
+                if (minBlocks)
                 {
-                    readVarBlock(fp, io, variable, stepRelative, j, coreBlocks[j].Count,
-                                 coreBlocks[j].Start);
+                    Dims s(minBlocks->BlocksInfo[j].Start, minBlocks->BlocksInfo[j].Start + ndim);
+                    Dims c(minBlocks->BlocksInfo[j].Count, minBlocks->BlocksInfo[j].Count + ndim);
+                    readVarBlock(fp, io, variable, stepRelative, j, c, s);
                 }
                 else
                 {
-                    // GSE todo
+                    readVarBlock(fp, io, variable, stepRelative, j, coreBlocks[j].Count,
+                                 coreBlocks[j].Start);
                 }
             }
         }


### PR DESCRIPTION
… an array, and process steps one by one. This feature already works for BP4 (engines without MinBlockInfo).

```
bpls -l gs100.bp   U -n 8 -s "15,15,15" -c "2,2,2"  -Ddt
Step 0:
  double   U     {64, 64, 64}
          block 0: [ 0:31,  0:31,  0:31] = 0.143987 / 1.05572
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.01178 1.00994 0.981661 0.996005 0.985869 0.969777 0.974578 0.980411
          block 1: [32:63,  0:31,  0:31] = 0.114091 / 1.05794
    slice (15:16, 15:16, 15:16)
    (15,15,15)    0.99592 1.00419 1.00139 1.01154 0.999587 0.99117 0.988277 1.00301
          block 2: [ 0:31, 32:63,  0:31] = 0.139151 / 1.05407
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.0295 1.00625 1.03203 1.01771 1.01785 1.00173 1.00144 0.990033
          block 3: [32:63, 32:63,  0:31] = 0.127115 / 1.05663
    slice (15:16, 15:16, 15:16)
    (15,15,15)    0.992668 0.98768 0.980861 1.00169 1.01884 1.0013 0.998214 0.969815
          block 4: [ 0:31,  0:31, 32:63] = 0.132198 / 1.05461
    slice (15:16, 15:16, 15:16)
    (15,15,15)    0.993235 1.00659 1.01786 1.01642 1.00041 1.00257 0.980475 1.02104
          block 5: [32:63,  0:31, 32:63] = 0.138885 / 1.05286
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.00215 1.00356 0.991466 0.991788 0.973158 1.02105 1.02089 1.00773
          block 6: [ 0:31, 32:63, 32:63] = 0.122457 / 1.05438
    slice (15:16, 15:16, 15:16)
    (15,15,15)    0.989067 0.973152 0.985412 0.984829 0.99022 0.986866 1.01868 0.998391
          block 7: [32:63, 32:63, 32:63] = 0.141551 / 1.05132
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.00082 1.01427 1.0061 1.0212 1.01071 1.0293 1.01758 0.981118
Step 1:
  double   U     {64, 64, 64}
          block 0: [ 0:31,  0:31,  0:31] = 0.130314 / 1.05551
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.01516 1.02168 1.02357 1.02386 0.973349 1.01045 1.03225 1.02563
          block 1: [32:63,  0:31,  0:31] = 0.162061 / 1.05855
    slice (15:16, 15:16, 15:16)
    (15,15,15)    0.984604 1.00562 0.972373 1.00556 0.978335 1.01503 1.0165 1.00428
          block 2: [ 0:31, 32:63,  0:31] = 0.1385 / 1.05266
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.02036 1.03167 1 1.02619 0.999974 1.00464 0.986409 1.00526
          block 3: [32:63, 32:63,  0:31] = 0.141734 / 1.05157
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.03128 1.00518 0.981163 1.00319 1.00701 0.999283 0.982179 0.995538
          block 4: [ 0:31,  0:31, 32:63] = 0.162507 / 1.0549
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.00926 1.00301 1.00695 0.966757 1.01269 1.00045 1.01177 0.978236
          block 5: [32:63,  0:31, 32:63] = 0.152429 / 1.05481
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.01499 0.976249 1.00086 0.967617 0.993308 0.972678 0.970272 0.971036
          block 6: [ 0:31, 32:63, 32:63] = 0.176187 / 1.05321
    slice (15:16, 15:16, 15:16)
    (15,15,15)    0.993198 1.00238 0.985165 0.966682 1.00654 1.00015 1.00097 0.985218
          block 7: [32:63, 32:63, 32:63] = 0.140663 / 1.05448
    slice (15:16, 15:16, 15:16)
    (15,15,15)    1.00833 1.02655 0.977203 1.00574 0.997505 0.990438 1.03918 1.00651
```