### PR TITLE
Add support to read a BP5/TEXT/IMAGE from TAR files…

### DIFF
--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -173,6 +173,7 @@ public:
     MACRO(RemoteDataPath, String, std::string, "")                                                 \
     MACRO(RemoteHost, String, std::string, "")                                                     \
     MACRO(UUID, String, std::string, "")                                                           \
+    MACRO(TarInfo, String, std::string, "")                                                        \
     MACRO(MaxOpenFilesAtOnce, UInt, unsigned int, UINT_MAX)
 
     struct BP5Params

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -403,6 +403,35 @@ void BP5Reader::EndStep()
     MinBlocksInfoMap.clear();
 }
 
+std::string BP5Reader::UpdateWithTarInfo(const std::string &path, Params &params)
+{
+    if (m_dataIsRemote)
+        return path;
+    auto fileName = adios2sys::SystemTools::GetFilenameName(path);
+    std::string retval = path;
+    if (m_Parameters.verbose > 1)
+    {
+        std::cout << "--- UpdateWithTarInfo path = " << path << ", fileName = " << fileName
+                  << "  map size = " << m_TarInfoMap.size() << std::endl;
+    }
+    auto it = m_TarInfoMap.find(fileName);
+    if (it != m_TarInfoMap.end())
+    {
+        std::string offset = std::to_string(std::get<0>(it->second));
+        std::string size = std::to_string(std::get<1>(it->second));
+        params["taroffset"] = offset;
+        params["tarsize"] = size;
+        // Do not use this for URLs: retval = adios2sys::SystemTools::GetFilenamePath(path);
+        retval = path.substr(0, path.length() - fileName.length() - 1);
+        if (m_Parameters.verbose > 1)
+        {
+            std::cout << "--- UpdateWithTarInfo Add params taroffset = " << offset
+                      << ", tarsize = " << size << " for file " << retval << std::endl;
+        }
+    }
+    return retval;
+}
+
 std::pair<double, double> BP5Reader::ReadData(adios2::transportman::TransportMan &FileManager,
                                               const size_t maxOpenFiles, const size_t WriterRank,
                                               const size_t Timestep, const size_t StartOffset,
@@ -420,13 +449,14 @@ std::pair<double, double> BP5Reader::ReadData(adios2::transportman::TransportMan
     TP startSubfile = NOW();
     if (FileManager.m_Transports.count(SubfileNum) == 0)
     {
-        const std::string subFileName =
+        std::string subFileName =
             GetBPSubStreamName(m_Name, SubfileNum, m_Minifooter.HasSubFiles, true);
         if (FileManager.m_Transports.size() >= maxOpenFiles)
         {
             auto m = FileManager.m_Transports.begin();
             FileManager.CloseFiles((int)m->first);
         }
+        subFileName = UpdateWithTarInfo(subFileName, m_IO.m_TransportsParameters[0]);
         FileManager.OpenFileID(subFileName, SubfileNum, Mode::Read, m_IO.m_TransportsParameters[0],
                                /*{{"transport", "File"}},*/ true);
         if (!m_WriterIsActive)
@@ -536,7 +566,15 @@ void BP5Reader::PerformGets()
             int localPort = pair.second;
             if (m_Remote && localPort > -1)
             {
-                m_Remote->Open("localhost", localPort, RemoteName, m_OpenMode, RowMajorOrdering);
+                Params p;
+                if (!m_Parameters.TarInfo.empty())
+                    p.emplace("TarInfo", m_Parameters.TarInfo);
+                if (!m_Parameters.SelectSteps.empty())
+                    p.emplace("SelectSteps", m_Parameters.SelectSteps);
+                if (m_Parameters.IgnoreFlattenSteps)
+                    p.emplace("IgnoreFlattenSteps", "true");
+
+                m_Remote->Open("localhost", localPort, RemoteName, m_OpenMode, RowMajorOrdering, p);
             }
         }
 #endif
@@ -1029,6 +1067,12 @@ void BP5Reader::Init()
         m_SelectedSteps.ParseSelection(m_Parameters.SelectSteps);
     }
 
+    // Don't try to open the remote file when we open local metadata.  Do that on demand.
+    if (!m_Parameters.RemoteDataPath.empty())
+        m_dataIsRemote = true;
+    if (getenv("DoRemote") || getenv("DoXRootD"))
+        m_dataIsRemote = true;
+
     if (m_ReadMetadataFromFile)
     {
         /* Do a collective wait for the file(s) to appear within timeout.
@@ -1044,12 +1088,6 @@ void BP5Reader::Init()
         TimePoint timeoutInstant = Now() + timeoutSeconds;
         OpenFiles(timeoutInstant, pollSeconds, timeoutSeconds);
         UpdateBuffer(timeoutInstant, pollSeconds / 10, timeoutSeconds);
-
-        // Don't try to open the remote file when we open local metadata.  Do that on demand.
-        if (!m_Parameters.RemoteDataPath.empty())
-            m_dataIsRemote = true;
-        if (getenv("DoRemote") || getenv("DoXRootD"))
-            m_dataIsRemote = true;
     }
 }
 
@@ -1128,7 +1166,8 @@ size_t BP5Reader::OpenWithTimeout(std::shared_ptr<Transport> &file, const std::s
         {
             errno = 0;
             const bool profile = true;
-            file = m_TransportFactory.OpenFileTransport(fileName, adios2::Mode::Read,
+            std::string newFileName = UpdateWithTarInfo(fileName, m_IO.m_TransportsParameters[0]);
+            file = m_TransportFactory.OpenFileTransport(newFileName, adios2::Mode::Read,
                                                         m_IO.m_TransportsParameters[0], profile,
                                                         false, m_Comm);
             flag = 0; // found file
@@ -1160,14 +1199,14 @@ void BP5Reader::OpenFiles(TimePoint &timeoutInstant, const Seconds &pollSeconds,
     if (m_Comm.Rank() == 0)
     {
         /* Open the metadata index table */
-        const std::string metadataIndexFile(GetBPMetadataIndexFileName(m_Name));
+        std::string metadataIndexFile(GetBPMetadataIndexFileName(m_Name));
 
         flag = OpenWithTimeout(m_MDIndexFile, metadataIndexFile, timeoutInstant, pollSeconds,
                                lasterrmsg);
         if (flag == 0)
         {
             /* Open the metadata file */
-            const std::string metadataFile(GetBPMetadataFileName(m_Name));
+            std::string metadataFile(GetBPMetadataFileName(m_Name));
 
             /* We found md.idx. If we don't find md.0 immediately  we should
              * wait a little bit hoping for the file system to catch up.
@@ -1292,6 +1331,15 @@ void BP5Reader::InitTransports()
         Params defaultTransportParameters;
         defaultTransportParameters["transport"] = "File";
         m_IO.m_TransportsParameters.push_back(defaultTransportParameters);
+    }
+    if (!m_Parameters.TarInfo.empty())
+    {
+        m_TarInfoMap = helper::StringToTarInfo(m_Parameters.TarInfo);
+        if (m_Parameters.verbose > 1)
+        {
+            std::cout << "--- BP5Reader TarInfo = " << m_Parameters.TarInfo
+                      << "\n    map size = " << m_TarInfoMap.size() << std::endl;
+        }
     }
 }
 

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -15,6 +15,7 @@
 #include "adios2/engine/bp5/BP5Engine.h"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/helper/adiosRangeFilter.h"
+#include "adios2/helper/adiosString.h"
 #include "adios2/toolkit/format/bp5/BP5Deserializer.h"
 #include "adios2/toolkit/format/buffer/heap/BufferMalloc.h"
 #include "adios2/toolkit/kvcache/KVCacheCommon.h"
@@ -278,6 +279,9 @@ private:
     helper::Comm singleComm;
     unsigned int m_Threads;
     std::vector<transportman::TransportMan> fileManagers; // manager per thread
+
+    helper::TarInfoMap m_TarInfoMap;
+    std::string UpdateWithTarInfo(const std::string &path, Params &params);
 };
 
 } // end namespace engine

--- a/source/adios2/engine/campaign/CampaignData.h
+++ b/source/adios2/engine/campaign/CampaignData.h
@@ -179,6 +179,8 @@ public:
     // return 0 if there is no replica found for 'hostname', otherwise the replica index
     size_t FindReplicaOnHost(const size_t datasetIdx, std::string hostname);
 
+    std::string GetTarIdx(const size_t dsIdx, const size_t repIdx);
+
 private:
     void DumpToFileOrMemory(const CampaignFile &file, std::string &keyHex, const std::string &path,
                             char *data);

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -260,18 +260,34 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
     CampaignDataset &ds = m_CampaignData.datasets[dsIdx];
     CampaignReplica &rep = ds.replicas[repIdx];
 
-    std::string tarpath;
+    std::string remotePath = m_CampaignData.directory[rep.dirIdx].path + "/" + rep.name;
+    std::string taropt;
+
     if (rep.archiveIdx > 0)
     {
         auto itTarName = m_CampaignData.tarnames.find(rep.archiveIdx);
         if (itTarName != m_CampaignData.tarnames.end())
         {
-            tarpath = itTarName->second + "/";
+            std::string tarpath = itTarName->second;
+            remotePath = m_CampaignData.directory[rep.dirIdx].path + "/" + tarpath;
+            taropt = m_CampaignData.GetTarIdx(dsIdx, repIdx);
+            if (taropt.empty())
+            {
+                std::cout << "ERROR: Remote file " << remotePath
+                          << " is in a TAR file but without offset info. Skip" << std::endl;
+                return "";
+            }
+            if (m_Options.verbose > 0)
+            {
+
+                std::cout << "Open remote file in TAR file " << remotePath << " with tar indices "
+                          << taropt << "\n";
+            }
+            io.SetParameter("TarInfo", taropt);
+            io.SetEngine("BP5");
         }
     }
 
-    const std::string remotePath =
-        m_CampaignData.directory[rep.dirIdx].path + "/" + tarpath + rep.name;
     const std::string remoteURL = m_CampaignData.hosts[rep.hostIdx].hostname + ":" + remotePath;
     localPath =
         m_Options.cachepath + PathSeparator + ds.uuid.substr(0, 3) + PathSeparator + ds.uuid;
@@ -347,7 +363,7 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
             if (ds.format == FileFormat::TEXT)
             {
                 // TEXT -> create a variable, will read from DB directly, no local path
-                CreateTextVariable(ds.name, f.lengthOriginal, dsIdx, repIdx);
+                CreateTextVariable(ds.name, f.lengthOriginal, dsIdx, repIdx, false);
                 continue;
             }
             else if (ds.format == FileFormat::IMAGE)
@@ -355,7 +371,7 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
                 // IMAGE -> create a variable, will read from DB directly, no local path
                 std::string imgName =
                     ds.name + "/" + std::to_string(rep.x) + "x" + std::to_string(rep.y);
-                CreateImageVariable(imgName, f.lengthOriginal, dsIdx, repIdx);
+                CreateImageVariable(imgName, f.lengthOriginal, dsIdx, repIdx, false);
                 continue;
             }
             else
@@ -379,14 +395,14 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
         if (ds.format == FileFormat::TEXT)
         {
             // TEXT -> create a variable, will read from remote
-            CreateTextVariable(ds.name, rep.size, dsIdx, repIdx);
+            CreateTextVariable(ds.name, rep.size, dsIdx, repIdx, false, remotePath, taropt);
         }
         else if (ds.format == FileFormat::IMAGE)
         {
             // IMAGE -> create a variable, will read from remote
             std::string imgName =
                 ds.name + "/" + std::to_string(rep.x) + "x" + std::to_string(rep.y);
-            CreateImageVariable(imgName, rep.size, dsIdx, repIdx);
+            CreateImageVariable(imgName, rep.size, dsIdx, repIdx, false, remotePath, taropt);
         }
         else
         {
@@ -445,8 +461,8 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
         }
         else if (m_CampaignData.hosts[rep.hostIdx].defaultProtocol == "https")
         {
-            std::string url = "https://" + m_CampaignData.hosts[rep.hostIdx].longhostname + "/" +
-                              m_CampaignData.directory[rep.dirIdx].path + "/" + tarpath + rep.name;
+            std::string url =
+                "https://" + m_CampaignData.hosts[rep.hostIdx].longhostname + "/" + remotePath;
             Params p;
             p.emplace("Library", "https");
             // p.emplace("hostname", m_CampaignData.hosts[rep.hostIdx].longhostname);
@@ -717,6 +733,7 @@ void CampaignReader::InitTransports()
 
         adios2::core::IO &io = m_IO.m_ADIOS.DeclareIO("CampaignReader" + std::to_string(dsIdx));
         std::string localPath;
+        std::string taropt;
         size_t repIdx = m_CampaignData.FindReplicaOnHost(dsIdx, m_Options.hostname);
         if (!repIdx)
         {
@@ -743,16 +760,53 @@ void CampaignReader::InitTransports()
         else
         {
             CampaignReplica &rep = ds.replicas[repIdx];
-            localPath = m_CampaignData.directory[rep.dirIdx].path + PathSeparator + rep.name;
-            if (m_Options.verbose > 0)
+            if (rep.archiveIdx == 0)
             {
-                std::cout << "Open local file " << localPath << "\n";
+                localPath = m_CampaignData.directory[rep.dirIdx].path + PathSeparator + rep.name;
+                if (m_Options.verbose > 0)
+                {
+                    std::cout << "Open local file " << localPath << "\n";
+                }
             }
+            else
+            {
+                auto itTarName = m_CampaignData.tarnames.find(rep.archiveIdx);
+                if (itTarName != m_CampaignData.tarnames.end())
+                {
+                    std::string tarpath = itTarName->second;
+                    localPath = m_CampaignData.directory[rep.dirIdx].path + PathSeparator + tarpath;
+                    taropt = m_CampaignData.GetTarIdx(dsIdx, repIdx);
+                    if (taropt.empty())
+                    {
+                        std::cout << "ERROR: Local file " << localPath
+                                  << " is in a TAR file but without offset info. Skip" << std::endl;
+                        continue;
+                    }
+                    if (m_Options.verbose > 0)
+                    {
+
+                        std::cout << "Open local file in TAR file " << localPath
+                                  << " with tar indices " << taropt << "\n";
+                    }
+                    io.SetParameter("TarInfo", taropt);
+                    io.SetEngine("BP5");
+                }
+                else
+                {
+                    localPath =
+                        m_CampaignData.directory[rep.dirIdx].path + PathSeparator + rep.name;
+                    if (m_Options.verbose > 0)
+                    {
+                        std::cout << "Open local file in archive dir " << localPath << "\n";
+                    }
+                }
+            }
+
             if (ds.format == FileFormat::TEXT)
             {
                 // TEXT -> create a variable
                 CreateTextVariable(ds.name, adios2sys::SystemTools::FileLength(localPath), dsIdx,
-                                   repIdx, localPath);
+                                   repIdx, true, localPath, taropt);
             }
         }
 
@@ -795,48 +849,104 @@ void CampaignReader::InitTransports()
                           << m_CampaignData.directory[rep.dirIdx].path << PathSeparator << rep.name
                           << "\n";
             }
-            if (m_CampaignData.directory[rep.dirIdx].archive)
+
+            // need to check if we already defined this image with this resolution in this loop
+            std::string imgName =
+                ds.name + "/" + std::to_string(rep.x) + "x" + std::to_string(rep.y);
+            auto v = m_IO.InquireVariable<uint8_t>(imgName);
+            if (v)
             {
-                // this is an image in an archived place, skip
                 continue;
             }
-            else if (rep.files.size())
+
+            if (rep.files.size())
             {
                 // this replica has embedded image
                 // IMAGE -> create a variable, will read from DB directly, no local path
-                std::string imgName =
-                    ds.name + "/" + std::to_string(rep.x) + "x" + std::to_string(rep.y);
                 if (m_Options.verbose > 1)
                 {
                     std::cout << "        --- embedded image " << imgName << "\n";
                 }
                 auto f = rep.files.begin();
-                CreateImageVariable(imgName, f->lengthOriginal, dsIdx, repIdx);
+                CreateImageVariable(imgName, f->lengthOriginal, dsIdx, repIdx, true);
             }
             else if (m_CampaignData.hosts[rep.hostIdx].hostname == m_Options.hostname)
             {
                 // this replica is local
-                localPath = m_CampaignData.directory[rep.dirIdx].path + PathSeparator + rep.name;
-                if (m_Options.verbose > 1)
+                std::string taropt;
+                if (rep.archiveIdx == 0)
                 {
-                    std::cout << "        --- local image " << localPath << " and resolution "
-                              << rep.x << "x" << rep.y << std::endl;
+                    localPath =
+                        m_CampaignData.directory[rep.dirIdx].path + PathSeparator + rep.name;
+                    if (m_Options.verbose > 0)
+                    {
+                        std::cout << "Open local file " << localPath << "\n";
+                    }
                 }
-                std::string imgName =
-                    ds.name + "/" + std::to_string(rep.x) + "x" + std::to_string(rep.y);
+                else
+                {
+                    auto itTarName = m_CampaignData.tarnames.find(rep.archiveIdx);
+                    if (itTarName != m_CampaignData.tarnames.end())
+                    {
+                        std::string tarpath = itTarName->second;
+                        localPath =
+                            m_CampaignData.directory[rep.dirIdx].path + PathSeparator + tarpath;
+                        taropt = m_CampaignData.GetTarIdx(dsIdx, repIdx);
+                        if (taropt.empty())
+                        {
+                            std::cout << "ERROR: Local image " << localPath
+                                      << " is in a TAR file but without offset info. Skip"
+                                      << std::endl;
+                            continue;
+                        }
+                        if (m_Options.verbose > 0)
+                        {
+
+                            std::cout << "Open local image in TAR file " << localPath
+                                      << " with tar indices " << taropt << "\n";
+                        }
+                    }
+                    else
+                    {
+                        localPath =
+                            m_CampaignData.directory[rep.dirIdx].path + PathSeparator + rep.name;
+                        if (m_Options.verbose > 1)
+                        {
+                            std::cout << "        --- local image " << localPath
+                                      << " and resolution " << rep.x << "x" << rep.y << std::endl;
+                        }
+                    }
+                }
                 CreateImageVariable(imgName, adios2sys::SystemTools::FileLength(localPath), dsIdx,
-                                    repIdx, localPath);
+                                    repIdx, true, localPath, taropt);
             }
             else
             {
                 // this is a remote image
-                std::string imgName =
+                adios2::core::IO &io =
+                    m_IO.m_ADIOS.DeclareIO("CampaignReader" + std::to_string(dsIdx));
+                localPath = SaveRemoteMD(dsIdx, repIdx, io);
+                if (!localPath.empty())
+                {
+                    if (m_Options.verbose > 0)
+                    {
+                        std::cout << "    " << ds.name << " local file " << localPath << "\n";
+                    }
+                }
+                else
+                {
+                    if (m_Options.verbose > 0)
+                    {
+                        std::cout << "    " << ds.name << " Skipping \n";
+                    }
+                }
+                /*std::string imgName =
                     ds.name + "/" + std::to_string(rep.x) + "x" + std::to_string(rep.y);
                 if (m_Options.verbose > 1)
                 {
                     std::cout << "        --- remote image " << imgName << "\n";
                 }
-                CreateImageVariable(imgName, rep.size, dsIdx, repIdx);
+                CreateImageVariable(imgName, rep.size, dsIdx, repIdx, false);*/
             }
         }
     }
@@ -943,30 +1053,63 @@ void CampaignReader::CreateDatasetAttributes(const std::string type, const std::
 }
 
 void CampaignReader::CreateTextVariable(const std::string &name, const size_t len,
-                                        const size_t dsIdx, const size_t repIdx,
-                                        const std::string localPath)
+                                        const size_t dsIdx, const size_t repIdx, const bool local,
+                                        const std::string &path, const std::string &taropt)
 {
-    // TEXT -> create a variable, will read from DB directly, no local path
-    Variable<char> &v = m_IO.DefineVariable<char>(name, Dims{len}, Dims{0ULL}, Dims{len}, false);
+    // embedded TEXT -> create a variable, will read from DB directly, no local path
+    // local TEXT in file or in a TAR file
+    // remote TEXT not in DB: read it from remote place, either file or from TAR
+    size_t taroffset = 0;
+    size_t tarsize = 0;
+    if (!taropt.empty())
+    {
+        helper::TarInfoMap tim = helper::StringToTarInfo(taropt);
+        for (const auto &ti : tim)
+        {
+            taroffset = std::get<0>(ti.second);
+            tarsize = std::get<1>(ti.second);
+        }
+    }
+    size_t fileSize = (tarsize > 0 ? tarsize : len);
+    Variable<char> &v =
+        m_IO.DefineVariable<char>(name, Dims{fileSize}, Dims{0ULL}, Dims{fileSize}, false);
     v.m_AvailableStepsCount = 1;
     v.m_AvailableStepsStart = 0;
-    CampaignVarInternalInfo internalInfo(&v, dsIdx, repIdx, localPath);
+    CampaignVarInternalInfo internalInfo(&v, dsIdx, repIdx, local, path);
+    internalInfo.taroffset = taroffset;
+    internalInfo.tarsize = tarsize;
     m_CampaignVarInternalInfo.emplace(v.m_Name, internalInfo);
-    CreateDatasetAttributes("text", name, dsIdx, repIdx, localPath);
+    CreateDatasetAttributes("text", name, dsIdx, repIdx, (local ? path : ""));
 }
 
 void CampaignReader::CreateImageVariable(const std::string &name, const size_t len,
-                                         const size_t dsIdx, const size_t repIdx,
-                                         const std::string localPath)
+                                         const size_t dsIdx, const size_t repIdx, const bool local,
+                                         const std::string &path, const std::string &taropt)
 {
-    // TEXT -> create a variable, will read from DB directly, no local path
+    // IMAGE -> create a variable, will read from DB directly, no local path
+    // local IMAGE in file or in a TAR file
+    // remote IMAGE not in DB: read it from remote place, either file or from TAR
+    size_t taroffset = 0;
+    size_t tarsize = 0;
+    if (!taropt.empty())
+    {
+        helper::TarInfoMap tim = helper::StringToTarInfo(taropt);
+        for (const auto &ti : tim)
+        {
+            taroffset = std::get<0>(ti.second);
+            tarsize = std::get<1>(ti.second);
+        }
+    }
+    size_t fileSize = (tarsize > 0 ? tarsize : len);
     Variable<uint8_t> &v =
-        m_IO.DefineVariable<uint8_t>(name, Dims{len}, Dims{0ULL}, Dims{len}, false);
+        m_IO.DefineVariable<uint8_t>(name, Dims{fileSize}, Dims{0ULL}, Dims{fileSize}, false);
     v.m_AvailableStepsCount = 1;
     v.m_AvailableStepsStart = 0;
-    CampaignVarInternalInfo internalInfo(&v, dsIdx, repIdx, localPath);
+    CampaignVarInternalInfo internalInfo(&v, dsIdx, repIdx, local, path);
+    internalInfo.taroffset = taroffset;
+    internalInfo.tarsize = tarsize;
     m_CampaignVarInternalInfo.emplace(v.m_Name, internalInfo);
-    CreateDatasetAttributes("image", name, dsIdx, repIdx, localPath);
+    CreateDatasetAttributes("image", name, dsIdx, repIdx, (local ? path : ""));
 }
 
 void CampaignReader::DestructorClose(bool Verbose) noexcept { m_CampaignData.Close(); }
