### PR TITLE
ADIOSFilePool: per-SubPool locking for concurrent file access

### DIFF
--- a/source/utils/xrootd-plugin/XrdSsiSvService.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvService.cpp
@@ -564,8 +564,8 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
         {
             auto poolEntry = m_FilePoolPtr->GetFree(Filename, ArrayOrder);
             pthread_t tid;
-            auto engine = poolEntry->m_engine;
-            auto io = poolEntry->m_io;
+            auto engine = poolEntry.file->m_engine;
+            auto io = poolEntry.file->m_io;
             adios2::Box<adios2::Dims> varSel(Start, Count);
             adios2::DataType TypeOfVar = io.InquireVariableType(VarName);
             if (TypeOfVar == adios2::DataType::None)


### PR DESCRIPTION
- Drop `pool_mutex` after map lookup so the slow file-open path only blocks requests for the same file, not the whole server
- Add per-SubPool `subpool_mutex` for fine-grained locking
- Store SubPools as `shared_ptr` to keep them alive after `pool_mutex` is released; return `PoolEntry` struct to callers
- `FlushUnused()` now correctly holds `pool_mutex` (was missing before — race condition)
