### PR TITLE
Refactor engine parameter parsing

### DIFF
--- a/testing/adios2/engine/ParamsHelpers.h
+++ b/testing/adios2/engine/ParamsHelpers.h
@@ -1,0 +1,127 @@
+/*
+ * Distributed under the OSI-approved Apache License, Version 2.0.  See
+ * accompanying file Copyright.txt for details.
+ *
+ * TestHelpers.h : Common helper functions for ADIOS2 engine tests
+ */
+
+#ifndef TEST_ADIOS2_ENGINE_PARAMS_HELPERS_H_
+#define TEST_ADIOS2_ENGINE_PARAMS_HELPERS_H_
+
+#include <adios2.h>
+
+#include <cctype>
+#include <stdexcept>
+#include <string>
+
+static std::string Trim(std::string &str)
+{
+    if (str != "")
+    {
+        size_t first = str.find_first_not_of(' ');
+        size_t last = str.find_last_not_of(' ');
+        return str.substr(first, (last - first + 1));
+    }
+    return str;
+}
+
+/*
+ * Engine parameters spec is a poor-man's JSON.  name=value pairs are separated
+ * by commas.  White space is trimmed off front and back.
+ *
+ * Values containing special characters can be quoted with single or double quotes:
+ *   DataTransport=awssdk,S3Endpoint="http://127.0.0.1:9000",S3Bucket=mybucket
+ */
+static adios2::Params ParseEngineParams(std::string Input)
+{
+    adios2::Params Ret = {};
+    size_t pos = 0;
+    size_t len = Input.length();
+
+    while (pos < len)
+    {
+        // Skip leading whitespace
+        while (pos < len && std::isspace(Input[pos]))
+        {
+            ++pos;
+        }
+        if (pos >= len)
+        {
+            break;
+        }
+
+        // Parse parameter name (up to '=')
+        size_t nameStart = pos;
+        while (pos < len && Input[pos] != '=')
+        {
+            ++pos;
+        }
+        if (pos >= len)
+        {
+            throw std::invalid_argument("Engine parameter missing '=' delimiter");
+        }
+        std::string paramName = Input.substr(nameStart, pos - nameStart);
+        paramName = Trim(paramName);
+        ++pos; // skip '='
+
+        // Parse parameter value
+        std::string paramValue;
+
+        // Skip whitespace before value
+        while (pos < len && std::isspace(Input[pos]))
+        {
+            ++pos;
+        }
+
+        if (pos < len && (Input[pos] == '"' || Input[pos] == '\''))
+        {
+            // Quoted value - read until matching quote
+            char quote = Input[pos];
+            ++pos; // skip opening quote
+            size_t valueStart = pos;
+            while (pos < len && Input[pos] != quote)
+            {
+                ++pos;
+            }
+            if (pos >= len)
+            {
+                throw std::invalid_argument("Engine parameter \"" + paramName +
+                                            "\" has unterminated quote");
+            }
+            paramValue = Input.substr(valueStart, pos - valueStart);
+            ++pos; // skip closing quote
+        }
+        else
+        {
+            // Unquoted value - read until comma or end
+            size_t valueStart = pos;
+            while (pos < len && Input[pos] != ',')
+            {
+                ++pos;
+            }
+            paramValue = Input.substr(valueStart, pos - valueStart);
+            paramValue = Trim(paramValue);
+        }
+
+        if (paramName.empty())
+        {
+            throw std::invalid_argument("Engine parameter has empty name");
+        }
+
+        if (paramValue.empty())
+        {
+            throw std::invalid_argument("Engine parameter has empty value");
+        }
+
+        Ret[paramName] = paramValue;
+
+        // Skip comma separator if present
+        if (pos < len && Input[pos] == ',')
+        {
+            ++pos;
+        }
+    }
+    return Ret;
+}
+
+#endif // TEST_ADIOS2_ENGINE_PARAMS_HELPERS_H_

