### PR TITLE
ci: fix conda windows error

### DIFF
--- a/scripts/ci/gh-actions/conda-env-win.yml
+++ b/scripts/ci/gh-actions/conda-env-win.yml
@@ -3,6 +3,8 @@ variables:
   CMAKE_PREFIX_PATH: "C:/Miniconda/envs/adios2/Library;$CMAKE_PREFIX_PATH"
 dependencies:
   - c-blosc2
-  - numpy>=1.19
-  - python=3.10
   - hdf5
+  - mpi4py
+  - msmpi
+  - numpy>=1.19
+  - python<3.13

--- a/scripts/ci/gh-actions/windows-setup.ps1
+++ b/scripts/ci/gh-actions/windows-setup.ps1
@@ -8,20 +8,11 @@ Write-Host "::endgroup::"
 
 Write-Host "::group::Installing common deps"
 # We cannot use conda channels due to licenses, use conda-forge
-conda.bat config --set solver classic
 conda.bat config --prepend channels conda-forge
 conda.bat config --append channels nodefaults
 conda.bat config --remove channels defaults
 conda.bat config --system --remove channels defaults
 conda.bat config --show channels
 conda.bat config --set channel_priority strict
-conda.bat update --all -y
 conda.bat env create -f "gha\scripts\ci\gh-actions\conda-env-win.yml"
 Write-Host "::endgroup::"
-
-if($Env:GH_YML_MATRIX_PARALLEL -eq "msmpi")
-{
-  Write-Host "::group::Installing msmpi"
-  conda.bat install -n adios2 -c conda-forge -y "msmpi" "mpi4py"
-  Write-Host "::endgroup::"
-}

--- a/scripts/ci/setup-run/ci-Windows.sh
+++ b/scripts/ci/setup-run/ci-Windows.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set +u
 
+export CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1
 conda activate adios2


### PR DESCRIPTION
The fix for the conda error in win2022 is not to update the base env before installing the adios2 env :shrug: