### PR TITLE
Add support to read a BP5 dataset / TEXT / IMAGE from TAR files...

### DIFF
--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -173,6 +173,7 @@ public:
     MACRO(RemoteDataPath, String, std::string, "")                                                 \
     MACRO(RemoteHost, String, std::string, "")                                                     \
     MACRO(UUID, String, std::string, "")                                                           \
+    MACRO(TarInfo, String, std::string, "")                                                        \
     MACRO(MaxOpenFilesAtOnce, UInt, unsigned int, UINT_MAX)
 
     struct BP5Params

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -15,6 +15,7 @@
 #include "adios2/engine/bp5/BP5Engine.h"
 #include "adios2/helper/adiosComm.h"
 #include "adios2/helper/adiosRangeFilter.h"
+#include "adios2/helper/adiosString.h"
 #include "adios2/toolkit/format/bp5/BP5Deserializer.h"
 #include "adios2/toolkit/format/buffer/heap/BufferMalloc.h"
 #include "adios2/toolkit/kvcache/KVCacheCommon.h"
@@ -278,6 +279,9 @@ private:
     helper::Comm singleComm;
     unsigned int m_Threads;
     std::vector<transportman::TransportMan> fileManagers; // manager per thread
+
+    helper::TarInfoMap m_TarInfoMap;
+    std::string UpdateWithTarInfo(const std::string &path, Params &params);
 };
 
 } // end namespace engine

--- a/source/adios2/engine/campaign/CampaignData.h
+++ b/source/adios2/engine/campaign/CampaignData.h
@@ -179,6 +179,8 @@ public:
     // return 0 if there is no replica found for 'hostname', otherwise the replica index
     size_t FindReplicaOnHost(const size_t datasetIdx, std::string hostname);
 
+    std::string GetTarIdx(const size_t dsIdx, const size_t repIdx);
+
 private:
     void DumpToFileOrMemory(const CampaignFile &file, std::string &keyHex, const std::string &path,
                             char *data);

--- a/source/adios2/engine/campaign/CampaignReader.h
+++ b/source/adios2/engine/campaign/CampaignReader.h
@@ -87,14 +87,21 @@ private:
         void *originalVar; // Variable<T> in m_IO
         size_t dsIdx;      // in m_CampaignData.datasets
         size_t repIdx;     // in m_CampaignData.datasets.replicas
-        std::string path;  // local file path, empty for in-DB data
-        CampaignVarInternalInfo(void *p, size_t i, size_t j) : originalVar(p), dsIdx(i), repIdx(j)
+        std::string path;  // local/remote file path, empty for in-DB data
+        bool local;        // local or remote?
+        CampaignVarInternalInfo(void *p, size_t i, size_t j, bool local)
+        : originalVar(p), dsIdx(i), repIdx(j), local(local), taroffset(0), tarsize(0),
+          params(Params())
         {
         }
-        CampaignVarInternalInfo(void *p, size_t i, size_t j, const std::string &path)
-        : originalVar(p), dsIdx(i), repIdx(j), path(path)
+        CampaignVarInternalInfo(void *p, size_t i, size_t j, bool local, const std::string &path)
+        : originalVar(p), dsIdx(i), repIdx(j), path(path), local(local), taroffset(0), tarsize(0),
+          params(Params())
         {
         }
+        size_t taroffset; // location in a TAR file
+        size_t tarsize;   // >0 means the data is in a TAR file at taroffset
+        Params params;    // info for https/s3
     };
     std::unordered_map<std::string, CampaignVarInternalInfo> m_CampaignVarInternalInfo;
 
@@ -139,10 +146,14 @@ private:
     void CreateDatasetAttributes(const std::string type, const std::string &name,
                                  const size_t dsIdx, const size_t repIdx,
                                  const std::string localPath);
-    void CreateTextVariable(const std::string &name, const size_t len, const size_t dsIdx,
-                            const size_t repIdx, const std::string localPath = "");
-    void CreateImageVariable(const std::string &name, const size_t len, const size_t dsIdx,
-                             const size_t repIdx, const std::string localPath = "");
+    CampaignVarInternalInfo *CreateTextVariable(const std::string &name, const size_t len,
+                                                const size_t dsIdx, const size_t repIdx,
+                                                const bool local, const std::string &path = "",
+                                                const std::string &taropt = "");
+    CampaignVarInternalInfo *CreateImageVariable(const std::string &name, const size_t len,
+                                                 const size_t dsIdx, const size_t repIdx,
+                                                 const bool local, const std::string &path = "",
+                                                 const std::string &taropt = "");
 
     void GetVariableFromDB(std::string name, size_t dsIdx, size_t repIdx, DataType type,
                            void *data);
