### PR TITLE
Implement and Document Selection-based Get()

### DIFF
--- a/bindings/CXX/adios2/cxx/Engine.cpp
+++ b/bindings/CXX/adios2/cxx/Engine.cpp
@@ -337,6 +337,9 @@ Engine::AllStepsBlocksInfo(const VariableNT &variable) const
     template void Engine::Get<T>(Variable<T>, std::vector<T> &, const Mode);                       \
     template void Engine::Get<T>(const std::string &, std::vector<T> &, const Mode);               \
                                                                                                    \
+    template void Engine::Get<T>(Variable<T>, T *, const Selection &, const Mode);                 \
+    template void Engine::Get<T>(Variable<T>, std::vector<T> &, const Selection &, const Mode);    \
+                                                                                                   \
     template void Engine::Get<T>(Variable<T>, typename Variable<T>::Info & info, const Mode);      \
     template void Engine::Get<T>(const std::string &, typename Variable<T>::Info &info,            \
                                  const Mode);                                                      \

--- a/bindings/CXX/adios2/cxx/Selection.cpp
+++ b/bindings/CXX/adios2/cxx/Selection.cpp
@@ -23,6 +23,13 @@ Selection::Selection() : m_Impl(std::make_shared<Impl>()) {}
 // Factory methods
 //============================================================================
 
+Selection Selection::All()
+{
+    Selection sel;
+    sel.m_Impl->m_Selection = core::Selection::All();
+    return sel;
+}
+
 Selection Selection::BoundingBox(const Dims &start, const Dims &count)
 {
     Selection sel;
@@ -143,6 +150,8 @@ Selection Selection::WithAccuracy(double error, double norm, bool relative) cons
 {
     return WithAccuracy(Accuracy{error, norm, relative});
 }
+
+std::string Selection::ToString() const { return m_Impl->m_Selection.ToString(); }
 
 const core::Selection &Selection::GetCoreSelection() const { return m_Impl->m_Selection; }
 

--- a/bindings/CXX/adios2/cxx/Selection.h
+++ b/bindings/CXX/adios2/cxx/Selection.h
@@ -8,6 +8,8 @@
 #ifndef ADIOS2_BINDINGS_CXX_CXX_SELECTION_H_
 #define ADIOS2_BINDINGS_CXX_CXX_SELECTION_H_
 
+#include <string>
+
 #include "adios2/common/ADIOSTypes.h"
 
 namespace adios2
@@ -34,6 +36,9 @@ public:
     // Factory methods (create new Selection)
     //========================================================================
 
+    /** Create a selection that reads the entire variable. */
+    static Selection All();
+
     /**
      * Create a bounding box selection (hyperslab).
      * @param start  Starting offsets in each dimension
@@ -43,7 +48,7 @@ public:
     static Selection BoundingBox(const Box<Dims> &box);
 
     /**
-     * Create a block selection for LocalArray variables.
+     * Create a block selection to read an individual write block.
      * @param blockID  Block index from the writing rank
      */
     static Selection Block(size_t blockID);
@@ -82,6 +87,9 @@ public:
 
     Selection WithAccuracy(const Accuracy &accuracy) const;
     Selection WithAccuracy(double error, double norm = L2_norm, bool relative = false) const;
+
+    /** Human-readable string representation */
+    std::string ToString() const;
 
     /** Access to internal implementation (for Engine use) */
     const core::Selection &GetCoreSelection() const;

--- a/docs/user_guide/source/api_full/cxx.rst
+++ b/docs/user_guide/source/api_full/cxx.rst
@@ -32,6 +32,7 @@ Only the ``adios2::ADIOS`` object is "owned" by the developer's program using ad
    adios2::Variable<T>   
    adios2::Attribute<T>  
    adios2::Engine
+   adios2::Selection
    adios2::Operator
 
 The following section provides a summary of the available functionality for each class.
@@ -80,6 +81,15 @@ The following section provides a summary of the available functionality for each
    :project: CXX
    :path: ../../bindings/CXX/adios2/cxx/
    :members:
+
+:ref:`Selection` class
+----------------------
+
+.. doxygenclass:: adios2::Selection
+   :project: CXX
+   :path: ../../bindings/CXX/adios2/cxx/
+   :members:
+
 
 :ref:`Operator` class
 ---------------------

--- a/docs/user_guide/source/components/components.rst
+++ b/docs/user_guide/source/components/components.rst
@@ -8,6 +8,7 @@ Interface Components
 .. include:: variable.rst
 .. include:: attribute.rst
 .. include:: engine.rst
+.. include:: selection.rst
 .. include:: operator.rst
 .. include:: runtime.rst
 .. include:: anatomy.rst

--- a/docs/user_guide/source/components/selection.rst
+++ b/docs/user_guide/source/components/selection.rst
@@ -1,0 +1,181 @@
+*********
+Selection
+*********
+
+The ``Selection`` class provides an explicit, self-contained specification for
+``Get()`` operations. It bundles all the parameters that describe what data to
+read — bounding box, block ID, step range, memory layout, and accuracy — into a
+single object that is passed to ``Engine::Get()``.
+
+Motivation
+----------
+
+The traditional ADIOS2 read pattern requires mutating a ``Variable`` object
+before calling ``Get()``:
+
+.. code-block:: c++
+
+   var.SetSelection({{0, 0}, {10, 20}});
+   var.SetStepSelection({0, 5});
+   engine.Get(var, data);
+
+This works, but the selection state lives inside the ``Variable`` and can become
+stale or unclear when the same variable is read with different selections in
+different parts of the code. The ``Selection`` class makes each ``Get()`` call
+self-documenting by specifying the selection explicitly at the call site:
+
+.. code-block:: c++
+
+   auto sel = adios2::Selection::BoundingBox({0, 0}, {10, 20}).WithSteps(0, 5);
+   engine.Get(var, data, sel);
+
+Creating Selections
+-------------------
+
+Selections are created using static factory methods. There are three selection
+types:
+
+.. code-block:: c++
+
+   // All — select the entire variable (this is also the default)
+   auto sel = adios2::Selection::All();
+
+   // Bounding box (hyperslab) — specify start offsets and counts per dimension
+   auto sel = adios2::Selection::BoundingBox({0, 0}, {10, 20});
+
+   // Block selection — select an individual write block by ID
+   auto sel = adios2::Selection::Block(3);
+
+   // Using Box<Dims> convenience type
+   adios2::Box<adios2::Dims> box = {{0, 0}, {10, 20}};
+   auto sel = adios2::Selection::BoundingBox(box);
+
+A default-constructed ``Selection`` is equivalent to ``Selection::All()``:
+
+.. code-block:: c++
+
+   adios2::Selection sel;
+   engine.Get(var, data, sel);  // reads the whole variable
+
+Fluent Style (Immutable)
+------------------------
+
+The ``With*()`` methods return a **new** ``Selection`` with the modification
+applied, leaving the original unchanged. This is useful for one-shot
+expressions:
+
+.. code-block:: c++
+
+   auto sel = adios2::Selection::BoundingBox({0, 0}, {10, 20})
+                  .WithSteps(0, 5)
+                  .WithMemory({0, 0}, {10, 40})
+                  .WithAccuracy({0.01, 0.0, false});
+   engine.Get(var, data, sel);
+
+Mutable Style (Reuse)
+---------------------
+
+The ``Set*()`` methods modify the ``Selection`` in place and return ``*this``
+for chaining. This is useful when reusing a selection across iterations:
+
+.. code-block:: c++
+
+   adios2::Selection sel;
+   sel.SetBoundingBox({0, 0}, {10, 20});
+   sel.SetAccuracy({0.01, 0.0, false});
+
+   for (size_t step = 0; step < nsteps; ++step)
+   {
+       sel.SetSteps(step, 1);
+       engine.Get(var, buffers[step], sel);
+   }
+
+Using Selections with Get()
+---------------------------
+
+New ``Engine::Get()`` overloads accept a ``Selection`` parameter:
+
+.. code-block:: c++
+
+   // Raw pointer version
+   engine.Get(var, data_ptr, sel, adios2::Mode::Sync);
+
+   // std::vector version (auto-resized)
+   std::vector<double> data;
+   engine.Get(var, data, sel);
+
+Buffer Pre-allocation with SelectionSize()
+------------------------------------------
+
+``Variable::SelectionSize()`` now accepts a ``Selection`` to compute the
+required buffer size without modifying the variable:
+
+.. code-block:: c++
+
+   auto sel = adios2::Selection::BoundingBox({0, 0}, {10, 20});
+   size_t nelems = var.SelectionSize(sel);
+   double *buf = new double[nelems];
+   engine.Get(var, buf, sel);
+
+Available Selection Parameters
+------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Factory / Setter
+     - Non-mutating modifier
+     - Description
+   * - All
+     - ``All()``
+     - —
+     - Select the entire variable (default)
+   * - Bounding Box
+     - ``BoundingBox(start, count)`` / ``SetBoundingBox()``
+     - —
+     - Hyperslab selection with start offsets and counts
+   * - Block
+     - ``Block(blockID)`` / ``SetBlock()``
+     - —
+     - Select an individual write block by ID
+   * - Steps
+     - ``SetSteps(start, count)``
+     - ``WithSteps()``
+     - Step range to read (default: current step, count 1)
+   * - Memory
+     - ``SetMemory(start, count)``
+     - ``WithMemory()``
+     - Memory layout specification for the destination buffer
+   * - Accuracy
+     - ``SetAccuracy(error, norm, relative)``
+     - ``WithAccuracy()``
+     - Lossy accuracy requirements
+
+Other methods:
+
+- ``Clear()`` — reset the selection to default state (All)
+- ``ClearMemory()`` — remove memory layout specification
+- ``ToString()`` — human-readable string representation for debugging
+
+.. code-block:: c++
+
+   auto sel = adios2::Selection::BoundingBox({0, 0}, {10, 20}).WithSteps(0, 5);
+   std::cout << sel.ToString() << std::endl;
+   // Output: Selection(BoundingBox start={0, 0} count={10, 20}, steps=[0, 5])
+
+Engine Support
+--------------
+
+Selection-based ``Get()`` is currently supported by the **BP5** and **SST**
+(with BP5 marshalling) engines. Other engines will throw a runtime error if a
+``Selection`` is passed to ``Get()``.
+
+Compatibility
+-------------
+
+The existing ``Variable::SetSelection()``, ``SetBlockSelection()``,
+``SetStepSelection()``, and ``SetMemorySelection()`` APIs remain available and
+are not deprecated. The ``Selection`` class is a convenience alternative that
+makes the selection explicit at the ``Get()`` call site rather than relying on
+state previously set on the ``Variable``.

--- a/docs/user_guide/source/introduction/whatsnew.rst
+++ b/docs/user_guide/source/introduction/whatsnew.rst
@@ -16,6 +16,46 @@ again with allocated buffer to retrieve data):
 This addresses a gap in the C API where string lengths could not be queried
 before reading.
 
