### PR TITLE
Order remote replicas in order of most likely accessible: …

### DIFF
--- a/source/adios2/engine/campaign/CampaignData.h
+++ b/source/adios2/engine/campaign/CampaignData.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include "adios2/common/ADIOSTypes.h" // HostOptions
+
 namespace adios2
 {
 namespace core
@@ -178,6 +180,15 @@ public:
 
     // return 0 if there is no replica found for 'hostname', otherwise the replica index
     size_t FindReplicaOnHost(const size_t datasetIdx, std::string hostname);
+
+    /* return remote replicas in order of
+     * 1. known remote host (has an entry in the hosts config) and not archive directory
+     * 2. known s3 host
+     * 3. https host
+     * 4. other "fs" archive locations on known hosts (but not HPSS, Kronos)
+     * 5. unknown hosts (not in hosts config)
+     */
+    std::vector<size_t> FindRemoteReplicas(const size_t datasetIdx, const HostOptions &hostOptions);
 
     std::string GetTarIdx(const size_t dsIdx, const size_t repIdx);
 

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -692,9 +692,8 @@ void CampaignReader::InitTransports()
             size_t repIdx = m_CampaignData.FindReplicaOnHost(dsIdx, m_Options.hostname);
             if (!repIdx)
             {
-                // pick the first replica. FIXME: need a smart way to pick a replica
-                auto itRep = ds.replicas.begin();
-                repIdx = itRep->first;
+                auto reps = m_CampaignData.FindRemoteReplicas(dsIdx, m_HostOptions);
+                size_t repIdx = reps.front();
                 std::string localPath = SaveRemoteMD(dsIdx, repIdx, io);
                 if (!localPath.empty())
                 {
@@ -756,10 +755,8 @@ void CampaignReader::InitTransports()
         size_t repIdx = m_CampaignData.FindReplicaOnHost(dsIdx, m_Options.hostname);
         if (!repIdx)
         {
-            /* FIXME: For now we only consider the first remote replica */
-            size_t repIdx;
-            auto itRep = ds.replicas.begin();
-            repIdx = itRep->first;
+            auto reps = m_CampaignData.FindRemoteReplicas(dsIdx, m_HostOptions);
+            size_t repIdx = reps.front();
             localPath = SaveRemoteMD(dsIdx, repIdx, io);
             if (!localPath.empty())
             {
@@ -858,10 +855,17 @@ void CampaignReader::InitTransports()
         {
             std::cout << "-- Image " << ds.name << ":\n";
         }
-        for (auto &itRep : ds.replicas)
+
+        size_t localRepIdx = m_CampaignData.FindReplicaOnHost(dsIdx, m_Options.hostname);
+        auto reps = m_CampaignData.FindRemoteReplicas(dsIdx, m_HostOptions);
+        if (localRepIdx)
         {
-            size_t repIdx = itRep.first;
-            CampaignReplica &rep = itRep.second;
+            reps.insert(reps.begin(), localRepIdx);
+        }
+
+        for (auto repIdx : reps)
+        {
+            CampaignReplica &rep = ds.replicas[repIdx];
             if (m_Options.verbose > 1)
             {
                 std::cout << "      " << m_CampaignData.hosts[rep.hostIdx].hostname << ":"


### PR DESCRIPTION
…known hosts in hosts.yaml and not archive locations, s3 hosts with known setup, https locations, then "fs" archives, then finally unknown hosts (just to cause some useful error message later).