### PR TITLE
BP5: Fix segfault with DataSizeBased aggregation and async write

### DIFF
--- a/source/adios2/engine/bp5/BP5Writer_EveryoneWrites_Async.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_EveryoneWrites_Async.cpp
@@ -217,6 +217,18 @@ int BP5Writer::AsyncWriteThread_EveryoneWrites(AsyncWriteInfo *info)
 
 void BP5Writer::WriteData_EveryoneWrites_Async(format::BufferV *Data, bool SerializedWriters)
 {
+    if (m_Parameters.AggregationType == (int)AggregationType::DataSizeBased)
+    {
+        if (!m_AggregatorInitializedThisStep)
+        {
+            // We can't allow ranks to change subfiles between calls to Put(), so we only
+            // do this initialization once per timestep. Consequently, partition decision
+            // could be based on incomplete step data.
+            InitAggregator(Data->Size());
+            InitTransports();
+            m_AggregatorInitializedThisStep = true;
+        }
+    }
 
     const aggregator::MPIChain *a = dynamic_cast<aggregator::MPIChain *>(m_Aggregator);
 

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -26,6 +26,8 @@ file(MAKE_DIRECTORY ${BP5_ASYNC_DIR}/tls-guided)
 file(MAKE_DIRECTORY ${BP5_ASYNC_DIR}/tls-naive)
 file(MAKE_DIRECTORY ${BP5_ASYNC_DIR}/ews-guided)
 file(MAKE_DIRECTORY ${BP5_ASYNC_DIR}/ews-naive)
+file(MAKE_DIRECTORY ${BP5_ASYNC_DIR}/dsb-guided)
+file(MAKE_DIRECTORY ${BP5_ASYNC_DIR}/dsb-naive)
 
 macro(bp5_gtest_add_tests_helper testname mpi)
   gtest_add_tests_helper(${testname} ${mpi} BP Engine.BP. .BP5
@@ -75,6 +77,12 @@ macro(async_gtest_add_tests_helper testname mpi)
   )
   gtest_add_tests_helper(${testname} ${mpi} BP Engine.BP. .Async.BP5.EWS.Naive
     WORKING_DIRECTORY ${BP5_ASYNC_DIR}/ews-naive EXTRA_ARGS "BP5" "AggregationType=EveryoneWritesSerial,AsyncWrite=Naive"
+  )
+  gtest_add_tests_helper(${testname} ${mpi} BP Engine.BP. .Async.BP5.DSB.Guided
+    WORKING_DIRECTORY ${BP5_ASYNC_DIR}/dsb-guided EXTRA_ARGS "BP5" "AggregationType=DataSizeBased,AsyncWrite=Guided"
+  )
+  gtest_add_tests_helper(${testname} ${mpi} BP Engine.BP. .Async.BP5.DSB.Naive
+    WORKING_DIRECTORY ${BP5_ASYNC_DIR}/dsb-naive EXTRA_ARGS "BP5" "AggregationType=DataSizeBased,AsyncWrite=Naive"
   )
 endmacro()
 


### PR DESCRIPTION
Fix an oversight with `DataSizeBased` aggregation that resulted in the aggregator not getting initialized when async write mode was enabled.

Help ensure that `DataSizeBased` aggregation continues to work with async mode by expanding the async write tests to include DSB (async write was previously only tested with EWS and TLS).