### PR TITLE
Modify ATS file format to accomodate for remote files in the series. …

### DIFF
--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -570,7 +570,12 @@ void CampaignReader::InitTransports()
                         std::cout << "      " << tsorder << ". " << ds.name << " local file "
                                   << localPath << "\n";
                     }
-                    atsfile << localPath << std::endl;
+                    CampaignDataset &ds = m_CampaignData.datasets[dsIdx];
+                    CampaignReplica &rep = ds.replicas[repIdx];
+                    atsfile << "- localpath: " << localPath << "\n  remotepath: "
+                            << m_CampaignData.directory[rep.dirIdx].path + PathSeparator + rep.name
+                            << "\n  remotehost: " << m_CampaignData.hosts[rep.hostIdx].hostname
+                            << "\n  uuid: " << ds.uuid << std::endl;
                 }
                 else
                 {
@@ -589,9 +594,10 @@ void CampaignReader::InitTransports()
                     std::cout << "      " << ds.tsorder << ". " << ds.name << " local file "
                               << localPath << "\n";
                 }
-                atsfile << localPath << std::endl;
+                atsfile << "- " << localPath << std::endl;
             }
         }
+        atsfile << "- end" << std::endl;
         atsfile.close();
         OpenDatasetWithADIOS(ts.name, ds.format, io, atsFilePath);
     }

--- a/source/adios2/engine/timeseries/TimeSeriesReader.h
+++ b/source/adios2/engine/timeseries/TimeSeriesReader.h
@@ -24,6 +24,7 @@
 #include "adios2/core/Engine.h"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/helper/adiosFunctions.h"
+#include "adios2/helper/adiosYAML.h"
 
 #include <deque>
 #include <fstream>
@@ -63,15 +64,9 @@ public:
 
 private:
     int m_Verbosity = 0;
-    int m_ReaderRank; // my rank in the readers' comm
-    std::ifstream m_ATSFile;
-    size_t m_ATSFileLastPos = 0;
+    int m_ReaderRank;         // my rank in the readers' comm
     std::string m_ATSFileDir; // directory of the ATS file, for relative paths
-    std::deque<std::string> m_Filenames;
-
-    // m_NoMoreFiles: becomes true when --end-- is read from the ATS file but we still have
-    // to finish processing the files in m_Filenames
-    bool m_NoMoreFiles = false;
+    helper::TimeSeriesList m_TimeSeriesList;
 
     int m_CurrentStep = 0;
     size_t m_StepsCount = 0;
@@ -130,7 +125,7 @@ private:
     void InitParameters() final;
     void InitTransports() final;
     void ProcessIO(adios2::core::IO &io, adios2::core::Engine &e);
-    void InitFile(std::string filename,
+    void InitFile(const helper::TimeSeriesEntry &tse,
                   bool process); // open one file and process its variables and attributes
     bool CheckForFiles();        // read (new) entries in ATS file until --end--
 
@@ -161,7 +156,7 @@ private:
      * Called if destructor is called on an open engine.  Should warn or take
      * any non-complex measure that might help recover.
      */
-    void DestructorClose(bool Verbose) noexcept final{};
+    void DestructorClose(bool Verbose) noexcept final { DoClose(); };
 
     template <class T>
     void GetCommon(Variable<T> &variable, T *data, adios2::Mode mode);

--- a/source/adios2/helper/adiosYAML.h
+++ b/source/adios2/helper/adiosYAML.h
@@ -12,6 +12,7 @@
 #define ADIOS2_HELPER_ADIOSYAML_H_
 
 /// \cond EXCLUDE_FROM_DOXYGEN
+#include <deque>
 #include <map>
 #include <memory> //std::shared_ptr
 #include <string>
@@ -26,6 +27,7 @@ namespace adios2
 {
 namespace helper
 {
+
 void ParseConfigYAMLIO(core::ADIOS &adios, const std::string &configFileYAML,
                        const std::string &configFileContents, core::IO &io);
 
@@ -37,6 +39,31 @@ void ParseUserOptionsFile(Comm &comm, const std::string &configFileYAML, UserOpt
 
 void ParseHostOptionsFile(Comm &comm, const std::string &configFileYAML, HostOptions &hosts,
                           std::string &homePath);
+
+// ATS file format support
+// <string-local-path>:
+//     remotehost: <string>
+//     remotepath: <string>
+//     uuid:  <uuid-string>
+// all sub-entries are optional, non-existent for local files
+// special name for termination of stream:  --end--:
+struct TimeSeriesEntry
+{
+    std::string localpath = "";
+    std::string remotehost = "";
+    std::string remotepath = "";
+    std::string uuid = "";
+};
+
+/** TimeSeriesList holds the list of files from in an ATS file */
+struct TimeSeriesList
+{
+    int lastUsedEntry = -1;
+    bool ended = false;
+    std::deque<TimeSeriesEntry> entries;
+};
+
+void ParseTimeSeriesFile(Comm &comm, const std::string &atsYAML, TimeSeriesList &tsl);
 
 } // end namespace helper
 } // end namespace adios2

--- a/testing/adios2/engine/time-series/TestTimeSeries.cpp
+++ b/testing/adios2/engine/time-series/TestTimeSeries.cpp
@@ -96,7 +96,7 @@ TEST_F(TimeSeries, WriteReadShape2D)
                 }
 
                 writer = outIO.Open(fileName, adios2::Mode::Write);
-                atsFile << fileName << std::endl;
+                atsFile << "- " << fileName << std::endl;
                 ++fileIdx;
             }
             writer.BeginStep();
