### PR TITLE
Fix in TimeSeries engine for variables without min/max (like char arr…

### DIFF
--- a/source/adios2/engine/timeseries/TimeSeriesReader.cpp
+++ b/source/adios2/engine/timeseries/TimeSeriesReader.cpp
@@ -17,6 +17,7 @@
 
 #include <ios>
 #include <iostream>
+#include <limits>
 #include <string>
 
 namespace adios2
@@ -300,15 +301,23 @@ void TimeSeriesReader::ProcessIO(adios2::core::IO &io, adios2::core::Engine &e)
         Variable<T> *vi = io.InquireVariable<T>(vname);                                            \
         MinMaxStruct MinMax;                                                                       \
         T min, max;                                                                                \
-        if (e.VariableMinMax(*vi, DefaultSizeT, MinMax))                                           \
+        if (TypeHasMinMax(type))                                                                   \
         {                                                                                          \
-            min = *reinterpret_cast<T *>(&MinMax.MinUnion);                                        \
-            max = *reinterpret_cast<T *>(&MinMax.MaxUnion);                                        \
+            if (e.VariableMinMax(*vi, DefaultSizeT, MinMax))                                       \
+            {                                                                                      \
+                min = *reinterpret_cast<T *>(&MinMax.MinUnion);                                    \
+                max = *reinterpret_cast<T *>(&MinMax.MaxUnion);                                    \
+            }                                                                                      \
+            else                                                                                   \
+            {                                                                                      \
+                min = vi->m_Min;                                                                   \
+                max = vi->m_Max;                                                                   \
+            }                                                                                      \
         }                                                                                          \
         else                                                                                       \
         {                                                                                          \
-            min = vi->m_Min;                                                                       \
-            max = vi->m_Max;                                                                       \
+            min = std::numeric_limits<T>::min();                                                   \
+            max = std::numeric_limits<T>::max();                                                   \
         }                                                                                          \
         Variable<T> v =                                                                            \
             DuplicateVariable(vi, m_IO, m_IOs.size() - 1, m_Engines.size() - 1, min, max);         \

--- a/source/adios2/engine/timeseries/TimeSeriesReader.tcc
+++ b/source/adios2/engine/timeseries/TimeSeriesReader.tcc
@@ -77,13 +77,16 @@ inline Variable<T> TimeSeriesReader::DuplicateVariable(Variable<T> *variable, IO
         }
         v->m_AvailableStepsCount += viis.stepCount;
 
-        if (helper::LessThan(min, v->m_Min))
+        if (TypeHasMinMax(variable->m_Type))
         {
-            v->m_Min = min;
-        }
-        if (helper::GreaterThan(max, v->m_Max))
-        {
-            v->m_Max = max;
+            if (helper::LessThan(min, v->m_Min))
+            {
+                v->m_Min = min;
+            }
+            if (helper::GreaterThan(max, v->m_Max))
+            {
+                v->m_Max = max;
+            }
         }
 
         // std::cout << "Updated variable " << v->m_Name << " from engine " << engineIdx
@@ -106,8 +109,11 @@ inline Variable<T> TimeSeriesReader::DuplicateVariable(Variable<T> *variable, IO
         v.m_JoinedDimPos = variable->m_JoinedDimPos;
         v.m_AvailableStepBlockIndexOffsets = variable->m_AvailableStepBlockIndexOffsets;
         v.m_AvailableShapes = variable->m_AvailableShapes;
-        v.m_Min = min;
-        v.m_Max = max;
+        if (TypeHasMinMax(variable->m_Type))
+        {
+            v.m_Min = min;
+            v.m_Max = max;
+        }
         v.m_Value = variable->m_Value;
         v.m_StepsStart = variable->m_StepsStart;
         v.m_StepsCount = variable->m_StepsCount;

--- a/testing/adios2/engine/time-series/TestTimeSeries.cpp
+++ b/testing/adios2/engine/time-series/TestTimeSeries.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include <bits/stdc++.h> // minmax_element
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
@@ -53,6 +54,8 @@ TEST_F(TimeSeries, WriteReadShape2D)
         bufOut[i] = rank + static_cast<double>(i) / 10.0;
     }
 
+    std::vector<char> textOut = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'};
+
     // Writer
     {
         adios2::IO outIO = adios.DeclareIO("Output");
@@ -64,6 +67,7 @@ TEST_F(TimeSeries, WriteReadShape2D)
         }
 
         auto var = outIO.DefineVariable<double>("v", {dim0, 1}, {off0, 0}, {1, 1});
+        auto varchar = outIO.DefineVariable<char>("vchar", {dim0, 1}, {off0, 0}, {1, 1});
         auto varfix =
             outIO.DefineVariable<double>("vfixdim", {dim0, fixDim}, {off0, 0}, {1, fixDim}, true);
 
@@ -100,6 +104,9 @@ TEST_F(TimeSeries, WriteReadShape2D)
             var.SetShape({dim0, i + 1});
             var.SetSelection({{off0, 0}, {1, i + 1}});
 
+            varchar.SetShape({dim0, i + 1});
+            varchar.SetSelection({{off0, 0}, {1, i + 1}});
+
             if (!rank)
             {
                 std::cout << "Step " << i << " shape (" << var.Shape()[0] << ", " << var.Shape()[1]
@@ -107,8 +114,8 @@ TEST_F(TimeSeries, WriteReadShape2D)
             }
 
             writer.Put(var, bufOut.data());
+            writer.Put(varchar, textOut.data());
             writer.Put(varfix, bufOut.data());
-
             writer.EndStep();
         }
 