@@ -1150,7 +1293,7 @@ void CampaignReader::GetVariableFromDB(std::string name, size_t dsIdx, size_t re
 }
 
 void CampaignReader::ReadRemoteFile(const std::string &remoteHost, const std::string &remotePath,
-                                    const size_t size, void *data)
+                                    const size_t offset, const size_t size, void *data)
 {
     std::unique_ptr<Remote> remote = nullptr;
 #ifdef ADIOS2_HAVE_XROOTD
@@ -1177,7 +1320,7 @@ void CampaignReader::ReadRemoteFile(const std::string &remoteHost, const std::st
                 ". Make sure connection manager is running, and the server specification for the "
                 "host is valid.");
     }
-    remote->Read(0, size, data);
+    remote->Read(offset, size, data);
 }
 
 #define declare_type(T)                                                                            \

--- a/source/adios2/engine/campaign/CampaignReader.h
+++ b/source/adios2/engine/campaign/CampaignReader.h
@@ -87,14 +87,18 @@ private:
         void *originalVar; // Variable<T> in m_IO
         size_t dsIdx;      // in m_CampaignData.datasets
         size_t repIdx;     // in m_CampaignData.datasets.replicas
-        std::string path;  // local file path, empty for in-DB data
-        CampaignVarInternalInfo(void *p, size_t i, size_t j) : originalVar(p), dsIdx(i), repIdx(j)
+        std::string path;  // local/remote file path, empty for in-DB data
+        bool local;        // local or remote?
+        CampaignVarInternalInfo(void *p, size_t i, size_t j, bool local)
+        : originalVar(p), dsIdx(i), repIdx(j), local(local), taroffset(0), tarsize(0)
         {
         }
