### PR TITLE
Fix segfault in BP5 writer when using append mode, everyone writes serial, and num aggregators not set

### DIFF
--- a/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
@@ -22,8 +22,6 @@ MPIChain::MPIChain() : MPIAggregator() {}
 void MPIChain::Init(const size_t numAggregators, const size_t subStreams,
                     helper::Comm const &parentComm)
 {
-    /* numAggregators ignored here as BP3/BP4 uses substreams = aggregators */
-    m_NumAggregators = subStreams;
     if (subStreams > 0)
     {
         InitComm(subStreams, parentComm);
@@ -33,6 +31,12 @@ void MPIChain::Init(const size_t numAggregators, const size_t subStreams,
     {
         InitCommOnePerNode(parentComm);
     }
+    // m_NumAggregators should be set here instead of before either Init, since InitCommOnePerNode
+    // updates m_SubStreams, but not m_NumAggregators. BP5Writer will use m_NumAggregators
+    // to set the size of m_AppendDataPos so not having m_NumAggregators set causes a segfault
+    // when writing a new BP5 file in append mode.
+    /* numAggregators ignored here as BP3/BP4 uses substreams = aggregators */
+    m_NumAggregators = m_SubStreams;
 
     HandshakeLinks();
 

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -237,6 +237,12 @@ gtest_add_tests_helper(DirectIO MPI_NONE BP Engine.BP. .BP5
 gtest_add_tests_helper(ReadMultithreaded MPI_NONE BP Engine.BP. .BP5
   WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5"
 )
+gtest_add_tests_helper(NewFileAppendMode MPI_NONE BP Engine.BP. .BP5.EWS
+  WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5" "EveryoneWritesSerial"
+)
+gtest_add_tests_helper(NewFileAppendMode MPI_NONE BP Engine.BP. .BP5.TLS
+  WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5" "TwoLevelShm"
+)
 
 # Only a single test is enough, pick the latest engine
 gtest_add_tests_helper(AccuracyDefaults MPI_NONE BP Engine.BP. .BP5

--- a/testing/adios2/engine/bp/TestBPNewFileAppendMode.cpp
+++ b/testing/adios2/engine/bp/TestBPNewFileAppendMode.cpp
@@ -1,0 +1,81 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * Test using Append mode for writing a new BP file with NumAggregators = 0
+ *
+ *  Created on: Jul 1, 2025
+ *      Author: Caitlin Ross
+ */
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+std::string engineName;                               // comes from command line
+std::string aggregationType = "EveryoneWritesSerial"; // comes from command line
+
+class BPNewFileAppendMode : public ::testing::Test
+{
+public:
+    BPNewFileAppendMode() = default;
+
+    // No specific setup needed for this test
+};
+
+TEST_F(BPNewFileAppendMode, ADIOS2BPNewFileAppendMode)
+{
+    std::string fname("ADIOS2BPNewFileAppendMode");
+    if (aggregationType == "EveryoneWritesSerial")
+    {
+        fname += "-EWS.bp";
+    }
+    else if (aggregationType == "TwoLevelShm")
+    {
+        fname += "-TLS.bp";
+    }
+
+    const size_t Nx = 6;
+
+    adios2::ADIOS adios;
+    {
+        adios2::IO io = adios.DeclareIO("TestIO");
+        const adios2::Dims shape{Nx};
+        const adios2::Dims start{0};
+        const adios2::Dims count{Nx};
+        io.DefineVariable<double>("r64", shape, start, count);
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        else
+        {
+            // Create the BP Engine
+            io.SetEngine("BPFile");
+        }
+        io.SetParameter("AggregationType", aggregationType);
+        io.SetParameter("NumAggregators", "0");
+
+        adios2::Engine engine = io.Open(fname, adios2::Mode::Append);
+
+        engine.Close();
+    }
+}
+
+int main(int argc, char **argv)
+{
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+    if (argc > 2)
+    {
+        aggregationType = std::string(argv[2]);
+    }
+
+    result = RUN_ALL_TESTS();
+    return result;
+}


### PR DESCRIPTION
If NumAggregators was set to 0 (to default to one file per node), a segfault would occur because `BP5Writer::m_NumAggregators` was never updated to the number of files. If opening a file with append mode and the file didn't already exist, `BP5Writer::m_AppendDataPos` had a size of 0 and would cause a segfault in `BP5Writer::InitBPBuffer`. 

I also added a simple test for it, and test it with both TLS and EWS. Even though it wasn't an issue in TLS, I figured maybe it would be good to test it to be sure it wouldn't break in the future. 