### PR TITLE
Campaign reader engine must call PerformGets in DoClose to enable mul…

### DIFF
--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -1069,6 +1069,7 @@ void CampaignReader::DoClose(const int transportIndex)
     {
         std::cout << "Campaign Reader " << m_ReaderRank << " Close(" << m_Name << ")\n";
     }
+    PerformGets();
     for (auto ep : m_Engines)
     {
         ep->Close();


### PR DESCRIPTION
…tithreaded handling of multiple engines reading