### PR TITLE
ci: add wheel integration tests

### DIFF
--- a/.github/workflows/pypackaging.yml
+++ b/.github/workflows/pypackaging.yml
@@ -25,6 +25,10 @@ on:
     types:
       - published
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -55,16 +59,11 @@ jobs:
           path: dist/*.tar.gz
 
   build_wheels:
-    name: Wheel on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build Wheels
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: write  # for upload-artifact
-    strategy:
-      fail-fast: false
-      matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
@@ -83,6 +82,39 @@ jobs:
         with:
           name: artifact_wheels
           path: wheelhouse/*.whl
+
+  test_wheels:
+    name: Test wheel on ubuntu
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
+        with:
+          name: artifact_wheels
+          path: dist
+      - run: python -m pip install --find-links=dist adios2
+      - run: python -c "import adios2"
+
+  test_sdist:
+    name: Test SDist on ${{ matrix.os }}
+    needs: make_sdist
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v4
+        with:
+          name: artifact_sdist
+          path: dist
+      - run: python -m pip install -vvv dist/*.tar.gz
+        shell: bash
+      - run: python -c "import adios2"
+        shell: bash
 
   upload_pypi:
     needs: [build_wheels, make_sdist]

--- a/bindings/Python/CMakeLists.txt
+++ b/bindings/Python/CMakeLists.txt
@@ -59,13 +59,17 @@ set_target_properties(adios2_py PROPERTIES
 
 set(install_location "${CMAKE_INSTALL_PYTHONDIR}/adios2")
 if (ADIOS2_USE_PIP)
-  set(install_location ${CMAKE_INSTALL_LIBDIR})
+  set(install_location adios2)
 endif()
 
 string(REGEX REPLACE "[^/]+" ".." relative_base "${install_location}/bindings")
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   set_property(TARGET adios2_py APPEND PROPERTY
     INSTALL_RPATH "$ORIGIN/${relative_base}/${CMAKE_INSTALL_LIBDIR}"
+  )
+elseif(APPLE)
+  set_property(TARGET adios2_py APPEND PROPERTY
+    INSTALL_RPATH "@loader_path/${relative_base}/${CMAKE_INSTALL_LIBDIR}"
   )
 endif()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ Changelog = "https://github.com/ornladios/ADIOS2/releases"
 test-command = "python -m unittest adios2.test.simple_read_write.TestSimpleReadWrite"
 
 [tool.scikit-build]
-wheel.packages = ["adios2"]
+wheel.packages = ["python/adios2"]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -9,10 +9,10 @@ add_custom_target(python_api ALL COMMAND ${CMAKE_COMMAND} -E copy_directory
 
 set(install_location ${CMAKE_INSTALL_PYTHONDIR}/adios2)
 if (ADIOS2_USE_PIP)
-  set(install_location ${CMAKE_INSTALL_LIBDIR})
+  set(install_location adios2)
 endif()
 
-install(DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/adios2/
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/adios2/
   DESTINATION ${install_location}
   COMPONENT adios2_python-python
   ${ADIOS2_MAYBE_EXCLUDE_FROM_ALL}


### PR DESCRIPTION
This is needed since it adds a simple import test for both our sdist and wheels in macos and linux. Windows seems to have problems that I do not have time to solve know, I will open a PR later to fix the windows sdist installation.

This incidentally fixes an issue with the macos sdist. We will probably to start making wheels for all the platforms, but lets wait for the nanobind transition so that we can reduce the number of wheels using abi3 compat