-        CampaignVarInternalInfo(void *p, size_t i, size_t j, const std::string &path)
-        : originalVar(p), dsIdx(i), repIdx(j), path(path)
+        CampaignVarInternalInfo(void *p, size_t i, size_t j, bool local, const std::string &path)
+        : originalVar(p), dsIdx(i), repIdx(j), path(path), local(local), taroffset(0), tarsize(0)
         {
         }
+        size_t taroffset; // location in a TAR file
+        size_t tarsize;   // >0 means the data is in a TAR file at taroffset
     };
     std::unordered_map<std::string, CampaignVarInternalInfo> m_CampaignVarInternalInfo;
 
@@ -140,9 +144,11 @@ private:
                                  const size_t dsIdx, const size_t repIdx,
                                  const std::string localPath);
     void CreateTextVariable(const std::string &name, const size_t len, const size_t dsIdx,
-                            const size_t repIdx, const std::string localPath = "");
+                            const size_t repIdx, const bool local, const std::string &path = "",
+                            const std::string &taropt = "");
     void CreateImageVariable(const std::string &name, const size_t len, const size_t dsIdx,
-                             const size_t repIdx, const std::string localPath = "");
+                             const size_t repIdx, const bool local, const std::string &path = "",
+                             const std::string &taropt = "");
 
     void GetVariableFromDB(std::string name, size_t dsIdx, size_t repIdx, DataType type,
                            void *data);
