### PR TITLE
init_fabric: use Trace verbosity instead of Critical for success message

### DIFF
--- a/source/adios2/toolkit/sst/dp/ucx_dp.c
+++ b/source/adios2/toolkit/sst/dp/ucx_dp.c
@@ -146,7 +146,7 @@ static ucs_status_t init_fabric(struct fabric_state *fabric, struct _SstParams *
         return status;
     }
 
-    Svcs->verbose(CP_Stream, DPCriticalVerbose, "UCX init Success\n");
+    Svcs->verbose(CP_Stream, DPTraceVerbose, "UCX init Success\n");
 
     return status;
 }


### PR DESCRIPTION
A success/non-error message should not end up in stderr, and in my case made some test scripts fail.