### PR TITLE
Support host aliases

### DIFF
--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -421,7 +421,8 @@ enum class HostAccessProtocol
     Invalid,
     SSH,
     XRootD,
-    S3
+    S3,
+    LocalHost
 };
 
 /** Host authentication protocols */

--- a/source/adios2/engine/campaign/CampaignData.cpp
+++ b/source/adios2/engine/campaign/CampaignData.cpp
@@ -752,16 +752,18 @@ void CampaignData::ReadToMemory(char *data, const size_t fileIdx, std::string &k
     DumpToFileOrMemory(fileIdx, keyHex, "", data);
 }
 
-size_t CampaignData::FindReplicaOnHost(const size_t datasetIdx, std::string hostname)
+size_t CampaignData::FindReplicaOnHost(const size_t datasetIdx,
+                                       std::vector<std::string> localHostAliases)
 {
     for (auto &it : datasets[datasetIdx].replicas)
     {
         auto repIdx = it.first;
         auto &rep = it.second;
-        if (hosts[rep.hostIdx].hostname == hostname)
-        {
-            return repIdx;
-        }
+        for (auto &localAlias : localHostAliases)
+            if (hosts[rep.hostIdx].hostname == localAlias)
+            {
+                return repIdx;
+            }
     }
     return 0;
 }

--- a/source/adios2/engine/campaign/CampaignData.h
+++ b/source/adios2/engine/campaign/CampaignData.h
@@ -181,7 +181,7 @@ public:
     void ReadToMemory(char *data, const size_t fileIdx, std::string &keyHex);
 
     // return 0 if there is no replica found for 'hostname', otherwise the replica index
-    size_t FindReplicaOnHost(const size_t datasetIdx, std::string hostname);
+    size_t FindReplicaOnHost(const size_t datasetIdx, std::vector<std::string> localHostAliases);
 
     /* return remote replicas in order of
      * 1. known remote host (has an entry in the hosts config) and not archive directory

--- a/source/adios2/engine/campaign/CampaignReader.h
+++ b/source/adios2/engine/campaign/CampaignReader.h
@@ -105,6 +105,8 @@ private:
     };
     std::unordered_map<std::string, CampaignVarInternalInfo> m_CampaignVarInternalInfo;
 
+    std::vector<std::string> m_LocalhostAliases; // config.yaml hostname + hosts.yaml "local" hosts
+
     void Init() final; ///< called from constructor, gets the selected Skeleton
                        /// transport method from settings
     void ReadConfig(std::string path);


### PR DESCRIPTION
 in ~/.config/hpc-campaign/hosts.yaml including aliases to the local machine

    E.g.

    NERSC:
      dtn-ssh:
          protocol: ssh
          ...

    NERSC.UEDGE: NERSC
    NERSC.HPSS: NERSC

    TESTMACHINE: local