@@ -120,7 +120,7 @@ TEST_F(TimeSeries, WriteReadShape2D)
         }
 
         writer.Close();
-        atsFile << "--end--" << std::endl;
+        atsFile << "- end" << std::endl;
         atsFile.close();
     }
 

--- a/testing/adios2/yaml/CMakeLists.txt
+++ b/testing/adios2/yaml/CMakeLists.txt
@@ -3,6 +3,17 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
+gtest_add_tests_helper(YAMLTimeSeries MPI_NONE "" "" "")
+foreach(tgt IN LISTS Test.YAMLTimeSeries-TARGETS)
+  target_compile_definitions(${tgt} PRIVATE
+    "YAML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+endforeach()
+#target_compile_definitions(${Test.YAMLTimeSeries} PRIVATE 
+#  "YAML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
+#)
+
+
 gtest_add_tests_helper(YAMLConfig MPI_ALLOW "" "" "")
 
 foreach(tgt IN LISTS Test.YAMLConfig-TARGETS)
@@ -10,3 +21,4 @@ foreach(tgt IN LISTS Test.YAMLConfig-TARGETS)
     "YAML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
   )
 endforeach()
+

--- a/testing/adios2/yaml/TestYAMLTimeSeries.cpp
+++ b/testing/adios2/yaml/TestYAMLTimeSeries.cpp
@@ -1,0 +1,99 @@
+#include <cstdint>
+
+#include <iostream>
+#include <stdexcept>
+
+#include <adios2.h>
+#include <adios2/helper/adiosCommDummy.h>
+#include <adios2/helper/adiosYAML.h>
+
+#include <gtest/gtest.h>
+
+#define str_helper(X) #X
+#define str(X) str_helper(X)
+
+class YAMLTimeSeriesTest : public ::testing::Test
+{
+public:
+    YAMLTimeSeriesTest() : configDir(str(YAML_CONFIG_DIR)) {}
+
+    std::string configDir;
+};
+
+TEST_F(YAMLTimeSeriesTest, Local)
+{
+    const std::string atsFile(configDir + std::string(&adios2::PathSeparator, 1) + "local.ats");
+
+    adios2::helper::Comm comm = adios2::helper::CommDummy();
+
+    adios2::helper::TimeSeriesList tsl;
+    EXPECT_NO_THROW(adios2::helper::ParseTimeSeriesFile(comm, atsFile, tsl));
+
+    EXPECT_TRUE(tsl.ended);
+    EXPECT_EQ(tsl.entries.size(), 4);
+    EXPECT_EQ(tsl.entries[0].localpath, "/tmp/data/local_1.h5");
+    EXPECT_EQ(tsl.entries[1].localpath, "/tmp/data/local_2.h5");
+    EXPECT_EQ(tsl.entries[2].localpath, "/tmp/data/local_3.h5");
+    EXPECT_EQ(tsl.entries[3].localpath, "/tmp/data/local_4.h5");
+}
+
+TEST_F(YAMLTimeSeriesTest, Remote)
+{
+    const std::string atsFile(configDir + std::string(&adios2::PathSeparator, 1) + "remote.ats");
+
+    adios2::helper::Comm comm = adios2::helper::CommDummy();
+
+    adios2::helper::TimeSeriesList tsl;
+    EXPECT_NO_THROW(adios2::helper::ParseTimeSeriesFile(comm, atsFile, tsl));
+
+    EXPECT_FALSE(tsl.ended);
+    EXPECT_EQ(tsl.entries.size(), 2);
+    EXPECT_EQ(tsl.entries[0].localpath, "/home/adios/data/remote_local_1");
+    EXPECT_EQ(tsl.entries[0].remotepath, "/remote/path1");
+    EXPECT_EQ(tsl.entries[0].remotehost, "Host1");
+    EXPECT_EQ(tsl.entries[0].uuid, "0123456789abcdef0123456879abcdef");
+    EXPECT_EQ(tsl.entries[1].localpath, "/home/adios/data/remote_local_2");
+    EXPECT_EQ(tsl.entries[1].remotepath, "/remote/path2");
+    EXPECT_EQ(tsl.entries[1].remotehost, "Host2");
+    EXPECT_EQ(tsl.entries[1].uuid, "abcdef0123456879abcdef0123456789");
+}
+
+TEST_F(YAMLTimeSeriesTest, Mixed)
+{
+    const std::string atsFile(configDir + std::string(&adios2::PathSeparator, 1) + "mixed.ats");
+
+    adios2::helper::Comm comm = adios2::helper::CommDummy();
+
+    adios2::helper::TimeSeriesList tsl;
+    EXPECT_NO_THROW(adios2::helper::ParseTimeSeriesFile(comm, atsFile, tsl));
+
+    EXPECT_TRUE(tsl.ended);
+    EXPECT_EQ(tsl.entries.size(), 4);
+    EXPECT_EQ(tsl.entries[0].localpath, "/tmp/data/local_1.h5");
+    EXPECT_EQ(tsl.entries[1].localpath, "/home/adios/data/remote_local_1");
+    EXPECT_EQ(tsl.entries[2].localpath, "/tmp/data/local_2.h5");
+    EXPECT_EQ(tsl.entries[3].localpath, "/home/adios/data/remote_local_2");
+
+    EXPECT_TRUE(tsl.entries[0].remotepath.empty());
+    EXPECT_EQ(tsl.entries[1].remotepath, "/remote/path1");
+    EXPECT_TRUE(tsl.entries[2].remotepath.empty());
+    EXPECT_EQ(tsl.entries[3].remotepath, "/remote/path2");
+
+    EXPECT_TRUE(tsl.entries[0].remotehost.empty());
+    EXPECT_EQ(tsl.entries[1].remotehost, "Host1");
+    EXPECT_TRUE(tsl.entries[2].remotehost.empty());
+    EXPECT_EQ(tsl.entries[3].remotehost, "Host2");
+
+    EXPECT_TRUE(tsl.entries[0].uuid.empty());
+    EXPECT_EQ(tsl.entries[1].uuid, "0123456789abcdef0123456879abcdef");
+    EXPECT_TRUE(tsl.entries[2].uuid.empty());
+    EXPECT_EQ(tsl.entries[3].uuid, "abcdef0123456879abcdef0123456789");
+}
+
+int main(int argc, char **argv)
+{
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+    result = RUN_ALL_TESTS();
+    return result;
+}