+Selection API for Get() Operations
+-----------------------------------
+
+A new ``Selection`` class provides an explicit, self-contained way to specify
+what data to read in ``Get()`` calls. Instead of mutating the ``Variable``
+object with ``SetSelection()``, ``SetBlockSelection()``, ``SetStepSelection()``,
+etc., all selection parameters are bundled into a ``Selection`` object that is
+passed directly to ``Get()``. This avoids relying on potentially stale variable
+state and makes the intent of each ``Get()`` call clear at the call site.
+
+Three selection types are available: ``Selection::All()`` (the default — reads
+the entire variable), ``Selection::BoundingBox(start, count)`` (hyperslab), and
+``Selection::Block(blockID)`` (individual write block). Additional parameters
+(steps, memory layout, accuracy) can be added via fluent ``With*()`` methods or
+mutable ``Set*()`` methods. A ``ToString()`` method is provided for debugging.
+
+.. code-block:: c++
+
+   // Select everything
+   engine.Get(var, data, adios2::Selection::All());
+
+   // Fluent style — bounding box with step range
+   auto sel = adios2::Selection::BoundingBox({0, 0}, {10, 20}).WithSteps(0, 5);
+   engine.Get(var, data, sel);
+
+   // Mutable style — reuse across iterations
+   adios2::Selection sel;
+   sel.SetBoundingBox({0, 0}, {10, 20});
+   for (size_t step = 0; step < nsteps; ++step)
+   {
+       sel.SetSteps(step, 1);
+       engine.Get(var, buffers[step], sel);
+   }
+
+   // Debug output
+   std::cout << sel.ToString() << std::endl;
+
+Existing ``SetSelection()``-based APIs remain available and are not deprecated.
+See :ref:`Selection` for full documentation.
+
 Cross-Endian Interoperability
 -----------------------------
 