@@ -196,7 +202,7 @@ private:
 
     // for reading individual remote file
     void ReadRemoteFile(const std::string &remoteHost, const std::string &remotePath,
-                        const size_t size, void *data);
+                        const size_t offset, const size_t size, void *data);
 
     // check if name is included and not excluded by patterns
     bool Matches(const std::string &dsname);

--- a/source/adios2/engine/campaign/CampaignReader.tcc
+++ b/source/adios2/engine/campaign/CampaignReader.tcc
@@ -105,6 +105,18 @@ Variable<T> *CampaignReader::CopyPropertiesToActualVariable(Variable<T> &campaig
 template <class T>
 void CampaignReader::GetSyncTCC(Variable<T> &variable, T *data)
 {
+    auto lf_CheckStartCount = [&](const std::string &name, const size_t length, const size_t start,
+                                  const size_t count) {
+        if (start + count > length)
+        {
+            helper::Throw<std::invalid_argument>(
+                "Engine", "CampaignReader", "Get(Sync)",
+                "Asking for reading too many elements of variable " + name + " of size = " +
+                    std::to_string(length) + " with count = " + std::to_string(count) +
+                    " from start = " + std::to_string(start));
+        }
+    };
+
     PERFSTUBS_SCOPED_TIMER("CampaignReader::Get");
     std::pair<Variable<T> *, Engine *> p = FindActualVariable(variable);
     if (p.first != nullptr)
@@ -119,19 +131,30 @@ void CampaignReader::GetSyncTCC(Variable<T> &variable, T *data)
         if (it != m_CampaignVarInternalInfo.end())
         {
             // FIXME: Selection support for TEXT/IMAGE variables
-            if (!it->second.path.empty())
+            if (it->second.local && !it->second.path.empty())
             {
                 // local file
                 std::ifstream is(it->second.path, std::ios::binary);
-                is.seekg(0, std::ios::end);
-                size_t length = is.tellg();
-                is.seekg(0, std::ios::beg);
+                size_t length = it->second.tarsize;
+                if (length == 0)
+                {
+                    is.seekg(0, std::ios::end);
+                    length = is.tellg();
+                    is.seekg(0, std::ios::beg);
+                }
+                else
+                {
+                    is.seekg(it->second.taroffset, std::ios::beg);
+                }
                 if (m_Options.verbose > 1)
                 {
                     std::cout << "---- Read local file " << it->second.path << "  size = " << length
                               << std::endl;
                 }
-                is.read((char *)data, length);
+                lf_CheckStartCount(variable.m_Name, length, variable.m_Start[0],
+                                   variable.m_Count[0]);
+                is.seekg(variable.m_Start[0], std::ios::cur);
+                is.read((char *)data, variable.m_Count[0]);
                 is.close();
             }
             else if (m_CampaignData.datasets[it->second.dsIdx]
@@ -145,19 +168,26 @@ void CampaignReader::GetSyncTCC(Variable<T> &variable, T *data)
             else
             {
                 // remote file
+                std::string remotePath = it->second.path;
                 auto &ds = m_CampaignData.datasets[it->second.dsIdx];
                 auto &rep = ds.replicas[it->second.repIdx];
                 if (m_Options.verbose > 0)
                 {
                     std::cout << " -- Read remote file "
-                              << m_CampaignData.hosts[rep.hostIdx].hostname << ":"
-                              << m_CampaignData.directory[rep.dirIdx].path << PathSeparator
-                              << rep.name << "  of size " << rep.size << "\n";
+                              << m_CampaignData.hosts[rep.hostIdx].hostname << ":" << remotePath
+                              << "  of size " << rep.size << "\n";
                 }
-                std::string remotePath =
-                    m_CampaignData.directory[rep.dirIdx].path + PathSeparator + rep.name;
-                ReadRemoteFile(m_CampaignData.hosts[rep.hostIdx].hostname, remotePath, rep.size,
-                               (void *)data);
+                size_t length = rep.size;
+                size_t offset = variable.m_Start[0];
+                if (it->second.tarsize > 0)
+                {
+                    offset = it->second.taroffset + variable.m_Start[0];
+                    length = it->second.tarsize;
+                }
+                lf_CheckStartCount(variable.m_Name, length, variable.m_Start[0],
+                                   variable.m_Count[0]);
+                ReadRemoteFile(m_CampaignData.hosts[rep.hostIdx].hostname, remotePath, offset,
+                               variable.m_Count[0], (void *)data);
             }
         }
     }

--- a/source/adios2/helper/adiosString.cpp
+++ b/source/adios2/helper/adiosString.cpp
@@ -16,6 +16,7 @@
 /// \cond EXCLUDE_FROM_DOXYGEN
 #include <fstream>
 #include <ios> //std::ios_base::failure
+#include <iostream>
 #include <random>
 #include <sstream>
 #include <stdexcept> // std::invalid_argument
@@ -518,6 +519,28 @@ std::vector<std::string> StringToVector(const std::string &s, const char delimit
     // Add the last segment
     result.emplace_back(s.substr(start));
     return result;
+}
+
+TarInfoMap StringToTarInfo(const std::string &s)
+{
+    TarInfoMap m;
+    auto entries = StringToVector(s, ';');
+    for (auto &e : entries)
+    {
+        auto triplet = StringToVector(e, ',');
+        if (triplet.size() == 1 && triplet[0].empty())
+            continue;
+        if (triplet.size() != 3)
+        {
+            helper::Throw<std::runtime_error>(
+                "Helper", "adiosString", "StringToTarInfo",
+                "Entry " + e + " is not a triplet of name,offset,size in the tar info string " + s);
+        }
+        m.emplace(triplet[0],
+                  std::make_tuple(helper::StringToSizeT(triplet[1], "tar info string offset"),
+                                  helper::StringToSizeT(triplet[2], "tar info string size")));
+    }
+    return m;
 }
 
 } // end namespace helper

--- a/source/adios2/helper/adiosString.h
+++ b/source/adios2/helper/adiosString.h
@@ -12,9 +12,9 @@
 #define ADIOS2_HELPER_ADIOSSTRING_H_
 
 /// \cond EXCLUDE_FROM_DOXYGEN
-#include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 /// \endcond
 
@@ -204,6 +204,12 @@ std::string RandomString(const size_t length);
  * Split a string into a vector of strings using the delimiter character.
  */
 std::vector<std::string> StringToVector(const std::string &s, const char delimiter = ';');
+
+/**
+ * Split a tar info string  (name,offset,size;name,offset,size;...) into a map.
+ */
+using TarInfoMap = std::unordered_map<std::string, std::tuple<size_t, size_t>>;
+TarInfoMap StringToTarInfo(const std::string &s);
 
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -119,7 +119,7 @@ void EVPathRemote::InitCMData()
 }
 
 void EVPathRemote::Open(const std::string hostname, const int32_t port, const std::string filename,
-                        const Mode mode, bool RowMajorOrdering)
+                        const Mode mode, bool RowMajorOrdering, const Params &params)
 {
 
     EVPathRemoteCommon::_OpenFileMsg open_msg;
@@ -163,6 +163,11 @@ void EVPathRemote::Open(const std::string hostname, const int32_t port, const st
     }
     open_msg.OpenResponseCondition = CMCondition_get(ev_state.cm, m_conn);
     open_msg.RowMajorOrder = RowMajorOrdering;
+    std::string pstr = ParamsToEncodedString(params);
+    std::vector<char> buffer(pstr.size() + 1);
+    std::memcpy(buffer.data(), pstr.c_str(), pstr.size() + 1);
+    open_msg.EngineParameters = buffer.data(); // pstr.c_str();
+
     CMCondition_set_client_data(ev_state.cm, open_msg.OpenResponseCondition, (void *)this);
     CMwrite(m_conn, ev_state.OpenFileFormat, &open_msg);
     if (CMCondition_wait(ev_state.cm, open_msg.OpenResponseCondition) != 1)

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -16,6 +16,7 @@
 
 #include "Remote.h"
 #include "adios2/common/ADIOSConfig.h"
+#include "adios2/common/ADIOSTypes.h"
 
 #include "remote_common.h"
 
@@ -48,7 +49,7 @@ public:
      * EVPathRemote object.
      */
     void Open(const std::string hostname, const int32_t port, const std::string filename,
-              const Mode mode, bool RowMajorOrdering);
+              const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
     void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename);
 

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -24,7 +24,7 @@ namespace adios2
 {
 
 void Remote::Open(const std::string hostname, const int32_t port, const std::string filename,
-                  const Mode mode, bool RowMajorOrdering)
+                  const Mode mode, bool RowMajorOrdering, const adios2::Params &params)
 {
     ThrowUp(("RemoteOpen"));
 };
