### PR TITLE
Changes to the build system for the bpcmp utility

### DIFF
--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -27,12 +27,12 @@ install(TARGETS bpls EXPORT adios2
 )
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/bpls/bpls.cmake.gen.in"
-  "${PROJECT_BINARY_DIR}/bpls.cmake.gen"
+  "${CMAKE_CURRENT_BINARY_DIR}/bpls.cmake.gen"
   @ONLY
 )
 file(GENERATE
   OUTPUT "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
-  INPUT "${PROJECT_BINARY_DIR}/bpls.cmake.gen"
+  INPUT "${CMAKE_CURRENT_BINARY_DIR}/bpls.cmake.gen"
 )
 
 # BPCMP
@@ -41,12 +41,12 @@ if(ADIOS2_HAVE_Python)
 
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/bpcmp/bpcmp.cmake.gen.in"
-    "${PROJECT_BINARY_DIR}/bpcmp.cmake.gen"
+    "${CMAKE_CURRENT_BINARY_DIR}/bpcmp.cmake.gen"
     @ONLY
   )
   file(GENERATE
     OUTPUT "${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake"
-    INPUT "${PROJECT_BINARY_DIR}/bpcmp.cmake.gen"
+    INPUT "${CMAKE_CURRENT_BINARY_DIR}/bpcmp.cmake.gen"
   )
 endif()
 

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -4,8 +4,8 @@
 #------------------------------------------------------------------------------#
 
 configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/verinfo.h.in
-  ${PROJECT_BINARY_DIR}/verinfo.h
+  "${CMAKE_CURRENT_SOURCE_DIR}/verinfo.h.in"
+  "${PROJECT_BINARY_DIR}/verinfo.h"
   @ONLY
 )
 
@@ -26,13 +26,13 @@ install(TARGETS bpls EXPORT adios2
   ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )
 configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/bpls/bpls.cmake.gen.in
-  ${PROJECT_BINARY_DIR}/bpls.cmake.gen
+  "${CMAKE_CURRENT_SOURCE_DIR}/bpls/bpls.cmake.gen.in"
+  "${PROJECT_BINARY_DIR}/bpls.cmake.gen"
   @ONLY
 )
 file(GENERATE
-  OUTPUT ${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake
-  INPUT ${PROJECT_BINARY_DIR}/bpls.cmake.gen
+  OUTPUT "${PROJECT_BINARY_DIR}/$<CONFIG>/bpls.cmake"
+  INPUT "${PROJECT_BINARY_DIR}/bpls.cmake.gen"
 )
 
 # BPCMP
@@ -40,13 +40,13 @@ if(ADIOS2_HAVE_Python)
   add_subdirectory(bpcmp)
 
   configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/bpcmp/bpcmp.cmake.gen.in
-    ${PROJECT_BINARY_DIR}/bpcmp.cmake.gen
+    "${CMAKE_CURRENT_SOURCE_DIR}/bpcmp/bpcmp.cmake.gen.in"
+    "${PROJECT_BINARY_DIR}/bpcmp.cmake.gen"
     @ONLY
   )
   file(GENERATE
-    OUTPUT ${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake
-    INPUT ${PROJECT_BINARY_DIR}/bpcmp.cmake.gen
+    OUTPUT "${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake"
+    INPUT "${PROJECT_BINARY_DIR}/bpcmp.cmake.gen"
   )
 endif()
 
@@ -112,8 +112,8 @@ install(PROGRAMS adios2_deactivate_bp
 
 # Simplified wrappers for adios2_reorganize
 configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/adios_reorganize/adios2_reorganize_wrapper
-  ${PROJECT_BINARY_DIR}/adios2_reorganize_wrapper
+  "${CMAKE_CURRENT_SOURCE_DIR}/adios_reorganize/adios2_reorganize_wrapper"
+  "${PROJECT_BINARY_DIR}/adios2_reorganize_wrapper"
   @ONLY
 )
 

--- a/source/utils/bpcmp/CMakeLists.txt
+++ b/source/utils/bpcmp/CMakeLists.txt
@@ -1,7 +1,6 @@
 configure_file(bpcmp.py "${PROJECT_BINARY_DIR}/bin/bpcmp.py" COPYONLY)
 
 install(PROGRAMS bpcmp.py
-  RENAME bpcmp
   DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_scripts-runtime
   ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}
 )