@@ -147,12 +154,13 @@ TEST_F(TimeSeries, WriteReadShape2D)
 
             auto shape = var.Shape();
             auto shapefix = varfix.Shape();
+            auto mm = var.MinMax();
 
             if (!rank)
             {
 
                 std::cout << "Step " << step << " shape (" << shape[0] << ", " << shape[1] << ")"
-                          << std::endl;
+                          << "  min/max = " << mm.first << " / " << mm.second << std::endl;
             }
 
             EXPECT_EQ(shape[0], nproc);
@@ -165,6 +173,7 @@ TEST_F(TimeSeries, WriteReadShape2D)
             {
                 EXPECT_EQ(bufOut[i], bufIn[i]);
             }
+
             varfix.SetSelection({{off0, 0}, {1, shapefix[1]}});
             reader.Get(varfix, bufIn, adios2::Mode::Sync);
             for (size_t i = 0; i < shapefix[1]; ++i)
@@ -199,11 +208,12 @@ TEST_F(TimeSeries, WriteReadShape2D)
             varfix.SetStepSelection({i, 1});
             auto shape = var.Shape();
             auto shapefix = varfix.Shape();
+            auto mm = var.MinMax(i);
             if (!rank)
             {
 
                 std::cout << "Step " << i << " shape (" << shape[0] << ", " << shape[1] << ")"
-                          << std::endl;
+                          << "  min/max = " << mm.first << " / " << mm.second << std::endl;
             }
             size_t expected_shape = i + 1;
             EXPECT_EQ(shape[0], nproc);
@@ -216,6 +226,7 @@ TEST_F(TimeSeries, WriteReadShape2D)
             {
                 EXPECT_EQ(bufOut[i], bufIn[i]);
             }
+
             varfix.SetSelection({{off0, 0}, {1, shapefix[1]}});
             reader.Get(varfix, bufIn, adios2::Mode::Sync);
             for (size_t i = 0; i < shapefix[1]; ++i)

--- a/testing/adios2/engine/time-series/TestTimeSeries.cpp
+++ b/testing/adios2/engine/time-series/TestTimeSeries.cpp
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <cstring>
 
-#include <bits/stdc++.h> // minmax_element
+#include <algorithm> // minmax_element
 #include <fstream>
 #include <iostream>
 #include <stdexcept>


### PR DESCRIPTION
…ay) which cause exception at open. Added a char array output to test to make sure opening works fine. Also extended test to test the correct minmax of the double array is reported at every step.