### PR TITLE
Catch error thrown by Campaign engine when engine.all_blocks_info() i…

### DIFF
--- a/python/adios2/engine.py
+++ b/python/adios2/engine.py
@@ -87,7 +87,6 @@ class Engine:
         try:
             for step in range(0, self.steps()):
                 output.append(self.blocks_info(name, step))
-            return output
         except ValueError:  # Campaign engine has no steps()
             vstep = 0
             while True:


### PR DESCRIPTION
…s called, and provide an alternative implementationfor this engine.