### PR TITLE
Fix issue with GCC 7.

### DIFF
--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -16,6 +16,16 @@
 /// \endcond
 
 #if __cplusplus >= 201703L
+#define ADIOS2_USE_STD_FILESYSTEM
+
+#if defined(__GNUC__) && (__GNUC__ < 8) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+// GCC version 7 does not support std::filesystem from C++17 even though it
+// reports to support C++17.
+#undef ADIOS2_USE_STD_FILESYSTEM
+#endif
+#endif
+
+#ifdef ADIOS2_USE_STD_FILESYSTEM
 #include <filesystem>
 #endif
 
@@ -348,7 +358,7 @@ size_t FileFStream::CurrentPos()
 
 void FileFStream::Truncate(const size_t length)
 {
-#if __cplusplus >= 201703L
+#ifdef ADIOS2_USE_STD_FILESYSTEM
     // C++17 specific stuff here
     WaitForOpen();
     std::filesystem::path p(m_Name);


### PR DESCRIPTION
This version of GCC came out around the same time as C++17. Although its preprocessor macros claim that it supports the C++17, there were still some portions of the specifications that were not supported. In particular, `std::filesystem` is not supported. In there case where this is needed, detect GCC 7 and do not attempt to use it.