### PR TITLE
Rerouting aggregator

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(adios2_core
   engine/bp5/BP5Writer.tcc
   engine/bp5/BP5Writer_TwoLevelShm_Async.cpp
   engine/bp5/BP5Writer_TwoLevelShm.cpp
+  engine/bp5/BP5Writer_WithRerouting.cpp
 
   engine/timeseries/TimeSeriesReader.cpp engine/timeseries/TimeSeriesReader.tcc
 

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(adios2_core
   helper/adiosNetwork.cpp
   helper/adiosPartitioner.cpp
   helper/adiosPluginManager.cpp
+  helper/adiosRerouting.cpp
   helper/adiosString.cpp helper/adiosString.tcc
   helper/adiosSystem.cpp
   helper/adiosType.cpp

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -151,6 +151,7 @@ public:
     MACRO(DirectIOAlignOffset, UInt, unsigned int, 512)                                            \
     MACRO(DirectIOAlignBuffer, UInt, unsigned int, 0)                                              \
     MACRO(AggregationType, AggregationType, int, (int)AggregationType::TwoLevelShm)                \
+    MACRO(EnableWriterRerouting, Bool, bool, false)                                                \
     MACRO(AsyncOpen, Bool, bool, true)                                                             \
     MACRO(AsyncWrite, AsyncWrite, int, (int)AsyncWrite::Sync)                                      \
     MACRO(GrowthFactor, Float, float, DefaultBufferGrowthFactor)                                   \

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -150,8 +150,8 @@ public:
     MACRO(DirectIO, Bool, bool, false)                                                             \
     MACRO(DirectIOAlignOffset, UInt, unsigned int, 512)                                            \
     MACRO(DirectIOAlignBuffer, UInt, unsigned int, 0)                                              \
-    MACRO(AggregationType, AggregationType, int, (int)AggregationType::TwoLevelShm)                \
-    MACRO(EnableWriterRerouting, Bool, bool, false)                                                \
+    MACRO(AggregationType, AggregationType, int, (int)AggregationType::DataSizeBased)              \
+    MACRO(EnableWriterRerouting, Bool, bool, true)                                                 \
     MACRO(AsyncOpen, Bool, bool, true)                                                             \
     MACRO(AsyncWrite, AsyncWrite, int, (int)AsyncWrite::Sync)                                      \
     MACRO(GrowthFactor, Float, float, DefaultBufferGrowthFactor)                                   \

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -90,15 +90,15 @@ helper::RankPartition BP5Writer::GetPartitionInfo(const uint64_t rankDataSize, c
     int numPartitions = subStreams <= 0 ? std::max(parentSize / 2, 1) : subStreams;
     m_Profiler.AddTimerWatch("PartitionRanks");
     m_Profiler.Start("PartitionRanks");
-    helper::Partitioning partitioning = helper::PartitionRanks(allsizes, numPartitions);
+    m_Partitioning = helper::PartitionRanks(allsizes, numPartitions);
     m_Profiler.Stop("PartitionRanks");
 
     if (parentRank == 0 && m_Parameters.verbose > 0)
     {
-        partitioning.PrintSummary();
+        m_Partitioning.PrintSummary();
     }
 
-    return partitioning.FindPartition(parentRank);
+    return m_Partitioning.FindPartition(parentRank);
 }
 
 StepStatus BP5Writer::BeginStep(StepMode mode, const float timeoutSeconds)

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -370,7 +370,16 @@ void BP5Writer::WriteData(format::BufferV *Data)
             break;
         case (int)AggregationType::EveryoneWritesSerial:
         case (int)AggregationType::DataSizeBased:
-            WriteData_EveryoneWrites(Data, true);
+            // For rerouting to be useful, there must be multiple writers sending
+            // data to multiple subfiles.
+            if (m_Parameters.EnableWriterRerouting && m_Comm.Size() > 1 && m_Aggregator->m_SubStreams > 1)
+            {
+                WriteData_WithRerouting(Data);
+            }
+            else
+            {
+                WriteData_EveryoneWrites(Data, true);
+            }
             break;
         case (int)AggregationType::TwoLevelShm:
             WriteData_TwoLevelShm(Data);

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -312,7 +312,12 @@ private:
     // is enabled
     void ReroutingCommunicationLoop();
     size_t m_TargetIndex;
-    std::atomic<bool> m_readyToWrite;
+    int m_TargetCoordinator;
+    std::mutex m_WriteMutex;
+    std::mutex m_NotifMutex;
+    std::condition_variable m_WriteCV;
+    bool m_ReadyToWrite;
+    bool m_FinishedWriting;
 
     /* Async write's future */
     std::future<int> m_WriteFuture;

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -201,6 +201,7 @@ private:
     /** Write Data to disk, in an aggregator chain */
     void WriteData(format::BufferV *Data);
     void WriteData_EveryoneWrites(format::BufferV *Data, bool SerializedWriters);
+    void WriteData_WithRerouting(format::BufferV *Data);
     void WriteData_EveryoneWrites_Async(format::BufferV *Data, bool SerializedWriters);
     void WriteData_TwoLevelShm(format::BufferV *Data);
     void WriteData_TwoLevelShm_Async(format::BufferV *Data);

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -308,6 +308,12 @@ private:
      */
     uint64_t CountStepsInMetadataIndex(format::BufferSTL &bufferSTL);
 
+    // Thread function for inter-rank communication when rerouting aggregation
+    // is enabled
+    void ReroutingCommunicationLoop();
+    size_t m_TargetIndex;
+    std::atomic<bool> m_readyToWrite;
+
     /* Async write's future */
     std::future<int> m_WriteFuture;
     // variables to delay writing to index file

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -78,6 +78,7 @@ private:
     std::map<std::string, AggTransportData> m_AggregatorSpecifics;
     helper::RankPartition GetPartitionInfo(const uint64_t rankDataSize, const int subStreams,
                                            helper::Comm const &parentComm);
+    helper::Partitioning m_Partitioning;
 
     /** Single object controlling BP buffering */
     format::BP5Serializer m_BP5Serializer;

--- a/source/adios2/engine/bp5/BP5Writer_WithRerouting.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_WithRerouting.cpp
@@ -60,6 +60,8 @@ void BP5Writer::ReroutingCommunicationLoop()
             writerQueue.push(static_cast<int>(rank));
         }
 
+        currentFilePos = m_DataPos;
+
         if (m_DataPosShared)
         {
             // We have shared data pos after a previous timestep, we should update our
@@ -144,6 +146,7 @@ void BP5Writer::ReroutingCommunicationLoop()
             else
             {
                 // TODO: Send WRITE_IDLE to the GC instead of ending the loop here
+                m_DataPos = currentFilePos;
                 break;
             }
         }

--- a/source/adios2/engine/bp5/BP5Writer_WithRerouting.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_WithRerouting.cpp
@@ -19,6 +19,8 @@
 #include <algorithm> // max
 #include <ctime>
 #include <iostream>
+#include <random>
+#include <thread>
 
 namespace adios2
 {
@@ -28,12 +30,128 @@ namespace engine
 {
 
 using namespace adios2::format;
+using namespace adios2::helper;
+
+void BP5Writer::ReroutingCommunicationLoop()
+{
+    // Sleep for a random amount of time between 0 and 6 seconds
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> distrib(0, 6000);
+    int sleepMillis = distrib(gen);
+    std::this_thread::sleep_for(std::chrono::milliseconds(sleepMillis));
+
+    int subCoord = m_Aggregator->m_AggregatorRank;
+    std::queue<int> writerQueue;
+    int writingRank = -1;
+    uint64_t currentFilePos;
+
+    // Now start the
+    std::cout << "    Rank " << m_Comm.Rank() << " ReroutingCommunicationLoop()" << std::endl;
+    std::cout << "        SC: " << subCoord << std::endl;
+    std::cout << "        GC: " << m_Comm.Size() - 1 << std::endl;
+    std::cout << "        subfile index: " << m_Aggregator->m_SubStreamIndex << std::endl;
+    std::cout << "        total subfiles: " << m_Aggregator->m_SubStreams << std::endl;
+
+    if (m_Rank == subCoord && m_DataPosShared == true)
+    {
+        // We are a subcoordinator and have shared data pos after a previous timestep,
+        // we should update our notion of m_DataPos
+        currentFilePos = m_SubstreamDataPos[a->m_SubStreamIndex];
+        m_DataPosShared = false;
+    }
+
+    // align to PAGE_SIZE
+    m_DataPos += helper::PaddingToAlignOffset(m_DataPos, m_Parameters.StripeSize);
+    m_StartDataPos = m_DataPos;
+
+    // First send a message to the SC to get added to their writing queue
+    adios2::helper::RerouteMessage submitMsg;
+    submitMsg.m_MsgType = RerouteMessage::MessageType::WRITE_SUBMISSION;
+    submitMsg.m_SrcRank = m_RankMPI;
+    submitMsg.m_DestRank = subCoord;
+    submitMsg.SendTo(m_Comm, subCoord);
+
+    while (true)
+    {
+        int msgReady = 0;
+
+        m_Comm.Iprobe(static_cast<int>(helper::Comm::Constants::CommRecvAny), 0, &msgReady);
+
+        if (msgReady)
+        {
+            // If there is a message ready, receive and handle it
+            adios2::helper::RerouteMessage message;
+            message.RecvFrom(m_Comm, static_cast<int>(helper::Comm::Constants::CommRecvAny));
+
+            switch (message.m_MsgType)
+            {
+            case (int)RerouteMessage::MessageType::WRITE_SUBMISSION:
+                writerQueue.push(message.m_SrcRank);
+                break;
+            case (int)RerouteMessage::MessageType::DO_WRITE:
+                m_TargetIndex = message.m_SubStreamIdx;
+                m_DataPos = message.m_Offset;
+                break;
+            default:
+                break;
+            }
+        }
+
+        // Check if writing has finished, and alert the target SC
+
+        // Check if anyone is writing right now, and if not, ask the next writer to start
+        if (writingRank == -1)
+        {
+            if (!writerQueue.empty())
+            {
+                int nextWriter = writerQueue.pop();
+                adios2::helper::RerouteMessage writeMsg;
+                writeMsg.m_MsgType = adios2::helper::RerouteMessage::MessageType::DO_WRITE;
+                writeMsg.m_SrcRank = m_RankMPI;
+                writeMsg.m_DestRank = nextWriter;
+                writeMsg.m_SubStreamIdx = m_Aggregator->m_SubStreamIndex;
+                writeMsg.m_Offset = currentFilePos;
+                writeMsg.SendTo(comm, nextWriter);
+                writingRank = nextWriter;
+            }
+
+        }
+    }
 
 
+
+}
 
 void BP5Writer::WriteData_WithRerouting(format::BufferV *Data)
 {
+    // - start the communcation loop running in a thread
+    // - begin polling the write barrier variable, once it flips. write:
+    //       - variables set by comm thread indicate subfile and offset
+    // - attempt to join the comm thread
+    // - return
 
+    // The communcation function:
+    //
+    // - Send a message to your SC, requesting to write
+    // - enter the message loop where you:
+    //       - check if a message is ready, and if so:
+    //          - receive the message
+    //          - handle the message, based on your role and the sender
+    //       - if no message is ready, check if the writing is finished, and if so:
+    //          - send a message to SC telling them:
+    //              - you're done
+    //              - the new offset (or the amount you wrote)
+
+    m_readyToWrite = false;
+
+    std::thread commThread(&BP5Writer::ReroutingCommunicationLoop, this);
+
+    std::cout << "Background thread for rank " << m_RankMPI << " is now running" << std::endl;
+
+    commThread.join();
+
+    std::cout << "Background thread for rank " << m_RankMPI << " is now finished" << std::endl;
 }
 
 } // end namespace engine

--- a/source/adios2/engine/bp5/BP5Writer_WithRerouting.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_WithRerouting.cpp
@@ -1,0 +1,41 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * BP5Writer.cpp
+ *
+ */
+
+#include "BP5Writer.h"
+
+#include "adios2/common/ADIOSMacros.h"
+#include "adios2/core/IO.h"
+#include "adios2/helper/adiosFunctions.h" //CheckIndexRange
+#include "adios2/toolkit/format/buffer/chunk/ChunkV.h"
+#include "adios2/toolkit/format/buffer/malloc/MallocV.h"
+#include "adios2/toolkit/transport/file/FileFStream.h"
+#include <adios2-perfstubs-interface.h>
+
+#include <algorithm> // max
+#include <ctime>
+#include <iostream>
+
+namespace adios2
+{
+namespace core
+{
+namespace engine
+{
+
+using namespace adios2::format;
+
+
+
+void BP5Writer::WriteData_WithRerouting(format::BufferV *Data)
+{
+
+}
+
+} // end namespace engine
+} // end namespace core
+} // end namespace adios2

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -91,6 +91,34 @@ std::string Comm::BroadcastFile(const std::string &fileName, const std::string h
     return fileContents;
 }
 
+Comm::Status Comm::Probe(int source, int tag, const std::string &hint) const
+{
+    if (source < 0 || source > m_Impl->Size() - 1)
+    {
+        if (source != static_cast<int>(Comm::Constants::CommRecvAny))
+        {
+            throw std::runtime_error(
+                "Invalid MPI source rank in Probe: " + std::to_string(source) +
+                " for a communicator of size " + std::to_string(m_Impl->Size()));
+        }
+    }
+    return m_Impl->Probe(source, tag, hint);
+}
+
+Comm::Status Comm::Iprobe(int source, int tag, int *flag, const std::string &hint) const
+{
+    if (source < 0 || source > m_Impl->Size() - 1)
+    {
+        if (source != static_cast<int>(Comm::Constants::CommRecvAny))
+        {
+            throw std::runtime_error(
+                "Invalid MPI source rank in Iprobe: " + std::to_string(source) +
+                " for a communicator of size " + std::to_string(m_Impl->Size()));
+        }
+    }
+    return m_Impl->Iprobe(source, tag, flag, hint);
+}
+
 std::vector<size_t> Comm::GetGathervDisplacements(const size_t *counts, const size_t countsSize)
 {
     std::vector<size_t> displacements(countsSize);

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -61,6 +61,14 @@ public:
     };
 
     /**
+     * @brief Various constants
+     */
+    enum class Constants
+    {
+        CommRecvAny = -10
+    };
+
+    /**
      * @brief Default constructor.  Produces an empty communicator.
      *
      * An empty communicator may not be used for communcation.

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -263,6 +263,10 @@ public:
     Req Irecv(T *buffer, const size_t count, int source, int tag,
               const std::string &hint = std::string()) const;
 
+    Status Probe(int source, int tag, const std::string &hint = std::string()) const;
+
+    Status Iprobe(int source, int tag, int *flag, const std::string &hint = std::string()) const;
+
     Win Win_allocate_shared(size_t size, int disp_unit, void *baseptr,
                             const std::string &hint = std::string());
     int Win_shared_query(Win &win, int rank, size_t *size, int *disp_unit, void *baseptr,
@@ -492,6 +496,10 @@ public:
 
     virtual Comm::Req Irecv(void *buffer, size_t count, Datatype datatype, int source, int tag,
                             const std::string &hint) const = 0;
+
+    virtual Comm::Status Probe(int source, int tag, const std::string &hint) const = 0;
+
+    virtual Comm::Status Iprobe(int source, int tag, int *flag, const std::string &hint) const = 0;
 
     virtual Comm::Win Win_allocate_shared(size_t size, int disp_unit, void *baseptr,
                                           const std::string &hint) const = 0;

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -259,9 +259,12 @@ Comm::Status Comm::Recv(T *buf, size_t count, int source, int tag,
 {
     if (source < 0 || source > m_Impl->Size() - 1)
     {
-        throw std::runtime_error(
-            "Invalid MPI source rank in Recv: " + std::to_string(source) +
-            " for a communicator of size " + std::to_string(m_Impl->Size()));
+        if (source != static_cast<int>(Comm::Constants::CommRecvAny))
+        {
+            throw std::runtime_error(
+                "Invalid MPI source rank in Recv: " + std::to_string(source) +
+                " for a communicator of size " + std::to_string(m_Impl->Size()));
+        }
     }
     return m_Impl->Recv(buf, count, CommImpl::GetDatatype<T>(), source, tag,
                         hint);
@@ -296,9 +299,12 @@ Comm::Req Comm::Irecv(T *buffer, const size_t count, int source, int tag,
 {
     if (source < 0 || source > m_Impl->Size() - 1)
     {
-        throw std::runtime_error(
-            "Invalid MPI source rank in Irecv: " + std::to_string(source) +
-            " for a communicator of size " + std::to_string(m_Impl->Size()));
+        if (source != static_cast<int>(Comm::Constants::CommRecvAny))
+        {
+            throw std::runtime_error(
+                "Invalid MPI source rank in Irecv: " + std::to_string(source) +
+                " for a communicator of size " + std::to_string(m_Impl->Size()));
+        }
     }
     return m_Impl->Irecv(buffer, count, CommImpl::GetDatatype<T>(), source, tag,
                          hint);

--- a/source/adios2/helper/adiosCommDummy.cpp
+++ b/source/adios2/helper/adiosCommDummy.cpp
@@ -111,6 +111,10 @@ public:
     Comm::Req Irecv(void *buffer, size_t count, Datatype datatype, int source, int tag,
                     const std::string &hint) const override;
 
+    Comm::Status Probe(int source, int tag, const std::string &hint) const override;
+
+    Comm::Status Iprobe(int source, int tag, int *flag, const std::string &hint) const override;
+
     Comm::Win Win_allocate_shared(size_t size, int disp_unit, void *baseptr,
                                   const std::string &hint) const override;
     int Win_shared_query(Comm::Win &win, int rank, size_t *size, int *disp_unit, void *baseptr,
@@ -278,6 +282,18 @@ Comm::Req CommImplDummy::Irecv(void *, size_t, Datatype, int, int, const std::st
 {
     auto req = std::unique_ptr<CommReqImplDummy>(new CommReqImplDummy());
     return MakeReq(std::move(req));
+}
+
+Comm::Status CommImplDummy::Probe(int source, int tag, const std::string &hint) const
+{
+    Comm::Status status;
+    return status;
+}
+
+Comm::Status CommImplDummy::Iprobe(int source, int tag, int *flag, const std::string &hint) const
+{
+    Comm::Status status;
+    return status;
 }
 
 Comm::Win CommImplDummy::Win_allocate_shared(size_t size, int disp_unit, void *baseptr,

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -202,6 +202,10 @@ public:
     Comm::Req Irecv(void *buffer, size_t count, Datatype datatype, int source, int tag,
                     const std::string &hint) const override;
 
+    Comm::Status Probe(int source, int tag, const std::string &hint) const override;
+
+    Comm::Status Iprobe(int source, int tag, int *flag, const std::string &hint) const override;
+
     Comm::Win Win_allocate_shared(size_t size, int disp_unit, void *baseptr,
                                   const std::string &hint) const override;
     int Win_shared_query(Comm::Win &win, int rank, size_t *size, int *disp_unit, void *baseptr,
@@ -511,6 +515,26 @@ Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, Datatype datatype, int 
     }
 
     return MakeReq(std::move(req));
+}
+
+Comm::Status CommImplMPI::Probe(int source, int tag, const std::string &hint) const
+{
+    MPI_Status mpiStatus;
+    CheckMPIReturn(MPI_Probe(GetMPISource(source), tag, m_MPIComm, &mpiStatus), hint);
+    Comm::Status status;
+    status.Source = mpiStatus.MPI_SOURCE;
+    status.Tag = mpiStatus.MPI_TAG;
+    return status;
+}
+
+Comm::Status CommImplMPI::Iprobe(int source, int tag, int *flag, const std::string &hint) const
+{
+    MPI_Status mpiStatus;
+    CheckMPIReturn(MPI_Iprobe(GetMPISource(source), tag, m_MPIComm, flag, &mpiStatus), hint);
+    Comm::Status status;
+    status.Source = mpiStatus.MPI_SOURCE;
+    status.Tag = mpiStatus.MPI_TAG;
+    return status;
 }
 
 Comm::Win CommImplMPI::Win_allocate_shared(size_t size, int disp_unit, void *baseptr,

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -73,7 +73,6 @@ int GetMPISource(int source)
 {
     if (source == static_cast<int>(Comm::Constants::CommRecvAny))
     {
-        std::cout << "Source override" << std::endl;
         return MPI_ANY_SOURCE;
     }
 

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -19,6 +19,7 @@
 #include "adios2/common/ADIOSTypes.h"
 
 #include <mpi.h>
+#include <iostream>
 
 namespace adios2
 {
@@ -67,6 +68,17 @@ const MPI_Datatype DatatypeToMPI[] = {
     MPI_LONG_DOUBLE_INT,
     MPI_SHORT_INT,
 };
+
+int GetMPISource(int source)
+{
+    if (source == static_cast<int>(Comm::Constants::CommRecvAny))
+    {
+        std::cout << "Source override" << std::endl;
+        return MPI_ANY_SOURCE;
+    }
+
+    return source;
+}
 
 MPI_Datatype ToMPI(CommImpl::Datatype dt) { return DatatypeToMPI[int(dt)]; }
 
@@ -388,8 +400,8 @@ Comm::Status CommImplMPI::Recv(void *buf, size_t count, Datatype datatype, int s
 {
     MPI_Status mpiStatus;
     CheckMPIReturn(
-        MPI_Recv(buf, static_cast<int>(count), ToMPI(datatype), source, tag, m_MPIComm, &mpiStatus),
-        hint);
+        MPI_Recv(buf, static_cast<int>(count), ToMPI(datatype), GetMPISource(source), tag,
+                 m_MPIComm, &mpiStatus), hint);
 
     Comm::Status status;
     status.Source = mpiStatus.MPI_SOURCE;
@@ -470,7 +482,7 @@ Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, Datatype datatype, int 
             int batchSize = static_cast<int>(DefaultMaxFileBatchSize);
             MPI_Request mpiReq;
             CheckMPIReturn(MPI_Irecv(static_cast<char *>(buffer) + position, batchSize,
-                                     ToMPI(datatype), source, tag, m_MPIComm, &mpiReq),
+                                     ToMPI(datatype), GetMPISource(source), tag, m_MPIComm, &mpiReq),
                            "in call to Irecv batch " + std::to_string(b) + " " + hint + "\n");
             req->m_MPIReqs.emplace_back(mpiReq);
 
@@ -483,7 +495,7 @@ Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, Datatype datatype, int 
             int batchSize = static_cast<int>(remainder);
             MPI_Request mpiReq;
             CheckMPIReturn(MPI_Irecv(static_cast<char *>(buffer) + position, batchSize,
-                                     ToMPI(datatype), source, tag, m_MPIComm, &mpiReq),
+                                     ToMPI(datatype), GetMPISource(source), tag, m_MPIComm, &mpiReq),
                            "in call to Irecv remainder batch " + hint + "\n");
             req->m_MPIReqs.emplace_back(mpiReq);
         }
@@ -493,7 +505,7 @@ Comm::Req CommImplMPI::Irecv(void *buffer, size_t count, Datatype datatype, int 
         int batchSize = static_cast<int>(count);
         MPI_Request mpiReq;
         CheckMPIReturn(
-            MPI_Irecv(buffer, batchSize, ToMPI(datatype), source, tag, m_MPIComm, &mpiReq),
+            MPI_Irecv(buffer, batchSize, ToMPI(datatype), GetMPISource(source), tag, m_MPIComm, &mpiReq),
             " in call to Isend with single batch " + hint + "\n");
         req->m_MPIReqs.emplace_back(mpiReq);
     }

--- a/source/adios2/helper/adiosRerouting.cpp
+++ b/source/adios2/helper/adiosRerouting.cpp
@@ -1,0 +1,86 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosRerouting.cpp
+ *
+ *  Created on: Sept 26, 2025
+ *      Author: Scott Wittenburg scott.wittenburg@kitware.com
+ */
+
+#include "adiosRerouting.h"
+#include "adios2/helper/adiosComm.h"
+#include "adios2/helper/adiosMemory.h"
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <utility>
+/// \endcond
+
+
+namespace adios2
+{
+namespace helper
+{
+
+void RerouteMessage::ToBuffer(std::vector<char> &buffer)
+{
+    size_t pos = 0;
+    buffer.resize(REROUTE_MESSAGE_SIZE);
+    helper::CopyToBuffer(buffer, pos, &this->m_MsgType);
+    helper::CopyToBuffer(buffer, pos, &this->m_SrcRank);
+    helper::CopyToBuffer(buffer, pos, &this->m_DestRank);
+    helper::CopyToBuffer(buffer, pos, &this->m_SubStreamIdx);
+    helper::CopyToBuffer(buffer, pos, &this->m_Offset);
+    helper::CopyToBuffer(buffer, pos, &this->m_Size);
+}
+
+
+void RerouteMessage::FromBuffer(const std::vector<char> &buffer)
+{
+    size_t pos = 0;
+    helper::CopyFromBuffer(buffer.data(), pos, &this->m_MsgType);
+    helper::CopyFromBuffer(buffer.data(), pos, &this->m_SrcRank);
+    helper::CopyFromBuffer(buffer.data(), pos, &this->m_DestRank);
+    helper::CopyFromBuffer(buffer.data(), pos, &this->m_SubStreamIdx);
+    helper::CopyFromBuffer(buffer.data(), pos, &this->m_Offset);
+    helper::CopyFromBuffer(buffer.data(), pos, &this->m_Size);
+}
+
+void RerouteMessage::SendTo(helper::Comm& comm, int destRank)
+{
+    std::vector<char> sendBuf;
+    this->ToBuffer(sendBuf);
+
+    // You'd think send and/or recv should be non-blocking for this to work,
+    // especially when sending to ourselves, but somehow blocking send and recv
+    // seems to work.
+
+    // Non-blocking send
+    // comm.Isend(sendBuf.data(), sendBuf.size(), desinationtRank, 0);
+
+    // "Blocking" send
+    comm.Send(sendBuf.data(), sendBuf.size(), destRank, 0);
+}
+
+void RerouteMessage::RecvFrom(helper::Comm& comm, int srcRank)
+{
+    std::vector<char> recvBuf;
+    recvBuf.resize(REROUTE_MESSAGE_SIZE);
+
+    // Non-blocking receive
+    // helper::Comm::Req req = comm.Irecv(recvBuf.data(), msgSize, recvFlag, 0);
+    // helper::Comm::Status status = req.Wait();
+
+    // "Blocking" receive
+    helper::Comm::Status status = comm.Recv(recvBuf.data(), REROUTE_MESSAGE_SIZE, srcRank, 0);
+
+    this->FromBuffer(recvBuf);
+}
+
+} // end namespace helper
+} // end namespace adios2

--- a/source/adios2/helper/adiosRerouting.cpp
+++ b/source/adios2/helper/adiosRerouting.cpp
@@ -53,6 +53,9 @@ void RerouteMessage::FromBuffer(const std::vector<char> &buffer)
 
 void RerouteMessage::SendTo(helper::Comm& comm, int destRank)
 {
+    std::cout << "Rank " << comm.Rank() << " sending "
+              << this->GetTypeString(this->m_MsgType) << " to " << destRank << std::endl;
+
     std::vector<char> sendBuf;
     this->ToBuffer(sendBuf);
 
@@ -80,6 +83,15 @@ void RerouteMessage::RecvFrom(helper::Comm& comm, int srcRank)
     helper::Comm::Status status = comm.Recv(recvBuf.data(), REROUTE_MESSAGE_SIZE, srcRank, 0);
 
     this->FromBuffer(recvBuf);
+
+    std::cout << "Rank " << comm.Rank() << " received "
+              << this->GetTypeString(this->m_MsgType) << " from " << status.Source
+              << std::endl;
+
+    if (status.Source != this->m_SrcRank)
+    {
+        std::cout << "   GAHHHHHHH!" << std::endl;
+    }
 }
 
 } // end namespace helper

--- a/source/adios2/helper/adiosRerouting.h
+++ b/source/adios2/helper/adiosRerouting.h
@@ -30,7 +30,9 @@ class RerouteMessage
 public:
     enum class MessageType
     {
+        DO_WRITE,
         WRITER_IDLE,
+        WRITE_SUBMISSION,
         REROUTE_REQUEST,
         REROUTE_ACK,
         REROUTE_REJECT,

--- a/source/adios2/helper/adiosRerouting.h
+++ b/source/adios2/helper/adiosRerouting.h
@@ -1,0 +1,65 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * adiosRerouting.h helpers for BP5 rerouting aggregation
+ *
+ *  Created on: Sept 26, 2025
+ *      Author: Scott Wittenburg scott.wittenburg@kitware.com
+ */
+
+#ifndef ADIOS2_HELPER_ADIOSREROUTING_H_
+#define ADIOS2_HELPER_ADIOSREROUTING_H_
+
+#include "adios2/helper/adiosComm.h"
+
+/// \cond EXCLUDE_FROM_DOXYGEN
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+/// \endcond
+
+namespace adios2
+{
+
+namespace helper
+{
+
+class RerouteMessage
+{
+public:
+    enum class MessageType
+    {
+        WRITER_IDLE,
+        REROUTE_REQUEST,
+        REROUTE_ACK,
+        REROUTE_REJECT,
+    };
+
+    // Store a RerouteMsg so it can sent/received over mpi
+    void ToBuffer(std::vector<char> &buffer);
+
+    // Reconstitute member fields from buffer
+    void FromBuffer(const std::vector<char> &buffer);
+
+    // Send the contents of this message to another rank
+    void SendTo(helper::Comm& comm, int destRank);
+
+    // Receive a message from another rank to populate this message
+    void RecvFrom(helper::Comm& comm, int srcRank);
+
+    MessageType m_MsgType;
+    int m_SrcRank;
+    int m_DestRank;
+    unsigned long m_SubStreamIdx;
+    unsigned long m_Offset;
+    unsigned long m_Size;
+
+    static const size_t REROUTE_MESSAGE_SIZE = sizeof(MessageType) + sizeof(int) +
+        sizeof(int) + sizeof(unsigned long) + sizeof(unsigned long) + sizeof(unsigned long);
+};
+
+} // end namespace helper
+} // end namespace adios2
+
+#endif /* ADIOS2_HELPER_ADIOSREROUTING_H_ */

--- a/source/adios2/helper/adiosRerouting.h
+++ b/source/adios2/helper/adiosRerouting.h
@@ -33,10 +33,33 @@ public:
         DO_WRITE,
         WRITER_IDLE,
         WRITE_SUBMISSION,
+        WRITE_COMPLETION,
         REROUTE_REQUEST,
         REROUTE_ACK,
         REROUTE_REJECT,
     };
+
+    std::string GetTypeString(MessageType mtype)
+    {
+        switch (mtype)
+        {
+        case MessageType::DO_WRITE:
+            return std::string("DO_WRITE");
+            break;
+        case MessageType::WRITER_IDLE:
+            return std::string("WRITER_IDLE");
+            break;
+        case MessageType::WRITE_SUBMISSION:
+            return std::string("WRITE_SUBMISSION");
+            break;
+        case MessageType::WRITE_COMPLETION:
+            return std::string("WRITE_COMPLETION");
+            break;
+        default:
+            return std::string("UNKNOWN");
+            break;
+        }
+    }
 
     // Store a RerouteMsg so it can sent/received over mpi
     void ToBuffer(std::vector<char> &buffer);

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -248,6 +248,8 @@ macro(bp5agg_gtest_add_tests testname mpi)
     WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5" "TwoLevelShm")
   gtest_add_tests_helper(${testname} ${mpi} BP Engine.BPAGG. .BP5.DSB
     WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5" "DataSizeBased")
+  gtest_add_tests_helper(${testname} ${mpi} BP Engine.BPAGG. .BP5.DSB.RR
+    WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5" "DataSizeBased" "WithRerouting")
 endmacro()
 
 if (ADIOS2_HAVE_MPI)

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -126,9 +126,12 @@ bp_gtest_add_tests_helper(LargeMetadata MPI_ALLOW)
 bp5_gtest_add_tests_helper(WriteStatsOnly MPI_ALLOW)
 
 if (ADIOS2_HAVE_MPI)
-  # Extra arguments: aggregation type, num subfiles, num timesteps, verbose level
+  # Extra arguments: aggregation type, num subfiles, num timesteps, verbose level, rerouting?
   gtest_add_tests_helper(DataSizeAggregate MPI_ONLY BP Engine.BP. .BP5.DSB
     WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "DataSizeBased" "3" "5" "2"
+  )
+  gtest_add_tests_helper(DataSizeAggregate MPI_ONLY BP Engine.BP. .BP5.DSB.Rerouting
+    WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "DataSizeBased" "2" "1" "5" "WithRerouting"
   )
 endif()
 

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -247,6 +247,11 @@ macro(bp5agg_gtest_add_tests testname mpi)
     WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5" "DataSizeBased")
 endmacro()
 
+if (ADIOS2_HAVE_MPI)
+  gtest_add_tests_helper(RerouteMessage MPI_ONLY BP Engine.BPReroute. .BP5.RR
+    WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5")
+endif()
+
 # BP5 only for now, so test all the aggregators while we're at it
 bp5agg_gtest_add_tests(ParameterSelectSteps MPI_ALLOW)
 bp5agg_gtest_add_tests(AppendAfterSteps MPI_ALLOW)

--- a/testing/adios2/engine/bp/TestBPDataSizeAggregate.cpp
+++ b/testing/adios2/engine/bp/TestBPDataSizeAggregate.cpp
@@ -94,6 +94,8 @@ TEST_F(DSATest, TestWriteUnbalancedData)
     uint64_t globalNy = sumFirstN(columnsPerRank, columnsPerRank.size());
     uint64_t largestValue = (globalNx * globalNy) - 1;
 
+    std::string filename = std::string("unbalanced_output") + "_RR" + (rerouting ? "Y" : "N");
+
     {
         adios2::IO bpIO = adios.DeclareIO("WriteIO");
         bpIO.SetEngine("BPFile");
@@ -101,16 +103,14 @@ TEST_F(DSATest, TestWriteUnbalancedData)
         bpIO.SetParameter("NumSubFiles", numberOfSubFiles);
         bpIO.SetParameter("verbose", verbose);
 
-        if (rerouting)
-        {
-            bpIO.SetParameter("EnableWriterRerouting", "true");
-        }
+        const char* rr = (rerouting ? "true" : "false");
+        bpIO.SetParameter("EnableWriterRerouting", rr);
 
         adios2::Variable<uint64_t> varGlobalArray =
             bpIO.DefineVariable<uint64_t>("GlobalArray", {globalNx, globalNy});
         EXPECT_TRUE(varGlobalArray);
 
-        adios2::Engine bpWriter = bpIO.Open("unbalanced_output.bp", adios2::Mode::Write);
+        adios2::Engine bpWriter = bpIO.Open(filename, adios2::Mode::Write);
 
         for (size_t step = 0; step < nSteps; ++step)
         {
@@ -159,7 +159,7 @@ TEST_F(DSATest, TestWriteUnbalancedData)
         adios2::IO io = adios.DeclareIO("ReadIO");
 
         io.SetEngine("BPFile");
-        adios2::Engine bpReader = io.Open("unbalanced_output.bp", adios2::Mode::ReadRandomAccess);
+        adios2::Engine bpReader = io.Open(filename, adios2::Mode::ReadRandomAccess);
 
         auto var_array = io.InquireVariable<uint64_t>("GlobalArray");
         EXPECT_TRUE(var_array);

--- a/testing/adios2/engine/bp/TestBPDataSizeAggregate.cpp
+++ b/testing/adios2/engine/bp/TestBPDataSizeAggregate.cpp
@@ -18,7 +18,8 @@ uint64_t nSteps = 1;
 std::string aggregationType = "DataSizeBased"; // comes from command line
 std::string numberOfSubFiles = "2";            // comes from command line
 std::string numberOfSteps = "1";               // comes from command line
-std::string verbose = "0";
+std::string verbose = "0";                     // comes from command line
+bool rerouting = false;                        // comes from command line
 
 uint64_t sumFirstN(const std::vector<uint64_t> &vec, uint64_t n)
 {
@@ -99,6 +100,11 @@ TEST_F(DSATest, TestWriteUnbalancedData)
         bpIO.SetParameter("AggregationType", aggregationType);
         bpIO.SetParameter("NumSubFiles", numberOfSubFiles);
         bpIO.SetParameter("verbose", verbose);
+
+        if (rerouting)
+        {
+            bpIO.SetParameter("EnableWriterRerouting", "true");
+        }
 
         adios2::Variable<uint64_t> varGlobalArray =
             bpIO.DefineVariable<uint64_t>("GlobalArray", {globalNx, globalNy});
@@ -213,6 +219,14 @@ int main(int argc, char **argv)
     if (argc > 4)
     {
         verbose = std::string(argv[4]);
+    }
+    if (argc > 5)
+    {
+        std::string lastArg = std::string(argv[5]);
+        if (lastArg.compare("WithRerouting") == 0)
+        {
+            rerouting = true;
+        }
     }
 
     try

--- a/testing/adios2/engine/bp/TestBPNewFileAppendMode.cpp
+++ b/testing/adios2/engine/bp/TestBPNewFileAppendMode.cpp
@@ -14,6 +14,7 @@
 
 std::string engineName;                               // comes from command line
 std::string aggregationType = "EveryoneWritesSerial"; // comes from command line
+bool rerouting = false;                               // overridden on command line
 
 class BPNewFileAppendMode : public ::testing::Test
 {
@@ -43,6 +44,8 @@ TEST_F(BPNewFileAppendMode, ADIOS2BPNewFileAppendMode)
         fname += "-EW.bp";
     }
 
+    fname += std::string("_RR") + (rerouting ? "Y" : "N");
+
     const size_t Nx = 6;
 
     adios2::ADIOS adios;
@@ -64,6 +67,9 @@ TEST_F(BPNewFileAppendMode, ADIOS2BPNewFileAppendMode)
         io.SetParameter("AggregationType", aggregationType);
         io.SetParameter("NumAggregators", "0");
 
+        const char* rr = (rerouting ? "true" : "false");
+        io.SetParameter("EnableWriterRerouting", rr);
+
         adios2::Engine engine = io.Open(fname, adios2::Mode::Append);
 
         engine.Close();
@@ -82,6 +88,15 @@ int main(int argc, char **argv)
     if (argc > 2)
     {
         aggregationType = std::string(argv[2]);
+    }
+
+    if (argc > 3)
+    {
+        std::string lastArg = std::string(argv[3]);
+        if (lastArg.compare("WithRerouting") == 0)
+        {
+            rerouting = true;
+        }
     }
 
     result = RUN_ALL_TESTS();

--- a/testing/adios2/engine/bp/TestBPRerouteMessage.cpp
+++ b/testing/adios2/engine/bp/TestBPRerouteMessage.cpp
@@ -1,0 +1,108 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ */
+
+#include <adios2.h>
+#include <adios2/helper/adiosCommMPI.h>
+#include <adios2/helper/adiosRerouting.h>
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <numeric>
+#include <thread>
+
+using namespace adios2;
+
+namespace
+{
+int worldRank, worldSize;
+
+void SendAndReceiveMessage(helper::Comm &comm, int destRank, int srcRank)
+{
+    std::cout << "Sending to " << destRank << " and expecting to receive from: " << srcRank << std::endl;
+
+    // Send a message to another rank
+    adios2::helper::RerouteMessage origMsg;
+    origMsg.m_MsgType = adios2::helper::RerouteMessage::MessageType::WRITER_IDLE;
+    origMsg.m_SrcRank = worldRank;
+    origMsg.m_DestRank = destRank;
+    origMsg.m_Offset = 2138;
+    origMsg.m_Size = 1213;
+    origMsg.SendTo(comm, destRank);
+
+    // Receive a message from another (any) rank
+    adios2::helper::RerouteMessage receivedMsg;
+    receivedMsg.RecvFrom(comm, static_cast<int>(helper::Comm::Constants::CommRecvAny));
+
+    ASSERT_EQ(receivedMsg.m_MsgType, origMsg.m_MsgType);
+    ASSERT_EQ(receivedMsg.m_SrcRank, srcRank);
+    ASSERT_EQ(receivedMsg.m_DestRank, worldRank);
+    ASSERT_EQ(receivedMsg.m_Offset, origMsg.m_Offset);
+    ASSERT_EQ(receivedMsg.m_Size, origMsg.m_Size);
+}
+}
+
+class RerouteTest : public ::testing::Test
+{
+public:
+    RerouteTest() = default;
+};
+
+
+TEST_F(RerouteTest, TestMessageBuffer)
+{
+    adios2::helper::RerouteMessage origMsg;
+
+    origMsg.m_MsgType = adios2::helper::RerouteMessage::MessageType::WRITER_IDLE;
+    origMsg.m_SrcRank = 3;
+    origMsg.m_DestRank = 0;
+    origMsg.m_SubStreamIdx = 1;
+    origMsg.m_Offset = 2138;
+    origMsg.m_Size = 1213;
+
+    std::vector<char> buf;
+    origMsg.ToBuffer(buf);
+
+    adios2::helper::RerouteMessage newMsg;
+    newMsg.FromBuffer(buf);
+
+    ASSERT_EQ(newMsg.m_MsgType, origMsg.m_MsgType);
+    ASSERT_EQ(newMsg.m_SrcRank, origMsg.m_SrcRank);
+    ASSERT_EQ(newMsg.m_DestRank, origMsg.m_DestRank);
+    ASSERT_EQ(newMsg.m_SubStreamIdx, origMsg.m_SubStreamIdx);
+    ASSERT_EQ(newMsg.m_Offset, origMsg.m_Offset);
+    ASSERT_EQ(newMsg.m_Size, origMsg.m_Size);
+}
+
+TEST_F(RerouteTest, TestSendReceiveRoundRobin)
+{
+    helper::Comm comm = adios2::helper::CommDupMPI(MPI_COMM_WORLD);
+
+    int destRank = worldRank >= worldSize - 1 ? 0 : worldRank + 1;
+    int expectedSender = worldRank <= 0 ? worldSize - 1 : worldRank - 1;
+
+    SendAndReceiveMessage(comm, destRank, expectedSender);
+}
+
+TEST_F(RerouteTest, TestSendReceiveSelf)
+{
+    helper::Comm comm = adios2::helper::CommDupMPI(MPI_COMM_WORLD);
+
+    int destRank = worldRank;
+    int expectedSender = worldRank;
+
+    SendAndReceiveMessage(comm, destRank, expectedSender);
+}
+
+int main(int argc, char **argv)
+{
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+    ::testing::InitGoogleTest(&argc, argv);
+
+    int result = RUN_ALL_TESTS();
+
+    MPI_Finalize();
+    return result;
+}

--- a/testing/adios2/engine/bp/TestBPRerouteMessage.cpp
+++ b/testing/adios2/engine/bp/TestBPRerouteMessage.cpp
@@ -30,6 +30,13 @@ void SendAndReceiveMessage(helper::Comm &comm, int destRank, int srcRank)
     origMsg.m_Size = 1213;
     origMsg.SendTo(comm, destRank);
 
+    int ready = 0;
+
+    while (!ready)
+    {
+        comm.Iprobe(static_cast<int>(helper::Comm::Constants::CommRecvAny), 0, &ready);
+    }
+
     // Receive a message from another (any) rank
     adios2::helper::RerouteMessage receivedMsg;
     receivedMsg.RecvFrom(comm, static_cast<int>(helper::Comm::Constants::CommRecvAny));

--- a/testing/adios2/engine/bp/TestBPStepsFileGlobalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsFileGlobalArray.cpp
@@ -18,6 +18,7 @@
 
 std::string engineName;   // comes from command line
 std::string aggType = ""; // overridden on command line
+bool rerouting = false;   // overridden on command line
 
 // Number of elements per process
 const std::size_t Nx = 10;
@@ -121,7 +122,7 @@ TEST_P(BPStepsFileGlobalArrayReaders, EveryStep)
 {
     const ReadMode readMode = GetReadMode();
     std::string fname_prefix = "BPStepsFileGlobalArray.EveryStep." + ReadModeToString(readMode) +
-                               AggregationTypeAlias(aggType);
+                               AggregationTypeAlias(aggType) + "_RR" + (rerouting ? "Y" : "N");
     int mpiRank = 0, mpiSize = 1;
     const std::size_t NSteps = 4;
 
@@ -160,6 +161,10 @@ TEST_P(BPStepsFileGlobalArrayReaders, EveryStep)
         {
             io.SetParameter("AggregationType", aggType);
         }
+
+        const char* rr = (rerouting ? "true" : "false");
+        io.SetParameter("EnableWriterRerouting", rr);
+
         adios2::Engine engine = io.Open(fname, adios2::Mode::Write);
 
         auto var_i32 = io.DefineVariable<int32_t>("i32", shape, start, count);
@@ -380,7 +385,8 @@ TEST_P(BPStepsFileGlobalArrayReaders, NewVarPerStep)
 {
     const ReadMode readMode = GetReadMode();
     std::string fname_prefix = "BPStepsFileGlobalArray.NewVarPerStep." +
-                               ReadModeToString(readMode) + AggregationTypeAlias(aggType);
+                               ReadModeToString(readMode) + AggregationTypeAlias(aggType) +
+                               "_RR" + (rerouting ? "Y" : "N");
     int mpiRank = 0, mpiSize = 1;
     const std::size_t NSteps = 4;
 
@@ -421,6 +427,10 @@ TEST_P(BPStepsFileGlobalArrayReaders, NewVarPerStep)
         {
             io.SetParameter("AggregationType", aggType);
         }
+
+        const char* rr = (rerouting ? "true" : "false");
+        io.SetParameter("EnableWriterRerouting", rr);
+
         adios2::Engine engine = io.Open(fname, adios2::Mode::Write);
 
         for (int step = 0; step < static_cast<int>(NSteps); ++step)
@@ -667,7 +677,8 @@ TEST_P(BPStepsFileGlobalArrayParameters, EveryOtherStep)
     const ReadMode readMode = GetReadMode();
     std::string fname_prefix = "BPStepsFileGlobalArray.EveryOtherStep.Steps" +
                                std::to_string(NSteps) + ".Oddity" + std::to_string(Oddity) + "." +
-                               ReadModeToString(readMode) + AggregationTypeAlias(aggType);
+                               ReadModeToString(readMode) + AggregationTypeAlias(aggType) +
+                               "_RR" + (rerouting ? "Y" : "N");
     int mpiRank = 0, mpiSize = 1;
 
 #if ADIOS2_USE_MPI
@@ -709,6 +720,10 @@ TEST_P(BPStepsFileGlobalArrayParameters, EveryOtherStep)
         {
             io.SetParameter("AggregationType", aggType);
         }
+
+        const char* rr = (rerouting ? "true" : "false");
+        io.SetParameter("EnableWriterRerouting", rr);
+
         adios2::Engine engine = io.Open(fname, adios2::Mode::Write);
 
         auto var_i32 = io.DefineVariable<int32_t>("i32", shape, start, count);
@@ -980,6 +995,15 @@ int main(int argc, char **argv)
     if (argc > 2)
     {
         aggType = std::string(argv[2]);
+    }
+
+    if (argc > 3)
+    {
+        std::string lastArg = std::string(argv[3]);
+        if (lastArg.compare("WithRerouting") == 0)
+        {
+            rerouting = true;
+        }
     }
 
     result = RUN_ALL_TESTS();


### PR DESCRIPTION
Implement aggregation method inspired by the paper "Can I/O Variability Be Reduced on QoS-Less HPC Storage Systems?" ([link](https://doi.org/10.1109/TC.2018.2881709)).

Currently only works with `DataSizeBased` aggregation.

Does not yet do any actual re-routing, only re-implements writing using a new multithreaded messaging scheme based on the paper above. 

Adds some missing functionality to `adiosComm` (probe api and support for `MPI_ANY_SOURCE`)