### PR TITLE
Fix NULL pointer dereference in SST writer close

### DIFF
--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -234,8 +234,11 @@ static int registerContactInfo(const char *Name, SstStream Stream, attr_list DPA
 static void removeContactInfoFile(SstStream Stream)
 {
     const char *Name = Stream->AbsoluteFilename;
-    unlink(Name);
-    RemoveNameFromExitList(Name);
+    if (Name)
+    {
+        unlink(Name);
+        RemoveNameFromExitList(Name);
+    }
 }
 
 static void removeContactInfo(SstStream Stream)


### PR DESCRIPTION
## Summary
- Add NULL check in `removeContactInfoFile()` to prevent crash when `Stream->AbsoluteFilename` is NULL

Fixes TSAN crash in `SstWriteFails.InvalidBeginStep` test where SST writer closes before contact info registration completes.

## Test plan
- [x] Existing test `SstWriteFails.InvalidBeginStep` should pass under TSAN

🤖 Generated with [Claude Code](https://claude.ai/code)