### PR TITLE
Shared remote connection

### DIFF
--- a/examples/campaign/campaign_many_files.py
+++ b/examples/campaign/campaign_many_files.py
@@ -8,7 +8,7 @@ import adios2
 NFILES = 100
 
 # User data
-myArray = numpy.array([0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+myArray = numpy.arange(0.0, 9.0, 1)
 Nx = myArray.size
 
 for n in range(NFILES):

--- a/examples/campaign/campaign_many_files.py
+++ b/examples/campaign/campaign_many_files.py
@@ -1,0 +1,17 @@
+import numpy
+import adios2
+
+#
+# Create many files for a campaign, each with a single small array
+#
+
+NFILES = 100
+
+# User data
+myArray = numpy.array([0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+Nx = myArray.size
+
+for n in range(NFILES):
+    myArray += 1.0
+    with adios2.Stream(f"data{n:03}.bp", "w") as fh:
+        fh.write("d", myArray, [Nx], [0], [Nx])

--- a/examples/campaign/campaign_many_files.sh
+++ b/examples/campaign/campaign_many_files.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Add to PYTHONPATH the location of the campaign manager scripts
+
+python3 ./campaign_many_files.py
+
+python3 -m hpc_campaign_manager campaign_many_files.aca delete --campaign  create dataset data*.bp
+python3 -m hpc_campaign_manager --hostname localhost campaign_many_files_localhost.aca delete --campaign  create dataset data*.bp
+
+
+python3 -m hpc_campaign_manager campaign_many_files_localhost.aca info 

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -415,10 +415,16 @@ void BP5Reader::PerformGets()
 #endif
 #ifdef ADIOS2_HAVE_SST
         {
-            m_Remote = std::unique_ptr<EVPathRemote>(new EVPathRemote(m_HostOptions));
-            int localPort =
-                m_Remote->LaunchRemoteServerViaConnectionManager(m_Parameters.RemoteHost);
-            m_Remote->Open("localhost", localPort, RemoteName, m_OpenMode, RowMajorOrdering);
+            auto pair = CManagerSingleton::MakeEVPathConnection(m_Parameters.RemoteHost);
+            // m_Remote = std::unique_ptr<EVPathRemote>(new EVPathRemote(m_HostOptions));
+            // int localPort =
+            //    m_Remote->LaunchRemoteServerViaConnectionManager(m_Parameters.RemoteHost);
+            m_Remote = pair.first;
+            int localPort = pair.second;
+            if (m_Remote && localPort > -1)
+            {
+                m_Remote->Open("localhost", localPort, RemoteName, m_OpenMode, RowMajorOrdering);
+            }
         }
 #endif
 #ifdef ADIOS2_HAVE_KVCACHE

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -102,7 +102,7 @@ private:
     /* transport manager for managing the active flag file */
     transportman::TransportMan m_ActiveFlagFileManager;
     bool m_dataIsRemote = false;
-    std::unique_ptr<Remote> m_Remote;
+    std::shared_ptr<Remote> m_Remote;
     bool m_WriterIsActive = true;
     adios2::profiling::JSONProfiler m_JSONProfiler;
 

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -100,6 +100,12 @@ class CManagerSingleton
 public:
     static CManagerSingleton &Instance(EVPathRemoteCommon::Remote_evpath_state &ev_state);
 
+    /* Map of hostname : connection/port */
+    static std::map<std::string, std::pair<std::shared_ptr<EVPathRemote>, int>> m_EVPathRemotes;
+    /* Helper function to manage connections, one per host */
+    static std::pair<std::shared_ptr<EVPathRemote>, int>
+    MakeEVPathConnection(const std::string &hostName);
+
 private:
     CManager m_cm = NULL;
     EVPathRemoteCommon::Remote_evpath_state internalEvState;
@@ -111,7 +117,11 @@ private:
         CMfork_comm_thread(internalEvState.cm);
     }
 
-    ~CManagerSingleton() { CManager_close(m_cm); }
+    ~CManagerSingleton()
+    {
+        m_EVPathRemotes.clear();
+        CManager_close(m_cm);
+    }
 };
 #endif
 


### PR DESCRIPTION
Use a single socket connection to a remote server from all engines accessing (different) files from the same host. This eliminates creating too many connections and tunnels to the same host when processing a campaign with lots of files. 