### PR TITLE
Detect the new flag HDF5_PROVIDES_PARALLEL from 2.0

### DIFF
--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -9,3 +9,12 @@ if(CMAKE_VERSION VERSION_LESS 3.19)
 else()
   include(${CMAKE_ROOT}/Modules/FindHDF5.cmake)
 endif()
+
+if ( HDF5_PROVIDES_PARALLEL )   
+    if(NOT DEFINED HDF5_IS_PARALLEL)  
+       message (STATUS "ADIOS is double checking to use the HDF2.0 parallel flag")      
+       set(HDF5_IS_PARALLEL ${HDF5_PROVIDES_PARALLEL})
+       message (STATUS "HDF is set to parralel: ${HDF5_IS_PARALLEL}")
+     endif()
+endif()
+


### PR DESCRIPTION
Detect HDF5 2.0 flag in cmake/FindHDF5.cmake after the cmake finished its FindHDF5.cmake