### PR TITLE
Create parent directory of temporary .ats file. 

### DIFF
--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -687,8 +687,9 @@ void CampaignReader::InitTransports()
 
         std::string localCachePath =
             m_Options.cachepath + PathSeparator + ds.uuid.substr(0, 3) + PathSeparator + ds.uuid;
-        helper::CreateDirectory(localCachePath);
         std::string atsFilePath = localCachePath + PathSeparator + ts.name + ".ats";
+        auto atsDir = adios2sys::SystemTools::GetFilenamePath(atsFilePath);
+        helper::CreateDirectory(atsDir);
         if (m_Options.verbose > 0)
         {
             std::cout << "    " << tsIdx << ". " << ts.name << "  --> " << atsFilePath << std::endl;


### PR DESCRIPTION
Fix for when a dataset is a path, not just a simple filename.