### PR TITLE
CampaignReader  include/exclude patterns (regular expressions)

### DIFF
--- a/source/adios2/engine/campaign/CampaignReader.h
+++ b/source/adios2/engine/campaign/CampaignReader.h
@@ -20,6 +20,8 @@
 #include "adios2/helper/adiosFunctions.h"
 #include "adios2/toolkit/remote/Remote.h"
 
+#include <regex>
+
 namespace adios2
 {
 namespace core
@@ -55,7 +57,11 @@ public:
 
 private:
     UserOptions::Campaign m_Options;
-    int m_ReaderRank; // my rank in the readers' comm
+    std::vector<std::string> m_IncludePatterns;  // reg.expr. include datasets
+    std::vector<std::regex> m_IncludePatternsRe; // reg.expr. include datasets, compiled
+    std::vector<std::string> m_ExcludePatterns;  // reg.expr. exclude datasets
+    std::vector<std::regex> m_ExcludePatternsRe; // reg.expr. exclude datasets, compiled
+    int m_ReaderRank;                            // my rank in the readers' comm
 
     int m_CurrentStep = 0;
 
@@ -191,6 +197,9 @@ private:
     // for reading individual remote file
     void ReadRemoteFile(const std::string &remoteHost, const std::string &remotePath,
                         const size_t size, void *data);
+
+    // check if name is included and not excluded by patterns
+    bool Matches(const std::string &dsname);
 };
 
 } // end namespace engine

--- a/source/adios2/helper/adiosString.cpp
+++ b/source/adios2/helper/adiosString.cpp
@@ -503,5 +503,22 @@ std::string RandomString(const size_t length)
     return str.substr(0, len);
 }
 
+std::vector<std::string> StringToVector(const std::string &s, const char delimiter)
+{
+    std::vector<std::string> result;
+    std::string::size_type start = 0;
+    std::string::size_type end;
+
+    while ((end = s.find(delimiter, start)) != std::string::npos)
+    {
+        result.emplace_back(s.substr(start, end - start));
+        start = end + 1;
+    }
+
+    // Add the last segment
+    result.emplace_back(s.substr(start));
+    return result;
+}
+
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/helper/adiosString.h
+++ b/source/adios2/helper/adiosString.h
@@ -200,6 +200,11 @@ std::string RemoveTrailingSlash(const std::string &name) noexcept;
  */
 std::string RandomString(const size_t length);
 
+/**
+ * Split a string into a vector of strings using the delimiter character.
+ */
+std::vector<std::string> StringToVector(const std::string &s, const char delimiter = ';');
+
 } // end namespace helper
 } // end namespace adios2
 


### PR DESCRIPTION
New parameters for CampaignReader: only open datasets that match regex patterns:
`include-dataset=F.*05/gs.bp;F.*06/.*`
`exclude-dataset=.*png;.*json`
Semicolon-separated strings, each a regular expression. A dataset will be opened if it 1) matches an include expression, and 2) it does not match an exclude expression. If there are no include-patterns, then everything matches, of course.