### PR TITLE
Raise an exception when an XRootD get fails.

### DIFF
--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -330,7 +330,8 @@ bool XrootdRemote::WaitForGet(GetHandle handle)
 {
     std::promise<bool> *p = (std::promise<bool> *)handle;
     bool result = p->get_future().get();
-    if (!result)  throw std::runtime_error("XRootD - Get failed for file " + m_Filename);
+    if (!result)
+        throw std::runtime_error("XRootD - Get failed for file " + m_Filename);
     delete p;
     return true;
 }


### PR DESCRIPTION
This isn't an ideal implementation.  XRootD is more like httpd than it is our EVPath-based remote server.  We don't actually know on Open() if the file exists on the XRootD server because we don't communicate with the server on Open.  Instead, we find out when the first Get() fails, but actually since we do those in parallel there are multiple Get()s in-flight before we actually get one back that has failed, so there's a bit of noise in stderr because of this.  But this is better than not raising an exception at all, which is what we have been doing.