### PR TITLE
Bump NumPy minimum required version to 1.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "numpy",
+  "numpy>=1.22",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes https://github.com/ornladios/ADIOS2/issues/4674.