### PR TITLE
CI: use gfortran-13 in macos xcode-15 jobs

### DIFF
--- a/scripts/ci/cmake/ci-macos-14-xcode15_4-shared-serial.cmake
+++ b/scripts/ci/cmake/ci-macos-14-xcode15_4-shared-serial.cmake
@@ -1,7 +1,7 @@
 # Client maintainer: vicente.bolea@kitware.com
 set(ENV{CC}  clang)
 set(ENV{CXX} clang++)
-set(ENV{FC}  gfortran-12)
+set(ENV{FC} gfortran-13)
 
 set(dashboard_cache "
 BUILD_TESTING:BOOL=ON

--- a/scripts/ci/cmake/ci-macos-14-xcode15_4-static-serial.cmake
+++ b/scripts/ci/cmake/ci-macos-14-xcode15_4-static-serial.cmake
@@ -1,7 +1,6 @@
 # Client maintainer: vicente.bolea@kitware.com
 set(ENV{CC}  clang)
 set(ENV{CXX} clang++)
-set(ENV{FC}  gfortran-12)
 
 set(dashboard_cache "
 BUILD_SHARED_LIBS=OFF
@@ -39,7 +38,6 @@ CMAKE_C_COMPILER_LAUNCHER=ccache
 CMAKE_CXX_COMPILER_LAUNCHER=ccache
 CMAKE_C_FLAGS:STRING=-Wall
 CMAKE_CXX_FLAGS:STRING=-Wall
-CMAKE_Fortran_FLAGS:STRING=-Wall
 ")
 
 set(ENV{MACOSX_DEPLOYMENT_TARGET} "14.5")

--- a/scripts/ci/gh-actions/macos-setup.sh
+++ b/scripts/ci/gh-actions/macos-setup.sh
@@ -15,7 +15,7 @@ then
   exit 2
 fi
 sudo xcode-select --switch "/Applications/Xcode_${XCODE_VER}.app"
-sudo ln -v -s "$(which gfortran-12)" /usr/local/bin/gfortran
+sudo ln -v -s "$(which gfortran-13)" /usr/local/bin/gfortran
 
 echo "Installing Miniconda"
 


### PR DESCRIPTION
GCC11 is not available anymore in xcode-15 in macos Github Action images.

Here is the commit that removed them: https://github.com/actions/runner-images/commit/e7dc7ab548155846173a54ca7f08dd196f8c3d62