### PR TITLE
H5VolReadWrite: Do not use variable after memory is freed

### DIFF
--- a/source/h5vol/H5VolReadWrite.c
+++ b/source/h5vol/H5VolReadWrite.c
@@ -440,13 +440,9 @@ bool gRemoveUnderGrp(H5VL_ObjDef_t *owner, const char *obj_name)
             return true;
         }
 
-    free(fullPath);
-#ifdef NEVER
-    return false;
-#else
     printf("\n......... NOTE: unable to remove GROUP %s \n\n", fullPath);
-    return true;
-#endif
+    free(fullPath);
+    return false;
 }
 
 void gLoadAttrDef(H5VL_AttrDef_t *attrDef)


### PR DESCRIPTION
Fix issue found by compiler warning newly emitted in #4666 