--- a/source/utils/bpcmp/CMakeLists.txt
+++ b/source/utils/bpcmp/CMakeLists.txt
@@ -1,4 +1,4 @@
-configure_file(bpcmp.py ${PROJECT_BINARY_DIR}/bin/bpcmp.py COPYONLY)
+configure_file(bpcmp.py "${PROJECT_BINARY_DIR}/bin/bpcmp.py" COPYONLY)
 
 install(PROGRAMS bpcmp.py
   RENAME bpcmp

--- a/source/utils/bpcmp/bpcmp.cmake.gen.in
+++ b/source/utils/bpcmp/bpcmp.cmake.gen.in
@@ -1,23 +1,26 @@
 cmake_minimum_required(VERSION 3.6)
 
 if(OUTPUT_FILE)
-  set(output_arg OUTPUT_FILE "${OUTPUT_FILE}")
+  set(maybe_output_arg OUTPUT_FILE "${OUTPUT_FILE}")
+else()
+  set(maybe_output_arg)
 endif()
+
 if(ERROR_FILE)
-  set(error_arg ERROR_FILE "${ERROR_FILE}")
-endif()
-if(NOT INPUT_FILE1)
-  set(error_arg INPUT_FILE1 "${INPUT_FILE1}")
-endif()
-if(NOT INPUT_FILE2)
-  set(error_arg INPUT_FILE2 "${INPUT_FILE2}")
+  set(maybe_error_arg ERROR_FILE "${ERROR_FILE}")
+elseif(NOT INPUT_FILE1)
+  set(maybe_error_arg INPUT_FILE1 "${INPUT_FILE1}")
+elseif(NOT INPUT_FILE2)
+  set(maybe_error_arg INPUT_FILE2 "${INPUT_FILE2}")
+else()
+  set(maybe_error_arg)
 endif()
 
 execute_process(
   COMMAND ${Python_EXECUTABLE} ${PROJECT_BINARY_DIR}/bin/bpcmp.py ${INPUT_FILE1} ${INPUT_FILE2} ${ARG1} ${ARG2} ${ARG3}
   RESULT_VARIABLE result
-  ${output_arg}
-  ${error_arg}
+  ${maybe_output_arg}
+  ${maybe_error_arg}
 )
 
 if(NOT result EQUAL 0)

--- a/source/utils/bpls/bpls.cmake.gen.in
+++ b/source/utils/bpls/bpls.cmake.gen.in
@@ -1,17 +1,21 @@
 cmake_minimum_required(VERSION 3.6)
 
 if(OUTPUT_FILE)
-  set(output_arg OUTPUT_FILE "${OUTPUT_FILE}")
+  set(maybe_output_arg OUTPUT_FILE "${OUTPUT_FILE}")
+else()
+  set(maybe_output_arg)
 endif()
 if(ERROR_FILE)
-  set(error_arg ERROR_FILE "${ERROR_FILE}")
+  set(maybe_error_arg ERROR_FILE "${ERROR_FILE}")
+else()
+  set(maybe_error_arg)
 endif()
 
 execute_process(
   COMMAND $<TARGET_FILE:bpls> ${INPUT_FILE} ${ARG1} ${ARG2} ${ARG3} ${ARG4} ${ARG5} ${ARG6} ${ARG7} ${ARG8} ${ARG9} ${ARG10} ${ARG11} ${ARG12} ${ARG13} ${ARG14} ${ARG15} ${ARG16} ${ARG17} ${ARG18} ${ARG19} ${ARG20}
   RESULT_VARIABLE result
-  ${output_arg}
-  ${error_arg}
+  ${maybe_output_arg}
+  ${maybe_error_arg}
 )
 
 if(NOT result EQUAL 0)


### PR DESCRIPTION
Closes #4333 

The changes requested in the issue were:
1. Use `CMAKE_CURRENT_BINARY_DIR` instead of `PROJECT_BINARY_DIR`
2. Add quotes for all paths
3. Use the `maybe_xyz` convention in all cases when something might be generated or not

I made the changes everywhere relevant in the utils folder.

In a hierarchical project with subdirectories, when CMake processes a CMakeLists.txt file within a subdirectory, `CMAKE_CURRENT_BINARY_DIR` will reflect the specific build output directory for that subdirectory. `PROJECT_BINARY_DIR` refers to the build directory associated with the most recently encountered project() command. 

This means, in some places it's better to use `PROJECT_BINARY_DIR`.
Example, if I change it from `PROJECT_BINARY_DIR` to `CMAKE_CURRENT_BINARY_DIR` in `source/utils/CMakeLists.txt`:
```cmake
OUTPUT "${PROJECT_BINARY_DIR}/$<CONFIG>/bpcmp.cmake" 
```
the bpcmp.cmake file will be in `/path/to/adios/build/source/utils/Release` instead of `/path/to/adios/build/Release`

But this file is used for Testing for which `PROJECT_BINARY_DIR` is `/path/to/adios/build` and `CMAKE_CURRENT_BINARY_DIR` is `/path/to/adios/build/Testing/..` so I would manually have to correct the path. 

Same is for where I am storing `bpcmp.py` file, it should be in the `bin` folder of the build directory and not in the `source/utils/bpcmp/bin` folder.