@@ -194,9 +205,13 @@ private:
     CampaignData m_CampaignData;
     std::unique_ptr<Remote> m_ConnectionManager = nullptr; // for reading keys from conn.manager
 
-    // for reading individual remote file
+    // for reading individual remote file (using remote server)
     void ReadRemoteFile(const std::string &remoteHost, const std::string &remotePath,
-                        const size_t size, void *data);
+                        const size_t offset, const size_t size, void *data);
+
+    // for reading individual remote file (using https/s3)
+    void ReadRemoteFile(const std::string &remoteHost, const std::string &remotePath,
+                        const Params &params, const size_t offset, const size_t size, char *data);
 
     // check if name is included and not excluded by patterns
     bool Matches(const std::string &dsname);

--- a/source/adios2/helper/adiosString.h
+++ b/source/adios2/helper/adiosString.h
@@ -12,9 +12,9 @@
 #define ADIOS2_HELPER_ADIOSSTRING_H_
 
 /// \cond EXCLUDE_FROM_DOXYGEN
-#include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 /// \endcond
 
@@ -179,6 +179,13 @@ size_t StringToByteUnits(const std::string &input, const std::string &hint);
 Params LowerCaseParams(const Params &params);
 
 /**
+ * pretty-print format a parameter map.
+ * @param params parameter map
+ * @return String for printing the map.
+ */
+std::string ParamsToString(const Params &params);
+
+/**
  * Extract inputs subset that matches a prefix input
  * @param prefix input prefix
  * @param inputs input names
@@ -204,6 +211,12 @@ std::string RandomString(const size_t length);
  * Split a string into a vector of strings using the delimiter character.
  */
 std::vector<std::string> StringToVector(const std::string &s, const char delimiter = ';');
+
+/**
+ * Split a tar info string  (name,offset,size;name,offset,size;...) into a map.
+ */
+using TarInfoMap = std::unordered_map<std::string, std::tuple<size_t, size_t>>;
+TarInfoMap StringToTarInfo(const std::string &s);
 
 } // end namespace helper
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -119,7 +119,7 @@ void EVPathRemote::InitCMData()
 }
 
 void EVPathRemote::Open(const std::string hostname, const int32_t port, const std::string filename,
-                        const Mode mode, bool RowMajorOrdering)
+                        const Mode mode, bool RowMajorOrdering, const Params &params)
 {
 
     EVPathRemoteCommon::_OpenFileMsg open_msg;
@@ -163,6 +163,11 @@ void EVPathRemote::Open(const std::string hostname, const int32_t port, const st
     }
     open_msg.OpenResponseCondition = CMCondition_get(ev_state.cm, m_conn);
     open_msg.RowMajorOrder = RowMajorOrdering;
+    std::string pstr = ParamsToEncodedString(params);
+    std::vector<char> buffer(pstr.size() + 1);
+    std::memcpy(buffer.data(), pstr.c_str(), pstr.size() + 1);
+    open_msg.EngineParameters = buffer.data(); // pstr.c_str();
+
     CMCondition_set_client_data(ev_state.cm, open_msg.OpenResponseCondition, (void *)this);
     CMwrite(m_conn, ev_state.OpenFileFormat, &open_msg);
     if (CMCondition_wait(ev_state.cm, open_msg.OpenResponseCondition) != 1)

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -16,6 +16,7 @@
 
 #include "Remote.h"
 #include "adios2/common/ADIOSConfig.h"
+#include "adios2/common/ADIOSTypes.h"
 
 #include "remote_common.h"
 
@@ -48,7 +49,7 @@ public:
      * EVPathRemote object.
      */
     void Open(const std::string hostname, const int32_t port, const std::string filename,
-              const Mode mode, bool RowMajorOrdering);
+              const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
     void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename);
 

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -24,7 +24,7 @@ namespace adios2
 {
 
 void Remote::Open(const std::string hostname, const int32_t port, const std::string filename,
-                  const Mode mode, bool RowMajorOrdering)
+                  const Mode mode, bool RowMajorOrdering, const adios2::Params &params)
 {
     ThrowUp(("RemoteOpen"));
 };
