### PR TITLE
Fix ReadTheDocs build: add setuptools for pkg_resources

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,5 +15,6 @@ dependencies:
   - sphinx
   - pip:
     - blockdiag
+    - setuptools
     - sphinxcontrib-blockdiag
     - sphinx_rtd_theme


### PR DESCRIPTION
sphinxcontrib-blockdiag imports pkg_resources, which requires setuptools to be explicitly installed.