### PR TITLE
Operator::AddExtraParameters() to allow engine pass parameters before…

### DIFF
--- a/source/adios2/core/Operator.cpp
+++ b/source/adios2/core/Operator.cpp
@@ -89,21 +89,14 @@ size_t Operator::GetEstimatedSize(const size_t ElemCount, const size_t ElemSize,
     return ElemCount * ElemSize + 128;
 };
 
+void Operator::AddExtraParameters(const Params &params) {}
+
 size_t Operator::Operate(const char *dataIn, const Dims &blockStart, const Dims &blockCount,
                          const DataType type, char *bufferOut)
 {
     return 0;
 }
-size_t Operator::Operate(const char *dataIn, const Dims &blockStart, const Dims &blockCount,
-                         const DataType type, char *bufferOut, Params params)
-{
-    return 0;
-}
-size_t Operator::InverseOperate(const char *bufferIn, const size_t sizeIn, char *dataOut,
-                                Params params)
-{
-    return 0;
-}
+
 size_t Operator::InverseOperate(const char *bufferIn, const size_t sizeIn, char *dataOut)
 {
     return 0;

--- a/source/adios2/core/Operator.h
+++ b/source/adios2/core/Operator.h
@@ -67,6 +67,8 @@ public:
     virtual size_t GetEstimatedSize(const size_t ElemCount, const size_t ElemSize,
                                     const size_t ndims, const size_t *dims) const;
 
+    virtual void AddExtraParameters(const Params &params);
+
     /**
      * @param dataIn
      * @param blockStart
@@ -81,22 +83,6 @@ public:
                            const DataType type, char *bufferOut);
 
     /**
-     * @param dataIn
-     * @param blockStart
-     * @param blockCount
-     * @param type
-     * @param bufferOut
-     * @param parameters
-     * @return size of compressed buffer
-     *
-     * This is the extended Operate API that includes parameters create by CreateOperatorParameters.
-     * Currently those include EngineName and VariableName.  This API will only be called if the
-     * default Operate is *not* redefined in the subclass.
-     */
-    virtual size_t Operate(const char *dataIn, const Dims &blockStart, const Dims &blockCount,
-                           const DataType type, char *bufferOut, Params params);
-
-    /**
      * @param bufferIn
      * @param sizeIn
      * @param dataOut
@@ -105,22 +91,6 @@ public:
      * should be used preferentially if the operator does not require per-invocation parameters.
      */
     virtual size_t InverseOperate(const char *bufferIn, const size_t sizeIn, char *dataOut);
-
-    /**
-     * @param bufferIn
-     * @param sizeIn
-     * @param dataOut
-     * @param params
-     * @return size of decompressed buffer
-     *
-     * This is the extended InverseOperate API that includes
-     * parameters create by CreateOperatorParameters.  Currently those
-     * include EngineName and VariableName.  This API will only be
-     * called if the default InverseOperate is *not* redefined in the
-     * subclass.
-     */
-    virtual size_t InverseOperate(const char *bufferIn, const size_t sizeIn, char *dataOut,
-                                  Params params);
 
     virtual bool IsDataTypeValid(const DataType type) const = 0;
 

--- a/source/adios2/operator/OperatorFactory.cpp
+++ b/source/adios2/operator/OperatorFactory.cpp
@@ -199,12 +199,15 @@ size_t Decompress(const char *bufferIn, const size_t sizeIn, char *dataOut, Memo
     {
         op = MakeOperator(OperatorTypeToString(compressorType), {});
     }
-    size_t sizeOut = op->InverseOperate(bufferIn, sizeIn, dataOut);
-    if ((sizeOut == 0) && engine && var)
+
+    if (engine && var)
     {
         Params operatorParams = CreateOperatorParams(engine, var);
-        sizeOut = op->InverseOperate(bufferIn, sizeIn, dataOut, operatorParams);
+        op->AddExtraParameters(operatorParams);
     }
+
+    size_t sizeOut = op->InverseOperate(bufferIn, sizeIn, dataOut);
+
     if (sizeOut == 0) // the inverse operator was not applied
     {
         size_t headerSize = op->GetHeaderSize();

--- a/source/adios2/operator/plugin/PluginOperator.cpp
+++ b/source/adios2/operator/plugin/PluginOperator.cpp
@@ -101,9 +101,12 @@ size_t PluginOperator::GetEstimatedSize(const size_t ElemCount, const size_t Ele
     return commonHeaderSize + paramsSize + implSize;
 }
 
+void PluginOperator::AddExtraParameters(const Params &params) { m_ExtraParams = params; }
+
 size_t PluginOperator::Operate(const char *dataIn, const Dims &blockStart, const Dims &blockCount,
                                const DataType type, char *bufferOut)
 {
+    m_Impl->m_Plugin->AddExtraParameters(m_ExtraParams);
     // handle common header first
     size_t offset = 0;
     const uint8_t bufferVersion = 1;
@@ -146,6 +149,7 @@ size_t PluginOperator::InverseOperate(const char *bufferIn, const size_t sizeIn,
     // now set up the plugin if it hasn't already
     PluginInit(pluginName, pluginLibrary);
 
+    m_Impl->m_Plugin->AddExtraParameters(m_ExtraParams);
     // add offset to bufferIn, so plugin doesn't have to worry about plugin
     // header or common header
     size_t pluginSize =

--- a/source/adios2/operator/plugin/PluginOperator.h
+++ b/source/adios2/operator/plugin/PluginOperator.h
@@ -40,6 +40,7 @@ public:
     size_t GetEstimatedSize(const size_t ElemCount, const size_t ElemSize, const size_t ndims,
                             const size_t *dims) const override;
 
+    void AddExtraParameters(const Params &params) override;
     size_t Operate(const char *dataIn, const Dims &blockStart, const Dims &blockCount,
                    const DataType type, char *bufferOut) override;
 
@@ -53,6 +54,7 @@ protected:
 private:
     struct Impl;
     std::unique_ptr<Impl> m_Impl;
+    Params m_ExtraParams;
 };
 
 } // end namespace plugin

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -853,17 +853,10 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
             BufferV::BufferPos pos = CurDataBuffer->Allocate(AllocSize, ElemSize);
             char *CompressedData = (char *)GetPtr(pos.bufferIdx, pos.posInBuffer);
             DataOffset = m_PriorDataBufferSizeTotal + pos.globalPos;
+            Params operatorParams = core::CreateOperatorParams(m_Engine, VB);
+            VB->m_Operations[0]->AddExtraParameters(operatorParams);
             CompressedSize = VB->m_Operations[0]->Operate((const char *)Data, tmpOffsets, tmpCount,
                                                           (DataType)Rec->Type, CompressedData);
-            if (CompressedSize == 0)
-            {
-                Params operatorParams = core::CreateOperatorParams(m_Engine, VB);
-                // Try to other Operate API if the operator was not applied
-                CompressedSize = VB->m_Operations[0]->Operate((const char *)Data, tmpOffsets,
-                                                              tmpCount, (DataType)Rec->Type,
-                                                              CompressedData, operatorParams);
-            }
-
             // if the operator was not applied
             if (CompressedSize == 0)
                 CompressedSize = helper::CopyMemoryWithOpHeader(


### PR DESCRIPTION
… Operate()/InverseOperate()

This modification allows now to pass engine name and variable name to external plugin operators as well. 
