### PR TITLE
FileStdio: Fix transport issue when opening in append mode

### DIFF
--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -83,7 +83,11 @@ void FileStdio::Open(const std::string &name, const Mode openMode, const bool as
         break;
     case Mode::Append:
         errno = 0;
-        m_File = std::fopen(name.c_str(), "rwb");
+        m_File = std::fopen(name.c_str(), "r+b");
+        if (!m_File)
+        {
+            m_File = std::fopen(name.c_str(), "w+b");
+        }
         std::fseek(m_File, 0, SEEK_END);
         break;
     case Mode::Read:
@@ -137,7 +141,11 @@ void FileStdio::OpenChain(const std::string &name, Mode openMode, const helper::
         break;
     case Mode::Append:
         errno = 0;
-        m_File = std::fopen(name.c_str(), "rwb");
+        m_File = std::fopen(name.c_str(), "r+b");
+        if (!m_File)
+        {
+            m_File = std::fopen(name.c_str(), "w+b");
+        }
         std::fseek(m_File, 0, SEEK_END);
         break;
     case Mode::Read:


### PR DESCRIPTION
The docs for `std::fopen` state clearly that providing any access mode not in the table is undefined behavior:

https://en.cppreference.com/w/cpp/io/c/fopen.html#File_access_flags

However, replacing "rw" with either "a" or "a+" does not seem to fix issues that have cropped up with a wider range of append use cases that arise with the DataSizeBased/Rerouting aggregation methods.

So here we avoid using the append mode flags at all, preferring to accomplish a similar effect manualy. We first attempt to open in "r+" (read/write), which returns nullptr if the file does not exist. In case we get that result, we then attempt to open in "w+" mode.