--- a/testing/adios2/yaml/local.ats
+++ b/testing/adios2/yaml/local.ats
@@ -1,0 +1,6 @@
+- /tmp/data/local_1.h5
+- localpath: /tmp/data/local_2.h5
+- /tmp/data/local_3.h5
+
+- /tmp/data/local_4.h5
+- end

--- a/testing/adios2/yaml/mixed.ats
+++ b/testing/adios2/yaml/mixed.ats
@@ -1,0 +1,20 @@
+- /tmp/data/local_1.h5
+
+- localpath: /home/adios/data/remote_local_1
+  remotepath: /remote/path1
+  remotehost: Host1
+  uuid: 0123456789abcdef0123456879abcdef
+
+- localpath: /tmp/data/local_2.h5
+
+# Commented out file should not appear in list
+# - localpath: /tmp/data/local_2.h5
+#
+
+- localpath: /home/adios/data/remote_local_2
+  remotepath: /remote/path2
+  remotehost: Host2
+  uuid: abcdef0123456879abcdef0123456789
+
+- end
+- should-not-appear-in-list.txt

--- a/testing/adios2/yaml/remote.ats
+++ b/testing/adios2/yaml/remote.ats
@@ -1,0 +1,8 @@
+- localpath: /home/adios/data/remote_local_1
+  remotepath: /remote/path1
+  remotehost: Host1
+  uuid: 0123456789abcdef0123456879abcdef
+- localpath: /home/adios/data/remote_local_2
+  remotepath: /remote/path2
+  remotehost: Host2
+  uuid: abcdef0123456879abcdef0123456789


### PR DESCRIPTION
…New format is a YAML Sequence of Scalar (local file) or Map (remote file) entries. The CampaignReader is using the remote definition to support time-series in campaigns.

local file entry:
`- /tmp/data/local_1.h5`
or
`- localpath: /tmp/data/local_2.h5`

remote file entry:
```
- localpath: /home/adios/data/remote_local_1
  remotepath: /remote/path1
  remotehost: Host1
  uuid: 0123456789abcdef0123456879abcdef
```

stream termination signaling entry:
`- end`