@@ -208,6 +208,36 @@ std::string Remote::GetKeyFromConnectionManager(const std::string keyID)
 
     socket.Close();
     return keyhex;
+}
+
+std::string ParamsToEncodedString(const adios2::Params &params)
+{
+    std::string pstr;
+    if (params.size() > 0)
+    {
+        for (const auto &p : params)
+        {
+            if (!pstr.empty())
+                pstr += EVPathRemoteCommon::EngineParametersSeparator;
+            pstr += p.first + "=" + p.second;
+        }
+    }
+    return pstr;
+}
+
+adios2::Params EncodedStringToParams(const std::string &pstr)
+{
+    adios2::Params p;
+    if (pstr.empty())
+        return p;
+    auto entries = helper::StringToVector(pstr, EVPathRemoteCommon::EngineParametersSeparator);
+    for (auto const &e : entries)
+    {
+        auto pair = helper::StringToVector(e, '=');
+        if (pair.size() == 2 && !pair[0].empty())
+            p.emplace(pair[0], pair[1]);
+    }
+    return p;
 }
 
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -15,6 +15,7 @@
 #include "adios2/toolkit/profiling/iochrono/IOChrono.h"
 
 #include "adios2/common/ADIOSConfig.h"
+#include "adios2/common/ADIOSTypes.h"
 
 namespace adios2
 {
@@ -36,7 +37,7 @@ public:
     virtual explicit operator bool() const { return false; }
 
     virtual void Open(const std::string hostname, const int32_t port, const std::string filename,
-                      const Mode mode, bool RowMajorOrdering);
+                      const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
     virtual void OpenSimpleFile(const std::string hostname, const int32_t port,
                                 const std::string filename);
@@ -60,6 +61,9 @@ public:
 private:
     const std::shared_ptr<adios2::HostOptions> m_HostOptions;
 };