@@ -208,6 +208,36 @@ std::string Remote::GetKeyFromConnectionManager(const std::string keyID)
 
     socket.Close();
     return keyhex;
+}
+
+std::string ParamsToEncodedString(const adios2::Params &params)
+{
+    std::string pstr;
+    if (params.size() > 0)
+    {
+        for (const auto &p : params)
+        {
+            if (!pstr.empty())
+                pstr += EVPathRemoteCommon::EngineParametersSeparator;
+            pstr += p.first + "=" + p.second;
+        }
+    }
+    return pstr;
+}
+
+adios2::Params EncodedStringToParams(const std::string &pstr)
+{
+    adios2::Params p;
+    if (pstr.empty())
+        return p;
+    auto entries = helper::StringToVector(pstr, EVPathRemoteCommon::EngineParametersSeparator);
+    for (auto const &e : entries)
+    {
+        auto pair = helper::StringToVector(e, '=');
+        if (pair.size() == 2 && !pair[0].empty())
+            p.emplace(pair[0], pair[1]);
+    }
+    return p;
 }
 
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -15,6 +15,7 @@
 #include "adios2/toolkit/profiling/iochrono/IOChrono.h"
 
 #include "adios2/common/ADIOSConfig.h"
+#include "adios2/common/ADIOSTypes.h"
 
 namespace adios2
 {
@@ -36,7 +37,7 @@ public:
     virtual explicit operator bool() const { return false; }
 
     virtual void Open(const std::string hostname, const int32_t port, const std::string filename,
-                      const Mode mode, bool RowMajorOrdering);
+                      const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
     virtual void OpenSimpleFile(const std::string hostname, const int32_t port,
                                 const std::string filename);
@@ -60,6 +61,9 @@ public:
 private:
     const std::shared_ptr<adios2::HostOptions> m_HostOptions;
 };
+
+std::string ParamsToEncodedString(const adios2::Params &params);
+adios2::Params EncodedStringToParams(const std::string &pstr);
 
 } // end namespace adios2
 

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -306,7 +306,7 @@ namespace adios2
 XrootdRemote::XrootdRemote(const adios2::HostOptions &hostOptions) : Remote(hostOptions) {}
 XrootdRemote::~XrootdRemote() {}
 void XrootdRemote::Open(const std::string hostname, const int32_t port, const std::string filename,
-                        const Mode mode, bool RowMajorOrdering)
+                        const Mode mode, bool RowMajorOrdering, const Params &params)
 {
 #ifdef ADIOS2_HAVE_XROOTD
     m_Filename = filename;

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -101,7 +101,7 @@ public:
     explicit operator bool() const { return m_OpenSuccess; }
 
     void Open(const std::string hostname, const int32_t port, const std::string filename,
-              const Mode mode, bool RowMajorOrdering);
+              const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
     GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
                   Dims &Start, Accuracy &accuracy, void *dest);

--- a/source/adios2/toolkit/remote/remote_common.cpp
+++ b/source/adios2/toolkit/remote/remote_common.cpp
@@ -13,6 +13,7 @@ FMField OpenFileList[] = {
     {"FileName", "string", sizeof(char *), FMOffset(OpenFileMsg, FileName)},
     {"Mode", "integer", sizeof(RemoteFileMode), FMOffset(OpenFileMsg, Mode)},
     {"RowMajorOrder", "integer", sizeof(int), FMOffset(OpenFileMsg, RowMajorOrder)},
+    {"EngineParameters", "string", sizeof(char *), FMOffset(OpenFileMsg, EngineParameters)},
     {NULL, NULL, 0, 0}};
 
 FMStructDescRec OpenFileStructs[] = {{"OpenFile", OpenFileList, sizeof(struct _OpenFileMsg), NULL},

--- a/source/adios2/toolkit/remote/remote_common.h
+++ b/source/adios2/toolkit/remote/remote_common.h
@@ -9,6 +9,7 @@ namespace EVPathRemoteCommon
 {
 
 const int ServerPort = 26200;
+const char EngineParametersSeparator = char(9); // TAB
 
 #ifdef ADIOS2_HAVE_SST
 enum RemoteFileMode
@@ -24,6 +25,7 @@ typedef struct _OpenFileMsg
     char *FileName;
     RemoteFileMode Mode;
     int RowMajorOrder;
+    char *EngineParameters;
 } *OpenFileMsg;
 
 typedef struct _OpenResponseMsg
@@ -172,6 +174,7 @@ struct Remote_evpath_state
 };
 
 void RegisterFormats(struct Remote_evpath_state &ev_state);
