### PR TITLE
Python API support for CuPy.arrays and torch.Tensor

### DIFF
--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCupy-bindings.py
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCupy-bindings.py
@@ -69,5 +69,5 @@ if __name__ == '__main__':
           pinned_mempool.n_free_blocks())
 
     nSteps = 2
-    write_array("StepsWriteReadCuPy.bp", nSteps, gpuArray, cpuArray)
-    read_array("StepsWriteReadCuPy.bp", nSteps)
+    write_array("StepsCuPyBindings.bp", nSteps, gpuArray, cpuArray)
+    read_array("StepsCuPyBindings.bp", nSteps)

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCupy.py
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCupy.py
@@ -1,0 +1,40 @@
+import numpy as np
+import cupy as cp
+from adios2 import Stream
+
+def write_array(fileName, nSteps, gpuArray, cpuArray):
+    with Stream(fileName, "w") as wStream:
+        for _ in wStream.steps(nSteps):
+            wStream.write("cpuArray", cpuArray, cpuArray.shape,
+                          [0] * len(cpuArray.shape), cpuArray.shape)
+            wStream.write("gpuArray", gpuArray, gpuArray.shape,
+                          [0] * len(gpuArray.shape), gpuArray.shape)
+            # update buffers
+            gpuArray = gpuArray * 2
+            cpuArray = cpuArray + 1
+    print("Write to file %s: %s data from GPU and %s data from CPU" % (
+        fileName, gpuArray.shape, cpuArray.shape))
+
+def read_array(fileName, readGpuShape, readCpuShape):
+    with Stream(fileName, "r") as rStream:
+        for _ in rStream.steps():
+            step = rStream.current_step()
+            cpuBuffer = np.zeros(readCpuShape, dtype=np.float32)
+            rStream.read("cpuArray", cpuBuffer)
+
+            gpuBuffer = cp.zeros(readGpuShape, dtype=np.float32)
+            rStream.read("gpuArray", buffer=gpuBuffer)
+
+            print("Step %d: read GPU data\n %s" % (step, gpuBuffer))
+            print("Step %d: read CPU data\n %s" % (step, cpuBuffer))
+
+
+if __name__ == '__main__':
+    cpuArray = np.array([[0, 1.0, 2.0], [3.0, 4.0, 5.0]], dtype=np.float32)
+    gpuArray = cp.array([[0, 1.0, 2.0], [3.0, 4.0, 5.0]], dtype=np.float32)
+    print("Array allocation: ", gpuArray.device)
+    print("Bytes required to store the gpu array", gpuArray.nbytes)
+
+    nSteps = 2
+    write_array("StepsWriteReadTorch.bp", nSteps, gpuArray, cpuArray)
+    read_array("StepsWriteReadTorch.bp", gpuArray.shape, cpuArray.shape)

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadTorch-bindings.py
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadTorch-bindings.py
@@ -62,5 +62,5 @@ if __name__ == '__main__':
     print("Bytes required to store the gpu array", gpuArray.nbytes)
 
     nSteps = 2
-    write_array("StepsWriteReadTorch.bp", nSteps, gpuArray, cpuArray)
-    read_array("StepsWriteReadTorch.bp", nSteps)
+    write_array("StepsTorchBindings.bp", nSteps, gpuArray, cpuArray)
+    read_array("StepsTorchBindings.bp", nSteps)

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadTorch.py
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadTorch.py
@@ -1,0 +1,43 @@
+import numpy as np
+import torch
+from adios2 import Stream, FileReader
+
+def write_array(fileName, nSteps, gpuArray, cpuArray):
+    with Stream(fileName, "w") as wStream:
+        for _ in wStream.steps(nSteps):
+            wStream.write("cpuArray", cpuArray, cpuArray.shape,
+                          [0] * len(cpuArray.shape), cpuArray.shape)
+            wStream.write("gpuArray", gpuArray, gpuArray.shape,
+                          [0] * len(gpuArray.shape), gpuArray.shape)
+            # update buffers
+            gpuArray = gpuArray * 2
+            cpuArray = cpuArray + 1
+    print("Write to file %s: %s data from GPU and %s data from CPU" % (
+        fileName, gpuArray.shape, cpuArray.shape))
+
+def read_array(fileName, readGpuShape, readCpuShape):
+    with Stream(fileName, "r") as rStream:
+        for _ in rStream.steps():
+            step = rStream.current_step()
+            cpuBuffer = np.zeros(readCpuShape, dtype=np.float32)
+            rStream.read_in_buffer("cpuArray", cpuBuffer)
+
+            cuda0 = torch.device('cuda:0')
+            gpuBuffer = torch.zeros(readGpuShape, dtype=torch.float32, device=cuda0)
+            rStream.read_in_buffer("gpuArray", gpuBuffer)
+
+            print("Step %d: read GPU data\n %s" % (step, gpuBuffer))
+            print("Step %d: read CPU data\n %s" % (step, cpuBuffer))
+
+
+if __name__ == '__main__':
+    cpuArray = np.array([[0, 1.0, 2.0], [3.0, 4.0, 5.0]], dtype=np.float32)
+    cuda0 = torch.device('cuda:0')
+    gpuArray = torch.tensor([[0, 1.0, 2.0], [3.0, 4.0, 5.0]],
+                            dtype=torch.float32, device=cuda0)
+    print("Array allocation: ", gpuArray.device)
+    print("Bytes required to store the gpu array", gpuArray.nbytes)
+
+    nSteps = 2
+    write_array("StepsWriteReadTorch.bp", nSteps, gpuArray, cpuArray)
+    read_array("StepsWriteReadTorch.bp", gpuArray.shape, cpuArray.shape)

