### PR TITLE
BP5Reader: Fix a possible issue when writer map changes between steps

### DIFF
--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -1779,12 +1779,12 @@ size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t 
             s.SubfileCount = (uint32_t)helper::ReadValue<uint64_t>(buffer, position,
                                                                    m_Minifooter.IsLittleEndian);
             // Get the process -> subfile map
-            s.RankToSubfile.reserve(s.WriterCount);
+            s.RankToSubfile.resize(s.WriterCount);
             for (uint64_t i = 0; i < s.WriterCount; i++)
             {
                 const uint64_t subfileIdx =
                     helper::ReadValue<uint64_t>(buffer, position, m_Minifooter.IsLittleEndian);
-                s.RankToSubfile.push_back(subfileIdx);
+                s.RankToSubfile[i] = subfileIdx;
             }
             m_LastMapStep = m_StepsCount;
             m_LastWriterCount = s.WriterCount;


### PR DESCRIPTION
If the emplace call returned an existing WriterMapStruct, then that struct already had a RankToSubfile vector of the correct size. In that case, the reserve() call did not change anything, but using push_back() to add elements increased the size beyone the number of writers. So those correct values were never reached later when accessing, and instead the previous (incorrect) subfile values were found.