+
 #endif
 
 }; // end of namespace remote_common

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -18,7 +18,7 @@ namespace adios2
 {
 
 Transport::Transport(const std::string type, const std::string library, helper::Comm const &comm)
-: m_Type(type), m_Library(library), m_Comm(comm)
+: m_Type(type), m_Library(library), m_Comm(comm), m_BaseOffset(0), m_BaseSize(0)
 {
 }
 

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -36,6 +36,8 @@ public:
     bool m_IsOpen = false;             ///< true: open for communication, false: unreachable
     helper::Comm const &m_Comm;        ///< current multi-process communicator
     profiling::IOChrono m_Profiler;    ///< profiles Open, Write/Read, Close
+    size_t m_BaseOffset; ///< Starting offset in a larger container if exists, usually 0
+    size_t m_BaseSize;   ///< Actual size of file in a larger container if exists, usually 0
 
     struct Status
     {

--- a/source/adios2/toolkit/transport/file/FileHTTPS.h
+++ b/source/adios2/toolkit/transport/file/FileHTTPS.h
@@ -85,6 +85,7 @@ private:
     bool m_IsCached = false; // true if file is already in cache
     FileFStream *m_CacheFileRead;
     std::string m_CacheFilePath; // full path to file in cache
+    std::string m_FileNameInTar; // original file name if we work inside a TAR file
 };
 
 } // end namespace transport

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -539,11 +539,12 @@ bool TransportMan::FileExists(const std::string &name, const Params &parameters,
 // PRIVATE
 std::shared_ptr<Transport> TransportMan::OpenFileTransport(const std::string &fileName,
                                                            const Mode openMode,
-                                                           const Params &parameters,
+                                                           const Params &parameters_,
                                                            const bool profile, const bool useComm,
                                                            const helper::Comm &chainComm)
 {
     // This function expects Params with lower case keys!!!
+    const Params &parameters = helper::LowerCaseParams(parameters_);
 
     auto lf_GetBuffered = [&](const std::string bufferedDefault) -> bool {
         bool bufferedValue;
@@ -693,6 +694,16 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(const std::string &fi
         return helper::StringTo<bool>(directio, "");
     };
 
+    auto lf_GetTarInfo = [&](const Params &parameters) -> std::tuple<size_t, size_t> {
+        std::string baseOffset = "0";
+        std::string baseSize = "0";
+        helper::SetParameterValue("taroffset", parameters, baseOffset);
+        helper::SetParameterValue("tarsize", parameters, baseSize);
+        return std::make_tuple<size_t, size_t>(
+            helper::StringToSizeT(baseOffset, "convert tar offset string to size_t"),
+            helper::StringToSizeT(baseSize, "convert tar size string to size_t"));
+    };
+
     // BODY OF FUNCTION starts here
     std::shared_ptr<Transport> transport;
     const std::string library = helper::LowerCase(lf_GetLibrary(DefaultFileLibrary, parameters));
@@ -707,6 +718,10 @@ std::shared_ptr<Transport> TransportMan::OpenFileTransport(const std::string &fi
         transport->InitProfiler(openMode, lf_GetTimeUnits(DefaultTimeUnit, parameters));
     }
 
+    // If "file" is actually in a TAR file, set BaseOffset and BaseSize
+    auto pair = lf_GetTarInfo(parameters);
+    transport->m_BaseOffset = std::get<0>(pair);
+    transport->m_BaseSize = std::get<1>(pair);
     transport->SetParameters(parameters);
 
     // open

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -218,7 +218,7 @@ public:
     void SetParameters(const Params &params, const int transportIndex = -1);
 
     std::shared_ptr<Transport> OpenFileTransport(const std::string &fileName, const Mode openMode,
-                                                 const Params &parameters, const bool profile,
+                                                 const Params &parameters_, const bool profile,
                                                  const bool useComm, const helper::Comm &chainComm);
 
 protected:


### PR DESCRIPTION
... if provided with a detailed index (name,offset,size;...) for all metadata and data files. Used for supporting TAR files added to Campaigns with a tar index. For now it supports reading BP5 files and TEXT/IMAGE from

- a TAR file on local disk
- a TAR file on an HTTPS server
- a remote TAR file accessible by adios2_remote_server

OpenFileTransport() expected Params to be all lower case, now it does it on its own since BP5 is calling it directly.