### PR TITLE
ci: make build_and_test dep on everything

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -619,7 +619,7 @@ jobs:
 #######################################
 
   build_and_test:
-    needs: [el8, ubuntu, macos, docker, contract]
+    needs: [el8, ubuntu, macos, windows, docker, contract]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All required jobs complete"


### PR DESCRIPTION
This is needed so that by marking build_and_test required
git status for merging PRs it transitively marks the rest of the
CI pipeline jobs required. Windows was missing.