+
+std::string ParamsToEncodedString(const adios2::Params &params);
+adios2::Params EncodedStringToParams(const std::string &pstr);
 
 } // end namespace adios2
 

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -306,7 +306,7 @@ namespace adios2
 XrootdRemote::XrootdRemote(const adios2::HostOptions &hostOptions) : Remote(hostOptions) {}
 XrootdRemote::~XrootdRemote() {}
 void XrootdRemote::Open(const std::string hostname, const int32_t port, const std::string filename,
-                        const Mode mode, bool RowMajorOrdering)
+                        const Mode mode, bool RowMajorOrdering, const Params &params)
 {
 #ifdef ADIOS2_HAVE_XROOTD
     m_Filename = filename;

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -101,7 +101,7 @@ public:
     explicit operator bool() const { return m_OpenSuccess; }
 
     void Open(const std::string hostname, const int32_t port, const std::string filename,
-              const Mode mode, bool RowMajorOrdering);
+              const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
     GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
                   Dims &Start, Accuracy &accuracy, void *dest);

--- a/source/adios2/toolkit/remote/remote_common.cpp
+++ b/source/adios2/toolkit/remote/remote_common.cpp
@@ -13,6 +13,7 @@ FMField OpenFileList[] = {
     {"FileName", "string", sizeof(char *), FMOffset(OpenFileMsg, FileName)},
     {"Mode", "integer", sizeof(RemoteFileMode), FMOffset(OpenFileMsg, Mode)},
     {"RowMajorOrder", "integer", sizeof(int), FMOffset(OpenFileMsg, RowMajorOrder)},
+    {"EngineParameters", "string", sizeof(char *), FMOffset(OpenFileMsg, EngineParameters)},
     {NULL, NULL, 0, 0}};
 
 FMStructDescRec OpenFileStructs[] = {{"OpenFile", OpenFileList, sizeof(struct _OpenFileMsg), NULL},

--- a/source/adios2/toolkit/remote/remote_common.h
+++ b/source/adios2/toolkit/remote/remote_common.h
@@ -9,6 +9,7 @@ namespace EVPathRemoteCommon
 {
 
 const int ServerPort = 26200;
+const char EngineParametersSeparator = char(9); // TAB
 
 #ifdef ADIOS2_HAVE_SST
 enum RemoteFileMode
@@ -24,6 +25,7 @@ typedef struct _OpenFileMsg
     char *FileName;
     RemoteFileMode Mode;
     int RowMajorOrder;
+    char *EngineParameters;
 } *OpenFileMsg;
 
 typedef struct _OpenResponseMsg
@@ -172,6 +174,7 @@ struct Remote_evpath_state
 };
 
 void RegisterFormats(struct Remote_evpath_state &ev_state);