--- a/testing/adios2/python/TestBPWriteReadArrays.py
+++ b/testing/adios2/python/TestBPWriteReadArrays.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+from adios2NPTypes import SmallTestData
+from mpi4py import MPI
+import numpy as np
+
+try:
+    import cupy as cp
+
+    ADIOS2_HAS_CUPY = True
+except ImportError:
+    ADIOS2_HAS_CUPY = False
+try:
+    import torch
+
+    ADIOS2_HAS_TORCH = True
+except ImportError:
+    ADIOS2_HAS_TORCH = False
+
+from adios2 import Stream, LocalValueDim
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+# Test data
+data = SmallTestData(rank)
+nx = data.Nx
+
+shape = [size * nx]
+start = [rank * nx]
+count = [nx]
+
+# Writer
+with Stream("arrays_np.bp", "w", comm=comm) as s:
+    for step in s.steps(5):
+        data.update(rank, step.current_step(), size)
+        s.write("varNumpy", data.u16, shape, start, count)
+        if ADIOS2_HAS_CUPY:
+            gpuArray = cp.asarray(data.u16)
+            s.write("varCupy", gpuArray, shape, start, count)
+        if ADIOS2_HAS_TORCH:
+            tensor = torch.tensor(data.u16)
+            s.write("varTensor", tensor, shape, start, count)
+
+comm.Barrier()
+
+# Reader
+data = SmallTestData(rank)
+
+with Stream("arrays_np.bp", "r", comm=comm) as fr:
+    # file only
+    assert fr.num_steps() == 5
+
+    for fr_step in fr.steps():
+        step = fr_step.current_step()
+        data.update(rank, step, size)
+
+        step_vars = fr_step.available_variables()
+        indataU16 = np.zeros(count, dtype=data.u16.dtype)
+        fr_step.read_in_buffer("varNumpy", indataU16, start, count)
+        if not (indataU16 == data.u16).all():
+            raise ValueError("u16 numpy array read failed")
+
+        if ADIOS2_HAS_CUPY:
+            cupyU16 = cp.zeros(count, dtype=data.u16.dtype)
+            fr_step.read_in_buffer("varCupy", cupyU16, start, count)
+            indataU16 = np.array(cupyU16)
+            if not (indataU16 == data.u16).all():
+                raise ValueError("u16 cupy array read failed")
+
+        if ADIOS2_HAS_TORCH:
+            torchU16 = torch.zeros(count, dtype=torch.uint16)
+            fr_step.read_in_buffer("varTensor", torchU16, start, count)
+            indataU16 = torchU16.numpy()
+            if not (indataU16 == data.u16).all():
+                raise ValueError("u16 torch tensor read failed")


### PR DESCRIPTION
On the **write** side:
```python
# define the torch tensor or the cupy array
cuda0 = torch.device('cuda:0')
gpuArray = torch.tensor([[0, 1.0, 2.0], [3.0, 4.0, 5.0]], dtype=torch.float32, device=cuda0)
# or 
gpuArray = cupy.array([[0, 1.0, 2.0], [3.0, 4.0, 5.0]], dtype=np.float32)

# write data directly from the python object
stream.write("gpuArray", gpuArray, gpuArray.shape, [0] * len(gpuArray.shape), gpuArray.shape)
```

On the **read** side, I added a function for receiving a pre-allocated buffer for the data
```python
cpuBuffer = numpy.zeros(cpuShape, dtype=np.float32)
gpuBuffer = cupy.zeros(gpuShape, dtype=np.float32)
tensorBuffer = torch.zeros(tensorShape, dtype=torch.float32, device=cuda0)

stream.read_in_buffer("cpuArray", cpuBuffer)
stream.read_in_buffer("gpuArray", gpuBuffer)
stream.read_in_buffer("tensorArray", tensorBuffer)
```

Testing was added for the new function.