### PR TITLE
Add accuracy parameters to XRootD HTTP protocol

### DIFF
--- a/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
@@ -208,7 +208,7 @@ void XrootdHttpRemote::Close() { m_OpenSuccess = false; }
 
 std::string XrootdHttpRemote::BuildRequestString(const char *VarName, size_t Step, size_t StepCount,
                                                  size_t BlockID, const Dims &Count,
-                                                 const Dims &Start)
+                                                 const Dims &Start, const Accuracy &accuracy)
 {
     // Build request string in the same format as XrootdRemote
     // Format: get
@@ -246,6 +246,11 @@ std::string XrootdHttpRemote::BuildRequestString(const char *VarName, size_t Ste
     {
         reqStream << "&Start=" << s;
     }
+
+    // Add accuracy parameters
+    reqStream << "&AccuracyError=" << accuracy.error;
+    reqStream << "&AccuracyNorm=" << accuracy.norm;
+    reqStream << "&AccuracyRelative=" << (accuracy.relative ? 1 : 0);
 
     return reqStream.str();
 }
@@ -366,7 +371,8 @@ Remote::GetHandle XrootdHttpRemote::Get(const char *VarName, size_t Step, size_t
     asyncOp->destSize = 0;
 
     // Build request string
-    std::string requestData = BuildRequestString(VarName, Step, StepCount, BlockID, Count, Start);
+    std::string requestData =
+        BuildRequestString(VarName, Step, StepCount, BlockID, Count, Start, accuracy);
 
     // Launch async HTTP request
     std::thread requestThread([this, asyncOp, requestData]() {

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.h
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.h
@@ -169,7 +169,8 @@ private:
      * @brief Build the SSI request string
      */
     std::string BuildRequestString(const char *VarName, size_t Step, size_t StepCount,
-                                   size_t BlockID, const Dims &Count, const Dims &Start);
+                                   size_t BlockID, const Dims &Count, const Dims &Start,
+                                   const Accuracy &accuracy);
 
     /**
      * @brief Perform an HTTP POST request


### PR DESCRIPTION
## Summary

- Extends XRootD HTTP remote interface to transmit accuracy parameters from client to server
- Enables lossy/approximate data retrieval over HTTP, matching EVPath remote protocol functionality

## Changes

**Client side (XrootdHttpRemote):**
- Add `Accuracy` parameter to `BuildRequestString()`
- Append `AccuracyError`, `AccuracyNorm`, `AccuracyRelative` to HTTP requests

**Server side (XrdSsiSvService):**
- Parse `AccuracyError`, `AccuracyNorm`, `AccuracyRelative` parameters
- Apply accuracy to variable via `SetAccuracy()` before `Get()`

## HTTP Request Format

```
get Filename=/path/to/data.bp
    &Varname=T
    &StepStart=0&StepCount=1
    &AccuracyError=5
    &AccuracyNorm=0
    &AccuracyRelative=0
```

## Test plan

- [x] Build with XRootD support
- [x] Verify accuracy parameters appear in HTTP requests
- [x] Test with XRootD HTTPS server

🤖 Generated with [Claude Code](https://claude.ai/code)