--- a/source/adios2/common/ADIOSTypes.cpp
+++ b/source/adios2/common/ADIOSTypes.cpp
@@ -205,6 +205,8 @@ std::string ToString(SelectionType value)
 {
     switch (value)
     {
+    case SelectionType::All:
+        return "SelectionType::All";
     case SelectionType::BoundingBox:
         return "SelectionType::BoundingBox";
     case SelectionType::WriteBlock:

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -131,6 +131,7 @@ enum class TimeUnit
 /** Type of selection */
 enum class SelectionType
 {
+    All,         ///< Select the entire variable (default)
     BoundingBox, ///< Contiguous block of data defined by offsets and counts
                  /// per dimension
     WriteBlock,  ///< Selection of an individual block written by a writer

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -373,6 +373,9 @@ std::vector<VariableStruct::BPInfo> Engine::BlocksInfoStruct(const VariableStruc
     template void Engine::Get<T>(Variable<T> &, std::vector<T> &, const Mode);                     \
     template void Engine::Get<T>(const std::string &, std::vector<T> &, const Mode);               \
                                                                                                    \
+    template void Engine::Get<T>(Variable<T> &, T *, const Selection &, const Mode);               \
+    template void Engine::Get<T>(Variable<T> &, std::vector<T> &, const Selection &, const Mode);  \
+                                                                                                   \
     template typename Variable<T>::BPInfo *Engine::Get<T>(Variable<T> &, const Mode);              \
     template typename Variable<T>::BPInfo *Engine::Get<T>(const std::string &, const Mode);        \
                                                                                                    \

--- a/source/adios2/core/Selection.cpp
+++ b/source/adios2/core/Selection.cpp
@@ -8,6 +8,8 @@
 #include "Selection.h"
 #include "adios2/helper/adiosFunctions.h"
 
+#include <sstream>
+
 namespace adios2
 {
 namespace core
@@ -16,6 +18,13 @@ namespace core
 //============================================================================
 // Factory methods
 //============================================================================
+
+Selection Selection::All()
+{
+    Selection sel;
+    // Default constructor already sets m_Type = SelectionType::All
+    return sel;
+}
 
 Selection Selection::BoundingBox(const Dims &start, const Dims &count)
 {
@@ -122,7 +131,7 @@ Selection &Selection::SetAccuracy(double error, double norm, bool relative)
 
 void Selection::Clear()
 {
-    m_Type = SelectionType::BoundingBox;
+    m_Type = SelectionType::All;
     m_Start.clear();
     m_Count.clear();
     m_BlockID = 0;
@@ -172,6 +181,78 @@ Selection Selection::WithAccuracy(const Accuracy &accuracy) const
 Selection Selection::WithAccuracy(double error, double norm, bool relative) const
 {
     return WithAccuracy(Accuracy{error, norm, relative});
+}
+
+std::string Selection::ToString() const
+{
+    std::ostringstream os;
+    os << "Selection(";
+
+    switch (m_Type)
+    {
+    case SelectionType::All:
+        os << "All";
+        break;
+    case SelectionType::BoundingBox:
+        os << "BoundingBox start={";
+        for (size_t i = 0; i < m_Start.size(); ++i)
+        {
+            if (i > 0)
+            {
+                os << ", ";
+            }
+            os << m_Start[i];
+        }
+        os << "} count={";
+        for (size_t i = 0; i < m_Count.size(); ++i)
+        {
+            if (i > 0)
+            {
+                os << ", ";
+            }
+            os << m_Count[i];
+        }
+        os << "}";
+        break;
+    case SelectionType::WriteBlock:
+        os << "Block " << m_BlockID;
+        break;
+    }
+
+    if (m_StepStart != 0 || m_StepCount != 1)
+    {
+        os << ", steps=[" << m_StepStart << ", " << m_StepCount << "]";
+    }
+    if (m_HasMemory)
+    {
+        os << ", memory start={";
+        for (size_t i = 0; i < m_MemoryStart.size(); ++i)
+        {
+            if (i > 0)
+            {
+                os << ", ";
+            }
+            os << m_MemoryStart[i];
+        }
+        os << "} count={";
+        for (size_t i = 0; i < m_MemoryCount.size(); ++i)
+        {
+            if (i > 0)
+            {
+                os << ", ";
+            }
+            os << m_MemoryCount[i];
+        }
+        os << "}";
+    }
+    if (m_Accuracy.error != 0.0 || m_Accuracy.norm != 0.0)
+    {
+        os << ", accuracy={" << m_Accuracy.error << ", " << m_Accuracy.norm << ", "
+           << (m_Accuracy.relative ? "relative" : "absolute") << "}";
+    }
+
+    os << ")";
+    return os.str();
 }
 
 } // end namespace core

--- a/source/adios2/core/Selection.h
+++ b/source/adios2/core/Selection.h
@@ -10,6 +10,8 @@
 
 #include "adios2/common/ADIOSTypes.h"
 
+#include <string>
+
 namespace adios2
 {
 namespace core
@@ -22,7 +24,7 @@ namespace core
  * 1. Immutable/fluent: Use factory methods + With*() to create new instances
  * 2. Mutable/reuse: Use Set*() methods to modify in place
  *
- * Thread-safety is the user's responsibility (don't share and mutate).
+ * A default-constructed Selection has type All, meaning the entire variable.
  */
 class Selection
 {
@@ -33,6 +35,9 @@ public:
     // Factory methods (create new Selection)
     //========================================================================
 
+    /** Create a selection that reads the entire variable. */
+    static Selection All();
+
     /**
      * Create a bounding box selection (hyperslab).
      * @param start  Starting offsets in each dimension
@@ -42,7 +47,7 @@ public:
     static Selection BoundingBox(const Box<Dims> &box);
 
     /**
-     * Create a block selection for LocalArray variables.
+     * Create a block selection to read an individual write block.
      * @param blockID  Block index from the writing rank
      */
     static Selection Block(size_t blockID);
@@ -102,8 +107,11 @@ public:
 
     const Accuracy &GetAccuracy() const noexcept { return m_Accuracy; }
 
+    /** Human-readable string representation */
+    std::string ToString() const;
+
 private:
-    SelectionType m_Type = SelectionType::BoundingBox;
+    SelectionType m_Type = SelectionType::All;
     Dims m_Start;
     Dims m_Count;
     size_t m_BlockID = 0;

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -1993,6 +1993,16 @@ void BP5Reader::DoGetAbsoluteSteps(const VariableBase &variable, std::vector<siz
     {                                                                                              \
         PERFSTUBS_SCOPED_TIMER("BP5Reader::Get");                                                  \
         GetDeferredCommon(variable, data);                                                         \
+    }                                                                                              \
+    void BP5Reader::DoGetSync(Variable<T> &variable, T *data, const Selection &selection)          \
+    {                                                                                              \
+        PERFSTUBS_SCOPED_TIMER("BP5Reader::Get");                                                  \
+        GetSyncCommon(variable, data, selection);                                                  \
+    }                                                                                              \
+    void BP5Reader::DoGetDeferred(Variable<T> &variable, T *data, const Selection &selection)      \
+    {                                                                                              \
+        PERFSTUBS_SCOPED_TIMER("BP5Reader::Get");                                                  \
+        GetDeferredCommon(variable, data, selection);                                              \
     }
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -214,7 +214,9 @@ private:
 
 #define declare_type(T)                                                                            \
     void DoGetSync(Variable<T> &, T *) final;                                                      \
-    void DoGetDeferred(Variable<T> &, T *) final;
+    void DoGetDeferred(Variable<T> &, T *) final;                                                  \
+    void DoGetSync(Variable<T> &, T *, const Selection &) final;                                   \
+    void DoGetDeferred(Variable<T> &, T *, const Selection &) final;
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
 
@@ -225,6 +227,10 @@ private:
     void GetSyncCommon(VariableBase &variable, void *data);
 
     void GetDeferredCommon(VariableBase &variable, void *data);
+
+    void GetSyncCommon(VariableBase &variable, void *data, const Selection &selection);
+
+    void GetDeferredCommon(VariableBase &variable, void *data, const Selection &selection);
 
     void DoGetStructSync(VariableStruct &, void *);
     void DoGetStructDeferred(VariableStruct &, void *);

--- a/source/adios2/engine/bp5/BP5Reader.tcc
+++ b/source/adios2/engine/bp5/BP5Reader.tcc
@@ -34,6 +34,18 @@ void BP5Reader::GetDeferredCommon(VariableBase &variable, void *data)
     (void)m_BP5Deserializer->QueueGet(variable, data, m_dataIsRemote);
 }
 
+inline void BP5Reader::GetSyncCommon(VariableBase &variable, void *data, const Selection &selection)
+{
+    bool need_sync = m_BP5Deserializer->QueueGet(variable, data, selection, m_dataIsRemote);
+    if (need_sync)
+        PerformGets();
+}
+
+void BP5Reader::GetDeferredCommon(VariableBase &variable, void *data, const Selection &selection)
+{
+    (void)m_BP5Deserializer->QueueGet(variable, data, selection, m_dataIsRemote);
+}
+
 } // end namespace engine
 } // end namespace core
 } // end namespace adios2

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -625,6 +625,49 @@ void SstReader::Init()
 ADIOS2_FOREACH_STDTYPE_1ARG(declare_gets)
 #undef declare_gets
 
+#define declare_gets_selection(T)                                                                  \
+    void SstReader::DoGetSync(Variable<T> &variable, T *data, const Selection &selection)          \
+    {                                                                                              \
+        if (m_BetweenStepPairs == false)                                                           \
+        {                                                                                          \
+            helper::Throw<std::logic_error>("Engine", "SstReader", "DoGetSync",                    \
+                                            "When using the SST engine in ADIOS2, "                \
+                                            "Get() calls must appear between "                     \
+                                            "BeginStep/EndStep pairs");                            \
+        }                                                                                          \
+        if (m_WriterMarshalMethod != SstMarshalBP5)                                                \
+        {                                                                                          \
+            helper::Throw<std::runtime_error>(                                                     \
+                "Engine", "SstReader", "DoGetSync",                                                \
+                "Selection-based Get() is only supported with BP5 marshalling in SST");            \
+        }                                                                                          \
+        bool need_sync = m_BP5Deserializer->QueueGet(variable, data, selection);                   \
+        if (need_sync)                                                                             \
+        {                                                                                          \
+            BP5PerformGets();                                                                      \
+        }                                                                                          \
+    }                                                                                              \
+                                                                                                   \
+    void SstReader::DoGetDeferred(Variable<T> &variable, T *data, const Selection &selection)      \
+    {                                                                                              \
+        if (m_BetweenStepPairs == false)                                                           \
+        {                                                                                          \
+            helper::Throw<std::logic_error>("Engine", "SstReader", "DoGetDeferred",                \
+                                            "When using the SST engine in ADIOS2, "                \
+                                            "Get() calls must appear between "                     \
+                                            "BeginStep/EndStep pairs");                            \
+        }                                                                                          \
+        if (m_WriterMarshalMethod != SstMarshalBP5)                                                \
+        {                                                                                          \
+            helper::Throw<std::runtime_error>(                                                     \
+                "Engine", "SstReader", "DoGetDeferred",                                            \
+                "Selection-based Get() is only supported with BP5 marshalling in SST");            \
+        }                                                                                          \
+        m_BP5Deserializer->QueueGet(variable, data, selection);                                    \
+    }
+ADIOS2_FOREACH_STDTYPE_1ARG(declare_gets_selection)
+#undef declare_gets_selection
+
 void SstReader::DoGetStructSync(VariableStruct &variable, void *data)
 {
     PERFSTUBS_SCOPED_TIMER("BP5Reader::Get");

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -83,6 +83,8 @@ private:
 #define declare_type(T)                                                                            \
     void DoGetSync(Variable<T> &, T *) final;                                                      \
     void DoGetDeferred(Variable<T> &, T *) final;                                                  \
+    void DoGetSync(Variable<T> &, T *, const Selection &) final;                                   \
+    void DoGetDeferred(Variable<T> &, T *, const Selection &) final;                               \
                                                                                                    \
     std::map<size_t, std::vector<typename Variable<T>::BPInfo>> DoAllStepsBlocksInfo(              \
         const Variable<T> &variable) const final;                                                  \

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -11,6 +11,7 @@
 
 #include "adios2/core/Attribute.h"
 #include "adios2/core/IO.h"
+#include "adios2/core/Selection.h"
 #include "adios2/core/Variable.h"
 
 #include "BP5Base.h"
@@ -67,6 +68,8 @@ public:
     void SetupForStep(size_t Step, size_t WriterCount);
     // return from QueueGet is true if a sync is needed to fill the data
     bool QueueGet(core::VariableBase &variable, void *DestData, bool dataIsRemote = false);
+    bool QueueGet(core::VariableBase &variable, void *DestData, const core::Selection &selection,
+                  bool dataIsRemote = false);
     bool QueueGetSingle(core::VariableBase &variable, void *DestData, size_t AbsStep,
                         size_t RelStep);
     bool QueueGetSingleRemote(core::VariableBase &variable, void *DestData, size_t RelStep,
@@ -248,6 +251,13 @@ private:
     int FindOffset(size_t Dims, const size_t *Size, const size_t *Index);
     bool GetSingleValueFromMetadata(core::VariableBase &variable, BP5VarRec *VarRec, void *DestData,
                                     size_t Step, size_t WriterRank);
+    bool GetSingleValueFromMetadata(core::VariableBase &variable, BP5VarRec *VarRec, void *DestData,
+                                    size_t Step, size_t WriterRank, SelectionType selType,
+                                    size_t blockID);
+    bool QueueGetSingle(core::VariableBase &variable, void *DestData, size_t AbsStep,
+                        size_t RelStep, const core::Selection &selection);
+    bool QueueGetSingleRemote(core::VariableBase &variable, void *DestData, size_t RelStep,
+                              size_t StepCount, const core::Selection &selection);
     void StructQueueReadChecks(core::VariableStruct *variable, BP5VarRec *VarRec);
 
     void *GetMetadataBase(BP5VarRec *VarRec, size_t Step, size_t WriterRank) const;

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -134,6 +134,7 @@ bp_gtest_add_tests_helper(WriteReadVector MPI_ALLOW)
 bp_gtest_add_tests_helper(WriteReadAttributesMultirank MPI_ALLOW)
 bp_gtest_add_tests_helper(LargeMetadata MPI_ALLOW)
 bp5_gtest_add_tests_helper(WriteStatsOnly MPI_ALLOW)
+bp5_gtest_add_tests_helper(SelectionGet MPI_NONE)
 
 if (ADIOS2_HAVE_MPI)
   # Extra arguments: aggregation type, num subfiles, num timesteps, verbose level

--- a/testing/adios2/engine/bp/TestBPSelectionGet.cpp
+++ b/testing/adios2/engine/bp/TestBPSelectionGet.cpp
@@ -1,0 +1,505 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * TestBPSelectionGet.cpp : Tests for Selection-based Get() API
+ */
+#include <cstdint>
+#include <cstring>
+
+#include <iostream>
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+std::string engineName;
+std::string engineParameters;
+
+class BPSelectionGetTest : public ::testing::Test
+{
+public:
+    BPSelectionGetTest() = default;
+};
+
+// Write a 2D global array (Ny x Nx) for NSteps steps, then read it back
+// using Selection::All, Selection::BoundingBox, and Selection::Block
+TEST_F(BPSelectionGetTest, GlobalArray2D)
+{
+    const size_t Ny = 4;
+    const size_t Nx = 5;
+    const size_t NSteps = 3;
+    const std::string fname("BPSelectionGet_GlobalArray2D.bp");
+
+    adios2::ADIOS adios;
+    // Write
+    {
+        adios2::IO io = adios.DeclareIO("WriteIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        if (!engineParameters.empty())
+        {
+            io.SetParameters(engineParameters);
+        }
+
+        auto var = io.DefineVariable<double>("data", {Ny, Nx}, {0, 0}, {Ny, Nx});
+
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            std::vector<double> data(Ny * Nx);
+            for (size_t i = 0; i < Ny * Nx; ++i)
+            {
+                data[i] = static_cast<double>(step * 100 + i);
+            }
+            writer.BeginStep();
+            writer.Put(var, data.data());
+            writer.EndStep();
+        }
+        writer.Close();
+    }
+
+    // Read with Selection::All
+    {
+        adios2::IO io = adios.DeclareIO("ReadAllIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        auto var = io.InquireVariable<double>("data");
+        ASSERT_TRUE(var);
+        ASSERT_EQ(var.Steps(), NSteps);
+
+        auto sel = adios2::Selection::All().WithSteps(0, 1);
+        std::vector<double> data(Ny * Nx);
+        reader.Get(var, data.data(), sel, adios2::Mode::Sync);
+
+        // Verify step 0 data
+        for (size_t i = 0; i < Ny * Nx; ++i)
+        {
+            EXPECT_DOUBLE_EQ(data[i], static_cast<double>(i))
+                << "Mismatch at index " << i << " for Selection::All step 0";
+        }
+
+        // Read step 2
+        auto sel2 = adios2::Selection::All().WithSteps(2, 1);
+        reader.Get(var, data.data(), sel2, adios2::Mode::Sync);
+        for (size_t i = 0; i < Ny * Nx; ++i)
+        {
+            EXPECT_DOUBLE_EQ(data[i], static_cast<double>(200 + i))
+                << "Mismatch at index " << i << " for Selection::All step 2";
+        }
+
+        reader.Close();
+    }
+
+    // Read with Selection::BoundingBox (subset)
+    {
+        adios2::IO io = adios.DeclareIO("ReadBBoxIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        auto var = io.InquireVariable<double>("data");
+        ASSERT_TRUE(var);
+
+        // Read a 2x3 sub-region starting at (1, 1) from step 1
+        const size_t subNy = 2, subNx = 3;
+        auto sel = adios2::Selection::BoundingBox({1, 1}, {subNy, subNx}).WithSteps(1, 1);
+        std::vector<double> subdata(subNy * subNx);
+        reader.Get(var, subdata.data(), sel, adios2::Mode::Sync);
+
+        // Verify: step 1 data[y][x] = 100 + y*Nx + x
+        for (size_t y = 0; y < subNy; ++y)
+        {
+            for (size_t x = 0; x < subNx; ++x)
+            {
+                double expected = 100.0 + (y + 1) * Nx + (x + 1);
+                EXPECT_DOUBLE_EQ(subdata[y * subNx + x], expected)
+                    << "Mismatch at (" << y << "," << x << ") for BoundingBox";
+            }
+        }
+
+        reader.Close();
+    }
+
+    // Read with Selection::BoundingBox using std::vector (auto-resize)
+    {
+        adios2::IO io = adios.DeclareIO("ReadBBoxVectorIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        auto var = io.InquireVariable<double>("data");
+        ASSERT_TRUE(var);
+
+        auto sel = adios2::Selection::BoundingBox({0, 0}, {Ny, Nx}).WithSteps(0, 1);
+        std::vector<double> data;
+        reader.Get(var, data, sel, adios2::Mode::Sync);
+
+        ASSERT_EQ(data.size(), Ny * Nx);
+        for (size_t i = 0; i < Ny * Nx; ++i)
+        {
+            EXPECT_DOUBLE_EQ(data[i], static_cast<double>(i));
+        }
+
+        reader.Close();
+    }
+}
+
+// Write local arrays (one block per rank), read back with Selection::Block
+TEST_F(BPSelectionGetTest, LocalArrayBlock)
+{
+    const size_t Nx = 10;
+    const size_t NSteps = 2;
+    const std::string fname("BPSelectionGet_LocalArrayBlock.bp");
+
+    adios2::ADIOS adios;
+    // Write a local array
+    {
+        adios2::IO io = adios.DeclareIO("WriteLocalIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        if (!engineParameters.empty())
+        {
+            io.SetParameters(engineParameters);
+        }
+
+        auto var = io.DefineVariable<int32_t>("localdata", {}, {}, {Nx});
+
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            std::vector<int32_t> data(Nx);
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                data[i] = static_cast<int32_t>(step * 1000 + i);
+            }
+            writer.BeginStep();
+            writer.Put(var, data.data());
+            writer.EndStep();
+        }
+        writer.Close();
+    }
+
+    // Read with Selection::Block
+    {
+        adios2::IO io = adios.DeclareIO("ReadBlockIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        auto var = io.InquireVariable<int32_t>("localdata");
+        ASSERT_TRUE(var);
+
+        // Read block 0 from step 0
+        auto sel = adios2::Selection::Block(0).WithSteps(0, 1);
+        std::vector<int32_t> data(Nx);
+        reader.Get(var, data.data(), sel, adios2::Mode::Sync);
+
+        for (size_t i = 0; i < Nx; ++i)
+        {
+            EXPECT_EQ(data[i], static_cast<int32_t>(i))
+                << "Mismatch at index " << i << " for Block step 0";
+        }
+
+        // Read block 0 from step 1
+        auto sel1 = adios2::Selection::Block(0).WithSteps(1, 1);
+        reader.Get(var, data.data(), sel1, adios2::Mode::Sync);
+
+        for (size_t i = 0; i < Nx; ++i)
+        {
+            EXPECT_EQ(data[i], static_cast<int32_t>(1000 + i))
+                << "Mismatch at index " << i << " for Block step 1";
+        }
+
+        reader.Close();
+    }
+}
+
+// Test Selection with deferred mode
+TEST_F(BPSelectionGetTest, DeferredGet)
+{
+    const size_t Nx = 8;
+    const std::string fname("BPSelectionGet_Deferred.bp");
+
+    adios2::ADIOS adios;
+    // Write
+    {
+        adios2::IO io = adios.DeclareIO("WriteDeferredIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        if (!engineParameters.empty())
+        {
+            io.SetParameters(engineParameters);
+        }
+
+        auto var = io.DefineVariable<float>("fdata", {Nx}, {0}, {Nx});
+
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+        std::vector<float> data(Nx);
+        for (size_t i = 0; i < Nx; ++i)
+        {
+            data[i] = static_cast<float>(i) * 1.5f;
+        }
+        writer.BeginStep();
+        writer.Put(var, data.data());
+        writer.EndStep();
+        writer.Close();
+    }
+
+    // Read deferred with Selection
+    {
+        adios2::IO io = adios.DeclareIO("ReadDeferredIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        auto var = io.InquireVariable<float>("fdata");
+        ASSERT_TRUE(var);
+
+        // Read first 4 elements with BoundingBox, deferred
+        auto sel = adios2::Selection::BoundingBox({0}, {4}).WithSteps(0, 1);
+        std::vector<float> data(4);
+        reader.Get(var, data.data(), sel, adios2::Mode::Deferred);
+        reader.PerformGets();
+
+        for (size_t i = 0; i < 4; ++i)
+        {
+            EXPECT_FLOAT_EQ(data[i], static_cast<float>(i) * 1.5f)
+                << "Mismatch at index " << i << " for deferred BoundingBox";
+        }
+
+        // Read last 4 elements
+        auto sel2 = adios2::Selection::BoundingBox({4}, {4}).WithSteps(0, 1);
+        std::vector<float> data2(4);
+        reader.Get(var, data2.data(), sel2, adios2::Mode::Deferred);
+        reader.PerformGets();
+
+        for (size_t i = 0; i < 4; ++i)
+        {
+            EXPECT_FLOAT_EQ(data2[i], static_cast<float>(i + 4) * 1.5f)
+                << "Mismatch at index " << i << " for deferred BoundingBox (second half)";
+        }
+
+        reader.Close();
+    }
+}
+
+// Test Selection::All with streaming mode (BeginStep/EndStep)
+TEST_F(BPSelectionGetTest, StreamingAll)
+{
+    const size_t Nx = 6;
+    const size_t NSteps = 3;
+    const std::string fname("BPSelectionGet_StreamingAll.bp");
+
+    adios2::ADIOS adios;
+    // Write
+    {
+        adios2::IO io = adios.DeclareIO("WriteStreamIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        if (!engineParameters.empty())
+        {
+            io.SetParameters(engineParameters);
+        }
+
+        auto var = io.DefineVariable<int64_t>("sdata", {Nx}, {0}, {Nx});
+
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            std::vector<int64_t> data(Nx);
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                data[i] = static_cast<int64_t>(step * 10 + i);
+            }
+            writer.BeginStep();
+            writer.Put(var, data.data());
+            writer.EndStep();
+        }
+        writer.Close();
+    }
+
+    // Read in streaming mode with Selection::All
+    {
+        adios2::IO io = adios.DeclareIO("ReadStreamIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        adios2::Engine reader = io.Open(fname, adios2::Mode::Read);
+
+        size_t step = 0;
+        while (reader.BeginStep() == adios2::StepStatus::OK)
+        {
+            auto var = io.InquireVariable<int64_t>("sdata");
+            ASSERT_TRUE(var);
+
+            auto sel = adios2::Selection::All();
+            std::vector<int64_t> data(Nx);
+            reader.Get(var, data.data(), sel, adios2::Mode::Sync);
+
+            for (size_t i = 0; i < Nx; ++i)
+            {
+                EXPECT_EQ(data[i], static_cast<int64_t>(step * 10 + i))
+                    << "Mismatch at step " << step << " index " << i;
+            }
+
+            reader.EndStep();
+            ++step;
+        }
+        EXPECT_EQ(step, NSteps);
+
+        reader.Close();
+    }
+}
+
+// Test SelectionSize() with all selection types
+TEST_F(BPSelectionGetTest, SelectionSize)
+{
+    const size_t Ny = 4;
+    const size_t Nx = 5;
+    const size_t NSteps = 2;
+    const size_t LocalNx = 10;
+
+    adios2::ADIOS adios;
+
+    // Write a global array and a local array
+    const std::string fname("BPSelectionGet_SelectionSize.bp");
+    {
+        adios2::IO io = adios.DeclareIO("WriteSizeIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        if (!engineParameters.empty())
+        {
+            io.SetParameters(engineParameters);
+        }
+
+        auto gvar = io.DefineVariable<double>("global", {Ny, Nx}, {0, 0}, {Ny, Nx});
+        auto lvar = io.DefineVariable<int32_t>("local", {}, {}, {LocalNx});
+
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+        for (size_t step = 0; step < NSteps; ++step)
+        {
+            std::vector<double> gdata(Ny * Nx, 1.0);
+            std::vector<int32_t> ldata(LocalNx, 1);
+            writer.BeginStep();
+            writer.Put(gvar, gdata.data());
+            writer.Put(lvar, ldata.data());
+            writer.EndStep();
+        }
+        writer.Close();
+    }
+
+    // Test SelectionSize in random access mode
+    {
+        adios2::IO io = adios.DeclareIO("ReadSizeIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        auto gvar = io.InquireVariable<double>("global");
+        ASSERT_TRUE(gvar);
+        auto lvar = io.InquireVariable<int32_t>("local");
+        ASSERT_TRUE(lvar);
+
+        // All — should return full global array size
+        auto selAll = adios2::Selection::All().WithSteps(0, 1);
+        EXPECT_EQ(gvar.SelectionSize(selAll), Ny * Nx);
+
+        // All with multiple steps
+        auto selAllMulti = adios2::Selection::All().WithSteps(0, 2);
+        EXPECT_EQ(gvar.SelectionSize(selAllMulti), Ny * Nx * 2);
+
+        // All — still correct after SetSelection narrows m_Count
+        gvar.SetSelection({{0, 0}, {2, 3}});
+        EXPECT_EQ(gvar.SelectionSize(selAll), Ny * Nx)
+            << "SelectionSize(All) should use shape, not stale m_Count";
+
+        // BoundingBox
+        auto selBBox = adios2::Selection::BoundingBox({0, 0}, {2, 3}).WithSteps(0, 1);
+        EXPECT_EQ(gvar.SelectionSize(selBBox), 2u * 3u);
+
+        // Block for local array
+        auto selBlock = adios2::Selection::Block(0).WithSteps(0, 1);
+        EXPECT_EQ(lvar.SelectionSize(selBlock), LocalNx);
+
+        reader.Close();
+    }
+}
+
+// Test ToString() method
+TEST_F(BPSelectionGetTest, SelectionToString)
+{
+    auto all = adios2::Selection::All();
+    EXPECT_NE(all.ToString().find("All"), std::string::npos);
+
+    auto bbox = adios2::Selection::BoundingBox({1, 2}, {10, 20});
+    std::string s = bbox.ToString();
+    EXPECT_NE(s.find("BoundingBox"), std::string::npos);
+    EXPECT_NE(s.find("10"), std::string::npos);
+    EXPECT_NE(s.find("20"), std::string::npos);
+
+    auto block = adios2::Selection::Block(5);
+    EXPECT_NE(block.ToString().find("Block"), std::string::npos);
+    EXPECT_NE(block.ToString().find("5"), std::string::npos);
+
+    auto withSteps = adios2::Selection::All().WithSteps(3, 7);
+    std::string ws = withSteps.ToString();
+    EXPECT_NE(ws.find("All"), std::string::npos);
+    EXPECT_NE(ws.find("3"), std::string::npos);
+    EXPECT_NE(ws.find("7"), std::string::npos);
+}
+
+int main(int argc, char **argv)
+{
+#if ADIOS2_USE_MPI
+    int provided;
+    MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
+#endif
+
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+    if (argc > 2)
+    {
+        engineParameters = std::string(argv[2]);
+    }
+    result = RUN_ALL_TESTS();
+
+#if ADIOS2_USE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}


### PR DESCRIPTION
This PR actually implements the previous Selection-based Get() interfaces.  Note that this is BP5 and SST only at this point.  Selection class is tweaked slightly to make the All() selection explicit, and I've added a ToString() call that operates on Selections for developer convenience.  Documentation is added including a whatsnew update for the next release.