+
 #endif
 
 }; // end of namespace remote_common

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -18,7 +18,7 @@ namespace adios2
 {
 
 Transport::Transport(const std::string type, const std::string library, helper::Comm const &comm)
-: m_Type(type), m_Library(library), m_Comm(comm)
+: m_Type(type), m_Library(library), m_Comm(comm), m_BaseOffset(0), m_BaseSize(0)
 {
 }
 

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -36,6 +36,8 @@ public:
     bool m_IsOpen = false;             ///< true: open for communication, false: unreachable
     helper::Comm const &m_Comm;        ///< current multi-process communicator
     profiling::IOChrono m_Profiler;    ///< profiles Open, Write/Read, Close
+    size_t m_BaseOffset; ///< Starting offset in a larger container if exists, usually 0
+    size_t m_BaseSize;   ///< Actual size of file in a larger container if exists, usually 0
 
     struct Status
     {

--- a/source/adios2/toolkit/transport/file/FileHTTPS.cpp
+++ b/source/adios2/toolkit/transport/file/FileHTTPS.cpp
@@ -241,14 +241,14 @@ void FileHTTPS::Read(char *buffer, size_t size, size_t start)
 
     const size_t BUF_SIZE = 8192;
     std::string request = "GET " + m_path + " HTTP/1.1\r\nHost: " + m_hostname +
-                          "\r\nRange: bytes=" + std::to_string(start) + "-" +
-                          std::to_string(start + size - 1) + "\r\n\r\n";
+                          "\r\nRange: bytes=" + std::to_string(start + m_BaseOffset) + "-" +
+                          std::to_string(start + m_BaseOffset + size - 1) + "\r\n\r\n";
 
     m_ssl.Connect(m_hostname, m_server_port);
 
     if (m_Verbose > 1)
     {
-        std::cout << "Request: [" << request << "]" << std::endl;
+        std::cout << "FileHTTPS::Read Request: [" << request << "]" << std::endl;
     }
 
     m_ssl.Write(request.c_str(), (int)request.size());
@@ -305,6 +305,17 @@ void FileHTTPS::Read(char *buffer, size_t size, size_t start)
 
 size_t FileHTTPS::GetSize()
 {
+
+    if (m_IsCached && !m_RecheckMetadata)
+    {
+        return m_Size;
+    }
+
+    if (m_BaseSize > 0)
+    {
+        return m_BaseSize;
+    }
+
     m_ssl.Connect(m_hostname, m_server_port);
 
     std::string request =
@@ -312,7 +323,7 @@ size_t FileHTTPS::GetSize()
 
     if (m_Verbose > 1)
     {
-        std::cout << "Request: [" << request << "]" << std::endl;
+        std::cout << "FileHTTPS::GetSize Request: [" << request << "]" << std::endl;
     }
     m_ssl.Write(request.c_str(), (int)request.size());
 

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -693,6 +693,16 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(const std::string &fi
         return helper::StringTo<bool>(directio, "");
     };
 
+    auto lf_GetTarInfo = [&](const Params &parameters) -> std::tuple<size_t, size_t> {
+        std::string baseOffset = "0";
+        std::string baseSize = "0";
+        helper::SetParameterValue("taroffset", parameters, baseOffset);
+        helper::SetParameterValue("tarsize", parameters, baseSize);
+        return std::make_tuple<size_t, size_t>(
+            helper::StringToSizeT(baseOffset, "convert tar offset string to size_t"),
+            helper::StringToSizeT(baseSize, "convert tar size string to size_t"));
+    };
+
     // BODY OF FUNCTION starts here
     std::shared_ptr<Transport> transport;
     const std::string library = helper::LowerCase(lf_GetLibrary(DefaultFileLibrary, parameters));
@@ -707,6 +717,10 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(const std::string &fi
         transport->InitProfiler(openMode, lf_GetTimeUnits(DefaultTimeUnit, parameters));
     }
 
+    // If "file" is actually in a TAR file, set BaseOffset and BaseSize
+    auto pair = lf_GetTarInfo(parameters);
+    transport->m_BaseOffset = std::get<0>(pair);
+    transport->m_BaseSize = std::get<1>(pair);
     transport->SetParameters(parameters);
 
     // open


### PR DESCRIPTION
… if provided with a detailed index "name,offset,size;..." for all metadata and data files. Used for supporting TAR files added to Campaigns with a tar index. For now it supports reading from a local TAR file and from a TAR file on a HTTPS server.