### PR TITLE
Free the MPI_Info object created in GroupBySHM(). 

### DIFF
--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -253,6 +253,7 @@ std::unique_ptr<CommImpl> CommImplMPI::GroupByShm(const std::string &hint) const
     MPI_Info_create(&info);
     CheckMPIReturn(MPI_Comm_split_type(m_MPIComm, MPI_COMM_TYPE_SHARED, 0, info, &nodeComm), hint);
     return std::unique_ptr<CommImpl>(new CommImplMPI(nodeComm));
+    MPI_Info_free(&info);
 }
 
 int CommImplMPI::Rank() const


### PR DESCRIPTION
According to valgrind, it accomplishes nothing.