--- a/testing/adios2/engine/common/CMakeLists.txt
+++ b/testing/adios2/engine/common/CMakeLists.txt
@@ -30,10 +30,10 @@ endif()
 
 if(ADIOS2_HAVE_SST)
   gtest_add_tests_helper(Common MPI_ONLY "" Engine. .SST.FFS
-    EXTRA_ARGS "SST" "0" "MarshalMethod:FFS"
+    EXTRA_ARGS "SST" "0" "MarshalMethod=FFS"
   )
   gtest_add_tests_helper(Common MPI_ONLY "" Engine. .SST.BP
-    EXTRA_ARGS "SST" "0" "MarshalMethod:BP"
+    EXTRA_ARGS "SST" "0" "MarshalMethod=BP"
   )
 endif()
 

--- a/testing/adios2/engine/common/TestEngineCommon.cpp
+++ b/testing/adios2/engine/common/TestEngineCommon.cpp
@@ -21,115 +21,13 @@
 
 #include <adios2.h>
 
+#include "../ParamsHelpers.h"
 #include "../TestHelpers.h"
 
 int numprocs, wrank;
 std::string engineName;           // comes from command line
 bool serializeWriterReader;       // comes from command line
 adios2::Params engineParams = {}; // parsed from command line
-
-std::string Trim(std::string &str)
-{
-    size_t first = str.find_first_not_of(' ');
-    size_t last = str.find_last_not_of(' ');
-    return str.substr(first, (last - first + 1));
-}
-
-/*
- * Engine parameters spec is a poor-man's JSON.  name:value pairs are separated
- * by commas.  White space is trimmed off front and back.
- *
- * Values containing colons (like URLs) can be quoted with single or double quotes:
- *   DataTransport:awssdk,S3Endpoint:"http://127.0.0.1:9000",S3Bucket:mybucket
- *   or
- *   DataTransport:awssdk,S3Endpoint:'http://127.0.0.1:9000',S3Bucket:mybucket
- */
-adios2::Params ParseEngineParams(std::string Input)
-{
-    adios2::Params Ret = {};
-    size_t pos = 0;
-    size_t len = Input.length();
-
-    while (pos < len)
-    {
-        // Skip leading whitespace
-        while (pos < len && std::isspace(Input[pos]))
-        {
-            ++pos;
-        }
-        if (pos >= len)
-        {
-            break;
-        }
-
-        // Parse parameter name (up to ':')
-        size_t nameStart = pos;
-        while (pos < len && Input[pos] != ':')
-        {
-            ++pos;
-        }
-        if (pos >= len)
-        {
-            throw std::invalid_argument("Engine parameter missing ':' delimiter");
-        }
-        std::string paramName = Input.substr(nameStart, pos - nameStart);
-        paramName = Trim(paramName);
-        ++pos; // skip ':'
-
-        // Parse parameter value
-        std::string paramValue;
-
-        // Skip whitespace before value
-        while (pos < len && std::isspace(Input[pos]))
-        {
-            ++pos;
-        }
-
-        if (pos < len && (Input[pos] == '"' || Input[pos] == '\''))
-        {
-            // Quoted value - read until matching quote
-            char quote = Input[pos];
-            ++pos; // skip opening quote
-            size_t valueStart = pos;
-            while (pos < len && Input[pos] != quote)
-            {
-                ++pos;
-            }
-            if (pos >= len)
-            {
-                throw std::invalid_argument("Engine parameter \"" + paramName +
-                                            "\" has unterminated quote");
-            }
-            paramValue = Input.substr(valueStart, pos - valueStart);
-            ++pos; // skip closing quote
-        }
-        else
-        {
-            // Unquoted value - read until comma or end
-            size_t valueStart = pos;
-            while (pos < len && Input[pos] != ',')
-            {
-                ++pos;
-            }
-            paramValue = Input.substr(valueStart, pos - valueStart);
-            paramValue = Trim(paramValue);
-        }
-
-        if (paramName.empty())
-        {
-            throw std::invalid_argument("Engine parameter has empty name");
-        }
-
-        Ret[paramName] = paramValue;
-
-        // Skip comma separator if present
-        if (pos < len && Input[pos] == ',')
-        {
-            ++pos;
-        }
-    }
-    return Ret;
-}
 
 static unsigned int ParseUintParam(const std::string &optionName, char *arg)
 {

--- a/testing/adios2/engine/sst/TestSstParamFails.cpp
+++ b/testing/adios2/engine/sst/TestSstParamFails.cpp
@@ -10,6 +10,8 @@
 
 #include <adios2.h>
 
+#include "../ParamsHelpers.h"
+
 #include <gtest/gtest.h>
 
 class SstParamFailTest : public ::testing::Test
@@ -21,43 +23,10 @@ public:
 int TimeGapExpected = 0;
 std::string fname = "ADIOS2Sst";
 
-static std::string Trim(std::string &str)
-{
-    size_t first = str.find_first_not_of(' ');
-    size_t last = str.find_last_not_of(' ');
-    return str.substr(first, (last - first + 1));
-}
-
-/*
- * Engine parameters spec is a poor-man's JSON.  name:value pairs are separated
- * by commas.  White space is trimmed off front and back.  No quotes or anything
- * fancy allowed.
- */
-static adios2::Params ParseEngineParams(std::string Input)
-{
-    std::istringstream ss(Input);
-    std::string Param;
-    adios2::Params Ret = {};
-
-    while (std::getline(ss, Param, ','))
-    {
-        std::istringstream ss2(Param);
-        std::string ParamName;
-        std::string ParamValue;
-        std::getline(ss2, ParamName, ':');
-        if (!std::getline(ss2, ParamValue, ':'))
-        {
-            throw std::invalid_argument("Engine parameter \"" + Param + "\" missing value");
-        }
-        Ret[Trim(ParamName)] = Trim(ParamValue);
-    }
-    return Ret;
-}
-
 // ADIOS2 Sst param fail
 TEST_F(SstParamFailTest, ParamNoValue)
 {
-    EXPECT_THROW(adios2::Params engineParams = ParseEngineParams("MarshalMethod:"),
+    EXPECT_THROW(adios2::Params engineParams = ParseEngineParams("MarshalMethod="),
                  std::invalid_argument);
 }
 
@@ -71,7 +40,7 @@ TEST_F(SstParamFailTest, ParamNoValue2)
 // ADIOS2 Sst param fail
 TEST_F(SstParamFailTest, MarshalMethodUnknown)
 {
-    adios2::Params engineParams = ParseEngineParams("MarshalMethod:unknown");
+    adios2::Params engineParams = ParseEngineParams("MarshalMethod=unknown");
 
 #if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);
@@ -94,7 +63,7 @@ TEST_F(SstParamFailTest, MarshalMethodUnknown)
 // ADIOS2 Sst param fail
 TEST_F(SstParamFailTest, CompressionMethodUnknown)
 {
-    adios2::Params engineParams = ParseEngineParams("CompressionMethod:unknown");
+    adios2::Params engineParams = ParseEngineParams("CompressionMethod=unknown");
 
 #if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);
@@ -117,7 +86,7 @@ TEST_F(SstParamFailTest, CompressionMethodUnknown)
 // ADIOS2 Sst param fail
 TEST_F(SstParamFailTest, QueueFullPolicyUnknown)
 {
-    adios2::Params engineParams = ParseEngineParams("QueueFullPolicy:unknown");
+    adios2::Params engineParams = ParseEngineParams("QueueFullPolicy=unknown");
 
 #if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);
@@ -140,7 +109,7 @@ TEST_F(SstParamFailTest, QueueFullPolicyUnknown)
 // ADIOS2 Sst param fail
 TEST_F(SstParamFailTest, RendezvousReaderCountBad)
 {
-    adios2::Params engineParams = ParseEngineParams("RendezvousReaderCount:unknown");
+    adios2::Params engineParams = ParseEngineParams("RendezvousReaderCount=unknown");
 
 #if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);
@@ -163,7 +132,7 @@ TEST_F(SstParamFailTest, RendezvousReaderCountBad)
 // ADIOS2 Sst param fail
 TEST_F(SstParamFailTest, QueueLimitBad)
 {
-    adios2::Params engineParams = ParseEngineParams("QueueLimit:unknown");
+    adios2::Params engineParams = ParseEngineParams("QueueLimit=unknown");
 
 #if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);
@@ -186,7 +155,7 @@ TEST_F(SstParamFailTest, QueueLimitBad)
 // ADIOS2 Sst param fail
 TEST_F(SstParamFailTest, PreciousFirstTimestepParamTest)
 {
-    adios2::Params engineParams = ParseEngineParams("FirstTimestepPrecious:unknown");
+    adios2::Params engineParams = ParseEngineParams("FirstTimestepPrecious=unknown");
 
 #if ADIOS2_USE_MPI
     adios2::ADIOS adios(MPI_COMM_WORLD);

--- a/testing/adios2/engine/sst/TestSstWriterFails.cpp
+++ b/testing/adios2/engine/sst/TestSstWriterFails.cpp
@@ -11,6 +11,8 @@
 
 #include <adios2.h>
 
+#include "../ParamsHelpers.h"
+
 #include <gtest/gtest.h>
 
 class SstWriteFails : public ::testing::Test
@@ -24,39 +26,6 @@ std::string fname = "ADIOS2SstFAIL";
 
 int CompressSz = 0;
 int CompressZfp = 0;
-
-static std::string Trim(std::string &str)
-{
-    size_t first = str.find_first_not_of(' ');
-    size_t last = str.find_last_not_of(' ');
-    return str.substr(first, (last - first + 1));
-}
-
-/*
- * Engine parameters spec is a poor-man's JSON.  name:value pairs are separated
- * by commas.  White space is trimmed off front and back.  No quotes or anything
- * fancy allowed.
- */
-static adios2::Params ParseEngineParams(std::string Input)
-{
-    std::istringstream ss(Input);
-    std::string Param;
-    adios2::Params Ret = {};
-
-    while (std::getline(ss, Param, ','))
-    {
-        std::istringstream ss2(Param);
-        std::string ParamName;
-        std::string ParamValue;
-        std::getline(ss2, ParamName, ':');
-        if (!std::getline(ss2, ParamValue, ':'))
-        {
-            throw std::invalid_argument("Engine parameter \"" + Param + "\" missing value");
-        }
-        Ret[Trim(ParamName)] = Trim(ParamValue);
-    }
-    return Ret;
-}
 
 // ADIOS2 SST write
 TEST_F(SstWriteFails, InvalidPut)

--- a/testing/adios2/engine/staging-common/ParseArgs.h
+++ b/testing/adios2/engine/staging-common/ParseArgs.h
@@ -1,3 +1,5 @@
+#include "../ParamsHelpers.h"
+
 #ifndef _WIN32
 #include "strings.h"
 #else
@@ -51,107 +53,6 @@ bool Cleanup = false;
 std::string shutdown_name = "DieTest";
 adios2::Mode GlobalWriteMode = adios2::Mode::Deferred;
 adios2::Mode GlobalReadMode = adios2::Mode::Deferred;
-
-static std::string Trim(std::string &str)
-{
-    size_t first = str.find_first_not_of(' ');
-    size_t last = str.find_last_not_of(' ');
-    return str.substr(first, (last - first + 1));
-}
-
-/*
- * Engine parameters spec is a poor-man's JSON.  name=value pairs are separated
- * by commas.  White space is trimmed off front and back.
- *
- * Values containing special characters can be quoted with single or double quotes:
- *   DataTransport=awssdk,S3Endpoint="http://127.0.0.1:9000",S3Bucket=mybucket
- */
-static adios2::Params ParseEngineParams(std::string Input)
-{
-    adios2::Params Ret = {};
-    size_t pos = 0;
-    size_t len = Input.length();
-
-    while (pos < len)
-    {
-        // Skip leading whitespace
-        while (pos < len && std::isspace(Input[pos]))
-        {
-            ++pos;
-        }
-        if (pos >= len)
-        {
-            break;
-        }
-
-        // Parse parameter name (up to '=')
-        size_t nameStart = pos;
-        while (pos < len && Input[pos] != '=')
-        {
-            ++pos;
-        }
-        if (pos >= len)
-        {
-            throw std::invalid_argument("Engine parameter missing '=' delimiter");
-        }
-        std::string paramName = Input.substr(nameStart, pos - nameStart);
-        paramName = Trim(paramName);
-        ++pos; // skip '='
-
-        // Parse parameter value
-        std::string paramValue;
-
-        // Skip whitespace before value
-        while (pos < len && std::isspace(Input[pos]))
-        {
-            ++pos;
-        }
-
-        if (pos < len && (Input[pos] == '"' || Input[pos] == '\''))
-        {
-            // Quoted value - read until matching quote
-            char quote = Input[pos];
-            ++pos; // skip opening quote
-            size_t valueStart = pos;
-            while (pos < len && Input[pos] != quote)
-            {
-                ++pos;
-            }
-            if (pos >= len)
-            {
-                throw std::invalid_argument("Engine parameter \"" + paramName +
-                                            "\" has unterminated quote");
-            }
-            paramValue = Input.substr(valueStart, pos - valueStart);
-            ++pos; // skip closing quote
-        }
-        else
-        {
-            // Unquoted value - read until comma or end
-            size_t valueStart = pos;
-            while (pos < len && Input[pos] != ',')
-            {
-                ++pos;
-            }
-            paramValue = Input.substr(valueStart, pos - valueStart);
-            paramValue = Trim(paramValue);
-        }
-
-        if (paramName.empty())
-        {
-            throw std::invalid_argument("Engine parameter has empty name");
-        }
-
-        Ret[paramName] = paramValue;
-
-        // Skip comma separator if present
-        if (pos < len && Input[pos] == ',')
-        {
-            ++pos;
-        }
-    }
-    return Ret;
-}
 
 void ParseArgs(int argc, char **argv)
 {

--- a/testing/adios2/output_archive/ReadCommon.cpp
+++ b/testing/adios2/output_archive/ReadCommon.cpp
@@ -12,6 +12,8 @@
 
 #include <adios2.h>
 
+#include "../engine/ParamsHelpers.h"
+
 #include <gtest/gtest.h>
 
 #include "TestData.h"
@@ -286,34 +288,6 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
 
     // Close the file
     engine.Close();
-}
-
-static std::string Trim(std::string &str)
-{
-    size_t first = str.find_first_not_of(' ');
-    size_t last = str.find_last_not_of(' ');
-    return str.substr(first, (last - first + 1));
-}
-
-static adios2::Params ParseEngineParams(std::string Input)
-{
-    std::istringstream ss(Input);
-    std::string Param;
-    adios2::Params Ret = {};
-
-    while (std::getline(ss, Param, ','))
-    {
-        std::istringstream ss2(Param);
-        std::string ParamName;
-        std::string ParamValue;
-        std::getline(ss2, ParamName, '=');
-        if (!std::getline(ss2, ParamValue, '='))
-        {
-            throw std::invalid_argument("Engine parameter \"" + Param + "\" missing value");
-        }
-        Ret[Trim(ParamName)] = Trim(ParamValue);
-    }
-    return Ret;
 }
 
 void ParseArgs(int argc, char **argv)

--- a/testing/adios2/performance/metadata/PerfMetaData.cpp
+++ b/testing/adios2/performance/metadata/PerfMetaData.cpp
@@ -15,6 +15,8 @@
 
 #include <adios2.h>
 
+#include "../../engine/ParamsHelpers.h"
+
 #ifndef _WIN32
 #include "strings.h"
 #else
@@ -56,39 +58,6 @@ typedef enum
 } TestModeEnum;
 
 TestModeEnum TestMode = WriterConsolidation;
-
-static std::string Trim(std::string &str)
-{
-    size_t first = str.find_first_not_of(' ');
-    size_t last = str.find_last_not_of(' ');
-    return str.substr(first, (last - first + 1));
-}
-
-/*
- * Engine parameters spec is a poor-man's JSON.  name:value pairs are separated
- * by equal.  White space is trimmed off front and back.  No quotes or anything
- * fancy allowed.
- */
-static adios2::Params ParseEngineParams(std::string Input)
-{
-    std::istringstream ss(Input);
-    std::string Param;
-    adios2::Params Ret = {};
-
-    while (std::getline(ss, Param, ','))
-    {
-        std::istringstream ss2(Param);
-        std::string ParamName;
-        std::string ParamValue;
-        std::getline(ss2, ParamName, '=');
-        if (!std::getline(ss2, ParamValue, '='))
-        {
-            throw std::invalid_argument("Engine parameter \"" + Param + "\" missing value");
-        }
-        Ret[Trim(ParamName)] = Trim(ParamValue);
-    }
-    return Ret;
-}
 
 static void Usage()
 {


### PR DESCRIPTION
The goal of this PR is reduce the number of redefinitions of a couple helper methods in various places under the `testing` directory. There is now a single definition of `ParseEngineParams(std::string input)` and `Trim(std::string& str)`, located in a new helper file `ParamsHelpers.h`.

