### PR TITLE
Fix DataMan Python tests: add RUN_SERIAL

### DIFF
--- a/testing/adios2/engine/dataman/CMakeLists.txt
+++ b/testing/adios2/engine/dataman/CMakeLists.txt
@@ -29,6 +29,8 @@ if (ADIOS2_HAVE_Python)
     python_add_test(NAME Test.Engine.DataMan1D.Serial SCRIPT TestDataMan1D.py)
     python_add_test(NAME Test.Engine.DataMan1xN.Serial SCRIPT TestDataMan1xN.py)
     python_add_test(NAME Test.Engine.DataManSingleValues SCRIPT TestDataManSingleValues.py)
+    set_tests_properties(Test.Engine.DataMan1D.Serial Test.Engine.DataMan1xN.Serial Test.Engine.DataManSingleValues
+        PROPERTIES RUN_SERIAL TRUE)
 endif()
 
 if(ADIOS2_HAVE_ZFP)


### PR DESCRIPTION
All three Python DataMan tests use hardcoded port 12306. Without RUN_SERIAL, they can run in parallel and conflict.