### PR TITLE
reuse: add REUSE compliance

### DIFF
--- a/.e4s/e4s.yaml
+++ b/.e4s/e4s.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 - e4s_product: adios2
   version: 0.1.0
   website: https://github.com/ornladios/adios2

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ---
 name: Bug report
 about: Create a report to help us improve

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ---
 name: Feature request
 about: Propose a new feature

--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 <!--
   Replace the following vars with its corresponding values:
   - @VERSION@ (example 2.9.0)

--- a/.github/actions/save-context-artifacts/action.yml
+++ b/.github/actions/save-context-artifacts/action.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Upload Contexts
 description: Dump GitHub Action CI contexts and upload as artifacts
 runs:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 version: 2
 enable-beta-ecosystems: true
 updates:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Backport PR
 
 on:

--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #######################################
 # Ideally this would be done in seperate workflows but placing them all
 # in one is currently necessary to enforce job dependencies

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: external
 on:
   push:

--- a/.github/workflows/pypackaging.yml
+++ b/.github/workflows/pypackaging.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Python Packaging
 
 on:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: REUSE Compliance
+
+on:
+  push:
+    branches:
+      - master
+      - 'release*'
+  pull_request:
+    branches:
+      - master
+      - 'release*'
+jobs:
+  reuse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check REUSE compliance
+        uses: fsfe/reuse-action@v5

--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: OpenSSF Scorecard
 on:
   branch_protection_rule:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: 'Close stale issues and PRs'
 on:
   schedule:

--- a/.gitlab/config/SpackCIBridge.py
+++ b/.gitlab/config/SpackCIBridge.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import atexit
 import base64

--- a/.gitlab/config/ccache.cmake
+++ b/.gitlab/config/ccache.cmake
@@ -1,12 +1,7 @@
-##============================================================================
-##  Copyright (c) Kitware, Inc.
-##  All rights reserved.
-##  See LICENSE.txt for details.
-##
-##  This software is distributed WITHOUT ANY WARRANTY; without even
-##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-##  PURPOSE.  See the above copyright notice for more information.
-##============================================================================
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+# Copyright (C) Kitware, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 

--- a/.gitlab/config/dynamic_pipeline.yml.in
+++ b/.gitlab/config/dynamic_pipeline.yml.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 default:
   id_tokens:
     OLCF_ID_TOKEN:

--- a/.gitlab/config/generate_pipelines.py
+++ b/.gitlab/config/generate_pipelines.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.
 #

--- a/.gitlab/config/kokkos.sh
+++ b/.gitlab/config/kokkos.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 
 WORKDIR="$1"

--- a/.gitlab/gitlab-ci-ascent.yml
+++ b/.gitlab/gitlab-ci-ascent.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Ad-hoc build that runs in the ECP Hardware, concretely in OLCF Ascent.
 .setup_env_ecpci: &setup_env_ecpci |
   module purge

--- a/.gitlab/gitlab-ci-frontier.yml
+++ b/.gitlab/gitlab-ci-frontier.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Ad-hoc build that runs in the ECP Hardware, concretely in OLCF Frontier.
 
 default:

--- a/.gitlab/gitlab-ci-spack.yml
+++ b/.gitlab/gitlab-ci-spack.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #  This file is used to define the GitLab CI/CD pipeline for the ADIOS2 project.
 default:
   interruptible: true

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,260 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: ADIOS2
+Upstream-Contact: adios@ornl.gov
+Source: https://github.com/ornladios/ADIOS2
+
+# -- thirdparty/atl --
+Files: thirdparty/atl/*
+Copyright: 2010 Georgia Tech Research Corporation
+License: BSD-3-Clause
+
+# -- thirdparty/dill --
+Files: thirdparty/dill/*
+Copyright: 2010 Georgia Tech Research Corporation
+License: BSD-3-Clause
+
+# -- thirdparty/EVPath (main) --
+Files: thirdparty/EVPath/EVPath/*
+Copyright: 2010 Georgia Tech Research Corporation
+License: BSD-3-Clause
+
+# -- thirdparty/EVPath bundled zpl-enet --
+Files: thirdparty/EVPath/EVPath/zpl-enet/*
+Copyright: 2002-2016 Lee Salzman
+           2017-2018 Vladyslav Hrytsenko, Dominik Madarász
+License: MIT
+
+# -- thirdparty/ffs --
+Files: thirdparty/ffs/*
+Copyright: 2010 Georgia Tech Research Corporation
+License: BSD-3-Clause
+
+# -- thirdparty/GTest --
+Files: thirdparty/GTest/*
+Copyright: 2008 Google Inc.
+License: BSD-3-Clause
+
+# -- thirdparty/KWSys --
+Files: thirdparty/KWSys/*
+Copyright: 2000-2016 Kitware, Inc. and Contributors
+License: BSD-3-Clause
+
+# -- thirdparty/nanobind --
+Files: thirdparty/nanobind/nanobind/*
+Copyright: 2022 Wenzel Jakob <wenzel.jakob@epfl.ch>
+License: BSD-3-Clause
+
+# -- thirdparty/nanobind bundled robin_map --
+Files: thirdparty/nanobind/nanobind/ext/robin_map/*
+Copyright: 2017 Thibaut Goetghebuer-Planchon <tessil@gmx.com>
+License: MIT
+
+# -- thirdparty/enet --
+Files: thirdparty/enet/*
+Copyright: 2002-2020 Lee Salzman
+License: MIT
+
+# -- thirdparty/nlohmann_json --
+# The amalgamated json.hpp embeds a CC0-1.0 code snippet alongside MIT code
+Files: thirdparty/nlohmann_json/*
+Copyright: 2013-2022 Niels Lohmann <http://nlohmann.me>
+License: MIT AND CC0-1.0
+
+# -- thirdparty/perfstubs --
+Files: thirdparty/perfstubs/*
+Copyright: 2019-2022 Kevin Huck and University of Oregon
+License: BSD-3-Clause
+
+# -- thirdparty/pugixml --
+Files: thirdparty/pugixml/*
+Copyright: 2006-2025 Arseny Kapoulkine <arseny.kapoulkine@gmail.com>
+License: MIT
+
+# -- thirdparty/yaml-cpp --
+Files: thirdparty/yaml-cpp/*
+Copyright: 2008-2015 Jesse Beder
+License: MIT
+
+# -- thirdparty/mingw-w64 (public domain runtime headers) --
+Files: thirdparty/mingw-w64/*
+Copyright: mingw-w64 contributors
+License: LicenseRef-public-domain
+
+# -- thirdparty CMakeLists wrappers (ADIOS2-authored) --
+Files: thirdparty/CMakeLists.txt
+       thirdparty/atl/CMakeLists.txt
+       thirdparty/dill/CMakeLists.txt
+       thirdparty/enet/CMakeLists.txt
+       thirdparty/EVPath/CMakeLists.txt
+       thirdparty/ffs/CMakeLists.txt
+       thirdparty/GTest/CMakeLists.txt
+       thirdparty/KWSys/CMakeLists.txt
+       thirdparty/mingw-w64/CMakeLists.txt
+       thirdparty/nanobind/CMakeLists.txt
+       thirdparty/nlohmann_json/CMakeLists.txt
+       thirdparty/perfstubs/CMakeLists.txt
+       thirdparty/pugixml/CMakeLists.txt
+       thirdparty/yaml-cpp/CMakeLists.txt
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- README/update scripts in thirdparty wrappers --
+Files: thirdparty/*/Readme.txt
+       thirdparty/*/update.sh
+       thirdparty/update-common.sh
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Generated/binary files in docs --
+Files: docs/*
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- readthedocs config --
+Files: readthedocs.yml
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- thirdparty root config files (ADIOS2-authored) --
+Files: thirdparty/.clang-tidy
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Root dotfiles and config files --
+Files: .clang-format
+       .clang-tidy
+       .e4s/e4s.yaml
+       .flake8
+       .git-remote-files
+       .gitattributes
+       .gitignore
+       .shellcheck_exclude_paths
+       CODEOWNERS
+       Copyright.txt
+       pyproject.toml
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- CI image config files --
+Files: scripts/ci/images/.gitignore
+       scripts/ci/images/oneAPI.repo
+       scripts/ci/cmake/adios-asan.supp
+       scripts/docker/spin-xrootd/xrootd-http.cfg
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Developer git hooks (shell scripts without extension) --
+Files: scripts/developer/git/setup-hooks
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Bindings/Matlab text files --
+Files: bindings/Matlab/HOWTO-debug.txt
+       bindings/Matlab/README.txt
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Bindings/Matlab binary test data --
+Files: bindings/Matlab/test/heat.bp
+       bindings/Matlab/test/heat.bp.dir/*
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Example XML, JSON, TOML config files --
+Files: examples/basics/queryWorker/configs/*
+       examples/hello/skeleton/*.xml
+       examples/plugins/engine/*.xml
+       examples/plugins/operator/*.xml
+       examples/simulations/GrayScott.jl/.JuliaFormatter.toml
+       examples/simulations/GrayScott.jl/Project.toml
+       examples/simulations/GrayScott.jl/examples/*.json
+       examples/simulations/GrayScott.jl/test/Project.toml
+       examples/simulations/gray-scott/*.xml
+       examples/simulations/gray-scott/catalyst/*.json
+       examples/simulations/gray-scott/simulation/*.json
+       examples/simulations/gray-scott/*.session
+       examples/simulations/gray-scott/*.session.gui
+       examples/simulations/gray-scott-struct/*.xml
+       examples/simulations/gray-scott-struct/catalyst/*.json
+       examples/simulations/gray-scott-struct/simulation/*.json
+       examples/simulations/gray-scott-struct/*.session
+       examples/simulations/gray-scott-struct/*.session.gui
+       examples/simulations/gray-scott-struct/*.json
+       examples/simulations/heatTransfer/*.xml
+       examples/useCases/fidesOneCell/*.json
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Example binary/image files --
+Files: examples/simulations/gray-scott/img/*
+       examples/simulations/gray-scott-struct/img/*
+       examples/simulations/lorenz_ode/*.svg
+       examples/useCases/fidesOneCell/*.png
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Source utility data/config files --
+Files: source/h5vol/READ.ME
+       source/utils/adios_iotest/iotest-config/*
+       source/utils/profiler/sample_data/*
+       source/utils/profiler/tests/commands
+       source/utils/profiler_simplified/data/*
+       source/utils/profiler_simplified/python_plots/*
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Testing binary data (backward compatibility BP files) --
+Files: testing/adios2/backward_compatibility/*
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Testing binary data (Python bindings) --
+Files: testing/adios2/bindings/python/heat.bp/*
+       testing/adios2/bindings/python/types_np.h5
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Testing XML config files --
+Files: testing/adios2/engine/bp/operations/*.xml
+       testing/adios2/xml/*.xml
+       testing/adios2/yaml/*.ats
+       testing/contract/lammps/adios2_config.xml
+       testing/adios2/backward_compatibility/*.xml
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Testing expected output/log files --
+Files: testing/adios2/engine/skeleton/*.txt
+       testing/adios2/engine/sst/Testing/Temporary/LastTest.log
+       testing/adios2/performance/metadata/README
+       testing/examples/heatTransfer/*.txt
+       testing/utils/bpcmp/*.txt
+       testing/utils/changingshape/*.txt
+       testing/utils/cwriter/*.txt
+       testing/utils/iotest/*.txt
+       testing/adios2/backward_compatibility/*.txt
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Testing iotest XML/config files --
+Files: testing/utils/iotest/*.xml
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Testing output archives (binary) --
+Files: testing/adios2/output_archive/zipped_output/*
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Testing install files --
+Files: testing/install/CatalystEnginePlugin/*.xml
+       testing/install/EncryptionOperator/test-public.key
+       testing/install/EncryptionOperator/test-secret.key
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0
+
+# -- Testing contract test data --
+Files: testing/contract/lammps/in.test
+       testing/contract/scorpio/*.dump
+Copyright: Oak Ridge National Laboratory and Contributors
+License: Apache-2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/CTestCustom.cmake.in
+++ b/CTestCustom.cmake.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 # Contributor's Guidelines to ADIOS 2
 
 This guide will walk you through how to submit changes to ADIOS 2 and interact

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,11 @@
+Copyright (c) <year> <owner>. 
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/LicenseRef-public-domain.txt
+++ b/LICENSES/LicenseRef-public-domain.txt
@@ -1,0 +1,2 @@
+This file has no copyright assigned and is placed in the Public Domain.
+No rights reserved. You may use, copy, modify, and distribute it freely.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Documentation](https://readthedocs.org/projects/adios2/badge/?version=latest)](https://adios2.readthedocs.io/en/latest/?badge=latest)
 [![Circle CI](https://circleci.com/gh/ornladios/ADIOS2.svg?style=shield)](https://circleci.com/gh/ornladios/ADIOS2)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 # Security Policy
 
 ## Supported Versions

--- a/bindings/C/CMakeLists.txt
+++ b/bindings/C/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/bindings/C/adios2/c/adios2_c_adios.cpp
+++ b/bindings/C/adios2/c/adios2_c_adios.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_adios.h
+++ b/bindings/C/adios2/c/adios2_c_adios.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_adios_mpi.cpp
+++ b/bindings/C/adios2/c/adios2_c_adios_mpi.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_attribute.cpp
+++ b/bindings/C/adios2/c/adios2_c_attribute.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_attribute.h
+++ b/bindings/C/adios2/c/adios2_c_attribute.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_engine.cpp
+++ b/bindings/C/adios2/c/adios2_c_engine.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_engine.h
+++ b/bindings/C/adios2/c/adios2_c_engine.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_internal.h
+++ b/bindings/C/adios2/c/adios2_c_internal.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See

--- a/bindings/C/adios2/c/adios2_c_internal.inl
+++ b/bindings/C/adios2/c/adios2_c_internal.inl
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See

--- a/bindings/C/adios2/c/adios2_c_io.cpp
+++ b/bindings/C/adios2/c/adios2_c_io.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_io.h
+++ b/bindings/C/adios2/c/adios2_c_io.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_io.tcc
+++ b/bindings/C/adios2/c/adios2_c_io.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_io_mpi.cpp
+++ b/bindings/C/adios2/c/adios2_c_io_mpi.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_operator.cpp
+++ b/bindings/C/adios2/c/adios2_c_operator.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_operator.h
+++ b/bindings/C/adios2/c/adios2_c_operator.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_types.h
+++ b/bindings/C/adios2/c/adios2_c_types.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_variable.cpp
+++ b/bindings/C/adios2/c/adios2_c_variable.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2/c/adios2_c_variable.h
+++ b/bindings/C/adios2/c/adios2_c_variable.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/C/adios2_c.h
+++ b/bindings/C/adios2_c.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/bindings/CXX/CMakeLists.txt
+++ b/bindings/CXX/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/bindings/CXX/adios2.h
+++ b/bindings/CXX/adios2.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/ADIOS.cpp
+++ b/bindings/CXX/adios2/cxx/ADIOS.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/ADIOS.h
+++ b/bindings/CXX/adios2/cxx/ADIOS.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/ADIOS.inl
+++ b/bindings/CXX/adios2/cxx/ADIOS.inl
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/ADIOSMPI.cpp
+++ b/bindings/CXX/adios2/cxx/ADIOSMPI.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/ADIOSView.h
+++ b/bindings/CXX/adios2/cxx/ADIOSView.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_BINDINGS_CXX_CXX_ADIOS_VIEW_H_
 #define ADIOS2_BINDINGS_CXX_CXX_ADIOS_VIEW_H_
 

--- a/bindings/CXX/adios2/cxx/Attribute.cpp
+++ b/bindings/CXX/adios2/cxx/Attribute.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Attribute.h
+++ b/bindings/CXX/adios2/cxx/Attribute.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Engine.cpp
+++ b/bindings/CXX/adios2/cxx/Engine.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Engine.h
+++ b/bindings/CXX/adios2/cxx/Engine.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Engine.tcc
+++ b/bindings/CXX/adios2/cxx/Engine.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Group.cpp
+++ b/bindings/CXX/adios2/cxx/Group.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Group.h
+++ b/bindings/CXX/adios2/cxx/Group.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Group.tcc
+++ b/bindings/CXX/adios2/cxx/Group.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/IO.cpp
+++ b/bindings/CXX/adios2/cxx/IO.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/IO.h
+++ b/bindings/CXX/adios2/cxx/IO.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/IO.tcc
+++ b/bindings/CXX/adios2/cxx/IO.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/IOMPI.cpp
+++ b/bindings/CXX/adios2/cxx/IOMPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/KokkosView.h
+++ b/bindings/CXX/adios2/cxx/KokkosView.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_BINDINGS_CXX_CXX_KOKKOS_VIEW_H_
 #define ADIOS2_BINDINGS_CXX_CXX_KOKKOS_VIEW_H_
 

--- a/bindings/CXX/adios2/cxx/Operator.cpp
+++ b/bindings/CXX/adios2/cxx/Operator.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Operator.h
+++ b/bindings/CXX/adios2/cxx/Operator.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Query.cpp
+++ b/bindings/CXX/adios2/cxx/Query.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "Query.h"
 #include "adios2/toolkit/query/Worker.h"
 

--- a/bindings/CXX/adios2/cxx/Query.h
+++ b/bindings/CXX/adios2/cxx/Query.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Selection.cpp
+++ b/bindings/CXX/adios2/cxx/Selection.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Selection.h
+++ b/bindings/CXX/adios2/cxx/Selection.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Types.cpp
+++ b/bindings/CXX/adios2/cxx/Types.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Types.h
+++ b/bindings/CXX/adios2/cxx/Types.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Types.tcc
+++ b/bindings/CXX/adios2/cxx/Types.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Variable.cpp
+++ b/bindings/CXX/adios2/cxx/Variable.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Variable.h
+++ b/bindings/CXX/adios2/cxx/Variable.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/Variable.tcc
+++ b/bindings/CXX/adios2/cxx/Variable.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/VariableDerived.cpp
+++ b/bindings/CXX/adios2/cxx/VariableDerived.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "VariableDerived.h"
 
 #include "adios2/core/VariableDerived.h"

--- a/bindings/CXX/adios2/cxx/VariableDerived.h
+++ b/bindings/CXX/adios2/cxx/VariableDerived.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_BINDINGS_CXX_VARIABLE_DERIVED_H_
 #define ADIOS2_BINDINGS_CXX_VARIABLE_DERIVED_H_
 

--- a/bindings/CXX/adios2/cxx/VariableNT.cpp
+++ b/bindings/CXX/adios2/cxx/VariableNT.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/VariableNT.h
+++ b/bindings/CXX/adios2/cxx/VariableNT.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/fstream/ADIOS2fstream.cpp
+++ b/bindings/CXX/adios2/cxx/fstream/ADIOS2fstream.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/fstream/ADIOS2fstream.h
+++ b/bindings/CXX/adios2/cxx/fstream/ADIOS2fstream.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/fstream/ADIOS2fstream.tcc
+++ b/bindings/CXX/adios2/cxx/fstream/ADIOS2fstream.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/adios2/cxx/fstream/ADIOS2fstreamMPI.cpp
+++ b/bindings/CXX/adios2/cxx/fstream/ADIOS2fstreamMPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/CXX/cxx11_wrapper.h.in
+++ b/bindings/CXX/cxx11_wrapper.h.in
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/CMakeLists.txt
+++ b/bindings/Fortran/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/bindings/Fortran/f2c/adios2_f2c_adios.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_adios.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/f2c/adios2_f2c_adios_mpi.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_adios_mpi.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/f2c/adios2_f2c_attribute.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_attribute.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/f2c/adios2_f2c_common.h
+++ b/bindings/Fortran/f2c/adios2_f2c_common.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/f2c/adios2_f2c_engine.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_engine.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/f2c/adios2_f2c_io.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_io.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/f2c/adios2_f2c_io_mpi.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_io_mpi.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/f2c/adios2_f2c_operator.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_operator.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/f2c/adios2_f2c_variable.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_variable.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Fortran/modules/adios2_adios_init_mod.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_mod.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_adios_init_mpi_smod.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_mpi_smod.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_adios_init_serial_smod.F90
+++ b/bindings/Fortran/modules/adios2_adios_init_serial_smod.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_adios_mod.f90
+++ b/bindings/Fortran/modules/adios2_adios_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_attribute_data_mod.f90
+++ b/bindings/Fortran/modules/adios2_attribute_data_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_attribute_mod.f90
+++ b/bindings/Fortran/modules/adios2_attribute_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_engine_begin_step_mod.f90
+++ b/bindings/Fortran/modules/adios2_engine_begin_step_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_engine_get_mod.f90
+++ b/bindings/Fortran/modules/adios2_engine_get_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_engine_mod.f90
+++ b/bindings/Fortran/modules/adios2_engine_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_engine_put_mod.f90
+++ b/bindings/Fortran/modules/adios2_engine_put_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_functions_allocate_mod.f90
+++ b/bindings/Fortran/modules/adios2_functions_allocate_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 module adios2_functions_allocate_mod
     implicit none
 

--- a/bindings/Fortran/modules/adios2_functions_mod.f90
+++ b/bindings/Fortran/modules/adios2_functions_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_io_define_attribute_mod.f90
+++ b/bindings/Fortran/modules/adios2_io_define_attribute_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_io_define_derived_variable_mod.f90
+++ b/bindings/Fortran/modules/adios2_io_define_derived_variable_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_io_define_variable_mod.f90
+++ b/bindings/Fortran/modules/adios2_io_define_variable_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_io_mod.f90
+++ b/bindings/Fortran/modules/adios2_io_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_io_open_mod.F90
+++ b/bindings/Fortran/modules/adios2_io_open_mod.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_io_open_mpi_smod.F90
+++ b/bindings/Fortran/modules/adios2_io_open_mpi_smod.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_io_open_serial_smod.F90
+++ b/bindings/Fortran/modules/adios2_io_open_serial_smod.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_mod.f90
+++ b/bindings/Fortran/modules/adios2_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_operator_mod.f90
+++ b/bindings/Fortran/modules/adios2_operator_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_parameters_mod.f90
+++ b/bindings/Fortran/modules/adios2_parameters_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_variable_max_mod.f90
+++ b/bindings/Fortran/modules/adios2_variable_max_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_variable_min_mod.f90
+++ b/bindings/Fortran/modules/adios2_variable_min_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/adios2_variable_mod.f90
+++ b/bindings/Fortran/modules/adios2_variable_mod.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/contains/adios2_engine_get.f90
+++ b/bindings/Fortran/modules/contains/adios2_engine_get.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/contains/adios2_engine_get_by_name.f90
+++ b/bindings/Fortran/modules/contains/adios2_engine_get_by_name.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/contains/adios2_engine_get_deferred.f90
+++ b/bindings/Fortran/modules/contains/adios2_engine_get_deferred.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/contains/adios2_engine_get_deferred_by_name.f90
+++ b/bindings/Fortran/modules/contains/adios2_engine_get_deferred_by_name.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/contains/adios2_engine_put.f90
+++ b/bindings/Fortran/modules/contains/adios2_engine_put.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/contains/adios2_engine_put_by_name.f90
+++ b/bindings/Fortran/modules/contains/adios2_engine_put_by_name.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/contains/adios2_engine_put_deferred.f90
+++ b/bindings/Fortran/modules/contains/adios2_engine_put_deferred.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Fortran/modules/contains/adios2_engine_put_deferred_by_name.f90
+++ b/bindings/Fortran/modules/contains/adios2_engine_put_deferred_by_name.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 !  accompanying file Copyright.txt for details.

--- a/bindings/Matlab/Makefile
+++ b/bindings/Matlab/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ###  CORI
 ADIOS_DIR=/global/homes/p/pnorbert/adios/master/login
 #ADIOS_LIBS=-Wl,-rpath=${ADIOS_DIR}/lib64 -L${ADIOS_DIR}/lib64 -ladios2 

--- a/bindings/Matlab/adios.m
+++ b/bindings/Matlab/adios.m
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 function adios()
 %ADIOS Reader for the ADIOS BP file format
 %   

--- a/bindings/Matlab/adiosclose.m
+++ b/bindings/Matlab/adiosclose.m
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 function adiosclose(varargin)
 %ADIOSCLOSE Close an ADIOS BP file.
 %   

--- a/bindings/Matlab/adiosclosec.c
+++ b/bindings/Matlab/adiosclosec.c
@@ -1,8 +1,8 @@
 /*
- * ADIOS is freely available under the terms of the BSD license described
- * in the COPYING file in the top level directory of this source distribution.
+ * Copyright (C) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
  *
- * Copyright (c) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /*=================================================================

--- a/bindings/Matlab/adiosload.m
+++ b/bindings/Matlab/adiosload.m
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 function adiosload(file, prefix)
 %ADIOSLOAD Read all variables in an ADIOS BP file
 %

--- a/bindings/Matlab/adiosopen.m
+++ b/bindings/Matlab/adiosopen.m
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 function info = adiosopen(varargin)
 %ADIOSOPEN Open an ADIOS BP file and provide information on it.
 %   

--- a/bindings/Matlab/adiosopenc.c
+++ b/bindings/Matlab/adiosopenc.c
@@ -1,8 +1,8 @@
 /*
- * ADIOS is freely available under the terms of the BSD license described
- * in the COPYING file in the top level directory of this source distribution.
+ * Copyright (C) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
  *
- * Copyright (c) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /*=================================================================

--- a/bindings/Matlab/adiosread.m
+++ b/bindings/Matlab/adiosread.m
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 function [data, attributes] = adiosread(varargin)
 %ADIOSREAD Read data from an ADIOS BP file.
 %   

--- a/bindings/Matlab/adiosreadc.c
+++ b/bindings/Matlab/adiosreadc.c
@@ -1,8 +1,8 @@
 /*
- * ADIOS is freely available under the terms of the BSD license described
- * in the COPYING file in the top level directory of this source distribution.
+ * Copyright (C) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
  *
- * Copyright (c) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /*=================================================================

--- a/bindings/Matlab/test/TestADIOSRead.m
+++ b/bindings/Matlab/test/TestADIOSRead.m
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 function TestADIOSRead(verbose)
 if (nargin == 0)
     verbose = 0;

--- a/bindings/Matlab/test/test1_read.m
+++ b/bindings/Matlab/test/test1_read.m
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 function test1_read(verbose)
 if (nargin == 0)
     verbose = 0;

--- a/bindings/Matlab/test/test1_read.py
+++ b/bindings/Matlab/test/test1_read.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/bindings/Matlab/test/test1_read_hl.py
+++ b/bindings/Matlab/test/test1_read_hl.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/bindings/Matlab/test/test1_write.py
+++ b/bindings/Matlab/test/test1_write.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/bindings/Matlab/test/test1_write_hl.py
+++ b/bindings/Matlab/test/test1_write_hl.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/bindings/Python/CMakeLists.txt
+++ b/bindings/Python/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if(ADIOS2_USE_PythonStableABI)
   set(maybe_adios2_py_stable_abi STABLE_ABI)
 else()

--- a/bindings/Python/__init__.py.in
+++ b/bindings/Python/__init__.py.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .adios2_bindings@ADIOS2_LIBRARY_SUFFIX@ import *
 
 __version__ = "@ADIOS2_VERSION@"

--- a/bindings/Python/nbADIOS.cpp
+++ b/bindings/Python/nbADIOS.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbADIOS.h
+++ b/bindings/Python/nbADIOS.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbADIOSMPI.cpp
+++ b/bindings/Python/nbADIOSMPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbAttribute.cpp
+++ b/bindings/Python/nbAttribute.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbAttribute.h
+++ b/bindings/Python/nbAttribute.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbEngine.cpp
+++ b/bindings/Python/nbEngine.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbEngine.h
+++ b/bindings/Python/nbEngine.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbGlue.cpp
+++ b/bindings/Python/nbGlue.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbIO.cpp
+++ b/bindings/Python/nbIO.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbIO.h
+++ b/bindings/Python/nbIO.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbIOMPI.cpp
+++ b/bindings/Python/nbIOMPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbOperator.cpp
+++ b/bindings/Python/nbOperator.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbOperator.h
+++ b/bindings/Python/nbOperator.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbQuery.cpp
+++ b/bindings/Python/nbQuery.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbQuery.h
+++ b/bindings/Python/nbQuery.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbTypes.h
+++ b/bindings/Python/nbTypes.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbVariable.cpp
+++ b/bindings/Python/nbVariable.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbVariable.h
+++ b/bindings/Python/nbVariable.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbVariableDerived.cpp
+++ b/bindings/Python/nbVariableDerived.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/nbVariableDerived.h
+++ b/bindings/Python/nbVariableDerived.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/bindings/Python/test/simple_read_write.py
+++ b/bindings/Python/test/simple_read_write.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2 import *
 import adios2.bindings as bindings
 

--- a/bindings/Python/usercustomize.py.in
+++ b/bindings/Python/usercustomize.py.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """This script is used to setup the testing environment for the project."""
 
 import sys

--- a/cmake/ADIOSBisonFlexSub.cmake
+++ b/cmake/ADIOSBisonFlexSub.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FUNCTION (SETUP_ADIOS_BISON_FLEX_SUB)
 
 set (BISON_FLEX_PRECOMPILE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/toolkit/derived/parser/pregen-source")

--- a/cmake/ADIOSFunctions.cmake
+++ b/cmake/ADIOSFunctions.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/CMakeFindDependencyMacro.cmake
+++ b/cmake/CMakeFindDependencyMacro.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/CheckTypeRepresentation.cmake
+++ b/cmake/CheckTypeRepresentation.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/cmake/CheckTypeRepresentationCompile.c.in
+++ b/cmake/CheckTypeRepresentationCompile.c.in
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @headers@
 
 #undef KEY

--- a/cmake/CheckTypeRepresentationCompile.f.in
+++ b/cmake/CheckTypeRepresentationCompile.f.in
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program check_type_representation_compile
   type check_type_representation_info
     character(len=16) :: header = "16 byte header ["

--- a/cmake/CheckTypeRepresentationRun.c.in
+++ b/cmake/CheckTypeRepresentationRun.c.in
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @headers@
 
 #include <stdio.h>

--- a/cmake/DetectOptions.cmake
+++ b/cmake/DetectOptions.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/EmptyDir.cmake
+++ b/cmake/EmptyDir.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if(NOT DIR_NAME)
   message(FATAL_ERROR "DIR_NAME is not defined")
 endif()

--- a/cmake/FindBZip2.cmake
+++ b/cmake/FindBZip2.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindCaliper.cmake
+++ b/cmake/FindCaliper.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindCrayDRC.cmake
+++ b/cmake/FindCrayDRC.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ######################################################
 # - Try to find craydrc (http://directory.fsf.org/wiki/Libfabric)
 # Once done this will define

--- a/cmake/FindDAOS.cmake
+++ b/cmake/FindDAOS.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindDataSpaces.cmake
+++ b/cmake/FindDataSpaces.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindIME.cmake
+++ b/cmake/FindIME.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindLIBFABRIC.cmake
+++ b/cmake/FindLIBFABRIC.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ######################################################
 # - Try to find libfabric (http://directory.fsf.org/wiki/Libfabric)
 # Once done this will define

--- a/cmake/FindMPI.cmake
+++ b/cmake/FindMPI.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindPkgConfig.cmake
+++ b/cmake/FindPkgConfig.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindSZ.cmake
+++ b/cmake/FindSZ.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindSodium.cmake
+++ b/cmake/FindSodium.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Written in 2016 by Henrik Steffen Gaßmann <henrik@gassmann.onl>
 #
 # To the extent possible under law, the author(s) have dedicated all

--- a/cmake/FindUCX.cmake
+++ b/cmake/FindUCX.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/FindZeroMQ.cmake
+++ b/cmake/FindZeroMQ.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/Findpugixml.cmake
+++ b/cmake/Findpugixml.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(FindPackageHandleStandardArgs)
 
 function(__pugixml_get_version)

--- a/cmake/GoogleTest.cmake
+++ b/cmake/GoogleTest.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/Internal/FloatRepresentationTable.cmake
+++ b/cmake/Internal/FloatRepresentationTable.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/cmake/SSTFunctions.cmake
+++ b/cmake/SSTFunctions.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/adios2-config-common.cmake.in
+++ b/cmake/adios2-config-common.cmake.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if(POLICY CMP0028)
   cmake_policy(SET CMP0028 NEW)
 endif()

--- a/cmake/adios2-config-install.cmake.in
+++ b/cmake/adios2-config-install.cmake.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_policy(PUSH)
 cmake_policy(VERSION 3.12)
 

--- a/cmake/adios2-config.cmake.in
+++ b/cmake/adios2-config.cmake.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(_ADIOS2_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
 list(INSERT CMAKE_MODULE_PATH 0 "@ADIOS2_SOURCE_DIR@/cmake")
 

--- a/cmake/check_libfabric_cxi.c
+++ b/cmake/check_libfabric_cxi.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <stdbool.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_cxi_ext.h>

--- a/cmake/install/packaging/CMakeLists.txt
+++ b/cmake/install/packaging/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/cmake/install/post/CMakeLists.txt
+++ b/cmake/install/post/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if(ADIOS2_HAVE_Fortran)
   set(ADIOS2_CONFIG_FORTRAN 1)
 else()

--- a/cmake/install/post/adios2-config-dummy/CMakeLists.txt
+++ b/cmake/install/post/adios2-config-dummy/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.12)
 
 project(adios2-config-dummy C CXX)

--- a/cmake/install/post/adios2-config-dummy/foo.F90
+++ b/cmake/install/post/adios2-config-dummy/foo.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 subroutine foo
 #ifdef WITH_ADIOS2
   use adios2

--- a/cmake/install/post/adios2-config-dummy/foo.c
+++ b/cmake/install/post/adios2-config-dummy/foo.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifdef WITH_ADIOS2
 #include <adios2_c.h>
 #if ADIOS2_USE_MPI

--- a/cmake/install/post/adios2-config-dummy/foo.cxx
+++ b/cmake/install/post/adios2-config-dummy/foo.cxx
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifdef WITH_ADIOS2
 #include <adios2.h>
 #endif

--- a/cmake/install/post/adios2-config-dummy/foo.h
+++ b/cmake/install/post/adios2-config-dummy/foo.h
@@ -1,1 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 void foo(void);

--- a/cmake/install/post/adios2-config-dummy/main.c
+++ b/cmake/install/post/adios2-config-dummy/main.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "foo.h"
 
 int main(int argc, char **argv)

--- a/cmake/install/post/adios2-config-dummy/main.cxx
+++ b/cmake/install/post/adios2-config-dummy/main.cxx
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "foo.h"
 
 int main(int argc, char **argv)

--- a/cmake/install/post/adios2-config-dummy/main.f90
+++ b/cmake/install/post/adios2-config-dummy/main.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program main
   call foo()
 end program main

--- a/cmake/install/post/adios2-config.post.sh.in
+++ b/cmake/install/post/adios2-config.post.sh.in
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 function usage() {
   echo "adios2-config [OPTION]"

--- a/cmake/install/post/adios2-config.pre.sh.in
+++ b/cmake/install/post/adios2-config.pre.sh.in
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ADIOS2_PREFIX=$(perl -MCwd -e 'print Cwd::abs_path shift' $(dirname ${BASH_SOURCE})/..)
 

--- a/cmake/install/post/generate-adios2-config.sh.in
+++ b/cmake/install/post/generate-adios2-config.sh.in
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Disable the make jobserver???
 unset MAKEFLAGS
 unset MAKE

--- a/cmake/install/pre/CMakeLists.txt
+++ b/cmake/install/pre/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 install(CODE "
   message(\"Pre-installation cleanup of CMake files\")
   file(REMOVE_RECURSE \"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_CMAKEDIR}\")

--- a/cmake/upstream/CMakeFindDependencyMacro.cmake
+++ b/cmake/upstream/CMakeFindDependencyMacro.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/cmake/upstream/FindBZip2.cmake
+++ b/cmake/upstream/FindBZip2.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/cmake/upstream/FindHDF5.cmake
+++ b/cmake/upstream/FindHDF5.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/cmake/upstream/FindMPI.cmake
+++ b/cmake/upstream/FindMPI.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/cmake/upstream/FindMPI/fortranparam_mpi.f90.in
+++ b/cmake/upstream/FindMPI/fortranparam_mpi.f90.in
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
       program mpi_ver
       @MPI_Fortran_INCLUDE_LINE@
       print *, 'INFO:SUBARRAYS[', MPI_SUBARRAYS_SUPPORTED, ']-ASYNCPROT[', MPI_ASYNC_PROTECTS_NONBLOCKING, ']'

--- a/cmake/upstream/FindMPI/libver_mpi.c
+++ b/cmake/upstream/FindMPI/libver_mpi.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <mpi.h>
 
 #ifdef __cplusplus

--- a/cmake/upstream/FindMPI/libver_mpi.f90.in
+++ b/cmake/upstream/FindMPI/libver_mpi.f90.in
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
       program mpi_ver
       @MPI_Fortran_INCLUDE_LINE@
       character(len=MPI_MAX_LIBRARY_VERSION_STRING) :: mpilibver_str

--- a/cmake/upstream/FindMPI/mpiver.f90.in
+++ b/cmake/upstream/FindMPI/mpiver.f90.in
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
       program mpi_ver
       @MPI_Fortran_INCLUDE_LINE@
       integer(kind=kind(MPI_VERSION)), parameter :: zero = ichar('0')

--- a/cmake/upstream/FindMPI/test_mpi.c
+++ b/cmake/upstream/FindMPI/test_mpi.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <mpi.h>
 
 #ifdef __cplusplus

--- a/cmake/upstream/FindMPI/test_mpi.f90.in
+++ b/cmake/upstream/FindMPI/test_mpi.f90.in
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
       program hello
       @MPI_Fortran_INCLUDE_LINE@
       integer@MPI_Fortran_INTEGER_LINE@ ierror

--- a/cmake/upstream/FindPkgConfig.cmake
+++ b/cmake/upstream/FindPkgConfig.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/cmake/upstream/FindPython.cmake
+++ b/cmake/upstream/FindPython.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/cmake/upstream/FindPython/Support.cmake
+++ b/cmake/upstream/FindPython/Support.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/cmake/upstream/GoogleTest.cmake
+++ b/cmake/upstream/GoogleTest.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/developer_docs/bp5format.md
+++ b/developer_docs/bp5format.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 # BP5 Metadata Marshaling, writer-side focus
 
 BP5 Metadata Marshalling is based upon FFS, which provides the ability

--- a/developer_docs/bp5reader.md
+++ b/developer_docs/bp5reader.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 # BP5 Metadata handling, reader-side focus
 
 This document is to read in the context of [BP5 Metadata

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/ReadMe.md
+++ b/examples/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 # ADIOS2 Examples
 
 This directory contains examples of how to use ADIOS2 in different scenarios.

--- a/examples/basics/CMakeLists.txt
+++ b/examples/basics/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/basics/ReadMe.md
+++ b/examples/basics/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ## ADIOS2 basics examples
 
 The _basics_ examples are meant to introduce you to basic concepts of ADIOS2, such as

--- a/examples/basics/globalArray1D/CMakeLists.txt
+++ b/examples/basics/globalArray1D/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/basics/globalArray1D/decomp.F90
+++ b/examples/basics/globalArray1D/decomp.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 ! Helper functions for all examples
 module decomp
 contains

--- a/examples/basics/globalArray1D/decomp.c
+++ b/examples/basics/globalArray1D/decomp.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/globalArray1D/decomp.h
+++ b/examples/basics/globalArray1D/decomp.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/globalArray1D/globalArray1DRead.F90
+++ b/examples/basics/globalArray1D/globalArray1DRead.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program adios2_global_array_1d_read
     use mpivars
     use adios2

--- a/examples/basics/globalArray1D/globalArray1DRead.c
+++ b/examples/basics/globalArray1D/globalArray1DRead.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/globalArray1D/globalArray1DWrite.F90
+++ b/examples/basics/globalArray1D/globalArray1DWrite.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program adios2_global_array_1d_write
     use mpivars
     use adios2

--- a/examples/basics/globalArray1D/globalArray1DWrite.c
+++ b/examples/basics/globalArray1D/globalArray1DWrite.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/globalArray1D/mpivars.F90
+++ b/examples/basics/globalArray1D/mpivars.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 module mpivars
     implicit none
     include 'mpif.h'

--- a/examples/basics/globalArray1D/mpivars.c
+++ b/examples/basics/globalArray1D/mpivars.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/globalArray1D/mpivars.h
+++ b/examples/basics/globalArray1D/mpivars.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/globalArrayND/CMakeLists.txt
+++ b/examples/basics/globalArrayND/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/basics/globalArrayND/globalArrayNDWrite.cpp
+++ b/examples/basics/globalArrayND/globalArrayNDWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/globalArrayND/global_array_read_deferred.py
+++ b/examples/basics/globalArrayND/global_array_read_deferred.py
@@ -1,5 +1,9 @@
 #!/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Demonstrating deferred read
 # multiple f.read(...) can be scheduled and executed once by
 # f.read_complete()

--- a/examples/basics/joinedArray/CMakeLists.txt
+++ b/examples/basics/joinedArray/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/basics/joinedArray/joinedArray.py
+++ b/examples/basics/joinedArray/joinedArray.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Demonstrates writing joined array with ADIOS.
 # Joined Array is a Global Array, where in one dimension we don't need to

--- a/examples/basics/joinedArray/joinedArrayWrite.cpp
+++ b/examples/basics/joinedArray/joinedArrayWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/localArray/CMakeLists.txt
+++ b/examples/basics/localArray/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/basics/localArray/localArrayRead.cpp
+++ b/examples/basics/localArray/localArrayRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/localArray/localArrayWrite.cpp
+++ b/examples/basics/localArray/localArrayWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/queryWorker/CMakeLists.txt
+++ b/examples/basics/queryWorker/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/basics/queryWorker/ReadMe.md
+++ b/examples/basics/queryWorker/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ### ADIOS2 queryWorker example
 
 The _queryWorker_ example demonstrates how to read variables using ADIOS2's BP engine

--- a/examples/basics/queryWorker/queryWorker.cpp
+++ b/examples/basics/queryWorker/queryWorker.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "adios2.h"
 #include <mpi.h>
 

--- a/examples/basics/values/CMakeLists.txt
+++ b/examples/basics/values/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/basics/values/mpivars.F90
+++ b/examples/basics/values/mpivars.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 module mpivars
     implicit none
     include 'mpif.h'

--- a/examples/basics/values/values.F90
+++ b/examples/basics/values/values.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program adios2_values
     use mpivars
     use adios2

--- a/examples/basics/values/values.py
+++ b/examples/basics/values/values.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Demonstrates writing Values (single element variables) with ADIOS
 # GlobalValue:  a single value written by one process

--- a/examples/basics/values/valuesWrite.cpp
+++ b/examples/basics/values/valuesWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/variablesShapes/CMakeLists.txt
+++ b/examples/basics/variablesShapes/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/basics/variablesShapes/variablesShapes.cpp
+++ b/examples/basics/variablesShapes/variablesShapes.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/basics/variablesShapes/variablesShapes_hl.cpp
+++ b/examples/basics/variablesShapes/variablesShapes_hl.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/campaign/CMakeLists.txt
+++ b/examples/campaign/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/campaign/campaign_many_files.py
+++ b/examples/campaign/campaign_many_files.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy
 import adios2
 

--- a/examples/campaign/campaign_many_files.sh
+++ b/examples/campaign/campaign_many_files.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Add to PYTHONPATH the location of the campaign manager scripts
 
 python3 ./campaign_many_files.py

--- a/examples/campaign/campaign_write.cpp
+++ b/examples/campaign/campaign_write.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/CMakeLists.txt
+++ b/examples/hello/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/ReadMe.md
+++ b/examples/hello/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ## ADIOS2 hello examples
 
 The _hello_ examples are meant to introduce you to ADIOS2's IO capabilities and engines.

--- a/examples/hello/bpAttributeWriteRead/CMakeLists.txt
+++ b/examples/hello/bpAttributeWriteRead/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpAttributeWriteRead/bpAttributeWriteRead.cpp
+++ b/examples/hello/bpAttributeWriteRead/bpAttributeWriteRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpAttributeWriteRead/bpAttributeWriteRead_tutorialSkeleton.cpp
+++ b/examples/hello/bpAttributeWriteRead/bpAttributeWriteRead_tutorialSkeleton.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpFWriteCRead/CMakeLists.txt
+++ b/examples/hello/bpFWriteCRead/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpFWriteCRead/CppReader.cpp
+++ b/examples/hello/bpFWriteCRead/CppReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpFWriteCRead/CppWriter.cpp
+++ b/examples/hello/bpFWriteCRead/CppWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpFWriteCRead/FReader.f90
+++ b/examples/hello/bpFWriteCRead/FReader.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program FReader
     use mpi
     use adios2

--- a/examples/hello/bpFWriteCRead/FWriter.f90
+++ b/examples/hello/bpFWriteCRead/FWriter.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program FWriter
     use mpi
     use adios2

--- a/examples/hello/bpFlushWriter/CMakeLists.txt
+++ b/examples/hello/bpFlushWriter/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpFlushWriter/bpFlushWriter.cpp
+++ b/examples/hello/bpFlushWriter/bpFlushWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpFlushWriter/bpFlushWriter_nompi.cpp
+++ b/examples/hello/bpFlushWriter/bpFlushWriter_nompi.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpOperatorSZWriter/CMakeLists.txt
+++ b/examples/hello/bpOperatorSZWriter/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpOperatorSZWriter/bpOperatorSZWriter.cpp
+++ b/examples/hello/bpOperatorSZWriter/bpOperatorSZWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpOperatorSZWriter/bpOperatorSZWriter_tutorialSkeleton.cxx
+++ b/examples/hello/bpOperatorSZWriter/bpOperatorSZWriter_tutorialSkeleton.cxx
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpReader/CMakeLists.txt
+++ b/examples/hello/bpReader/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpReader/bpReader.cpp
+++ b/examples/hello/bpReader/bpReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpReader/bpReaderHeatMap2D-bindings.py
+++ b/examples/hello/bpReader/bpReaderHeatMap2D-bindings.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpReader/bpReaderHeatMap2D.cpp
+++ b/examples/hello/bpReader/bpReaderHeatMap2D.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpReader/bpReaderHeatMap2D.py
+++ b/examples/hello/bpReader/bpReaderHeatMap2D.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpReader/bpReaderHeatMap3D.F90
+++ b/examples/hello/bpReader/bpReaderHeatMap3D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program bpReaderHeatMap3D
 #if ADIOS2_USE_MPI
     use mpi

--- a/examples/hello/bpReader/bpReaderHeatMap3D.cpp
+++ b/examples/hello/bpReader/bpReaderHeatMap3D.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpReader/bpReader_tutorialSkeleton.cpp
+++ b/examples/hello/bpReader/bpReader_tutorialSkeleton.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpStepsWriteRead/CMakeLists.txt
+++ b/examples/hello/bpStepsWriteRead/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpStepsWriteRead/bpStepsWriteRead.cpp
+++ b/examples/hello/bpStepsWriteRead/bpStepsWriteRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpStepsWriteRead/bpStepsWriteRead_tutorialSkeleton.cxx
+++ b/examples/hello/bpStepsWriteRead/bpStepsWriteRead_tutorialSkeleton.cxx
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
 * Distributed under the OSI-approved Apache License, Version 2.0.  See
 * accompanying file Copyright.txt for details.
 *

--- a/examples/hello/bpStepsWriteReadCuda/CMakeLists.txt
+++ b/examples/hello/bpStepsWriteReadCuda/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCBindings.cu
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCBindings.cu
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCuda.cu
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCuda.cu
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCupy-bindings.py
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCupy-bindings.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import cupy as cp
 from adios2 import FileReader

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCupy.py
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadCupy.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import cupy as cp
 from adios2 import Stream

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadTorch-bindings.py
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadTorch-bindings.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 from adios2 import FileReader

--- a/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadTorch.py
+++ b/examples/hello/bpStepsWriteReadCuda/bpStepsWriteReadTorch.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 from adios2 import Stream, FileReader

--- a/examples/hello/bpStepsWriteReadDerived/CMakeLists.txt
+++ b/examples/hello/bpStepsWriteReadDerived/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpStepsWriteReadDerived/bpStepsWriteReadDerived.cpp
+++ b/examples/hello/bpStepsWriteReadDerived/bpStepsWriteReadDerived.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpStepsWriteReadHip/CMakeLists.txt
+++ b/examples/hello/bpStepsWriteReadHip/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpStepsWriteReadHip/bpStepsWriteReadHip.cpp
+++ b/examples/hello/bpStepsWriteReadHip/bpStepsWriteReadHip.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpStepsWriteReadKokkos/CMakeLists.txt
+++ b/examples/hello/bpStepsWriteReadKokkos/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.F90
+++ b/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMap2D
     use mpi
     use adios2

--- a/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.cpp
+++ b/examples/hello/bpStepsWriteReadKokkos/bpStepsWriteReadKokkos.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpStepsWriteReadKokkos/bpWriteReadKokkosView.cpp
+++ b/examples/hello/bpStepsWriteReadKokkos/bpWriteReadKokkosView.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpStepsWriteReadKokkos/view-cxx.cc
+++ b/examples/hello/bpStepsWriteReadKokkos/view-cxx.cc
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "flcl-cxx.hpp"
 #include <Kokkos_Core.hpp>
 

--- a/examples/hello/bpStepsWriteReadKokkos/view-f.f90
+++ b/examples/hello/bpStepsWriteReadKokkos/view-f.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 module view_f_mod
     use, intrinsic :: iso_c_binding
     use, intrinsic :: iso_fortran_env

--- a/examples/hello/bpThreadWrite/CMakeLists.txt
+++ b/examples/hello/bpThreadWrite/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpThreadWrite/bpThreadWrite.cpp
+++ b/examples/hello/bpThreadWrite/bpThreadWrite.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See

--- a/examples/hello/bpWriter/CMakeLists.txt
+++ b/examples/hello/bpWriter/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpWriter/bpPutDeferred.cpp
+++ b/examples/hello/bpWriter/bpPutDeferred.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpWriter/bpSubStreams.cpp
+++ b/examples/hello/bpWriter/bpSubStreams.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpWriter/bpWriter-bindings.py
+++ b/examples/hello/bpWriter/bpWriter-bindings.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpWriter/bpWriter.F90
+++ b/examples/hello/bpWriter/bpWriter.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program bpWriter
 #if ADIOS2_USE_MPI
     use mpi

--- a/examples/hello/bpWriter/bpWriter.c
+++ b/examples/hello/bpWriter/bpWriter.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpWriter/bpWriter.cpp
+++ b/examples/hello/bpWriter/bpWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/bpWriter/bpWriter.py
+++ b/examples/hello/bpWriter/bpWriter.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/bpWriter/bpWriter_tutorialSkeleton.cpp
+++ b/examples/hello/bpWriter/bpWriter_tutorialSkeleton.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/datamanKokkos/CMakeLists.txt
+++ b/examples/hello/datamanKokkos/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/datamanKokkos/dataManReaderKokkos.cpp
+++ b/examples/hello/datamanKokkos/dataManReaderKokkos.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2.h>
 #include <chrono>
 #include <iostream>

--- a/examples/hello/datamanKokkos/dataManWriterKokkos.cpp
+++ b/examples/hello/datamanKokkos/dataManWriterKokkos.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/datamanReader/CMakeLists.txt
+++ b/examples/hello/datamanReader/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/datamanReader/dataManReader.cpp
+++ b/examples/hello/datamanReader/dataManReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/datamanReader/dataManReader.py
+++ b/examples/hello/datamanReader/dataManReader.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/datamanWriter/CMakeLists.txt
+++ b/examples/hello/datamanWriter/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/datamanWriter/dataManWriter.cpp
+++ b/examples/hello/datamanWriter/dataManWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/datamanWriter/dataManWriter.py
+++ b/examples/hello/datamanWriter/dataManWriter.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/dataspacesReader/CMakeLists.txt
+++ b/examples/hello/dataspacesReader/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/dataspacesReader/dataSpacesReader.cpp
+++ b/examples/hello/dataspacesReader/dataSpacesReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/dataspacesWriter/CMakeLists.txt
+++ b/examples/hello/dataspacesWriter/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/dataspacesWriter/dataSpacesWriter.cpp
+++ b/examples/hello/dataspacesWriter/dataSpacesWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/deferredRead/deferred_timing_test.py
+++ b/examples/hello/deferredRead/deferred_timing_test.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/hdf5Reader/CMakeLists.txt
+++ b/examples/hello/hdf5Reader/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/hdf5Reader/hdf5Reader.cpp
+++ b/examples/hello/hdf5Reader/hdf5Reader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/hdf5Reader/hdf5Reader_nompi.cpp
+++ b/examples/hello/hdf5Reader/hdf5Reader_nompi.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/hdf5SubFile/CMakeLists.txt
+++ b/examples/hello/hdf5SubFile/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/hdf5SubFile/hdf5SubFile.cpp
+++ b/examples/hello/hdf5SubFile/hdf5SubFile.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/hdf5Writer/CMakeLists.txt
+++ b/examples/hello/hdf5Writer/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/hdf5Writer/hdf5Writer.cpp
+++ b/examples/hello/hdf5Writer/hdf5Writer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/hdf5Writer/hdf5Writer_nompi.cpp
+++ b/examples/hello/hdf5Writer/hdf5Writer_nompi.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/helloWorld/CMakeLists.txt
+++ b/examples/hello/helloWorld/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/helloWorld/hello-world-bindings.py
+++ b/examples/hello/helloWorld/hello-world-bindings.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/helloWorld/hello-world-hl.cpp
+++ b/examples/hello/helloWorld/hello-world-hl.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/helloWorld/hello-world.c
+++ b/examples/hello/helloWorld/hello-world.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/helloWorld/hello-world.cpp
+++ b/examples/hello/helloWorld/hello-world.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/helloWorld/hello-world.py
+++ b/examples/hello/helloWorld/hello-world.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/helloWorld/hello-world_tutorialSkeleton.cpp
+++ b/examples/hello/helloWorld/hello-world_tutorialSkeleton.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/inlineFWriteCppRead/CMakeLists.txt
+++ b/examples/hello/inlineFWriteCppRead/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/inlineFWriteCppRead/inlineMixedLang.cpp
+++ b/examples/hello/inlineFWriteCppRead/inlineMixedLang.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/inlineFWriteCppRead/inlineMixedLang.f90
+++ b/examples/hello/inlineFWriteCppRead/inlineMixedLang.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 ! accompanying file Copyright.txt for details.

--- a/examples/hello/inlineMWE/CMakeLists.txt
+++ b/examples/hello/inlineMWE/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/inlineMWE/inlineMWE.cpp
+++ b/examples/hello/inlineMWE/inlineMWE.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/hello/inlineReaderWriter/CMakeLists.txt
+++ b/examples/hello/inlineReaderWriter/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/inlineReaderWriter/inlineReaderWriter.cpp
+++ b/examples/hello/inlineReaderWriter/inlineReaderWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/skeleton/CMakeLists.txt
+++ b/examples/hello/skeleton/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/skeleton/SkeletonArgs.cpp
+++ b/examples/hello/skeleton/SkeletonArgs.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/skeleton/SkeletonArgs.h
+++ b/examples/hello/skeleton/SkeletonArgs.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/skeleton/SkeletonPrint.h
+++ b/examples/hello/skeleton/SkeletonPrint.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/skeleton/skeletonReader.cpp
+++ b/examples/hello/skeleton/skeletonReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/hello/skeleton/skeletonWriter.cpp
+++ b/examples/hello/skeleton/skeletonWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/sstKokkos/CMakeLists.txt
+++ b/examples/hello/sstKokkos/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- #
 #Distributed under the OSI - approved Apache License, Version 2.0. See
 #accompanying file Copyright.txt for details.

--- a/examples/hello/sstKokkos/sstReaderKokkos.cpp
+++ b/examples/hello/sstKokkos/sstReaderKokkos.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/sstKokkos/sstWriterKokkos.cpp
+++ b/examples/hello/sstKokkos/sstWriterKokkos.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/sstReader/CMakeLists.txt
+++ b/examples/hello/sstReader/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/sstReader/sstReader-bindings.py
+++ b/examples/hello/sstReader/sstReader-bindings.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from mpi4py import MPI
 import numpy as np
 import adios2.bindings as adios2

--- a/examples/hello/sstReader/sstReader.cpp
+++ b/examples/hello/sstReader/sstReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/sstReader/sstReader.py
+++ b/examples/hello/sstReader/sstReader.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from mpi4py import MPI
 import numpy as np
 from adios2 import Stream, Adios, bindings

--- a/examples/hello/sstWriter/CMakeLists.txt
+++ b/examples/hello/sstWriter/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/hello/sstWriter/sstWriter-bindings.py
+++ b/examples/hello/sstWriter/sstWriter-bindings.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from mpi4py import MPI
 import numpy as np
 from time import sleep

--- a/examples/hello/sstWriter/sstWriter.cpp
+++ b/examples/hello/sstWriter/sstWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/hello/sstWriter/sstWriter.py
+++ b/examples/hello/sstWriter/sstWriter.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from mpi4py import MPI
 import numpy as np
 from time import sleep

--- a/examples/plugins/CMakeLists.txt
+++ b/examples/plugins/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/plugins/ReadMe.md
+++ b/examples/plugins/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ## ADIOS2 plugins examples
 
 The _plugins_ examples are meant to introduce you to the plugin capabilities of ADIOS2, such as

--- a/examples/plugins/engine/CMakeLists.txt
+++ b/examples/plugins/engine/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/plugins/engine/ExampleReadPlugin.cpp
+++ b/examples/plugins/engine/ExampleReadPlugin.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/engine/ExampleReadPlugin.h
+++ b/examples/plugins/engine/ExampleReadPlugin.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/engine/ExampleReadPlugin.tcc
+++ b/examples/plugins/engine/ExampleReadPlugin.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/engine/ExampleWritePlugin.cpp
+++ b/examples/plugins/engine/ExampleWritePlugin.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/engine/ExampleWritePlugin.h
+++ b/examples/plugins/engine/ExampleWritePlugin.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/engine/ExampleWritePlugin.tcc
+++ b/examples/plugins/engine/ExampleWritePlugin.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/engine/examplePluginEngineRead.cpp
+++ b/examples/plugins/engine/examplePluginEngineRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/engine/examplePluginEngineWrite.cpp
+++ b/examples/plugins/engine/examplePluginEngineWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/operator/CMakeLists.txt
+++ b/examples/plugins/operator/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/plugins/operator/examplePluginOperatorRead.cpp
+++ b/examples/plugins/operator/examplePluginOperatorRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/operator/examplePluginOperatorWrite.cpp
+++ b/examples/plugins/operator/examplePluginOperatorWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/operator/exampleSealedOperatorRead.cpp
+++ b/examples/plugins/operator/exampleSealedOperatorRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/plugins/operator/exampleSealedOperatorWrite.cpp
+++ b/examples/plugins/operator/exampleSealedOperatorWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/CMakeLists.txt
+++ b/examples/simulations/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if(ADIOS2_HAVE_MPI)
   add_subdirectory(gray-scott)
   add_subdirectory(gray-scott-struct)

--- a/examples/simulations/GrayScott.jl/ReadMe.md
+++ b/examples/simulations/GrayScott.jl/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ### ADIOS2 GrayScott.jl example
 
 Julia version

--- a/examples/simulations/GrayScott.jl/gray-scott.jl
+++ b/examples/simulations/GrayScott.jl/gray-scott.jl
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import GrayScott
 
 # using Profile

--- a/examples/simulations/GrayScott.jl/scripts/config_crusher.sh
+++ b/examples/simulations/GrayScott.jl/scripts/config_crusher.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 PROJ_DIR=/gpfs/alpine/proj-shared/csc383
 export JULIA_DEPOT_PATH=$PROJ_DIR/etc/crusher/julia_depot
 GS_DIR=$PROJ_DIR/wgodoy/ADIOS2/examples/simulations/GrayScott.jl

--- a/examples/simulations/GrayScott.jl/scripts/config_summit.sh
+++ b/examples/simulations/GrayScott.jl/scripts/config_summit.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Replace these 3 entries
 PROJ_DIR=/gpfs/alpine/proj-shared/csc383
 export JULIA_DEPOT_PATH=$PROJ_DIR/etc/summit/julia_depot

--- a/examples/simulations/GrayScott.jl/scripts/job_crusher.sh
+++ b/examples/simulations/GrayScott.jl/scripts/job_crusher.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #SBATCH -A CSC383_crusher
 #SBATCH -J gs-julia-1MPI-1GPU
 #SBATCH -o %x-%j.out

--- a/examples/simulations/GrayScott.jl/scripts/job_summit.sh
+++ b/examples/simulations/GrayScott.jl/scripts/job_summit.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #    Begin LSF directives
 #BSUB -P csc383
 #BSUB -W 00:02

--- a/examples/simulations/GrayScott.jl/src/GrayScott.jl
+++ b/examples/simulations/GrayScott.jl/src/GrayScott.jl
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 GrayScott.jl is a Simulation and Analysis parallel framework for solving the 
 Gray-Scott 3D diffusion reaction system of equations of two variables U and V on 

--- a/examples/simulations/GrayScott.jl/src/analysis/pdfcalc.jl
+++ b/examples/simulations/GrayScott.jl/src/analysis/pdfcalc.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import MPI
 import ArgParse

--- a/examples/simulations/GrayScott.jl/src/helper/Helper.jl
+++ b/examples/simulations/GrayScott.jl/src/helper/Helper.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 module Helper
 

--- a/examples/simulations/GrayScott.jl/src/helper/helperMPI.jl
+++ b/examples/simulations/GrayScott.jl/src/helper/helperMPI.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import MPI
 

--- a/examples/simulations/GrayScott.jl/src/helper/helperString.jl
+++ b/examples/simulations/GrayScott.jl/src/helper/helperString.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 export get_type
 

--- a/examples/simulations/GrayScott.jl/src/simulation/IO.jl
+++ b/examples/simulations/GrayScott.jl/src/simulation/IO.jl
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 module IO
 
 export init, write_step!

--- a/examples/simulations/GrayScott.jl/src/simulation/Inputs.jl
+++ b/examples/simulations/GrayScott.jl/src/simulation/Inputs.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 """
 Submodule used by GrayScott to handle inputs 

--- a/examples/simulations/GrayScott.jl/src/simulation/Simulation.jl
+++ b/examples/simulations/GrayScott.jl/src/simulation/Simulation.jl
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """ 
 The present file contains runtime backend for using CPU Threads, and optionally 
 CUDA.jl and AMDGPU.jl

--- a/examples/simulations/GrayScott.jl/src/simulation/Simulation_AMDGPU.jl
+++ b/examples/simulations/GrayScott.jl/src/simulation/Simulation_AMDGPU.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import AMDGPU
 

--- a/examples/simulations/GrayScott.jl/src/simulation/Simulation_CUDA.jl
+++ b/examples/simulations/GrayScott.jl/src/simulation/Simulation_CUDA.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import CUDA
 

--- a/examples/simulations/GrayScott.jl/src/simulation/Structs.jl
+++ b/examples/simulations/GrayScott.jl/src/simulation/Structs.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 """
 Settings carry the settings from the simulation config file (json or yaml formats)

--- a/examples/simulations/GrayScott.jl/test/functional/functional-GrayScott.jl
+++ b/examples/simulations/GrayScott.jl/test/functional/functional-GrayScott.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import GrayScott
 import Test: @testset, @test

--- a/examples/simulations/GrayScott.jl/test/runtests.jl
+++ b/examples/simulations/GrayScott.jl/test/runtests.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import MPI
 

--- a/examples/simulations/GrayScott.jl/test/unit/analysis/unit-pdfcalc.jl
+++ b/examples/simulations/GrayScott.jl/test/unit/analysis/unit-pdfcalc.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import Test: @testset, @test, @test_throws
 

--- a/examples/simulations/GrayScott.jl/test/unit/helper/unit-helperMPI.jl
+++ b/examples/simulations/GrayScott.jl/test/unit/helper/unit-helperMPI.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import Test: @testset, @test, @test_throws
 import GrayScott: Helper

--- a/examples/simulations/GrayScott.jl/test/unit/simulation/unit-IO.jl
+++ b/examples/simulations/GrayScott.jl/test/unit/simulation/unit-IO.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import Test: @testset, @test, @test_throws
 

--- a/examples/simulations/GrayScott.jl/test/unit/simulation/unit-Inputs.jl
+++ b/examples/simulations/GrayScott.jl/test/unit/simulation/unit-Inputs.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import Test: @testset, @test, @test_throws
 import GrayScott: Inputs

--- a/examples/simulations/GrayScott.jl/test/unit/simulation/unit-Simulation.jl
+++ b/examples/simulations/GrayScott.jl/test/unit/simulation/unit-Simulation.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import Test: @testset, @test, @test_throws
 # import submodule

--- a/examples/simulations/GrayScott.jl/test/unit/simulation/unit-Simulation_CUDA.jl
+++ b/examples/simulations/GrayScott.jl/test/unit/simulation/unit-Simulation_CUDA.jl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import Test: @testset, @test, @test_throws
 # import submodule

--- a/examples/simulations/ReadMe.md
+++ b/examples/simulations/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ## ADIOS2 simulations examples
 
 The _simulations_ examples are meant to demonstrate how to integrate ADIOS2 within your

--- a/examples/simulations/gray-scott-kokkos/CMakeLists.txt
+++ b/examples/simulations/gray-scott-kokkos/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/gray-scott-kokkos/ReadMe.md
+++ b/examples/simulations/gray-scott-kokkos/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ### ADIOS2 gray-scott-kokkos example
 
 This is a 3D 7-point stencil code to simulate the following [Gray-Scott

--- a/examples/simulations/gray-scott-kokkos/gray-scott.cpp
+++ b/examples/simulations/gray-scott-kokkos/gray-scott.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/gray-scott-kokkos/gray-scott.h
+++ b/examples/simulations/gray-scott-kokkos/gray-scott.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-kokkos/main.cpp
+++ b/examples/simulations/gray-scott-kokkos/main.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-kokkos/restart.cpp
+++ b/examples/simulations/gray-scott-kokkos/restart.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-kokkos/restart.h
+++ b/examples/simulations/gray-scott-kokkos/restart.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-kokkos/settings.cpp
+++ b/examples/simulations/gray-scott-kokkos/settings.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-kokkos/settings.h
+++ b/examples/simulations/gray-scott-kokkos/settings.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-kokkos/timer.hpp
+++ b/examples/simulations/gray-scott-kokkos/timer.hpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-kokkos/writer.cpp
+++ b/examples/simulations/gray-scott-kokkos/writer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-kokkos/writer.h
+++ b/examples/simulations/gray-scott-kokkos/writer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-struct/CMakeLists.txt
+++ b/examples/simulations/gray-scott-struct/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/gray-scott-struct/ReadMe.md
+++ b/examples/simulations/gray-scott-struct/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ### ADIOS2 gray-scott-struct example
 
 This is a 3D 7-point stencil code to simulate the following [Gray-Scott

--- a/examples/simulations/gray-scott-struct/analysis/pdf-calc.cpp
+++ b/examples/simulations/gray-scott-struct/analysis/pdf-calc.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/gray-scott-struct/catalyst/gs-pipeline.py
+++ b/examples/simulations/gray-scott-struct/catalyst/gs-pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from paraview.simple import *
 from paraview import print_info
 

--- a/examples/simulations/gray-scott-struct/catalyst/setup.sh
+++ b/examples/simulations/gray-scott-struct/catalyst/setup.sh
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # The ${PARAVIEW_BUILD_PATH}/lib directory should contain `libADIOSInSituPlugin.so`.
 export PARAVIEW_BUILD_PATH=/home/adios/Software/paraview/build
 # Set the following env variables.

--- a/examples/simulations/gray-scott-struct/cleanup.sh
+++ b/examples/simulations/gray-scott-struct/cleanup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Cmds: help  data  code  all
 cmd=${1:-help}
 

--- a/examples/simulations/gray-scott-struct/common/timer.hpp
+++ b/examples/simulations/gray-scott-struct/common/timer.hpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/gray-scott-struct/plot/decomp.py
+++ b/examples/simulations/gray-scott-struct/plot/decomp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np  # pylint: disable=import-error
 
 

--- a/examples/simulations/gray-scott-struct/plot/gsplot.py
+++ b/examples/simulations/gray-scott-struct/plot/gsplot.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import adios2  # pylint: disable=import-error
 import argparse
 import numpy as np  # pylint: disable=import-error

--- a/examples/simulations/gray-scott-struct/plot/pdfplot.py
+++ b/examples/simulations/gray-scott-struct/plot/pdfplot.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import adios2  # pylint: disable=import-error
 import argparse
 import numpy as np  # pylint: disable=import-error

--- a/examples/simulations/gray-scott-struct/simulation/gray-scott.cpp
+++ b/examples/simulations/gray-scott-struct/simulation/gray-scott.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/gray-scott-struct/simulation/gray-scott.h
+++ b/examples/simulations/gray-scott-struct/simulation/gray-scott.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-struct/simulation/main.cpp
+++ b/examples/simulations/gray-scott-struct/simulation/main.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-struct/simulation/restart.cpp
+++ b/examples/simulations/gray-scott-struct/simulation/restart.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-struct/simulation/restart.h
+++ b/examples/simulations/gray-scott-struct/simulation/restart.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-struct/simulation/settings.cpp
+++ b/examples/simulations/gray-scott-struct/simulation/settings.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-struct/simulation/settings.h
+++ b/examples/simulations/gray-scott-struct/simulation/settings.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-struct/simulation/writer.cpp
+++ b/examples/simulations/gray-scott-struct/simulation/writer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott-struct/simulation/writer.h
+++ b/examples/simulations/gray-scott-struct/simulation/writer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott/CMakeLists.txt
+++ b/examples/simulations/gray-scott/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/gray-scott/ReadMe.md
+++ b/examples/simulations/gray-scott/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ### ADIOS2 gray-scott example
 
 This is a 3D 7-point stencil code to simulate the following [Gray-Scott

--- a/examples/simulations/gray-scott/analysis/pdf-calc.cpp
+++ b/examples/simulations/gray-scott/analysis/pdf-calc.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/gray-scott/catalyst/gs-pipeline.py
+++ b/examples/simulations/gray-scott/catalyst/gs-pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from paraview.simple import *
 

--- a/examples/simulations/gray-scott/catalyst/setup.sh
+++ b/examples/simulations/gray-scott/catalyst/setup.sh
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # The ${PARAVIEW_BUILD_PATH}/lib directory should contain `libADIOSInSituPlugin.so`.
 export PARAVIEW_BUILD_PATH=/home/adios/Software/paraview/build
 # Set the following env variables.

--- a/examples/simulations/gray-scott/cleanup.sh
+++ b/examples/simulations/gray-scott/cleanup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Cmds: help  data  code  all
 cmd=${1:-help}
 

--- a/examples/simulations/gray-scott/common/timer.hpp
+++ b/examples/simulations/gray-scott/common/timer.hpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott/plot/decomp.py
+++ b/examples/simulations/gray-scott/plot/decomp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np  # pylint: disable=import-error
 
 

--- a/examples/simulations/gray-scott/plot/gsplot.py
+++ b/examples/simulations/gray-scott/plot/gsplot.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2 import Adios, Stream  # pylint: disable=import-error
 import argparse
 import numpy as np  # pylint: disable=import-error

--- a/examples/simulations/gray-scott/plot/pdfplot.py
+++ b/examples/simulations/gray-scott/plot/pdfplot.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2 import Adios, Stream  # pylint: disable=import-error
 import argparse
 import numpy as np  # pylint: disable=import-error

--- a/examples/simulations/gray-scott/simulation/gray-scott.cpp
+++ b/examples/simulations/gray-scott/simulation/gray-scott.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/gray-scott/simulation/gray-scott.h
+++ b/examples/simulations/gray-scott/simulation/gray-scott.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott/simulation/main.cpp
+++ b/examples/simulations/gray-scott/simulation/main.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott/simulation/restart.cpp
+++ b/examples/simulations/gray-scott/simulation/restart.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott/simulation/restart.h
+++ b/examples/simulations/gray-scott/simulation/restart.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott/simulation/settings.cpp
+++ b/examples/simulations/gray-scott/simulation/settings.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott/simulation/settings.h
+++ b/examples/simulations/gray-scott/simulation/settings.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott/simulation/writer.cpp
+++ b/examples/simulations/gray-scott/simulation/writer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/gray-scott/simulation/writer.h
+++ b/examples/simulations/gray-scott/simulation/writer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/heatTransfer/CMakeLists.txt
+++ b/examples/simulations/heatTransfer/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/heatTransfer/ReadMe.md
+++ b/examples/simulations/heatTransfer/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ### ADIOS2 heatTransfer example
 
 This example solves a 2D Poisson equation for temperature in homogeneous media

--- a/examples/simulations/heatTransfer/inline/CMakeLists.txt
+++ b/examples/simulations/heatTransfer/inline/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/heatTransfer/inline/InlineIO.cpp
+++ b/examples/simulations/heatTransfer/inline/InlineIO.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/inline/InlineIO.h
+++ b/examples/simulations/heatTransfer/inline/InlineIO.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/inline/main.cpp
+++ b/examples/simulations/heatTransfer/inline/main.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/read/CMakeLists.txt
+++ b/examples/simulations/heatTransfer/read/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/heatTransfer/read/PrintDataStep.h
+++ b/examples/simulations/heatTransfer/read/PrintDataStep.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/read/ReadSettings.cpp
+++ b/examples/simulations/heatTransfer/read/ReadSettings.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/read/ReadSettings.h
+++ b/examples/simulations/heatTransfer/read/ReadSettings.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/read/heatRead.cpp
+++ b/examples/simulations/heatTransfer/read/heatRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/readFileOnly/CMakeLists.txt
+++ b/examples/simulations/heatTransfer/readFileOnly/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/heatTransfer/readFileOnly/PrintData.h
+++ b/examples/simulations/heatTransfer/readFileOnly/PrintData.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/readFileOnly/heatReadFileOnly.cpp
+++ b/examples/simulations/heatTransfer/readFileOnly/heatReadFileOnly.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/heatTransfer/write/CMakeLists.txt
+++ b/examples/simulations/heatTransfer/write/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/heatTransfer/write/HeatTransfer.cpp
+++ b/examples/simulations/heatTransfer/write/HeatTransfer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/HeatTransfer.h
+++ b/examples/simulations/heatTransfer/write/HeatTransfer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/IO.h
+++ b/examples/simulations/heatTransfer/write/IO.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/IO_adios2.cpp
+++ b/examples/simulations/heatTransfer/write/IO_adios2.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/IO_ascii.cpp
+++ b/examples/simulations/heatTransfer/write/IO_ascii.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/IO_h5mixer.cpp
+++ b/examples/simulations/heatTransfer/write/IO_h5mixer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/IO_hdf5_a.cpp
+++ b/examples/simulations/heatTransfer/write/IO_hdf5_a.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/IO_ph5.cpp
+++ b/examples/simulations/heatTransfer/write/IO_ph5.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/Settings.cpp
+++ b/examples/simulations/heatTransfer/write/Settings.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/Settings.h
+++ b/examples/simulations/heatTransfer/write/Settings.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/heatTransfer/write/main.cpp
+++ b/examples/simulations/heatTransfer/write/main.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/korteweg-de-vries/CMakeLists.txt
+++ b/examples/simulations/korteweg-de-vries/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/korteweg-de-vries/KdV.cpp
+++ b/examples/simulations/korteweg-de-vries/KdV.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/simulations/korteweg-de-vries/ReadMe.md
+++ b/examples/simulations/korteweg-de-vries/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ### ADIOS2 korteweg-de-vries example
 
 Solves the initial value problem for the Korteweg de-Vries equation via the Zabusky and Krustal scheme.

--- a/examples/simulations/korteweg-de-vries/graph_solution.py
+++ b/examples/simulations/korteweg-de-vries/graph_solution.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import time
 import argparse

--- a/examples/simulations/lorenz_ode/CMakeLists.txt
+++ b/examples/simulations/lorenz_ode/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/simulations/lorenz_ode/ReadMe.md
+++ b/examples/simulations/lorenz_ode/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ### ADIOS2 Lorenz System Example
 
 The [Lorenz system](https://en.wikipedia.org/wiki/Lorenz_system) is a very simple ODE which exhibits large sensitivity

--- a/examples/simulations/lorenz_ode/lorenz.hpp
+++ b/examples/simulations/lorenz_ode/lorenz.hpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/lorenz_ode/lorenzReader.cpp
+++ b/examples/simulations/lorenz_ode/lorenzReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/simulations/lorenz_ode/lorenzWriter.cpp
+++ b/examples/simulations/lorenz_ode/lorenzWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/examples/useCases/CMakeLists.txt
+++ b/examples/useCases/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # ------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/useCases/ReadMe.md
+++ b/examples/useCases/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ## ADIOS2 useCases examples
 
 The _useCases_ examples are meant to demonstrate how to use ADIOS2 in different scenarios,

--- a/examples/useCases/ensembleRead/CMakeLists.txt
+++ b/examples/useCases/ensembleRead/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/useCases/ensembleRead/ensembleRead.cpp
+++ b/examples/useCases/ensembleRead/ensembleRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/useCases/ensembleRead/ensembleRead.py
+++ b/examples/useCases/ensembleRead/ensembleRead.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/useCases/fidesOneCell/CMakeLists.txt
+++ b/examples/useCases/fidesOneCell/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/useCases/fidesOneCell/ReadMe.md
+++ b/examples/useCases/fidesOneCell/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 ### Single cell example for visualization with Fides schema in ParaView
 
 This example writes 8 points in 3D space, the corners of a box, and then defines a single hexagon cell of those eight

--- a/examples/useCases/fidesOneCell/fidesOneCell.cpp
+++ b/examples/useCases/fidesOneCell/fidesOneCell.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/useCases/insituGlobalArrays/CMakeLists.txt
+++ b/examples/useCases/insituGlobalArrays/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
+++ b/examples/useCases/insituGlobalArrays/insituGlobalArraysReaderNxN.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/examples/useCases/insituGlobalArrays/insituGlobalArraysWriter.cpp
+++ b/examples/useCases/insituGlobalArrays/insituGlobalArraysWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/plugins/engines/CMakeLists.txt
+++ b/plugins/engines/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/plugins/engines/ParaViewFidesEngine.cpp
+++ b/plugins/engines/ParaViewFidesEngine.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/plugins/engines/ParaViewFidesEngine.h
+++ b/plugins/engines/ParaViewFidesEngine.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/plugins/operators/CMakeLists.txt
+++ b/plugins/operators/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/plugins/operators/EncryptionOperator.cpp
+++ b/plugins/operators/EncryptionOperator.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/plugins/operators/EncryptionOperator.h
+++ b/plugins/operators/EncryptionOperator.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/plugins/operators/adios2_seal_keygen.py
+++ b/plugins/operators/adios2_seal_keygen.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Manage Curve25519 keypairs for use with SealedEncryptionOperator."""
 
 import argparse

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/python/adios2/__init__.py
+++ b/python/adios2/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """The ADIOS2 high-level API module
 License:
   Distributed under the OSI-approved Apache License, Version 2.0.  See

--- a/python/adios2/adios.py
+++ b/python/adios2/adios.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """License:
 Distributed under the OSI-approved Apache License, Version 2.0.  See
 accompanying file Copyright.txt for details.

--- a/python/adios2/attribute.py
+++ b/python/adios2/attribute.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """License:
 Distributed under the OSI-approved Apache License, Version 2.0.  See
 accompanying file Copyright.txt for details.

--- a/python/adios2/derived_variable.py
+++ b/python/adios2/derived_variable.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """License:
 Distributed under the OSI-approved Apache License, Version 2.0.  See
 accompanying file Copyright.txt for details.

--- a/python/adios2/engine.py
+++ b/python/adios2/engine.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """License:
 Distributed under the OSI-approved Apache License, Version 2.0.  See
 accompanying file Copyright.txt for details.

--- a/python/adios2/file_reader.py
+++ b/python/adios2/file_reader.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """License:
 Distributed under the OSI-approved Apache License, Version 2.0.  See
 accompanying file Copyright.txt for details.

--- a/python/adios2/io.py
+++ b/python/adios2/io.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """License:
 Distributed under the OSI-approved Apache License, Version 2.0.  See
 accompanying file Copyright.txt for details.

--- a/python/adios2/operator.py
+++ b/python/adios2/operator.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """License:
 Distributed under the OSI-approved Apache License, Version 2.0.  See
 accompanying file Copyright.txt for details.

--- a/python/adios2/stream.py
+++ b/python/adios2/stream.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """License:
 Distributed under the OSI-approved Apache License, Version 2.0.  See
 accompanying file Copyright.txt for details.

--- a/python/adios2/variable.py
+++ b/python/adios2/variable.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """License:
 Distributed under the OSI-approved Apache License, Version 2.0.  See
 accompanying file Copyright.txt for details.

--- a/scripts/build_scripts/build-adios2-cuda-perlmutter.sh
+++ b/scripts/build_scripts/build-adios2-cuda-perlmutter.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # shellcheck disable=SC2191
 
 module load PrgEnv-gnu

--- a/scripts/build_scripts/build-adios2-kokkos-frontier.sh
+++ b/scripts/build_scripts/build-adios2-kokkos-frontier.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # shellcheck disable=SC2191
 
 module load PrgEnv-gnu-amd

--- a/scripts/build_scripts/build-adios2-kokkos-perlmutter.sh
+++ b/scripts/build_scripts/build-adios2-kokkos-perlmutter.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # shellcheck disable=SC2191
 
 module load PrgEnv-gnu

--- a/scripts/build_scripts/build-adios2-kvcache.sh
+++ b/scripts/build_scripts/build-adios2-kvcache.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This script is to build the remote server with cache enabled.
 # Attention: hiredis cannot be installed by apt-get, since the default version is too old (libhiredis0.14 (= 0.14.1-2)).
 #            We need to build it from source code. You can also use the following scripts to install hiredis (v1.2.0).

--- a/scripts/build_scripts/build-adios2-sycl-polaris.sh
+++ b/scripts/build_scripts/build-adios2-sycl-polaris.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # shellcheck disable=SC2191
 
 module load oneapi

--- a/scripts/ci/cmake/ci-ascent-common.cmake
+++ b/scripts/ci/cmake/ci-ascent-common.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(CTEST_TEST_ARGS

--- a/scripts/ci/cmake/ci-ascent-cuda.cmake
+++ b/scripts/ci/cmake/ci-ascent-cuda.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(dashboard_cache "

--- a/scripts/ci/cmake/ci-ascent-kokkos-cuda.cmake
+++ b/scripts/ci/cmake/ci-ascent-kokkos-cuda.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(kokkos_install_path $ENV{Kokkos_DIR})

--- a/scripts/ci/cmake/ci-ascent-nvhpc.cmake
+++ b/scripts/ci/cmake/ci-ascent-nvhpc.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(ENV{CC}  nvc)

--- a/scripts/ci/cmake/ci-ascent-xl.cmake
+++ b/scripts/ci/cmake/ci-ascent-xl.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(ENV{CC}  xlc)

--- a/scripts/ci/cmake/ci-common.cmake
+++ b/scripts/ci/cmake/ci-common.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif()

--- a/scripts/ci/cmake/ci-el7-spack.cmake
+++ b/scripts/ci/cmake/ci-el7-spack.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 include(ProcessorCount)

--- a/scripts/ci/cmake/ci-el7.cmake
+++ b/scripts/ci/cmake/ci-el7.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(ENV{CC}  gcc)

--- a/scripts/ci/cmake/ci-el8-icc-mpich.cmake
+++ b/scripts/ci/cmake/ci-el8-icc-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(ProcessorCount)
 ProcessorCount(NCPUS)
 math(EXPR N2CPUS "${NCPUS}*2")

--- a/scripts/ci/cmake/ci-el8-icc-ompi.cmake
+++ b/scripts/ci/cmake/ci-el8-icc-ompi.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  icc)
 set(ENV{CXX} icpc)
 set(ENV{FC}  ifort)

--- a/scripts/ci/cmake/ci-el8-icc-serial.cmake
+++ b/scripts/ci/cmake/ci-el8-icc-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  icc)
 set(ENV{CXX} icpc)
 set(ENV{FC}  ifort)

--- a/scripts/ci/cmake/ci-el8-oneapi-mpich.cmake
+++ b/scripts/ci/cmake/ci-el8-oneapi-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(ProcessorCount)
 ProcessorCount(NCPUS)
 math(EXPR N2CPUS "${NCPUS}*2")

--- a/scripts/ci/cmake/ci-el8-oneapi-ompi.cmake
+++ b/scripts/ci/cmake/ci-el8-oneapi-ompi.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  icx)
 set(ENV{CXX} icpx)
 set(ENV{FC}  ifort) # oneapi fortran compiler currently has issues

--- a/scripts/ci/cmake/ci-el8-oneapi-serial.cmake
+++ b/scripts/ci/cmake/ci-el8-oneapi-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  icx)
 set(ENV{CXX} icpx)
 set(ENV{FC}  ifort) # oneapi fortran compiler currently has issues

--- a/scripts/ci/cmake/ci-frontier-cray.cmake
+++ b/scripts/ci/cmake/ci-frontier-cray.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(ENV{CC}  craycc)

--- a/scripts/ci/cmake/ci-frontier-kokkos-hip.cmake
+++ b/scripts/ci/cmake/ci-frontier-kokkos-hip.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(ENV{CC}  gcc)

--- a/scripts/ci/cmake/ci-macos-14-xcode15_4-shared-serial.cmake
+++ b/scripts/ci/cmake/ci-macos-14-xcode15_4-shared-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 set(ENV{CC}  clang)
 set(ENV{CXX} clang++)

--- a/scripts/ci/cmake/ci-macos-14-xcode15_4-static-serial.cmake
+++ b/scripts/ci/cmake/ci-macos-14-xcode15_4-static-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 set(ENV{CC}  clang)
 set(ENV{CXX} clang++)

--- a/scripts/ci/cmake/ci-macos-15-xcode16_4-shared-serial.cmake
+++ b/scripts/ci/cmake/ci-macos-15-xcode16_4-shared-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 set(ENV{CC}  clang)
 set(ENV{CXX} clang++)

--- a/scripts/ci/cmake/ci-macos-15-xcode16_4-static-serial.cmake
+++ b/scripts/ci/cmake/ci-macos-15-xcode16_4-static-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 set(ENV{CC}  clang)
 set(ENV{CXX} clang++)

--- a/scripts/ci/cmake/ci-ubuntu22.04-clang11-mpich.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-clang11-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(ProcessorCount)
 ProcessorCount(NCPUS)
 math(EXPR N2CPUS "${NCPUS}*2")

--- a/scripts/ci/cmake/ci-ubuntu22.04-clang11-ompi.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-clang11-ompi.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  clang-11)
 set(ENV{CXX} clang++-11)
 set(ENV{FC}  gfortran-11)

--- a/scripts/ci/cmake/ci-ubuntu22.04-clang11-serial.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-clang11-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  clang-11)
 set(ENV{CXX} clang++-11)
 set(ENV{FC}  gfortran-11)

--- a/scripts/ci/cmake/ci-ubuntu22.04-clang11-static-mpich.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-clang11-static-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  clang-11)
 set(ENV{CXX} clang++-11)
 set(ENV{FC}  gfortran-11)

--- a/scripts/ci/cmake/ci-ubuntu22.04-clang14-mpich.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-clang14-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(ProcessorCount)
 ProcessorCount(NCPUS)
 math(EXPR N2CPUS "${NCPUS}*2")

--- a/scripts/ci/cmake/ci-ubuntu22.04-clang14-ompi.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-clang14-ompi.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  clang-14)
 set(ENV{CXX} clang++-14)
 set(ENV{FC}  gfortran-11)

--- a/scripts/ci/cmake/ci-ubuntu22.04-clang14-serial.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-clang14-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  clang-14)
 set(ENV{CXX} clang++-14)
 set(ENV{FC}  gfortran-11)

--- a/scripts/ci/cmake/ci-ubuntu22.04-gcc10-mpich.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-gcc10-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(ProcessorCount)
 ProcessorCount(NCPUS)
 math(EXPR N2CPUS "${NCPUS}*2")

--- a/scripts/ci/cmake/ci-ubuntu22.04-gcc11-mpich.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-gcc11-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(ProcessorCount)
 ProcessorCount(NCPUS)
 math(EXPR N2CPUS "${NCPUS}*2")

--- a/scripts/ci/cmake/ci-ubuntu22.04-gcc12-mpich.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-gcc12-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(ProcessorCount)
 ProcessorCount(NCPUS)
 math(EXPR N2CPUS "${NCPUS}*2")

--- a/scripts/ci/cmake/ci-ubuntu22.04-gcc9-mpich.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-gcc9-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include(ProcessorCount)
 ProcessorCount(NCPUS)
 math(EXPR N2CPUS "${NCPUS}*2")

--- a/scripts/ci/cmake/ci-ubuntu22.04-gcc9-ompi.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-gcc9-ompi.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  gcc)
 set(ENV{CXX} g++)
 set(ENV{FC}  gfortran)

--- a/scripts/ci/cmake/ci-ubuntu22.04-gcc9-serial-codeql.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-gcc9-serial-codeql.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  gcc)
 set(ENV{CXX} g++)
 set(ENV{FC}  gfortran)

--- a/scripts/ci/cmake/ci-ubuntu22.04-gcc9-serial.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-gcc9-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  gcc)
 set(ENV{CXX} g++)
 set(ENV{FC}  gfortran)

--- a/scripts/ci/cmake/ci-ubuntu22.04-gcc9-static-mpich.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-gcc9-static-mpich.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  gcc)
 set(ENV{CXX} g++)
 set(ENV{FC}  gfortran)

--- a/scripts/ci/cmake/ci-ubuntu22.04-gcc9-static-serial.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-gcc9-static-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  gcc)
 set(ENV{CXX} g++)
 

--- a/scripts/ci/cmake/ci-ubuntu22.04-rocm-serial.cmake
+++ b/scripts/ci/cmake/ci-ubuntu22.04-rocm-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  gcc)
 set(ENV{CXX} g++)
 set(ENV{FC}  gfortran)

--- a/scripts/ci/cmake/ci-uo-sanitizer-asan.cmake
+++ b/scripts/ci/cmake/ci-uo-sanitizer-asan.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(ENV{CC}  clang)

--- a/scripts/ci/cmake/ci-uo-sanitizer-msan.cmake
+++ b/scripts/ci/cmake/ci-uo-sanitizer-msan.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(ENV{CC}  clang)

--- a/scripts/ci/cmake/ci-uo-sanitizer-tsan.cmake
+++ b/scripts/ci/cmake/ci-uo-sanitizer-tsan.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(dashboard_cache "

--- a/scripts/ci/cmake/ci-uo-sanitizer-ubsan.cmake
+++ b/scripts/ci/cmake/ci-uo-sanitizer-ubsan.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Client maintainer: vicente.bolea@kitware.com
 
 set(ENV{CC}  gcc)

--- a/scripts/ci/cmake/ci-win2022-vs2022-msmpi.cmake
+++ b/scripts/ci/cmake/ci-win2022-vs2022-msmpi.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  cl)
 set(ENV{CXX} cl)
 set(ENV{CFLAGS} /WX)

--- a/scripts/ci/cmake/ci-win2025-vs2022-msmpi.cmake
+++ b/scripts/ci/cmake/ci-win2025-vs2022-msmpi.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  cl)
 set(ENV{CXX} cl)
 set(ENV{CFLAGS} /WX)

--- a/scripts/ci/cmake/ci-win2025-vs2022-serial.cmake
+++ b/scripts/ci/cmake/ci-win2025-vs2022-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  cl)
 set(ENV{CXX} cl)
 set(ENV{CFLAGS} /WX)

--- a/scripts/ci/cmake/ci-win2025-vs2022-static-serial.cmake
+++ b/scripts/ci/cmake/ci-win2025-vs2022-static-serial.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(ENV{CC}  cl)
 set(ENV{CXX} cl)
 set(ENV{CFLAGS} /WX)

--- a/scripts/ci/gh-actions/check-branch-name.sh
+++ b/scripts/ci/gh-actions/check-branch-name.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]
 then
   if [ -z "${BASE_REF}" ]

--- a/scripts/ci/gh-actions/conda-env-macos.yml
+++ b/scripts/ci/gh-actions/conda-env-macos.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: adios2
 variables:
   CMAKE_PREFIX_PATH: "/Users/runner/miniconda3/envs/adios2/:$CMAKE_PREFIX_PATH"

--- a/scripts/ci/gh-actions/conda-env-win.yml
+++ b/scripts/ci/gh-actions/conda-env-win.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: adios2
 variables:
   CMAKE_PREFIX_PATH: "C:/Miniconda/envs/adios2/Library;$CMAKE_PREFIX_PATH"

--- a/scripts/ci/gh-actions/config/adios-version.cmake
+++ b/scripts/ci/gh-actions/config/adios-version.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.12)
 
 # Write a file containing the ADIOS2 version to use in pip packaging.  This is

--- a/scripts/ci/gh-actions/config/ninja.cmake
+++ b/scripts/ci/gh-actions/config/ninja.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 set(version 1.11.0)

--- a/scripts/ci/gh-actions/get-changed-files.sh
+++ b/scripts/ci/gh-actions/get-changed-files.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 case "${GITHUB_EVENT_NAME}"
 in
   pull_request)

--- a/scripts/ci/gh-actions/linux-setup.sh
+++ b/scripts/ci/gh-actions/linux-setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash --login
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -ex
 
 export CI_ROOT_DIR="${GITHUB_WORKSPACE}/.."

--- a/scripts/ci/gh-actions/macos-setup.sh
+++ b/scripts/ci/gh-actions/macos-setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -xe
 
 echo "Setting up default XCode version"

--- a/scripts/ci/gh-actions/run.sh
+++ b/scripts/ci/gh-actions/run.sh
@@ -1,5 +1,9 @@
 #!/bin/bash --login
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -u
 set -e

--- a/scripts/ci/gh-actions/windows-setup.ps1
+++ b/scripts/ci/gh-actions/windows-setup.ps1
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 $ErrorActionPreference = "Stop"
 
 Write-Host "::group::Setup CONDA"

--- a/scripts/ci/gitlab-ci/run.sh
+++ b/scripts/ci/gitlab-ci/run.sh
@@ -1,4 +1,9 @@
 #!/bin/bash --login
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # shellcheck disable=SC1091
 set -ex
 

--- a/scripts/ci/gitlab-ci/setup-vars.sh
+++ b/scripts/ci/gitlab-ci/setup-vars.sh
@@ -1,4 +1,9 @@
 #!/bin/bash --login
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 # Strip the job name prefix

--- a/scripts/ci/images/0001-mpich-support-ch3-sock.patch
+++ b/scripts/ci/images/0001-mpich-support-ch3-sock.patch
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 From bde001bcdf8d14f9b6d6c3c216ab8c00f74b3c08 Mon Sep 17 00:00:00 2001
 From: Scott Wittenburg <scott.wittenburg@kitware.com>
 Date: Tue, 14 Nov 2023 13:46:37 -0700

--- a/scripts/ci/images/0002-adios2-add-xrootd-variant.patch
+++ b/scripts/ci/images/0002-adios2-add-xrootd-variant.patch
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 From fc4753e9535fa9148728207a29e9ee5a4c630946 Mon Sep 17 00:00:00 2001
 From: Scott Wittenburg <scott.wittenburg@kitware.com>
 Date: Tue, 21 Oct 2025 21:14:18 +0000

--- a/scripts/ci/images/Dockerfile.ci-el8-intel
+++ b/scripts/ci/images/Dockerfile.ci-el8-intel
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM almalinux:8
 
 RUN dnf upgrade -y && \

--- a/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-base
+++ b/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-base
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # vim: ft=dockerfile
 ARG BASE_IMAGE=docker.io/ecpe4s/ubuntu22.04-runner-amd64-gcc-11.4:2025.03.01
 FROM $BASE_IMAGE

--- a/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-clang
+++ b/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-clang
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE_IMAGE=ghcr.io/ornladios/adios2:ci-spack-ubuntu22.04-base
 FROM $BASE_IMAGE
 ARG CLANG_VERSION=11

--- a/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-gcc
+++ b/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-gcc
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE_IMAGE=ghcr.io/ornladios/adios2:ci-spack-ubuntu22.04-base
 FROM $BASE_IMAGE
 ARG GCC_VERSION=9

--- a/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-intel
+++ b/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-intel
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE_IMAGE=ghcr.io/ornladios/adios2:ci-spack-ubuntu22.04-base
 FROM $BASE_IMAGE
 

--- a/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-rocm-base
+++ b/scripts/ci/images/Dockerfile.ci-spack-ubuntu22.04-rocm-base
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE_IMAGE=rocm/dev-ubuntu-22.04
 FROM $BASE_IMAGE
 

--- a/scripts/ci/images/build-el8.sh
+++ b/scripts/ci/images/build-el8.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -ex
 DOCKER=${DOCKER:-podman}
 

--- a/scripts/ci/images/build-rocm.sh
+++ b/scripts/ci/images/build-rocm.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -ex
 
 # Build the base image

--- a/scripts/ci/images/build-ubuntu.sh
+++ b/scripts/ci/images/build-ubuntu.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ###
 ### To run with docker instead of podman, and push to your own repo rather than
 ### the main one, eg:

--- a/scripts/ci/images/formatting/Dockerfile
+++ b/scripts/ci/images/formatting/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM fedora:38@sha256:b9ff6f23cceb5bde20bb1f79b492b98d71ef7a7ae518ca1b15b26661a11e6a94
 
 RUN dnf update -y && \

--- a/scripts/ci/images/opensuse-tw/build-images-opensuse-tw
+++ b/scripts/ci/images/opensuse-tw/build-images-opensuse-tw
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This script is used to build the openSUSE Tumbleweed images
 
 set -xeuo pipefail

--- a/scripts/ci/images/opensuse-tw/opensuse-tw-asan.dockerfile
+++ b/scripts/ci/images/opensuse-tw/opensuse-tw-asan.dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ghcr.io/ornladios/adios2:ci-opensuse-tw-sanitizer-base
 
 # Install core dev packages

--- a/scripts/ci/images/opensuse-tw/opensuse-tw-full-stack-onbuild.dockerfile
+++ b/scripts/ci/images/opensuse-tw/opensuse-tw-full-stack-onbuild.dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ghcr.io/ornladios/adios2:ci-opensuse-tw-sanitizer-base
 
 # Set up some arguments

--- a/scripts/ci/images/opensuse-tw/opensuse-tw-msan.dockerfile
+++ b/scripts/ci/images/opensuse-tw/opensuse-tw-msan.dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG INSTALL_PREFIX=/opt/msan
 ARG TOOLCHAIN_FILE=toolchain-msan.cmake
 ARG CFLAGS="-fsanitize=memory -fsanitize-memory-track-origins"

--- a/scripts/ci/images/opensuse-tw/opensuse-tw-sanitizer-base.dockerfile
+++ b/scripts/ci/images/opensuse-tw/opensuse-tw-sanitizer-base.dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM opensuse/tumbleweed
 LABEL maintainer "Vicente Adolfo Bolea Sanchez<vicente.bolea@kitware.com>"
 

--- a/scripts/ci/images/opensuse-tw/opensuse-tw-tsan.dockerfile
+++ b/scripts/ci/images/opensuse-tw/opensuse-tw-tsan.dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG INSTALL_PREFIX=/opt/tsan
 ARG TOOLCHAIN_FILE=toolchain-tsan.cmake
 ARG CFLAGS="-fsanitize=thread"

--- a/scripts/ci/images/opensuse-tw/opensuse-tw-ubsan.dockerfile
+++ b/scripts/ci/images/opensuse-tw/opensuse-tw-ubsan.dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ghcr.io/ornladios/adios2:ci-opensuse-tw-sanitizer-base
 
 # Install core dev packages

--- a/scripts/ci/images/opensuse-tw/toolchain-msan.cmake
+++ b/scripts/ci/images/opensuse-tw/toolchain-msan.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(CMAKE_C_COMPILER /usr/bin/clang)
 set(CMAKE_CXX_COMPILER /usr/bin/clang++)
 set(_link_flags "-stdlib=libc++ -L /opt/msan/lib -lc++abi -Wl,-rpath,/opt/msan/lib -Wno-unused-command-line-argument")

--- a/scripts/ci/images/opensuse-tw/toolchain-tsan.cmake
+++ b/scripts/ci/images/opensuse-tw/toolchain-tsan.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(CMAKE_C_COMPILER /usr/bin/clang)
 set(CMAKE_CXX_COMPILER /usr/bin/clang++)
 set(_link_flags "-stdlib=libc++ -L /opt/tsan/lib -Wl,-rpath,/opt/tsan/lib -Wno-unused-command-line-argument")

--- a/scripts/ci/images/packages.yaml
+++ b/scripts/ci/images/packages.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 packages:
   all:
     target: [haswell]

--- a/scripts/ci/images/spack/Dockerfile
+++ b/scripts/ci/images/spack/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG baseos
 FROM docker.io/ornladios/adios2:spack-dependencies-${baseos}
 

--- a/scripts/ci/images/sync.dockerfile
+++ b/scripts/ci/images/sync.dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from python:3.6.15
 
 # run apt install without asking user

--- a/scripts/ci/scripts/github-list-prs.py
+++ b/scripts/ci/scripts/github-list-prs.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 import argparse
 import urllib.request

--- a/scripts/ci/scripts/github-prs-to-gitlab.sh
+++ b/scripts/ci/scripts/github-prs-to-gitlab.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 CLEANUP_SSH_AGENT=0

--- a/scripts/ci/scripts/run-black.sh
+++ b/scripts/ci/scripts/run-black.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 echo "---------- Begin ENV ----------"
 env | sort
 echo "----------  End ENV  ----------"

--- a/scripts/ci/scripts/run-clang-format.sh
+++ b/scripts/ci/scripts/run-clang-format.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 echo "---------- Begin ENV ----------"
 env | sort
 echo "----------  End ENV  ----------"

--- a/scripts/ci/scripts/run-flake8.sh
+++ b/scripts/ci/scripts/run-flake8.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 echo "---------- Begin ENV ----------"
 env | sort
 echo "----------  End ENV  ----------"

--- a/scripts/ci/scripts/run-pylint.sh
+++ b/scripts/ci/scripts/run-pylint.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 echo "---------- Begin ENV ----------"
 env | sort
 echo "----------  End ENV  ----------"

--- a/scripts/ci/scripts/run-shellcheck.sh
+++ b/scripts/ci/scripts/run-shellcheck.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # We need the same sort order
 export LC_ALL=C
 EXCLUDE_SCRIPTS=.shellcheck_exclude_paths

--- a/scripts/ci/setup-run/ci-Windows.sh
+++ b/scripts/ci/setup-run/ci-Windows.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set +u
 
 export CONDA_DLL_SEARCH_MODIFICATION_ENABLE=1

--- a/scripts/ci/setup-run/ci-el8-icc.sh
+++ b/scripts/ci/setup-run/ci-el8-icc.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 module load icc

--- a/scripts/ci/setup-run/ci-el8-oneapi.sh
+++ b/scripts/ci/setup-run/ci-el8-oneapi.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 module load icc
 module load compiler

--- a/scripts/ci/setup-run/ci-ubuntu22.04-clang11.sh
+++ b/scripts/ci/setup-run/ci-ubuntu22.04-clang11.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 spack env activate "adios2-ci-${GH_YML_MATRIX_PARALLEL}"

--- a/scripts/ci/setup-run/ci-ubuntu22.04-clang14.sh
+++ b/scripts/ci/setup-run/ci-ubuntu22.04-clang14.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 spack env activate "adios2-ci-${GH_YML_MATRIX_PARALLEL}"

--- a/scripts/ci/setup-run/ci-ubuntu22.04-gcc10.sh
+++ b/scripts/ci/setup-run/ci-ubuntu22.04-gcc10.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 update-alternatives --set gcc "$(update-alternatives --list gcc | grep gcc-10)"
 update-alternatives --set g++ "$(update-alternatives --list g++ | grep g++-10)"
 update-alternatives --set gfortran "$(update-alternatives --list gfortran | grep gfortran-10)"

--- a/scripts/ci/setup-run/ci-ubuntu22.04-gcc11.sh
+++ b/scripts/ci/setup-run/ci-ubuntu22.04-gcc11.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 update-alternatives --set gcc "$(update-alternatives --list gcc | grep gcc-11)"
 update-alternatives --set g++ "$(update-alternatives --list g++ | grep g++-11)"
 update-alternatives --set gfortran "$(update-alternatives --list gfortran | grep gfortran-11)"

--- a/scripts/ci/setup-run/ci-ubuntu22.04-gcc12.sh
+++ b/scripts/ci/setup-run/ci-ubuntu22.04-gcc12.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 update-alternatives --set gcc "$(update-alternatives --list gcc | grep gcc-12)"
 update-alternatives --set g++ "$(update-alternatives --list g++ | grep g++-12)"
 update-alternatives --set gfortran "$(update-alternatives --list gfortran | grep gfortran-12)"

--- a/scripts/ci/setup-run/ci-ubuntu22.04-gcc9.sh
+++ b/scripts/ci/setup-run/ci-ubuntu22.04-gcc9.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 update-alternatives --set gcc "$(update-alternatives --list gcc | grep gcc-9)"
 update-alternatives --set g++ "$(update-alternatives --list g++ | grep g++-9)"
 update-alternatives --set gfortran "$(update-alternatives --list gfortran | grep gfortran-9)"

--- a/scripts/ci/setup-run/ci-ubuntu22.04-rocm.sh
+++ b/scripts/ci/setup-run/ci-ubuntu22.04-rocm.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:/opt/rocm/"
 
 update-alternatives --set gcc "$(update-alternatives --list gcc | grep gcc-11)"

--- a/scripts/conda/adios2/meta.yaml
+++ b/scripts/conda/adios2/meta.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 package:
   name: adios2
   version: {{ GIT_DESCRIBE_TAG }}

--- a/scripts/conda/adios2/superbuild/CMakeLists.txt
+++ b/scripts/conda/adios2/superbuild/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.12)
 project(ADIOS2_SUPERBUILD C CXX)
 

--- a/scripts/dashboard/EnvironmentModules.cmake
+++ b/scripts/dashboard/EnvironmentModules.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/scripts/dashboard/adios_common.cmake
+++ b/scripts/dashboard/adios_common.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/scripts/dashboard/common.cmake
+++ b/scripts/dashboard/common.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/scripts/developer/create-changelog.sh
+++ b/scripts/developer/create-changelog.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # author: Vicente Bolea <vicente.bolea@kitware.com>
 
 function require_dependency()

--- a/scripts/developer/git/git-clang-format
+++ b/scripts/developer/git/git-clang-format
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 #===- git-clang-format - ClangFormat Git Integration ---------*- python -*--===#
 #

--- a/scripts/developer/git/setup-aliases
+++ b/scripts/developer/git/setup-aliases
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 echo "Setting up git aliases..."
 if ! which clang-format 1>/dev/null 2>&1
 then

--- a/scripts/developer/git/setup-remotes
+++ b/scripts/developer/git/setup-remotes
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 GH_UPSTREAM_URL=$(git remote show origin | grep "Fetch URL" | sed 's|.*: \(.*\)|\1|')
 BRANCH="$(git branch | sed -n 's|^\* \(.*\)|\1|p')"
 if [ "${GH_UPSTREAM_URL}" != "https://github.com/ornladios/ADIOS2.git" ] || \

--- a/scripts/developer/merge-pr-from-release.sh
+++ b/scripts/developer/merge-pr-from-release.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if [ $# -ne 1 -a $# -ne 2 ]
 then
   echo "[E] Usage: $0 pr_num [release_branch]"

--- a/scripts/developer/run-clang-format.sh
+++ b/scripts/developer/run-clang-format.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 CONTAINER_DRIVER=${CONTAINER_DRIVER:-docker}
 
 "${CONTAINER_DRIVER[@]}" run -itt --mount type=bind,source="$(pwd)",target=/root/adios2 \

--- a/scripts/developer/setup.sh
+++ b/scripts/developer/setup.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 function test_cmd {
   if ! $1 ;
   then

--- a/scripts/docker/Dockerfile.complete
+++ b/scripts/docker/Dockerfile.complete
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG baseos=ubuntu-bionic
 FROM ornladios/adios2:spack-dependencies-${baseos}
 

--- a/scripts/docker/Dockerfile.dependencies
+++ b/scripts/docker/Dockerfile.dependencies
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ARG baseos=ubuntu-bionic
 FROM spack/${baseos}
 

--- a/scripts/docker/modules.yaml
+++ b/scripts/docker/modules.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 modules:
   enable:
   - tcl

--- a/scripts/docker/packages.yaml
+++ b/scripts/docker/packages.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 packages:
   all:
     target: [haswell]

--- a/scripts/docker/setup-user.sh
+++ b/scripts/docker/setup-user.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if command -v apt-get >/dev/null
 then
   apt-get update

--- a/scripts/docker/spin-xrootd/Dockerfile
+++ b/scripts/docker/spin-xrootd/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM --platform=linux/amd64 fedora:latest
 
 # Install development tools

--- a/scripts/docker/spin-xrootd/README.md
+++ b/scripts/docker/spin-xrootd/README.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 # ADIOS2 XRootD HTTP Server for NERSC Spin
 
 Docker image that serves ADIOS2 BP5 datasets over HTTPS using the XRootD

--- a/scripts/docker/spin-xrootd/build.sh
+++ b/scripts/docker/spin-xrootd/build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Build container image for NERSC Spin deployment
 # This script builds an x86_64 image even on ARM Macs
 # The Dockerfile clones ADIOS2 from GitHub, so no local source is needed

--- a/scripts/docker/spin-xrootd/docker-entrypoint.sh
+++ b/scripts/docker/spin-xrootd/docker-entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 echo "=========================================="

--- a/scripts/runconf/runconf.sh
+++ b/scripts/runconf/runconf.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Usage: 
 #   ./runconf.sh ON lean   (MPI On, minimal adios2)
 #   ./runconf.sh ON        (MPI On, adios2 builds with all dependencies, might need -D*_DIR or -D*_ROOT)

--- a/scripts/runconf/runconf_olcf.sh
+++ b/scripts/runconf/runconf_olcf.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # This script is for configuring adios on the authors' machines
 # You can study it to figure out how to configure adios on your system

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # ------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/source/adios2/common/ADIOSBaseTypes.h
+++ b/source/adios2/common/ADIOSBaseTypes.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/common/ADIOSConfig.h.in
+++ b/source/adios2/common/ADIOSConfig.h.in
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/common/ADIOSMacros.h
+++ b/source/adios2/common/ADIOSMacros.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/common/ADIOSTypes.cpp
+++ b/source/adios2/common/ADIOSTypes.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/common/ADIOSTypes.inl
+++ b/source/adios2/common/ADIOSTypes.inl
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See

--- a/source/adios2/common/Selection.cpp
+++ b/source/adios2/common/Selection.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/common/Selection.h
+++ b/source/adios2/common/Selection.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/ADIOS.h
+++ b/source/adios2/core/ADIOS.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Attribute.cpp
+++ b/source/adios2/core/Attribute.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Attribute.h
+++ b/source/adios2/core/Attribute.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Attribute.tcc
+++ b/source/adios2/core/Attribute.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/AttributeBase.cpp
+++ b/source/adios2/core/AttributeBase.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/AttributeBase.h
+++ b/source/adios2/core/AttributeBase.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/CoreTypes.h
+++ b/source/adios2/core/CoreTypes.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Engine.tcc
+++ b/source/adios2/core/Engine.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Group.cpp
+++ b/source/adios2/core/Group.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Group.h
+++ b/source/adios2/core/Group.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Group.tcc
+++ b/source/adios2/core/Group.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/IO.tcc
+++ b/source/adios2/core/IO.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/IOHDF5.cpp
+++ b/source/adios2/core/IOHDF5.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/IOMPI.cpp
+++ b/source/adios2/core/IOMPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Info.cpp
+++ b/source/adios2/core/Info.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Info.h
+++ b/source/adios2/core/Info.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Operator.cpp
+++ b/source/adios2/core/Operator.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Operator.h
+++ b/source/adios2/core/Operator.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Span.cpp
+++ b/source/adios2/core/Span.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Span.h
+++ b/source/adios2/core/Span.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Span.tcc
+++ b/source/adios2/core/Span.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Stream.cpp
+++ b/source/adios2/core/Stream.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Stream.h
+++ b/source/adios2/core/Stream.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Stream.tcc
+++ b/source/adios2/core/Stream.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Variable.cpp
+++ b/source/adios2/core/Variable.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/VariableBase.h
+++ b/source/adios2/core/VariableBase.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/VariableDerived.cpp
+++ b/source/adios2/core/VariableDerived.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "VariableDerived.h"
 #include "adios2/helper/adiosType.h"
 

--- a/source/adios2/core/VariableDerived.h
+++ b/source/adios2/core/VariableDerived.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_CORE_VARIABLE_DERIVED_H_
 #define ADIOS2_CORE_VARIABLE_DERIVED_H_
 

--- a/source/adios2/core/VariableStruct.cpp
+++ b/source/adios2/core/VariableStruct.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/core/VariableStruct.h
+++ b/source/adios2/core/VariableStruct.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp3/BP3Reader.cpp
+++ b/source/adios2/engine/bp3/BP3Reader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp3/BP3Reader.h
+++ b/source/adios2/engine/bp3/BP3Reader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp3/BP3Reader.tcc
+++ b/source/adios2/engine/bp3/BP3Reader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp3/BP3Writer.cpp
+++ b/source/adios2/engine/bp3/BP3Writer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp3/BP3Writer.h
+++ b/source/adios2/engine/bp3/BP3Writer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp3/BP3Writer.tcc
+++ b/source/adios2/engine/bp3/BP3Writer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp4/BP4Reader.cpp
+++ b/source/adios2/engine/bp4/BP4Reader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp4/BP4Reader.h
+++ b/source/adios2/engine/bp4/BP4Reader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp4/BP4Reader.tcc
+++ b/source/adios2/engine/bp4/BP4Reader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp4/BP4Writer.cpp
+++ b/source/adios2/engine/bp4/BP4Writer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp4/BP4Writer.h
+++ b/source/adios2/engine/bp4/BP4Writer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp4/BP4Writer.tcc
+++ b/source/adios2/engine/bp4/BP4Writer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Engine.cpp
+++ b/source/adios2/engine/bp5/BP5Engine.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Reader.tcc
+++ b/source/adios2/engine/bp5/BP5Reader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Writer.tcc
+++ b/source/adios2/engine/bp5/BP5Writer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Writer_EveryoneWrites_Async.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_EveryoneWrites_Async.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Writer_TwoLevelShm.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_TwoLevelShm.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Writer_TwoLevelShm_Async.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_TwoLevelShm_Async.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/bp5/BP5Writer_WithRerouting.cpp
+++ b/source/adios2/engine/bp5/BP5Writer_WithRerouting.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/campaign/CampaignData.cpp
+++ b/source/adios2/engine/campaign/CampaignData.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/campaign/CampaignData.h
+++ b/source/adios2/engine/campaign/CampaignData.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/campaign/CampaignManager.cpp
+++ b/source/adios2/engine/campaign/CampaignManager.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/campaign/CampaignManager.h
+++ b/source/adios2/engine/campaign/CampaignManager.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/campaign/CampaignReader.h
+++ b/source/adios2/engine/campaign/CampaignReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/campaign/CampaignReader.tcc
+++ b/source/adios2/engine/campaign/CampaignReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/campaign/CampaignRecord.h
+++ b/source/adios2/engine/campaign/CampaignRecord.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/BP5Writer_TwoLevelShm.cpp
+++ b/source/adios2/engine/daos/BP5Writer_TwoLevelShm.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosEngine.cpp
+++ b/source/adios2/engine/daos/DaosEngine.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosEngine.h
+++ b/source/adios2/engine/daos/DaosEngine.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosReader.cpp
+++ b/source/adios2/engine/daos/DaosReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosReader.h
+++ b/source/adios2/engine/daos/DaosReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosReader.tcc
+++ b/source/adios2/engine/daos/DaosReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosWriter.cpp
+++ b/source/adios2/engine/daos/DaosWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosWriter.h
+++ b/source/adios2/engine/daos/DaosWriter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosWriter.tcc
+++ b/source/adios2/engine/daos/DaosWriter.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosWriter_EveryoneWrites_Async.cpp
+++ b/source/adios2/engine/daos/DaosWriter_EveryoneWrites_Async.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosWriter_TwoLevelShm.cpp
+++ b/source/adios2/engine/daos/DaosWriter_TwoLevelShm.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/daos/DaosWriter_TwoLevelShm_Async.cpp
+++ b/source/adios2/engine/daos/DaosWriter_TwoLevelShm_Async.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataman/DataManMonitor.cpp
+++ b/source/adios2/engine/dataman/DataManMonitor.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataman/DataManMonitor.h
+++ b/source/adios2/engine/dataman/DataManMonitor.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataman/DataManReader.cpp
+++ b/source/adios2/engine/dataman/DataManReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataman/DataManReader.h
+++ b/source/adios2/engine/dataman/DataManReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataman/DataManReader.tcc
+++ b/source/adios2/engine/dataman/DataManReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataman/DataManWriter.cpp
+++ b/source/adios2/engine/dataman/DataManWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataman/DataManWriter.h
+++ b/source/adios2/engine/dataman/DataManWriter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataman/DataManWriter.tcc
+++ b/source/adios2/engine/dataman/DataManWriter.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataspaces/DataSpacesReader.cpp
+++ b/source/adios2/engine/dataspaces/DataSpacesReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataspaces/DataSpacesReader.h
+++ b/source/adios2/engine/dataspaces/DataSpacesReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataspaces/DataSpacesReader.tcc
+++ b/source/adios2/engine/dataspaces/DataSpacesReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataspaces/DataSpacesWriter.cpp
+++ b/source/adios2/engine/dataspaces/DataSpacesWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataspaces/DataSpacesWriter.h
+++ b/source/adios2/engine/dataspaces/DataSpacesWriter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/dataspaces/DataSpacesWriter.tcc
+++ b/source/adios2/engine/dataspaces/DataSpacesWriter.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/hdf5/HDF5ReaderP.h
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/hdf5/HDF5ReaderP.tcc
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/hdf5/HDF5WriterP.cpp
+++ b/source/adios2/engine/hdf5/HDF5WriterP.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/hdf5/HDF5WriterP.h
+++ b/source/adios2/engine/hdf5/HDF5WriterP.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/inline/InlineReader.cpp
+++ b/source/adios2/engine/inline/InlineReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/inline/InlineReader.h
+++ b/source/adios2/engine/inline/InlineReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/inline/InlineReader.tcc
+++ b/source/adios2/engine/inline/InlineReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/inline/InlineWriter.cpp
+++ b/source/adios2/engine/inline/InlineWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/inline/InlineWriter.h
+++ b/source/adios2/engine/inline/InlineWriter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/inline/InlineWriter.tcc
+++ b/source/adios2/engine/inline/InlineWriter.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/mhs/MhsReader.cpp
+++ b/source/adios2/engine/mhs/MhsReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/mhs/MhsReader.h
+++ b/source/adios2/engine/mhs/MhsReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/mhs/MhsReader.tcc
+++ b/source/adios2/engine/mhs/MhsReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/mhs/MhsWriter.cpp
+++ b/source/adios2/engine/mhs/MhsWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/mhs/MhsWriter.h
+++ b/source/adios2/engine/mhs/MhsWriter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/mhs/MhsWriter.tcc
+++ b/source/adios2/engine/mhs/MhsWriter.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/null/NullReader.cpp
+++ b/source/adios2/engine/null/NullReader.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "NullReader.h"
 #include "NullReader.tcc"
 

--- a/source/adios2/engine/null/NullReader.h
+++ b/source/adios2/engine/null/NullReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/null/NullReader.tcc
+++ b/source/adios2/engine/null/NullReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/null/NullWriter.cpp
+++ b/source/adios2/engine/null/NullWriter.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "NullWriter.h"
 #include "NullWriter.tcc"
 

--- a/source/adios2/engine/null/NullWriter.h
+++ b/source/adios2/engine/null/NullWriter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/null/NullWriter.tcc
+++ b/source/adios2/engine/null/NullWriter.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/plugin/PluginEngine.cpp
+++ b/source/adios2/engine/plugin/PluginEngine.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/plugin/PluginEngine.h
+++ b/source/adios2/engine/plugin/PluginEngine.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/skeleton/SkeletonReader.cpp
+++ b/source/adios2/engine/skeleton/SkeletonReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/skeleton/SkeletonReader.h
+++ b/source/adios2/engine/skeleton/SkeletonReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/skeleton/SkeletonReader.tcc
+++ b/source/adios2/engine/skeleton/SkeletonReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/skeleton/SkeletonWriter.cpp
+++ b/source/adios2/engine/skeleton/SkeletonWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/skeleton/SkeletonWriter.h
+++ b/source/adios2/engine/skeleton/SkeletonWriter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/skeleton/SkeletonWriter.tcc
+++ b/source/adios2/engine/skeleton/SkeletonWriter.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscHelper.cpp
+++ b/source/adios2/engine/ssc/SscHelper.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscHelper.h
+++ b/source/adios2/engine/ssc/SscHelper.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReader.cpp
+++ b/source/adios2/engine/ssc/SscReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReader.h
+++ b/source/adios2/engine/ssc/SscReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReaderBase.cpp
+++ b/source/adios2/engine/ssc/SscReaderBase.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReaderBase.h
+++ b/source/adios2/engine/ssc/SscReaderBase.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReaderGeneric.cpp
+++ b/source/adios2/engine/ssc/SscReaderGeneric.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReaderGeneric.h
+++ b/source/adios2/engine/ssc/SscReaderGeneric.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReaderGeneric.tcc
+++ b/source/adios2/engine/ssc/SscReaderGeneric.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReaderNaive.cpp
+++ b/source/adios2/engine/ssc/SscReaderNaive.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReaderNaive.h
+++ b/source/adios2/engine/ssc/SscReaderNaive.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscReaderNaive.tcc
+++ b/source/adios2/engine/ssc/SscReaderNaive.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscWriter.cpp
+++ b/source/adios2/engine/ssc/SscWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscWriter.h
+++ b/source/adios2/engine/ssc/SscWriter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscWriterBase.cpp
+++ b/source/adios2/engine/ssc/SscWriterBase.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscWriterBase.h
+++ b/source/adios2/engine/ssc/SscWriterBase.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscWriterGeneric.cpp
+++ b/source/adios2/engine/ssc/SscWriterGeneric.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscWriterGeneric.h
+++ b/source/adios2/engine/ssc/SscWriterGeneric.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscWriterNaive.cpp
+++ b/source/adios2/engine/ssc/SscWriterNaive.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/ssc/SscWriterNaive.h
+++ b/source/adios2/engine/ssc/SscWriterNaive.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/sst/SstParamParser.cpp
+++ b/source/adios2/engine/sst/SstParamParser.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <memory>
 

--- a/source/adios2/engine/sst/SstParamParser.h
+++ b/source/adios2/engine/sst/SstParamParser.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_ENGINE_SST_SSTPARAMPARSER_H_
 #define ADIOS2_ENGINE_SST_SSTPARAMPARSER_H_
 

--- a/source/adios2/engine/sst/SstReader.cpp
+++ b/source/adios2/engine/sst/SstReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/sst/SstReader.h
+++ b/source/adios2/engine/sst/SstReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/sst/SstReader.tcc
+++ b/source/adios2/engine/sst/SstReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/sst/SstWriter.cpp
+++ b/source/adios2/engine/sst/SstWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/sst/SstWriter.h
+++ b/source/adios2/engine/sst/SstWriter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/sst/SstWriter.tcc
+++ b/source/adios2/engine/sst/SstWriter.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/timeseries/TimeSeriesReader.cpp
+++ b/source/adios2/engine/timeseries/TimeSeriesReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/timeseries/TimeSeriesReader.h
+++ b/source/adios2/engine/timeseries/TimeSeriesReader.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/engine/timeseries/TimeSeriesReader.tcc
+++ b/source/adios2/engine/timeseries/TimeSeriesReader.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosCUDA.cu
+++ b/source/adios2/helper/adiosCUDA.cu
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/helper/adiosCUDA.h
+++ b/source/adios2/helper/adiosCUDA.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/helper/adiosComm.cpp
+++ b/source/adios2/helper/adiosComm.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosComm.h
+++ b/source/adios2/helper/adiosComm.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosComm.inl
+++ b/source/adios2/helper/adiosComm.inl
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosComm.tcc
+++ b/source/adios2/helper/adiosComm.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosCommDummy.cpp
+++ b/source/adios2/helper/adiosCommDummy.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosCommDummy.h
+++ b/source/adios2/helper/adiosCommDummy.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosCommMPI.cpp
+++ b/source/adios2/helper/adiosCommMPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosCommMPI.h
+++ b/source/adios2/helper/adiosCommMPI.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosDynamicBinder.cpp
+++ b/source/adios2/helper/adiosDynamicBinder.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosDynamicBinder.h
+++ b/source/adios2/helper/adiosDynamicBinder.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosFunctions.h
+++ b/source/adios2/helper/adiosFunctions.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosGPUFunctions.h
+++ b/source/adios2/helper/adiosGPUFunctions.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_HELPER_ADIOSGPUFUNCTIONS_H_
 #define ADIOS2_HELPER_ADIOSGPUFUNCTIONS_H_
 

--- a/source/adios2/helper/adiosJSONcomplex.h
+++ b/source/adios2/helper/adiosJSONcomplex.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosLog.cpp
+++ b/source/adios2/helper/adiosLog.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosLog.h
+++ b/source/adios2/helper/adiosLog.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosMath.cpp
+++ b/source/adios2/helper/adiosMath.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosMath.h
+++ b/source/adios2/helper/adiosMath.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosMath.inl
+++ b/source/adios2/helper/adiosMath.inl
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosMemory.cpp
+++ b/source/adios2/helper/adiosMemory.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosMemory.h
+++ b/source/adios2/helper/adiosMemory.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosMemory.inl
+++ b/source/adios2/helper/adiosMemory.inl
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosMemory.tcc
+++ b/source/adios2/helper/adiosMemory.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosMpiHandshake.cpp
+++ b/source/adios2/helper/adiosMpiHandshake.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosMpiHandshake.h
+++ b/source/adios2/helper/adiosMpiHandshake.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosNetwork.cpp
+++ b/source/adios2/helper/adiosNetwork.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosNetwork.h
+++ b/source/adios2/helper/adiosNetwork.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosPartitioner.cpp
+++ b/source/adios2/helper/adiosPartitioner.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosPartitioner.h
+++ b/source/adios2/helper/adiosPartitioner.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosPluginManager.cpp
+++ b/source/adios2/helper/adiosPluginManager.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosPluginManager.h
+++ b/source/adios2/helper/adiosPluginManager.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosRangeFilter.cpp
+++ b/source/adios2/helper/adiosRangeFilter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosRangeFilter.h
+++ b/source/adios2/helper/adiosRangeFilter.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosRerouting.cpp
+++ b/source/adios2/helper/adiosRerouting.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosRerouting.h
+++ b/source/adios2/helper/adiosRerouting.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosString.cpp
+++ b/source/adios2/helper/adiosString.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosString.h
+++ b/source/adios2/helper/adiosString.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosString.tcc
+++ b/source/adios2/helper/adiosString.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosSystem.cpp
+++ b/source/adios2/helper/adiosSystem.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosSystem.h
+++ b/source/adios2/helper/adiosSystem.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosType.cpp
+++ b/source/adios2/helper/adiosType.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosType.h
+++ b/source/adios2/helper/adiosType.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosType.inl
+++ b/source/adios2/helper/adiosType.inl
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosXML.cpp
+++ b/source/adios2/helper/adiosXML.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosXML.h
+++ b/source/adios2/helper/adiosXML.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosXMLUtil.cpp
+++ b/source/adios2/helper/adiosXMLUtil.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosXMLUtil.h
+++ b/source/adios2/helper/adiosXMLUtil.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosYAML.cpp
+++ b/source/adios2/helper/adiosYAML.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/adiosYAML.h
+++ b/source/adios2/helper/adiosYAML.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/helper/kokkos/CMakeLists.txt
+++ b/source/adios2/helper/kokkos/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/source/adios2/helper/kokkos/adiosKokkos.cpp
+++ b/source/adios2/helper/kokkos/adiosKokkos.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/helper/kokkos/adiosKokkos.h
+++ b/source/adios2/helper/kokkos/adiosKokkos.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/operator/OperatorFactory.cpp
+++ b/source/adios2/operator/OperatorFactory.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/OperatorFactory.h
+++ b/source/adios2/operator/OperatorFactory.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressBZIP2.cpp
+++ b/source/adios2/operator/compress/CompressBZIP2.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressBZIP2.h
+++ b/source/adios2/operator/compress/CompressBZIP2.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressBigWhoop.cpp
+++ b/source/adios2/operator/compress/CompressBigWhoop.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressBigWhoop.h
+++ b/source/adios2/operator/compress/CompressBigWhoop.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressBlosc.cpp
+++ b/source/adios2/operator/compress/CompressBlosc.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressBlosc.h
+++ b/source/adios2/operator/compress/CompressBlosc.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressLibPressio.cpp
+++ b/source/adios2/operator/compress/CompressLibPressio.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressLibPressio.h
+++ b/source/adios2/operator/compress/CompressLibPressio.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressMGARD.cpp
+++ b/source/adios2/operator/compress/CompressMGARD.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressMGARD.h
+++ b/source/adios2/operator/compress/CompressMGARD.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressMGARDComplex.cpp
+++ b/source/adios2/operator/compress/CompressMGARDComplex.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressMGARDComplex.h
+++ b/source/adios2/operator/compress/CompressMGARDComplex.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressMGARDPlus.cpp
+++ b/source/adios2/operator/compress/CompressMGARDPlus.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressMGARDPlus.h
+++ b/source/adios2/operator/compress/CompressMGARDPlus.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressNull.cpp
+++ b/source/adios2/operator/compress/CompressNull.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressNull.h
+++ b/source/adios2/operator/compress/CompressNull.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressPNG.cpp
+++ b/source/adios2/operator/compress/CompressPNG.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressPNG.h
+++ b/source/adios2/operator/compress/CompressPNG.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressSZ.cpp
+++ b/source/adios2/operator/compress/CompressSZ.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressSZ.h
+++ b/source/adios2/operator/compress/CompressSZ.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressSZ3.cpp
+++ b/source/adios2/operator/compress/CompressSZ3.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressSZ3.h
+++ b/source/adios2/operator/compress/CompressSZ3.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressSirius.cpp
+++ b/source/adios2/operator/compress/CompressSirius.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressSirius.h
+++ b/source/adios2/operator/compress/CompressSirius.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressZFP.cpp
+++ b/source/adios2/operator/compress/CompressZFP.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/compress/CompressZFP.h
+++ b/source/adios2/operator/compress/CompressZFP.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/plugin/PluginOperator.cpp
+++ b/source/adios2/operator/plugin/PluginOperator.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/plugin/PluginOperator.h
+++ b/source/adios2/operator/plugin/PluginOperator.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/refactor/RefactorMDR.cpp
+++ b/source/adios2/operator/refactor/RefactorMDR.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/refactor/RefactorMDR.h
+++ b/source/adios2/operator/refactor/RefactorMDR.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/refactor/RefactorProDM.cpp
+++ b/source/adios2/operator/refactor/RefactorProDM.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/operator/refactor/RefactorProDM.h
+++ b/source/adios2/operator/refactor/RefactorProDM.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/plugin/PluginEngineInterface.h
+++ b/source/adios2/plugin/PluginEngineInterface.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/plugin/PluginOperatorInterface.h
+++ b/source/adios2/plugin/PluginOperatorInterface.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIAggregator.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIChain.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/aggregator/mpi/MPIChain.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIChain.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
+++ b/source/adios2/toolkit/aggregator/mpi/MPIShmChain.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/aggregator/mpi/MPIShmChain.h
+++ b/source/adios2/toolkit/aggregator/mpi/MPIShmChain.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/burstbuffer/FileDrainer.cpp
+++ b/source/adios2/toolkit/burstbuffer/FileDrainer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/burstbuffer/FileDrainer.h
+++ b/source/adios2/toolkit/burstbuffer/FileDrainer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/burstbuffer/FileDrainerSingleThread.cpp
+++ b/source/adios2/toolkit/burstbuffer/FileDrainerSingleThread.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/burstbuffer/FileDrainerSingleThread.h
+++ b/source/adios2/toolkit/burstbuffer/FileDrainerSingleThread.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/dataspaces/CMakeLists.txt
+++ b/source/adios2/toolkit/dataspaces/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 configure_file(
     ${ADIOS2_SOURCE_DIR}/source/adios2/toolkit/dataspaces/DSpacesConfig.h.in
     ${ADIOS2_BINARY_DIR}/source/adios2/toolkit/dataspaces/DSpacesConfig.h.in

--- a/source/adios2/toolkit/dataspaces/DSpacesConfig.h.in
+++ b/source/adios2/toolkit/dataspaces/DSpacesConfig.h.in
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/toolkit/dataspaces/ds.h
+++ b/source/adios2/toolkit/dataspaces/ds.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/dataspaces/ds_data.h
+++ b/source/adios2/toolkit/dataspaces/ds_data.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/dataspaces/ds_writer.c
+++ b/source/adios2/toolkit/dataspaces/ds_writer.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/derived/DerivedData.h
+++ b/source/adios2/toolkit/derived/DerivedData.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_DERIVED_Data_H_
 #define ADIOS2_DERIVED_Data_H_
 

--- a/source/adios2/toolkit/derived/Expression.cpp
+++ b/source/adios2/toolkit/derived/Expression.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_DERIVED_Expression_CPP_
 #define ADIOS2_DERIVED_Expression_CPP_
 

--- a/source/adios2/toolkit/derived/Expression.h
+++ b/source/adios2/toolkit/derived/Expression.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_DERIVED_Expression_H_
 #define ADIOS2_DERIVED_Expression_H_
 

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_DERIVED_Function_CPP_
 #define ADIOS2_DERIVED_Function_CPP_
 

--- a/source/adios2/toolkit/derived/Function.h
+++ b/source/adios2/toolkit/derived/Function.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_DERIVED_Function_H_
 #define ADIOS2_DERIVED_Function_H_
 

--- a/source/adios2/toolkit/derived/parser/ASTDriver.cpp
+++ b/source/adios2/toolkit/derived/parser/ASTDriver.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "ASTDriver.h"
 
 namespace adios2

--- a/source/adios2/toolkit/derived/parser/ASTDriver.h
+++ b/source/adios2/toolkit/derived/parser/ASTDriver.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ASTDRIVER_HH_
 #define ASTDRIVER_HH_
 

--- a/source/adios2/toolkit/derived/parser/ASTNode.cpp
+++ b/source/adios2/toolkit/derived/parser/ASTNode.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "ASTNode.h"
 
 namespace adios2

--- a/source/adios2/toolkit/derived/parser/ASTNode.h
+++ b/source/adios2/toolkit/derived/parser/ASTNode.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ASTNODE_HH
 #define ASTNODE_HH
 #include <string>

--- a/source/adios2/toolkit/derived/parser/lexer.l
+++ b/source/adios2/toolkit/derived/parser/lexer.l
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 %{
 #include <cerrno>
 #include <cstdlib>

--- a/source/adios2/toolkit/derived/parser/parser.y
+++ b/source/adios2/toolkit/derived/parser/parser.y
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 %skeleton "lalr1.cc"
 %require "3.8.2"
 %header

--- a/source/adios2/toolkit/derived/parser/pregen-source/lexer.cpp
+++ b/source/adios2/toolkit/derived/parser/pregen-source/lexer.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #line 1 "lexer.cpp"
 
 #line 3 "lexer.cpp"

--- a/source/adios2/toolkit/derived/parser/pregen-source/lexer.h
+++ b/source/adios2/toolkit/derived/parser/pregen-source/lexer.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef yyHEADER_H
 #define yyHEADER_H 1
 #define yyIN_HEADER 1

--- a/source/adios2/toolkit/derived/parser/pregen-source/location.hh
+++ b/source/adios2/toolkit/derived/parser/pregen-source/location.hh
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // A Bison parser, made by GNU Bison 3.8.2.
 
 // Locations for Bison parsers in C++

--- a/source/adios2/toolkit/derived/parser/pregen-source/parser.cpp
+++ b/source/adios2/toolkit/derived/parser/pregen-source/parser.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // A Bison parser, made by GNU Bison 3.8.2.
 
 // Skeleton implementation for Bison LALR(1) parsers in C++

--- a/source/adios2/toolkit/derived/parser/pregen-source/parser.h
+++ b/source/adios2/toolkit/derived/parser/pregen-source/parser.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // A Bison parser, made by GNU Bison 3.8.2.
 
 // Skeleton interface for Bison LALR(1) parsers in C++

--- a/source/adios2/toolkit/filepool/FilePool.cpp
+++ b/source/adios2/toolkit/filepool/FilePool.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "adios2/toolkit/filepool/FilePool.h"
 #include "adios2sys/SystemTools.hxx"
 

--- a/source/adios2/toolkit/filepool/FilePool.h
+++ b/source/adios2/toolkit/filepool/FilePool.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * FilePool
  *
  * The principal use case for the filepool abstraction is to

--- a/source/adios2/toolkit/filepool/SharedTarFDCache.cpp
+++ b/source/adios2/toolkit/filepool/SharedTarFDCache.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "adios2/toolkit/filepool/SharedTarFDCache.h"
 #include "adios2/helper/adiosCommDummy.h"
 

--- a/source/adios2/toolkit/filepool/SharedTarFDCache.h
+++ b/source/adios2/toolkit/filepool/SharedTarFDCache.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * SharedTarFDCache
  *
  * Process-wide singleton that allows multiple BP5 engines reading from

--- a/source/adios2/toolkit/format/bp/BPBase.cpp
+++ b/source/adios2/toolkit/format/bp/BPBase.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/BPBase.h
+++ b/source/adios2/toolkit/format/bp/BPBase.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/BPBase.inl
+++ b/source/adios2/toolkit/format/bp/BPBase.inl
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/BPBase.tcc
+++ b/source/adios2/toolkit/format/bp/BPBase.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/BPSerializer.cpp
+++ b/source/adios2/toolkit/format/bp/BPSerializer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/BPSerializer.h
+++ b/source/adios2/toolkit/format/bp/BPSerializer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/BPSerializer.inl
+++ b/source/adios2/toolkit/format/bp/BPSerializer.inl
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/BPSerializer.tcc
+++ b/source/adios2/toolkit/format/bp/BPSerializer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp3/BP3Base.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Base.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp3/BP3Base.h
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Base.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Deserializer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.h
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp3/BP3Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp3/BP3Serializer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp4/BP4Base.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Base.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Deserializer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.h
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
+++ b/source/adios2/toolkit/format/bp/bp4/BP4Serializer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bpBackCompatOperation/BPBackCompatOperation.h
+++ b/source/adios2/toolkit/format/bp/bpBackCompatOperation/BPBackCompatOperation.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bpBackCompatOperation/compress/BPBackCompatBlosc.cpp
+++ b/source/adios2/toolkit/format/bp/bpBackCompatOperation/compress/BPBackCompatBlosc.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp/bpBackCompatOperation/compress/BPBackCompatBlosc.h
+++ b/source/adios2/toolkit/format/bp/bpBackCompatOperation/compress/BPBackCompatBlosc.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp5/BP5Base.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Base.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp5/BP5Base.h
+++ b/source/adios2/toolkit/format/bp5/BP5Base.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.tcc
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp5/BP5Helper.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Helper.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp5/BP5Helper.h
+++ b/source/adios2/toolkit/format/bp5/BP5Helper.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/Buffer.cpp
+++ b/source/adios2/toolkit/format/buffer/Buffer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/Buffer.h
+++ b/source/adios2/toolkit/format/buffer/Buffer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/BufferV.cpp
+++ b/source/adios2/toolkit/format/buffer/BufferV.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/BufferV.h
+++ b/source/adios2/toolkit/format/buffer/BufferV.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
+++ b/source/adios2/toolkit/format/buffer/chunk/ChunkV.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/ffs/BufferFFS.cpp
+++ b/source/adios2/toolkit/format/buffer/ffs/BufferFFS.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/ffs/BufferFFS.h
+++ b/source/adios2/toolkit/format/buffer/ffs/BufferFFS.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/ffs/BufferSTL.tcc
+++ b/source/adios2/toolkit/format/buffer/ffs/BufferSTL.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/heap/BufferMalloc.cpp
+++ b/source/adios2/toolkit/format/buffer/heap/BufferMalloc.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/heap/BufferMalloc.h
+++ b/source/adios2/toolkit/format/buffer/heap/BufferMalloc.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/heap/BufferMalloc.tcc
+++ b/source/adios2/toolkit/format/buffer/heap/BufferMalloc.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.cpp
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.h
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
+++ b/source/adios2/toolkit/format/buffer/heap/BufferSTL.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/ipc/BufferSystemV.cpp
+++ b/source/adios2/toolkit/format/buffer/ipc/BufferSystemV.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/ipc/BufferSystemV.h
+++ b/source/adios2/toolkit/format/buffer/ipc/BufferSystemV.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/buffer/malloc/MallocV.h
+++ b/source/adios2/toolkit/format/buffer/malloc/MallocV.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.h
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
+++ b/source/adios2/toolkit/format/dataman/DataManSerializer.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.h
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
+++ b/source/adios2/toolkit/interop/hdf5/HDF5Common.tcc
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/interop/hdf5/HDF5CommonMPI.cpp
+++ b/source/adios2/toolkit/interop/hdf5/HDF5CommonMPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/kvcache/KVCacheCommon.cpp
+++ b/source/adios2/toolkit/kvcache/KVCacheCommon.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 //
 // Created by cguo51 on 12/30/23.
 //

--- a/source/adios2/toolkit/kvcache/KVCacheCommon.h
+++ b/source/adios2/toolkit/kvcache/KVCacheCommon.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 //
 // Created by cguo51 on 12/30/23.
 //

--- a/source/adios2/toolkit/kvcache/QueryBox.h
+++ b/source/adios2/toolkit/kvcache/QueryBox.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 //
 // Created by cguo51 on 7/27/23.
 //

--- a/source/adios2/toolkit/profiling/iochrono/IOChrono.cpp
+++ b/source/adios2/toolkit/profiling/iochrono/IOChrono.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/profiling/iochrono/IOChrono.h
+++ b/source/adios2/toolkit/profiling/iochrono/IOChrono.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/profiling/iochrono/Timer.cpp
+++ b/source/adios2/toolkit/profiling/iochrono/Timer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/profiling/iochrono/Timer.h
+++ b/source/adios2/toolkit/profiling/iochrono/Timer.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/query/BlockIndex.cpp
+++ b/source/adios2/toolkit/query/BlockIndex.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "BlockIndex.h"
 #include "Query.h"
 // #include "BlockIndex.tcc"

--- a/source/adios2/toolkit/query/BlockIndex.h
+++ b/source/adios2/toolkit/query/BlockIndex.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_BLOCK_INDEX_H
 #define ADIOS2_BLOCK_INDEX_H
 

--- a/source/adios2/toolkit/query/Index.h
+++ b/source/adios2/toolkit/query/Index.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_QUERY_INDEX_H
 #define ADIOS2_QUERY_INDEX_H
 

--- a/source/adios2/toolkit/query/JsonWorker.cpp
+++ b/source/adios2/toolkit/query/JsonWorker.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "Worker.h"
 #include "adios2/helper/adiosLog.h"
 

--- a/source/adios2/toolkit/query/Query.cpp
+++ b/source/adios2/toolkit/query/Query.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "Query.h"
 #include "BlockIndex.h"
 #include "adios2/helper/adiosFunctions.h"

--- a/source/adios2/toolkit/query/Query.h
+++ b/source/adios2/toolkit/query/Query.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_QUERY_H
 #define ADIOS2_QUERY_H
 

--- a/source/adios2/toolkit/query/Query.tcc
+++ b/source/adios2/toolkit/query/Query.tcc
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 namespace adios2
 {
 namespace query

--- a/source/adios2/toolkit/query/Util.h
+++ b/source/adios2/toolkit/query/Util.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_QUERY_UTIL_H
 #define ADIOS2_QUERY_UTIL_H
 

--- a/source/adios2/toolkit/query/Worker.cpp
+++ b/source/adios2/toolkit/query/Worker.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "Worker.h"
 #include "adios2/helper/adiosFunctions.h"
 

--- a/source/adios2/toolkit/query/Worker.h
+++ b/source/adios2/toolkit/query/Worker.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef QUERY_WORKER_H
 #define QUERY_WORKER_H
 

--- a/source/adios2/toolkit/query/XmlWorker.cpp
+++ b/source/adios2/toolkit/query/XmlWorker.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "Worker.h"
 
 #include "adios2/helper/adiosLog.h"

--- a/source/adios2/toolkit/remote/CMakeLists.txt
+++ b/source/adios2/toolkit/remote/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.h
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  * ganyushin@gmail.com

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  * ganyushin@gmail.com

--- a/source/adios2/toolkit/remote/remote_common.cpp
+++ b/source/adios2/toolkit/remote/remote_common.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "adios2/common/ADIOSConfig.h"
 
 #include "remote_common.h"

--- a/source/adios2/toolkit/remote/remote_common.h
+++ b/source/adios2/toolkit/remote/remote_common.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifdef ADIOS2_HAVE_SST
 #include "evpath.h"
 #endif

--- a/source/adios2/toolkit/remote/remote_server.cpp
+++ b/source/adios2/toolkit/remote/remote_server.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <iostream>
 #include <random>
 

--- a/source/adios2/toolkit/shm/SerializeProcesses.cpp
+++ b/source/adios2/toolkit/shm/SerializeProcesses.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/shm/SerializeProcesses.h
+++ b/source/adios2/toolkit/shm/SerializeProcesses.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/shm/Spinlock.cpp
+++ b/source/adios2/toolkit/shm/Spinlock.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/shm/Spinlock.h
+++ b/source/adios2/toolkit/shm/Spinlock.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/shm/TokenChain.h
+++ b/source/adios2/toolkit/shm/TokenChain.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/sst/CMakeLists.txt
+++ b/source/adios2/toolkit/sst/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/source/adios2/toolkit/sst/SSTConfig.h.in
+++ b/source/adios2/toolkit/sst/SSTConfig.h.in
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/toolkit/sst/cp/cp_common.c
+++ b/source/adios2/toolkit/sst/cp/cp_common.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/source/adios2/toolkit/sst/cp/cp_internal.h
+++ b/source/adios2/toolkit/sst/cp/cp_internal.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "dp_interface.h"
 #ifndef _MSC_VER
 #include <pthread.h>

--- a/source/adios2/toolkit/sst/cp/cp_reader.c
+++ b/source/adios2/toolkit/sst/cp/cp_reader.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <assert.h>
 #include <ctype.h>
 #include <float.h>

--- a/source/adios2/toolkit/sst/cp/cp_writer.c
+++ b/source/adios2/toolkit/sst/cp/cp_writer.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <assert.h>
 #include <limits.h>
 #include <signal.h>

--- a/source/adios2/toolkit/sst/cp/ffs_marshal.c
+++ b/source/adios2/toolkit/sst/cp/ffs_marshal.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/source/adios2/toolkit/sst/cp/ffs_marshal.h
+++ b/source/adios2/toolkit/sst/cp/ffs_marshal.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 enum DataType
 {
     None,

--- a/source/adios2/toolkit/sst/cp/ffs_zfp.c
+++ b/source/adios2/toolkit/sst/cp/ffs_zfp.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/source/adios2/toolkit/sst/dp/daos_dp.c
+++ b/source/adios2/toolkit/sst/dp/daos_dp.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <assert.h>
 #include <pthread.h>
 #include <stdio.h>

--- a/source/adios2/toolkit/sst/dp/dp.c
+++ b/source/adios2/toolkit/sst/dp/dp.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/source/adios2/toolkit/sst/dp/dummy_dp.c
+++ b/source/adios2/toolkit/sst/dp/dummy_dp.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/source/adios2/toolkit/sst/dp/evpath_dp.c
+++ b/source/adios2/toolkit/sst/dp/evpath_dp.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <assert.h>
 #include <limits.h>
 #ifndef _MSC_VER

--- a/source/adios2/toolkit/sst/dp/mpi_dp.c
+++ b/source/adios2/toolkit/sst/dp/mpi_dp.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /**
  * ADIOS is freely available under the terms of the BSD license described
  * in the COPYING file in the top level directory of this source distribution.

--- a/source/adios2/toolkit/sst/dp/rdma_dp.c
+++ b/source/adios2/toolkit/sst/dp/rdma_dp.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/source/adios2/toolkit/sst/dp/ucx_dp.c
+++ b/source/adios2/toolkit/sst/dp/ucx_dp.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /*----------------------------------------------------------------------------
  *
  *  WRF ADIOS2 I/O

--- a/source/adios2/toolkit/sst/dp_interface.h
+++ b/source/adios2/toolkit/sst/dp_interface.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef _DP_INTERFACE_H
 #define _DP_INTERFACE_H
 

--- a/source/adios2/toolkit/sst/sst.h
+++ b/source/adios2/toolkit/sst/sst.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  *  The SST external interfaces.
  *
  *  This is more a rough sketch than a final version.  The details will

--- a/source/adios2/toolkit/sst/sst_comm.cpp
+++ b/source/adios2/toolkit/sst/sst_comm.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See

--- a/source/adios2/toolkit/sst/sst_comm.h
+++ b/source/adios2/toolkit/sst/sst_comm.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/toolkit/sst/sst_comm_fwd.h
+++ b/source/adios2/toolkit/sst/sst_comm_fwd.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/toolkit/sst/sst_data.h
+++ b/source/adios2/toolkit/sst/sst_data.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef _SST_DATA_H_
 #define _SST_DATA_H_
 

--- a/source/adios2/toolkit/sst/util/CMakeLists.txt
+++ b/source/adios2/toolkit/sst/util/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/source/adios2/toolkit/sst/util/sst_conn_tool.c
+++ b/source/adios2/toolkit/sst/util/sst_conn_tool.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
   SST connection tool.
 
 

--- a/source/adios2/toolkit/sst/util/sst_conn_tool.cxx
+++ b/source/adios2/toolkit/sst/util/sst_conn_tool.cxx
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/adios2/toolkit/sst/win_interface.h
+++ b/source/adios2/toolkit/sst/win_interface.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #define FD_SETSIZE 1024
 #include "winsock2.h"
 #include <Windows.h>

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/Transport.h
+++ b/source/adios2/toolkit/transport/Transport.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.h
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileDaos.cpp
+++ b/source/adios2/toolkit/transport/file/FileDaos.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileDaos.h
+++ b/source/adios2/toolkit/transport/file/FileDaos.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileFStream.cpp
+++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileFStream.h
+++ b/source/adios2/toolkit/transport/file/FileFStream.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileHTTP.cpp
+++ b/source/adios2/toolkit/transport/file/FileHTTP.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileHTTP.h
+++ b/source/adios2/toolkit/transport/file/FileHTTP.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileHTTPS.cpp
+++ b/source/adios2/toolkit/transport/file/FileHTTPS.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "FileHTTPS.h"
 #include "adios2/helper/adiosString.h"
 #include <adios2sys/SystemTools.hxx>

--- a/source/adios2/toolkit/transport/file/FileHTTPS.h
+++ b/source/adios2/toolkit/transport/file/FileHTTPS.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS2_FILEHTTPS_H
 #define ADIOS2_FILEHTTPS_H
 

--- a/source/adios2/toolkit/transport/file/FileIME.cpp
+++ b/source/adios2/toolkit/transport/file/FileIME.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileIME.h
+++ b/source/adios2/toolkit/transport/file/FileIME.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  *
  * FilePOSIX.cpp file I/O using POSIX I/O library
  *

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileRemote.cpp
+++ b/source/adios2/toolkit/transport/file/FileRemote.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileRemote.h
+++ b/source/adios2/toolkit/transport/file/FileRemote.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileStdio.cpp
+++ b/source/adios2/toolkit/transport/file/FileStdio.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/file/FileStdio.h
+++ b/source/adios2/toolkit/transport/file/FileStdio.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/null/NullTransport.cpp
+++ b/source/adios2/toolkit/transport/null/NullTransport.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/null/NullTransport.h
+++ b/source/adios2/toolkit/transport/null/NullTransport.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transport/shm/ShmSystemV.h
+++ b/source/adios2/toolkit/transport/shm/ShmSystemV.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/transportman/TransportMan.h
+++ b/source/adios2/toolkit/transportman/TransportMan.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/zmq/zmqpubsub/ZmqPubSub.cpp
+++ b/source/adios2/toolkit/zmq/zmqpubsub/ZmqPubSub.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/zmq/zmqpubsub/ZmqPubSub.h
+++ b/source/adios2/toolkit/zmq/zmqpubsub/ZmqPubSub.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/zmq/zmqreqrep/ZmqReqRep.cpp
+++ b/source/adios2/toolkit/zmq/zmqreqrep/ZmqReqRep.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/adios2/toolkit/zmq/zmqreqrep/ZmqReqRep.h
+++ b/source/adios2/toolkit/zmq/zmqreqrep/ZmqReqRep.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/h5vol/CMakeLists.txt
+++ b/source/h5vol/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/source/h5vol/H5Vol.c
+++ b/source/h5vol/H5Vol.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "H5Vol.h"
 
 static hid_t m_VID = -1;

--- a/source/h5vol/H5Vol.h
+++ b/source/h5vol/H5Vol.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS_VOL_H
 #define ADIOS_VOL_H
 

--- a/source/h5vol/H5VolError.h
+++ b/source/h5vol/H5VolError.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS_ERR_H
 #define ADIOS_ERR_H
 

--- a/source/h5vol/H5VolReadWrite.c
+++ b/source/h5vol/H5VolReadWrite.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "H5VLpublic.h"
 #include "hdf5.h"
 #define H5S_FRIEND // suppress error for H5Spkg

--- a/source/h5vol/H5VolReadWrite.h
+++ b/source/h5vol/H5VolReadWrite.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef ADIOS_VOL_WRITER_H
 #define ADIOS_VOL_WRITER_H
 

--- a/source/h5vol/H5VolUtil.c
+++ b/source/h5vol/H5VolUtil.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "H5VolUtil.h"
 #include "H5VolError.h"
 

--- a/source/h5vol/H5VolUtil.h
+++ b/source/h5vol/H5VolUtil.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef H5VL_UTIL
 #define H5VL_UTIL
 

--- a/source/h5vol/H5Vol_attr.c
+++ b/source/h5vol/H5Vol_attr.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __H5VOL_ATTR_FUNC
 #define __H5VOL_ATTR_FUNC
 

--- a/source/h5vol/H5Vol_dataset.c
+++ b/source/h5vol/H5Vol_dataset.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __H5VOL_DATASET_FUNC
 #define __H5VOL_DATASET_FUNC
 

--- a/source/h5vol/H5Vol_def.h
+++ b/source/h5vol/H5Vol_def.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __H5VOL_DEFS
 #define __H5VOL_DEFS
 

--- a/source/h5vol/H5Vol_file.c
+++ b/source/h5vol/H5Vol_file.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "H5Vol_def.h"
 
 //

--- a/source/h5vol/H5Vol_group.c
+++ b/source/h5vol/H5Vol_group.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __H5VOL_GROUP_FUNC
 #define __H5VOL_GROUP_FUNC
 

--- a/source/h5vol/H5Vol_link.c
+++ b/source/h5vol/H5Vol_link.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __H5VOL_LINK_FUNC
 #define __H5VOL_LINK_FUNC
 

--- a/source/h5vol/H5Vol_object.c
+++ b/source/h5vol/H5Vol_object.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __H5VOL_OBJECT_FUNC
 #define __H5VOL_OBJECT_FUNC
 

--- a/source/utils/CMakeLists.txt
+++ b/source/utils/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/source/utils/Utils.cpp
+++ b/source/utils/Utils.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/utils/Utils.h
+++ b/source/utils/Utils.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/utils/adios2_deactivate_bp
+++ b/source/utils/adios2_deactivate_bp
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FNAME=$1
 if [ "x$FNAME" == "x" ]; then
     echo "Missing BP data set name"

--- a/source/utils/adios2_json_pp.py
+++ b/source/utils/adios2_json_pp.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import argparse
 from os.path import exists

--- a/source/utils/adios_iotest/CMakeLists.txt
+++ b/source/utils/adios_iotest/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/source/utils/adios_iotest/adiosStream.cpp
+++ b/source/utils/adios_iotest/adiosStream.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * adiosStream.cpp
  *
  *  Created on: Nov 2018

--- a/source/utils/adios_iotest/adiosStream.h
+++ b/source/utils/adios_iotest/adiosStream.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * adiosStream.h
  *
  *  Created on: Nov 2018

--- a/source/utils/adios_iotest/adios_iotest.cpp
+++ b/source/utils/adios_iotest/adios_iotest.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <chrono>
 #include <cstdlib>
 #include <fstream>

--- a/source/utils/adios_iotest/decomp.cpp
+++ b/source/utils/adios_iotest/decomp.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * decomp.h
  *
  *  Created on: Oct 2018

--- a/source/utils/adios_iotest/decomp.h
+++ b/source/utils/adios_iotest/decomp.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * decomp.h
  *
  *  Created on: Oct 2018

--- a/source/utils/adios_iotest/hdf5Stream.cpp
+++ b/source/utils/adios_iotest/hdf5Stream.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * hdf5Stream.cpp
  *
  *  Created on: Nov 2018

--- a/source/utils/adios_iotest/hdf5Stream.h
+++ b/source/utils/adios_iotest/hdf5Stream.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * hdf5Stream.h
  *
  *  Created on: Nov 2018

--- a/source/utils/adios_iotest/ioGroup.cpp
+++ b/source/utils/adios_iotest/ioGroup.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * ioGroup.cpp
  *
  *  Created on: Nov 2018

--- a/source/utils/adios_iotest/ioGroup.h
+++ b/source/utils/adios_iotest/ioGroup.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * ioGroup.h
  *
  *  Created on: Nov 2018

--- a/source/utils/adios_iotest/processConfig.cpp
+++ b/source/utils/adios_iotest/processConfig.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * processConfig.cpp
  *
  *  Created on: Oct 2018

--- a/source/utils/adios_iotest/processConfig.h
+++ b/source/utils/adios_iotest/processConfig.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * processConfig.h
  *
  *  Created on: Oct 2018

--- a/source/utils/adios_iotest/settings.cpp
+++ b/source/utils/adios_iotest/settings.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/utils/adios_iotest/settings.h
+++ b/source/utils/adios_iotest/settings.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/utils/adios_iotest/stream.cpp
+++ b/source/utils/adios_iotest/stream.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * stream.cpp
  *
  *  Created on: Nov 2018

--- a/source/utils/adios_iotest/stream.h
+++ b/source/utils/adios_iotest/stream.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * stream.h
  *
  *  Created on: Nov 2018

--- a/source/utils/adios_reorganize/Reorganize.cpp
+++ b/source/utils/adios_reorganize/Reorganize.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/utils/adios_reorganize/Reorganize.h
+++ b/source/utils/adios_reorganize/Reorganize.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/utils/adios_reorganize/adios2_reorganize_wrapper
+++ b/source/utils/adios_reorganize/adios2_reorganize_wrapper
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if [ $# -ne 2 ]
 then
   echo "Usage: $0 /path/to/input /path/to/output"

--- a/source/utils/adios_reorganize/main.cpp
+++ b/source/utils/adios_reorganize/main.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/source/utils/bp4dbg/CMakeLists.txt
+++ b/source/utils/bp4dbg/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 install(PROGRAMS bp4dbg.py
   RENAME bp4dbg
   DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_scripts-runtime

--- a/source/utils/bp4dbg/adios2/bp4dbg/__init__.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .data import *
 from .idxtable import *
 from .metadata import *

--- a/source/utils/bp4dbg/adios2/bp4dbg/data.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/data.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from os import fstat
 from .utils import *

--- a/source/utils/bp4dbg/adios2/bp4dbg/idxtable.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/idxtable.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from os import fstat
 from .utils import *

--- a/source/utils/bp4dbg/adios2/bp4dbg/metadata.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/metadata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from os import fstat
 from .utils import *

--- a/source/utils/bp4dbg/adios2/bp4dbg/utils.py
+++ b/source/utils/bp4dbg/adios2/bp4dbg/utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 LocalValueDim = 18446744073709551613
 
 dataTypes = {

--- a/source/utils/bp4dbg/bp4dbg.py
+++ b/source/utils/bp4dbg/bp4dbg.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from os.path import basename, exists, isdir
 import glob

--- a/source/utils/bp5dbg/CMakeLists.txt
+++ b/source/utils/bp5dbg/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 install(PROGRAMS bp5dbg.py
   RENAME bp5dbg
   DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT adios2_scripts-runtime

--- a/source/utils/bp5dbg/adios2/bp5dbg/__init__.py
+++ b/source/utils/bp5dbg/adios2/bp5dbg/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .idxtable import *
 from .metadata import *
 from .metametadata import *

--- a/source/utils/bp5dbg/adios2/bp5dbg/ffs.py
+++ b/source/utils/bp5dbg/adios2/bp5dbg/ffs.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 ctypes wrapper for libadios2_ffs to decode FFS-encoded BP5 metadata.
 """

--- a/source/utils/bp5dbg/adios2/bp5dbg/idxtable.py
+++ b/source/utils/bp5dbg/adios2/bp5dbg/idxtable.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from os import fstat
 
 import numpy as np

--- a/source/utils/bp5dbg/adios2/bp5dbg/metadata.py
+++ b/source/utils/bp5dbg/adios2/bp5dbg/metadata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from os import fstat
 import ctypes
 import struct

--- a/source/utils/bp5dbg/adios2/bp5dbg/metametadata.py
+++ b/source/utils/bp5dbg/adios2/bp5dbg/metametadata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from os import fstat
 
 import numpy as np

--- a/source/utils/bp5dbg/adios2/bp5dbg/utils.py
+++ b/source/utils/bp5dbg/adios2/bp5dbg/utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 LocalValueDim = 18446744073709551613
 

--- a/source/utils/bp5dbg/bp5dbg.py
+++ b/source/utils/bp5dbg/bp5dbg.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import glob
 from os.path import basename, exists, isdir

--- a/source/utils/bpcmp/CMakeLists.txt
+++ b/source/utils/bpcmp/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 configure_file(bpcmp.py "${PROJECT_BINARY_DIR}/bin/bpcmp.py" COPYONLY)
 
 install(PROGRAMS bpcmp.py

--- a/source/utils/bpcmp/bpcmp.cmake.gen.in
+++ b/source/utils/bpcmp/bpcmp.cmake.gen.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.6)
 
 if(OUTPUT_FILE)

--- a/source/utils/bpcmp/bpcmp.py
+++ b/source/utils/bpcmp/bpcmp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import sys
 import errno

--- a/source/utils/bpls/bpls.cmake.gen.in
+++ b/source/utils/bpls/bpls.cmake.gen.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.6)
 
 if(OUTPUT_FILE)

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1,8 +1,8 @@
 /*
- * ADIOS is freely available under the terms of the BSD license described
- * in the COPYING file in the top level directory of this source distribution.
+ * Copyright (C) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
  *
- * Copyright (c) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /*

--- a/source/utils/bpls/bpls.h
+++ b/source/utils/bpls/bpls.h
@@ -1,8 +1,8 @@
 /*
- * ADIOS is freely available under the terms of the BSD license described
- * in the COPYING file in the top level directory of this source distribution.
+ * Copyright (C) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
  *
- * Copyright (c) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "adios2/common/ADIOSConfig.h"

--- a/source/utils/profiler/ReadMe.md
+++ b/source/utils/profiler/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 These are the script I use to plot json profilers.
 In the ADIOS proflier, the important keys are:
    PP PDW ES ES_AWD ES_aggregate_info MetaInfoBcast FixedMetaInfoGather transport_0.wbytes

--- a/source/utils/profiler/scripts/common.py
+++ b/source/utils/profiler/scripts/common.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import matplotlib.pyplot as plt
 import parseMe
 import os

--- a/source/utils/profiler/scripts/draw.sh
+++ b/source/utils/profiler/scripts/draw.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ################################################################
 # Usage: ./script.sh <jobID> <scriptsHome> <extractedFilesBase> <timeStep> <aggType>
 # Example: ./script.sh 12345 /path/to/scripts /path/to/extracted 0 <aggType>

--- a/source/utils/profiler/scripts/extract.sh
+++ b/source/utils/profiler/scripts/extract.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ###########################################################################
 ## sample usage:
 ## > source extract.sh ES ../jsons/testMe_default ../jsons/testMe_flatten

--- a/source/utils/profiler/scripts/parseMe.py
+++ b/source/utils/profiler/scripts/parseMe.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import textwrap
 import os

--- a/source/utils/profiler/scripts/plotCall.py
+++ b/source/utils/profiler/scripts/plotCall.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import matplotlib.pyplot as plt
 import numpy as np
 import csv

--- a/source/utils/profiler/scripts/plotRanks.py
+++ b/source/utils/profiler/scripts/plotRanks.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import matplotlib.pyplot as plt
 import numpy as np
 import csv

--- a/source/utils/profiler/scripts/plotStack.py
+++ b/source/utils/profiler/scripts/plotStack.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import matplotlib.pyplot as plt
 import numpy as np
 import csv

--- a/source/utils/profiler/tests/1.sh
+++ b/source/utils/profiler/tests/1.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ####################################################################################
 # usage:
 #   takes two parmeter: a timestep descrption, and a adios profiler file

--- a/source/utils/profiler_simplified/ReadMe.md
+++ b/source/utils/profiler_simplified/ReadMe.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 These are the script I use to plot json profilers.
 In the ADIOS proflier, the important keys are:
    PP PDW ES ES_AWD ES_aggregate_info MetaInfoBcast FixedMetaInfoGather transport_0.wbytes

--- a/source/utils/profiler_simplified/plot_json.py
+++ b/source/utils/profiler_simplified/plot_json.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import sys
 import os

--- a/source/utils/profiler_simplified/writeSummary.sh
+++ b/source/utils/profiler_simplified/writeSummary.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ####################################
 ## summarizing for ADIOS writer   ##
 ####################################

--- a/source/utils/verinfo.h.in
+++ b/source/utils/verinfo.h.in
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #define ADIOS_INFO_VER_GIT       "@ADIOS2_VERSION_GIT_SHA@"
 #define ADIOS_INFO_COMPILER_ID   "@CMAKE_CXX_COMPILER_ID@"
 #define ADIOS_INFO_COMPILER_VER  "@CMAKE_CXX_COMPILER_VERSION@"

--- a/source/utils/xrootd-plugin/AdiosFilePool.cpp
+++ b/source/utils/xrootd-plugin/AdiosFilePool.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "AdiosFilePool.h"
 #include <cerrno>
 #include <cstdio>

--- a/source/utils/xrootd-plugin/AdiosFilePool.h
+++ b/source/utils/xrootd-plugin/AdiosFilePool.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/source/utils/xrootd-plugin/CMakeLists.txt
+++ b/source/utils/xrootd-plugin/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
   # ADIOS SSI service plugin (server-side, handles SSI protocol requests)
   add_library(adios2_xrootd SHARED XrdSsiSvProvider.cpp XrdSsiSvService.cpp XrdSsiSvStreamActive.cpp XrdSsiSvStreamPassive.cpp AdiosFilePool.cpp)
   target_include_directories(adios2_xrootd PRIVATE ${PROJECT_SOURCE_DIR}/bindings/CXX ${XROOTD_INCLUDE_DIRS})

--- a/source/utils/xrootd-plugin/XrdHttpSsiHandler.cpp
+++ b/source/utils/xrootd-plugin/XrdHttpSsiHandler.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /******************************************************************************/
 /*                                                                            */
 /*                X r d H t t p S s i H a n d l e r . c c                     */

--- a/source/utils/xrootd-plugin/XrdHttpSsiHandler.hh
+++ b/source/utils/xrootd-plugin/XrdHttpSsiHandler.hh
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __XRDHTTPSSIHANDLER_HH__
 #define __XRDHTTPSSIHANDLER_HH__
 /******************************************************************************/

--- a/source/utils/xrootd-plugin/XrdSsiSvProvider.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvProvider.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /******************************************************************************/
 /*                                                                            */
 /*                    X r d S s i S v S e r v i c e . c c                     */

--- a/source/utils/xrootd-plugin/XrdSsiSvService.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvService.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /******************************************************************************/
 /*                                                                            */
 /*                    X r d S s i S v S e r v i c e . c c                     */

--- a/source/utils/xrootd-plugin/XrdSsiSvService.hh
+++ b/source/utils/xrootd-plugin/XrdSsiSvService.hh
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __XRDSSISVSERVICE_HH__
 #define __XRDSSISVSERVICE_HH__
 /******************************************************************************/

--- a/source/utils/xrootd-plugin/XrdSsiSvStreamActive.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvStreamActive.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /******************************************************************************/
 /*                                                                            */
 /*                 X r d S s i S t r e a m A c t i v e . c c                  */

--- a/source/utils/xrootd-plugin/XrdSsiSvStreamActive.hh
+++ b/source/utils/xrootd-plugin/XrdSsiSvStreamActive.hh
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __XRDSSISVSTREAMACTIVE_HH__
 #define __XRDSSISVSTREAMACTIVE_HH__
 /******************************************************************************/

--- a/source/utils/xrootd-plugin/XrdSsiSvStreamPassive.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvStreamPassive.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /******************************************************************************/
 /*                                                                            */
 /*              X r d S s i S v S t r e a m P a s s i v e . c c               */

--- a/source/utils/xrootd-plugin/XrdSsiSvStreamPassive.hh
+++ b/source/utils/xrootd-plugin/XrdSsiSvStreamPassive.hh
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __XRDSSISVSTREAMPASSIVE_HH__
 #define __XRDSSISVSTREAMPASSIVE_HH__
 /******************************************************************************/

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # ------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/CMakeLists.txt
+++ b/testing/adios2/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/backward_compatibility/CMakeLists.txt
+++ b/testing/adios2/backward_compatibility/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/backward_compatibility/TestBP4ReadOldCompressed.cpp
+++ b/testing/adios2/backward_compatibility/TestBP4ReadOldCompressed.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/bindings/C/CMakeLists.txt
+++ b/testing/adios2/bindings/C/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/C/SmallTestData_c.h
+++ b/testing/adios2/bindings/C/SmallTestData_c.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/bindings/C/TestBPAvailableVariablesAttribites.cpp
+++ b/testing/adios2/bindings/C/TestBPAvailableVariablesAttribites.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/bindings/C/TestBPMemorySpace.cpp
+++ b/testing/adios2/bindings/C/TestBPMemorySpace.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/bindings/C/TestBPWriteAggregateReadLocal.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteAggregateReadLocal.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/bindings/C/TestBPWriteReadMultiblock.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteReadMultiblock.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/bindings/C/TestBPWriteStatsOnly.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteStatsOnly.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/bindings/C/TestNullWriteRead.cpp
+++ b/testing/adios2/bindings/C/TestNullWriteRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/bindings/CMakeLists.txt
+++ b/testing/adios2/bindings/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/fortran/CMakeLists.txt
+++ b/testing/adios2/bindings/fortran/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/fortran/SmallTestData_mod.F90
+++ b/testing/adios2/bindings/fortran/SmallTestData_mod.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 ! accompanying file Copyright.txt for details.
 !

--- a/testing/adios2/bindings/fortran/TestAdios2BindingsFortranIO.F90
+++ b/testing/adios2/bindings/fortran/TestAdios2BindingsFortranIO.F90
@@ -1,3 +1,6 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
 
 ! ======================================================================
 module testing_adios

--- a/testing/adios2/bindings/fortran/TestBPMemorySpace.F90
+++ b/testing/adios2/bindings/fortran/TestBPMemorySpace.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPMemorySpace
      use adios2
      implicit none

--- a/testing/adios2/bindings/fortran/TestBPMemorySpaceGPU.F90
+++ b/testing/adios2/bindings/fortran/TestBPMemorySpaceGPU.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPMemorySpace
      use adios2
      implicit none

--- a/testing/adios2/bindings/fortran/TestBPReadGlobalsByName.F90
+++ b/testing/adios2/bindings/fortran/TestBPReadGlobalsByName.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPReadGlobalsByName
     use mpi
     use adios2

--- a/testing/adios2/bindings/fortran/TestBPWriteMemorySelectionRead2D.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteMemorySelectionRead2D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteMemorySelectionRead2D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/TestBPWriteMemorySelectionRead3D.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteMemorySelectionRead3D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteMemorySelectionRead3D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/TestBPWriteReadAttributes.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteReadAttributes.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteAttributes
     use small_test_data
     use mpi

--- a/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap2D.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap2D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMap2D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap3D.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap3D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMap3D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap4D.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap4D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMap4D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap5D.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap5D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMap5D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap6D.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteReadHeatMap6D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMap6D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/TestBPWriteReadMemorySelection2D.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteReadMemorySelection2D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteMemorySelectionRead2D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/TestBPWriteStatsOnly.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteStatsOnly.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteStatsOnly
   use adios2
 

--- a/testing/adios2/bindings/fortran/TestBPWriteTypes.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypes.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteTypes
    use small_test_data
 #if ADIOS2_USE_MPI

--- a/testing/adios2/bindings/fortran/TestBPWriteTypesByName.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypesByName.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
  program TestBPWriteTypes
      use small_test_data
      use mpi

--- a/testing/adios2/bindings/fortran/TestBPWriteTypesLocal.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteTypesLocal.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
  program TestBPWriteTypes
      use small_test_data
      use mpi

--- a/testing/adios2/bindings/fortran/TestBPWriteVariableAttributes.F90
+++ b/testing/adios2/bindings/fortran/TestBPWriteVariableAttributes.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteVariableAttributes
     use small_test_data
     use mpi

--- a/testing/adios2/bindings/fortran/TestF2C_BPReadFBlocks.cpp
+++ b/testing/adios2/bindings/fortran/TestF2C_BPReadFBlocks.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/bindings/fortran/TestNullEngine.F90
+++ b/testing/adios2/bindings/fortran/TestNullEngine.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
  program TestNullEngine
      use mpi
      use adios2

--- a/testing/adios2/bindings/fortran/TestRemove.F90
+++ b/testing/adios2/bindings/fortran/TestRemove.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestRemove
     use small_test_data
 #if ADIOS2_USE_MPI

--- a/testing/adios2/bindings/fortran/operation/CMakeLists.txt
+++ b/testing/adios2/bindings/fortran/operation/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if(ADIOS2_HAVE_SZ)
   fortran_add_test_helper(BPWriteReadSZ2D MPI_ONLY)
   fortran_add_test_helper(BPWriteReadSZ3D MPI_ONLY)

--- a/testing/adios2/bindings/fortran/operation/TestBPWriteReadSZ2D.F90
+++ b/testing/adios2/bindings/fortran/operation/TestBPWriteReadSZ2D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMapSZ2D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/operation/TestBPWriteReadSZ3D.F90
+++ b/testing/adios2/bindings/fortran/operation/TestBPWriteReadSZ3D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMapSZ3D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/operation/TestBPWriteReadZfp2D.F90
+++ b/testing/adios2/bindings/fortran/operation/TestBPWriteReadZfp2D.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMapZfp2D
   use mpi
   use adios2

--- a/testing/adios2/bindings/fortran/operation/TestBPWriteReadZfp2DRemove.F90
+++ b/testing/adios2/bindings/fortran/operation/TestBPWriteReadZfp2DRemove.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPWriteReadHeatMapZfp2DRemove
   use mpi
   use adios2

--- a/testing/adios2/bindings/python/CMakeLists.txt
+++ b/testing/adios2/bindings/python/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestBPBlocksInfo.py
+++ b/testing/adios2/bindings/python/TestBPBlocksInfo.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI - approved Apache License, Version 2.0. See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestBPReadMultisteps.py
+++ b/testing/adios2/bindings/python/TestBPReadMultisteps.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestBPSelectSteps.py
+++ b/testing/adios2/bindings/python/TestBPSelectSteps.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestBPWriteRead2D.py
+++ b/testing/adios2/bindings/python/TestBPWriteRead2D.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestBPWriteReadString.py
+++ b/testing/adios2/bindings/python/TestBPWriteReadString.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestBPWriteReadTypes.py
+++ b/testing/adios2/bindings/python/TestBPWriteReadTypes.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestBPWriteReadTypes_nompi.py
+++ b/testing/adios2/bindings/python/TestBPWriteReadTypes_nompi.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestBPWriteStatsOnly.py
+++ b/testing/adios2/bindings/python/TestBPWriteStatsOnly.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestGetException_nompi.py
+++ b/testing/adios2/bindings/python/TestGetException_nompi.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import logging
 import adios2.bindings as adios2

--- a/testing/adios2/bindings/python/TestNullEngine.py
+++ b/testing/adios2/bindings/python/TestNullEngine.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/bindings/python/TestQuery.py
+++ b/testing/adios2/bindings/python/TestQuery.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 from mpi4py import MPI
 import numpy as np

--- a/testing/adios2/bindings/python/TestQueryLocalArray.py
+++ b/testing/adios2/bindings/python/TestQueryLocalArray.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 from mpi4py import MPI
 import numpy as np

--- a/testing/adios2/bindings/python/adios2NPTypes.py
+++ b/testing/adios2/bindings/python/adios2NPTypes.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/derived/CMakeLists.txt
+++ b/testing/adios2/derived/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 #Distributed under the OSI - approved Apache License, Version 2.0. See
 #accompanying file Copyright.txt for details.

--- a/testing/adios2/derived/TestBPDerivedCorrectness.cpp
+++ b/testing/adios2/derived/TestBPDerivedCorrectness.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 #include <cstring>
 

--- a/testing/adios2/derived/TestBPDerivedCorrectnessMPI.cpp
+++ b/testing/adios2/derived/TestBPDerivedCorrectnessMPI.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 #include <cstring>
 

--- a/testing/adios2/engine/CMakeLists.txt
+++ b/testing/adios2/engine/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/ParamsHelpers.h
+++ b/testing/adios2/engine/ParamsHelpers.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/TestHelpers.h
+++ b/testing/adios2/engine/TestHelpers.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # ------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/bp/TestBPAccuracyDefaults.cpp
+++ b/testing/adios2/engine/bp/TestBPAccuracyDefaults.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPAppendAfterSteps.cpp
+++ b/testing/adios2/engine/bp/TestBPAppendAfterSteps.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPBufferSize.cpp
+++ b/testing/adios2/engine/bp/TestBPBufferSize.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPChangingShape.cpp
+++ b/testing/adios2/engine/bp/TestBPChangingShape.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPChangingShapeWithinStep.cpp
+++ b/testing/adios2/engine/bp/TestBPChangingShapeWithinStep.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPDataSizeAggregate.cpp
+++ b/testing/adios2/engine/bp/TestBPDataSizeAggregate.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPDirectIO.cpp
+++ b/testing/adios2/engine/bp/TestBPDirectIO.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPFStreamWriteReadHighLevelAPI.cpp
+++ b/testing/adios2/engine/bp/TestBPFStreamWriteReadHighLevelAPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPFortranToCppReader.cpp
+++ b/testing/adios2/engine/bp/TestBPFortranToCppReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPFortranToCppWriter.F90
+++ b/testing/adios2/engine/bp/TestBPFortranToCppWriter.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program TestBPFortranToCppWriter
    use mpi
    use adios2

--- a/testing/adios2/engine/bp/TestBPInquireDefine.cpp
+++ b/testing/adios2/engine/bp/TestBPInquireDefine.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 //
 // Created by ganyush on 4/23/21.
 //

--- a/testing/adios2/engine/bp/TestBPInquireVariableException.cpp
+++ b/testing/adios2/engine/bp/TestBPInquireVariableException.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPJoinedArray.cpp
+++ b/testing/adios2/engine/bp/TestBPJoinedArray.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPLargeBlocks.cpp
+++ b/testing/adios2/engine/bp/TestBPLargeBlocks.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPLargeMetadata.cpp
+++ b/testing/adios2/engine/bp/TestBPLargeMetadata.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPMetadataFDClose.cpp
+++ b/testing/adios2/engine/bp/TestBPMetadataFDClose.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPMultiSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPMultiSpan.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPNewFileAppendMode.cpp
+++ b/testing/adios2/engine/bp/TestBPNewFileAppendMode.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
+++ b/testing/adios2/engine/bp/TestBPNoXMLRecovery.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <iostream>
 #include <vector>
 

--- a/testing/adios2/engine/bp/TestBPOpenWithMetadata.cpp
+++ b/testing/adios2/engine/bp/TestBPOpenWithMetadata.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPParameterSelectSteps.cpp
+++ b/testing/adios2/engine/bp/TestBPParameterSelectSteps.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPReadMultithreaded.cpp
+++ b/testing/adios2/engine/bp/TestBPReadMultithreaded.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPSelectionGet.cpp
+++ b/testing/adios2/engine/bp/TestBPSelectionGet.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPSelectionsCuda.cpp
+++ b/testing/adios2/engine/bp/TestBPSelectionsCuda.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPSelectionsOnColumnMajorData.cpp
+++ b/testing/adios2/engine/bp/TestBPSelectionsOnColumnMajorData.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPSelectionsOnRowMajorData.cpp
+++ b/testing/adios2/engine/bp/TestBPSelectionsOnRowMajorData.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPStepsFileGlobalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsFileGlobalArray.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPStepsFileLocalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsFileLocalArray.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPStepsInSituGlobalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsInSituGlobalArray.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPStepsInSituLocalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsInSituLocalArray.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPTimeAggregation.cpp
+++ b/testing/adios2/engine/bp/TestBPTimeAggregation.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteAggregateRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteAggregateRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteAppendReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteAppendReadADIOS2.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteMemorySelectionRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteMemorySelectionRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteMultiblockRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteMultiblockRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteNull.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteNull.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2Transport.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2Transport.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributesMultirank.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributesMultirank.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadFlatten.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadFlatten.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariables.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariables.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSel.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSel.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSelHighLevel.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSelHighLevel.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadMultiblock.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadMultiblock.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/TestBPWriteStatsOnly.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteStatsOnly.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/generateXRootDConfig.sh
+++ b/testing/adios2/engine/bp/generateXRootDConfig.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 echo "Generating config for XRootD with plugin library at $1"
 mkdir -p xroot/var/spool
 mkdir -p xroot/run/xrootd

--- a/testing/adios2/engine/bp/generateXRootDHttpConfig.sh
+++ b/testing/adios2/engine/bp/generateXRootDHttpConfig.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Generate XRootD configuration for HTTP-to-SSI bridge testing
 # Usage: generateXRootDHttpConfig.sh <adios2_xrootd_plugin> <adios2_xrootd_http_plugin> [xrd_port] [http_port]
 

--- a/testing/adios2/engine/bp/kill_xrootd.sh
+++ b/testing/adios2/engine/bp/kill_xrootd.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 kill -2 "$(cat /tmp/xrootd.pid)"
 #rm /tmp/xrootd.pid
 exit 0

--- a/testing/adios2/engine/bp/kill_xrootd_http.sh
+++ b/testing/adios2/engine/bp/kill_xrootd_http.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Kill XRootD HTTP server
 kill -2 "$(cat /tmp/xrootd-http.pid)"
 #rm /tmp/xrootd-http.pid

--- a/testing/adios2/engine/bp/operations/CMakeLists.txt
+++ b/testing/adios2/engine/bp/operations/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/bp/operations/CudaRoutines.cu
+++ b/testing/adios2/engine/bp/operations/CudaRoutines.cu
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "CudaRoutines.h"
 
 __global__ void __cuda_increment(int offset, float *vec, float val)

--- a/testing/adios2/engine/bp/operations/CudaRoutines.h
+++ b/testing/adios2/engine/bp/operations/CudaRoutines.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __TESTING_ADIOS2_CUDA_ROUTINES_H__
 #define __TESTING_ADIOS2_CUDA_ROUTINES_H__
 

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadBZIP2.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadBZIP2.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc2.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc2.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadLocalVariables.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadLocalVariables.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadMGARD.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadMGARD.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDCuda.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDCuda.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDMDR.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDMDR.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDPlus.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDPlus.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadProDM.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadProDM.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadSZ.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadSZ.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadSZ3.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadSZ3.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadSzComplex.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadSzComplex.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfp.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfp.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpComplex.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpComplex.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpConfig.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpConfig.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpHighLevelAPI.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpHighLevelAPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpRemoveOperations.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpRemoveOperations.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/bp/operations/configZfp_rate10.yaml
+++ b/testing/adios2/engine/bp/operations/configZfp_rate10.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # Config YAML file for the operator API using Zfp compression rate
 

--- a/testing/adios2/engine/bp/operations/configZfp_rate8.yaml
+++ b/testing/adios2/engine/bp/operations/configZfp_rate8.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # Config YAML file for the operator API using Zfp compression rate
 

--- a/testing/adios2/engine/bp/operations/configZfp_rate9.yaml
+++ b/testing/adios2/engine/bp/operations/configZfp_rate9.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # Config YAML file for the operator API using Zfp compression rate
 

--- a/testing/adios2/engine/bp/start_xrootd.sh
+++ b/testing/adios2/engine/bp/start_xrootd.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 
 if [ "$(id -u)" -eq 0 ]; then

--- a/testing/adios2/engine/bp/start_xrootd_http.sh
+++ b/testing/adios2/engine/bp/start_xrootd_http.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Start XRootD server with HTTP-to-SSI bridge enabled
 # Usage: start_xrootd_http.sh <xrootd_binary> <config_base_dir> [http_port]
 

--- a/testing/adios2/engine/common/CMakeLists.txt
+++ b/testing/adios2/engine/common/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/common/TestEngineCommon.cpp
+++ b/testing/adios2/engine/common/TestEngineCommon.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/dataman/CMakeLists.txt
+++ b/testing/adios2/engine/dataman/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/dataman/TestDataMan1D.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan1D.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/dataman/TestDataMan1D.py
+++ b/testing/adios2/engine/dataman/TestDataMan1D.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/dataman/TestDataMan1DSuperLarge.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan1DSuperLarge.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/dataman/TestDataMan1xN.py
+++ b/testing/adios2/engine/dataman/TestDataMan1xN.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/dataman/TestDataMan2DMemSelect.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan2DMemSelect.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/dataman/TestDataMan2DSz.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan2DSz.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/dataman/TestDataMan2DZfp.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan2DZfp.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/dataman/TestDataMan3DMemSelect.cpp
+++ b/testing/adios2/engine/dataman/TestDataMan3DMemSelect.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/dataman/TestDataManReaderDoubleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManReaderDoubleBuffer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/dataman/TestDataManReaderSingleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManReaderSingleBuffer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/dataman/TestDataManReliable.cpp
+++ b/testing/adios2/engine/dataman/TestDataManReliable.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/dataman/TestDataManSingleValues.py
+++ b/testing/adios2/engine/dataman/TestDataManSingleValues.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/dataman/TestDataManWriterDoubleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManWriterDoubleBuffer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/dataman/TestDataManWriterSingleBuffer.cpp
+++ b/testing/adios2/engine/dataman/TestDataManWriterSingleBuffer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/hdf5/CMakeLists.txt
+++ b/testing/adios2/engine/hdf5/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/hdf5/TestHDF5Append.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5Append.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/hdf5/TestHDF5StreamWriteReadHighLevelAPI.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5StreamWriteReadHighLevelAPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/hdf5/TestHDF5WriteMemorySelectionRead.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteMemorySelectionRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/hdf5/TestHDF5WriteReadAsStream.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteReadAsStream.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/hdf5/TestHDF5WriteReadAttributesADIOS2.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteReadAttributesADIOS2.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
+++ b/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/inline/CMakeLists.txt
+++ b/testing/adios2/engine/inline/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/inline/TestInlineWriteRead.cpp
+++ b/testing/adios2/engine/inline/TestInlineWriteRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/mhs/CMakeLists.txt
+++ b/testing/adios2/engine/mhs/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/mhs/TestMhsCommon.h
+++ b/testing/adios2/engine/mhs/TestMhsCommon.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2.h>
 #include <gtest/gtest.h>
 #include <iostream>

--- a/testing/adios2/engine/mhs/TestMhsMultiRank.cpp
+++ b/testing/adios2/engine/mhs/TestMhsMultiRank.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/mhs/TestMhsMultiReader.cpp
+++ b/testing/adios2/engine/mhs/TestMhsMultiReader.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/mhs/TestMhsSingleRank.cpp
+++ b/testing/adios2/engine/mhs/TestMhsSingleRank.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/null/CMakeLists.txt
+++ b/testing/adios2/engine/null/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/null/TestNullWriteRead.cpp
+++ b/testing/adios2/engine/null/TestNullWriteRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/nullcore/CMakeLists.txt
+++ b/testing/adios2/engine/nullcore/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/nullcore/TestNullCoreWrite.cpp
+++ b/testing/adios2/engine/nullcore/TestNullCoreWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/skeleton/CMakeLists.txt
+++ b/testing/adios2/engine/skeleton/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/skeleton/TestSkeletonReader.cpp
+++ b/testing/adios2/engine/skeleton/TestSkeletonReader.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <algorithm>
 #include <cstdint>
 #include <fstream>

--- a/testing/adios2/engine/skeleton/TestSkeletonWriter.cpp
+++ b/testing/adios2/engine/skeleton/TestSkeletonWriter.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/ssc/CMakeLists.txt
+++ b/testing/adios2/engine/ssc/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/ssc/TestSsc3DMemSelect.cpp
+++ b/testing/adios2/engine/ssc/TestSsc3DMemSelect.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/ssc/TestSsc7d.cpp
+++ b/testing/adios2/engine/ssc/TestSsc7d.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscBase.cpp
+++ b/testing/adios2/engine/ssc/TestSscBase.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscBaseThreading.cpp
+++ b/testing/adios2/engine/ssc/TestSscBaseThreading.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscBaseUnlocked.cpp
+++ b/testing/adios2/engine/ssc/TestSscBaseUnlocked.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscCommon.h
+++ b/testing/adios2/engine/ssc/TestSscCommon.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2.h>
 #include <gtest/gtest.h>
 #include <iostream>

--- a/testing/adios2/engine/ssc/TestSscLockBeforeEndStep.cpp
+++ b/testing/adios2/engine/ssc/TestSscLockBeforeEndStep.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscMoreReadersThanWriters.cpp
+++ b/testing/adios2/engine/ssc/TestSscMoreReadersThanWriters.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscMoreWritersThanReaders.cpp
+++ b/testing/adios2/engine/ssc/TestSscMoreWritersThanReaders.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscNoAttributes.cpp
+++ b/testing/adios2/engine/ssc/TestSscNoAttributes.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscNoSelection.cpp
+++ b/testing/adios2/engine/ssc/TestSscNoSelection.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscOnlyOneStep.cpp
+++ b/testing/adios2/engine/ssc/TestSscOnlyOneStep.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscOnlyTwoSteps.cpp
+++ b/testing/adios2/engine/ssc/TestSscOnlyTwoSteps.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscReaderMultiblock.cpp
+++ b/testing/adios2/engine/ssc/TestSscReaderMultiblock.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscSingleStep.cpp
+++ b/testing/adios2/engine/ssc/TestSscSingleStep.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscString.cpp
+++ b/testing/adios2/engine/ssc/TestSscString.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscStruct.cpp
+++ b/testing/adios2/engine/ssc/TestSscStruct.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscSuperLarge.cpp
+++ b/testing/adios2/engine/ssc/TestSscSuperLarge.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscUnbalanced.cpp
+++ b/testing/adios2/engine/ssc/TestSscUnbalanced.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
+++ b/testing/adios2/engine/ssc/TestSscVaryingSteps.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscWriterMultiblock.cpp
+++ b/testing/adios2/engine/ssc/TestSscWriterMultiblock.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscXgc2Way.cpp
+++ b/testing/adios2/engine/ssc/TestSscXgc2Way.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscXgc3Way.cpp
+++ b/testing/adios2/engine/ssc/TestSscXgc3Way.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscXgc3WayMatchedSteps.cpp
+++ b/testing/adios2/engine/ssc/TestSscXgc3WayMatchedSteps.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/ssc/TestSscZeroBlock.cpp
+++ b/testing/adios2/engine/ssc/TestSscZeroBlock.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/sst/CMakeLists.txt
+++ b/testing/adios2/engine/sst/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/sst/TestSstParamFails.cpp
+++ b/testing/adios2/engine/sst/TestSstParamFails.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/sst/TestSstWriterFails.cpp
+++ b/testing/adios2/engine/sst/TestSstWriterFails.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/CMakeLists.txt
+++ b/testing/adios2/engine/staging-common/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/staging-common/ParseArgs.h
+++ b/testing/adios2/engine/staging-common/ParseArgs.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "../ParamsHelpers.h"
 
 #ifndef _WIN32

--- a/testing/adios2/engine/staging-common/README.md
+++ b/testing/adios2/engine/staging-common/README.md
@@ -1,3 +1,7 @@
+.. SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+..
+.. SPDX-License-Identifier: Apache-2.0
+
 # Common Staging Test area
 
 _Note:_ This is a directory designed to hold tests that can be run with a variety of test engines

--- a/testing/adios2/engine/staging-common/TestBiDir.cpp
+++ b/testing/adios2/engine/staging-common/TestBiDir.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonClient.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonClient.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonRead.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonReadF.F90
+++ b/testing/adios2/engine/staging-common/TestCommonReadF.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 !!***************************
 subroutine usage()
     print *, "Usage: TestCommonReadF engine filename"

--- a/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonReadR64.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadR64.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonServer.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonServer.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonSpanRead.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonSpanRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonSpanWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonSpanWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonWriteAttrs.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteAttrs.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonWriteF.F90
+++ b/testing/adios2/engine/staging-common/TestCommonWriteF.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 subroutine usage()
     print *, "Usage: TestCommonWriteF engine filename"
 end subroutine usage

--- a/testing/adios2/engine/staging-common/TestCommonWriteLocal.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteLocal.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonWriteModes.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteModes.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestCommonWriteShared.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonWriteShared.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestData.h
+++ b/testing/adios2/engine/staging-common/TestData.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestData2.h
+++ b/testing/adios2/engine/staging-common/TestData2.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2.h>
 #include <gtest/gtest.h>
 #include <iostream>

--- a/testing/adios2/engine/staging-common/TestData_mod.F90
+++ b/testing/adios2/engine/staging-common/TestData_mod.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 ! Distributed under the OSI-approved Apache License, Version 2.0.  See
 ! accompanying file Copyright.txt for details.
 !

--- a/testing/adios2/engine/staging-common/TestDefSyncWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestDefSyncWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestDistributionRead.cpp
+++ b/testing/adios2/engine/staging-common/TestDistributionRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestDistributionWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestDistributionWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestLocalRead.cpp
+++ b/testing/adios2/engine/staging-common/TestLocalRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestLocalWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestLocalWrite.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2.h>
 #include <chrono>
 #include <ios>       //std::ios_base::failure

--- a/testing/adios2/engine/staging-common/TestOnDemandMPI.cpp
+++ b/testing/adios2/engine/staging-common/TestOnDemandMPI.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestOnDemandRead.cpp
+++ b/testing/adios2/engine/staging-common/TestOnDemandRead.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <chrono>
 #include <iostream>
 #include <numeric>

--- a/testing/adios2/engine/staging-common/TestOnDemandWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestOnDemandWrite.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <algorithm>
 #include <chrono>
 #include <functional>

--- a/testing/adios2/engine/staging-common/TestReadJoined.cpp
+++ b/testing/adios2/engine/staging-common/TestReadJoined.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestShapeChangingWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestShapeChangingWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestStagingMPMD.cpp
+++ b/testing/adios2/engine/staging-common/TestStagingMPMD.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/engine/staging-common/TestStructRead.cpp
+++ b/testing/adios2/engine/staging-common/TestStructRead.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestStructWrite.cpp
+++ b/testing/adios2/engine/staging-common/TestStructWrite.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/TestSupp.cmake
+++ b/testing/adios2/engine/staging-common/TestSupp.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 #
 # This Cmake testing specification is unfortunately complex, and will

--- a/testing/adios2/engine/staging-common/TestThreads.cpp
+++ b/testing/adios2/engine/staging-common/TestThreads.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2.h>
 #include <array>
 #include <condition_variable>

--- a/testing/adios2/engine/staging-common/TestWriteJoined.cpp
+++ b/testing/adios2/engine/staging-common/TestWriteJoined.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/engine/staging-common/run_test.py.gen.in
+++ b/testing/adios2/engine/staging-common/run_test.py.gen.in
@@ -1,4 +1,9 @@
 #!@PYTHON_EXECUTABLE@
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This script has been build to run the tests in the bin directory.
 import argparse
 import subprocess

--- a/testing/adios2/engine/time-series/CMakeLists.txt
+++ b/testing/adios2/engine/time-series/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # ------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/engine/time-series/TestTimeSeries.cpp
+++ b/testing/adios2/engine/time-series/TestTimeSeries.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/gpu-backend/CMakeLists.txt
+++ b/testing/adios2/gpu-backend/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # ------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/gpu-backend/TestBPWriteReadKokkos.cpp
+++ b/testing/adios2/gpu-backend/TestBPWriteReadKokkos.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/helper/CMakeLists.txt
+++ b/testing/adios2/helper/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 #Distributed under the OSI - approved Apache License, Version 2.0. See
 #accompanying file Copyright.txt for details.

--- a/testing/adios2/helper/TestDivideBlock.cpp
+++ b/testing/adios2/helper/TestDivideBlock.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/helper/TestHelperStrings.cpp
+++ b/testing/adios2/helper/TestHelperStrings.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/helper/TestMinMaxs.cpp
+++ b/testing/adios2/helper/TestMinMaxs.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/helper/TestPartitioners.cpp
+++ b/testing/adios2/helper/TestPartitioners.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/helper/TestRangeFilter.cpp
+++ b/testing/adios2/helper/TestRangeFilter.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2/helper/adiosRangeFilter.h>
 #include <fstream>
 #include <gtest/gtest.h>

--- a/testing/adios2/helper/TestReadNonBPFile.cpp
+++ b/testing/adios2/helper/TestReadNonBPFile.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2.h>
 #include <fstream>
 #include <gtest/gtest.h>

--- a/testing/adios2/helper/TestRerouteMessage.cpp
+++ b/testing/adios2/helper/TestRerouteMessage.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/hierarchy/CMakeLists.txt
+++ b/testing/adios2/hierarchy/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 #Distributed under the OSI - approved Apache License, Version 2.0. See
 #accompanying file Copyright.txt for details.

--- a/testing/adios2/hierarchy/TestBPHierarchicalReading.cpp
+++ b/testing/adios2/hierarchy/TestBPHierarchicalReading.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/interface/CMakeLists.txt
+++ b/testing/adios2/interface/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/interface/TestADIOSDefineAttribute.cpp
+++ b/testing/adios2/interface/TestADIOSDefineAttribute.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 
 #include <array>

--- a/testing/adios2/interface/TestADIOSDefineVariable.cpp
+++ b/testing/adios2/interface/TestADIOSDefineVariable.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 
 #include <array>

--- a/testing/adios2/interface/TestADIOSInfo.cpp
+++ b/testing/adios2/interface/TestADIOSInfo.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2/core/Info.h>
 #include <gtest/gtest.h>
 

--- a/testing/adios2/interface/TestADIOSInterface.cpp
+++ b/testing/adios2/interface/TestADIOSInterface.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 
 #include <iostream>

--- a/testing/adios2/interface/TestADIOSInterfaceWrite.cpp
+++ b/testing/adios2/interface/TestADIOSInterfaceWrite.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 
 #include <iostream>

--- a/testing/adios2/interface/TestADIOSNoMpi.cpp
+++ b/testing/adios2/interface/TestADIOSNoMpi.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include <adios2.h>
 

--- a/testing/adios2/interface/TestADIOSSelection.cpp
+++ b/testing/adios2/interface/TestADIOSSelection.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2.h>
 #include <iomanip>
 

--- a/testing/adios2/output_archive/CMakeLists.txt
+++ b/testing/adios2/output_archive/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # For each test set <S>, we expect to find Write<S>.cpp and Read<S>.cpp as programs to be built.
 # 

--- a/testing/adios2/output_archive/ReadAttribute.cpp
+++ b/testing/adios2/output_archive/ReadAttribute.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/output_archive/ReadCommon.cpp
+++ b/testing/adios2/output_archive/ReadCommon.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/output_archive/TestData.h
+++ b/testing/adios2/output_archive/TestData.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/output_archive/WriteAttribute.cpp
+++ b/testing/adios2/output_archive/WriteAttribute.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/output_archive/WriteCommon.cpp
+++ b/testing/adios2/output_archive/WriteCommon.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/output_archive/archive_utility.c
+++ b/testing/adios2/output_archive/archive_utility.c
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/testing/adios2/output_archive/create_archive.cmake
+++ b/testing/adios2/output_archive/create_archive.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 
 message(STATUS "Creating archive from ${SOURCE_DIR} into ${ARCHIVE_NAME}")
 file(GLOB files_to_archive "${SOURCE_DIR}/*")

--- a/testing/adios2/performance/CMakeLists.txt
+++ b/testing/adios2/performance/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/performance/manyvars/CMakeLists.txt
+++ b/testing/adios2/performance/manyvars/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/performance/manyvars/PerfManyVars.c
+++ b/testing/adios2/performance/manyvars/PerfManyVars.c
@@ -1,8 +1,8 @@
 /*
- * ADIOS is freely available under the terms of the BSD license described
- * in the COPYING file in the top level directory of this source distribution.
+ * Copyright (C) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
  *
- * Copyright (c) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* ADIOS C test:

--- a/testing/adios2/performance/manyvars/TestManyVars.cpp
+++ b/testing/adios2/performance/manyvars/TestManyVars.cpp
@@ -1,8 +1,8 @@
 /*
- * ADIOS is freely available under the terms of the BSD license described
- * in the COPYING file in the top level directory of this source distribution.
+ * Copyright (C) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
  *
- * Copyright (c) 2008 - 2009.  UT-BATTELLE, LLC. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /* ADIOS C test:

--- a/testing/adios2/performance/metadata/CMakeLists.txt
+++ b/testing/adios2/performance/metadata/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/performance/metadata/PerfMetaData.cpp
+++ b/testing/adios2/performance/metadata/PerfMetaData.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/performance/query/CMakeLists.txt
+++ b/testing/adios2/performance/query/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/performance/query/TestBPQuery.cpp
+++ b/testing/adios2/performance/query/TestBPQuery.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/python/CMakeLists.txt
+++ b/testing/adios2/python/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/python/TestADIOS.py
+++ b/testing/adios2/python/TestADIOS.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2.adios import Adios
 import unittest
 

--- a/testing/adios2/python/TestAttribute.py
+++ b/testing/adios2/python/TestAttribute.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2.adios import Adios
 
 import adios2.bindings as bindings

--- a/testing/adios2/python/TestBPChangingShapeHighLevelAPI.py
+++ b/testing/adios2/python/TestBPChangingShapeHighLevelAPI.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/python/TestBPPNGHighLevelAPI.py
+++ b/testing/adios2/python/TestBPPNGHighLevelAPI.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/python/TestBPWriteReadArrays.py
+++ b/testing/adios2/python/TestBPWriteReadArrays.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2NPTypes import SmallTestData
 from mpi4py import MPI
 import numpy as np

--- a/testing/adios2/python/TestBPWriteReadString.py
+++ b/testing/adios2/python/TestBPWriteReadString.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/python/TestBPWriteTypesHighLevelAPI.py
+++ b/testing/adios2/python/TestBPWriteTypesHighLevelAPI.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/python/TestBPWriteTypesHighLevelAPILocal.py
+++ b/testing/adios2/python/TestBPWriteTypesHighLevelAPILocal.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.
 #

--- a/testing/adios2/python/TestBPWriteTypesHighLevelAPI_HDF5.py
+++ b/testing/adios2/python/TestBPWriteTypesHighLevelAPI_HDF5.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/python/TestBPZfpHighLevelAPI.py
+++ b/testing/adios2/python/TestBPZfpHighLevelAPI.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/python/TestDerivedVariable.py
+++ b/testing/adios2/python/TestDerivedVariable.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2 import Stream
 from adios2.bindings import DerivedVarType
 import unittest

--- a/testing/adios2/python/TestEngine.py
+++ b/testing/adios2/python/TestEngine.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2.adios import Adios
 
 import adios2.bindings as bindings

--- a/testing/adios2/python/TestFileReader.py
+++ b/testing/adios2/python/TestFileReader.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2 import FileReader, Stream, LocalValueDim
 from random import randint
 

--- a/testing/adios2/python/TestIO.py
+++ b/testing/adios2/python/TestIO.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2.adios import Adios
 import adios2.bindings as bindings
 

--- a/testing/adios2/python/TestOperator.py
+++ b/testing/adios2/python/TestOperator.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2.adios import Adios
 
 import adios2.bindings as bindings

--- a/testing/adios2/python/TestStream.py
+++ b/testing/adios2/python/TestStream.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2 import Stream, LocalValueDim
 from random import randint
 import numpy as np

--- a/testing/adios2/python/TestVariable.py
+++ b/testing/adios2/python/TestVariable.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from adios2 import Stream, Adios
 from adios2.bindings import DerivedVarType, Linf_norm, L2_norm
 import unittest

--- a/testing/adios2/python/adios2NPTypes.py
+++ b/testing/adios2/python/adios2NPTypes.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/transports/CMakeLists.txt
+++ b/testing/adios2/transports/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/transports/TestFile.cpp
+++ b/testing/adios2/transports/TestFile.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/unit/CMakeLists.txt
+++ b/testing/adios2/unit/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 #Distributed under the OSI - approved Apache License, Version 2.0. See
 #accompanying file Copyright.txt for details.

--- a/testing/adios2/unit/TestAWSSDKTransport.cpp
+++ b/testing/adios2/unit/TestAWSSDKTransport.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/adios2/unit/TestChunkV.cpp
+++ b/testing/adios2/unit/TestChunkV.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/unit/TestCoreDims.cpp
+++ b/testing/adios2/unit/TestCoreDims.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2/helper/adiosType.h>
 #include <algorithm>
 #include <iostream>

--- a/testing/adios2/unit/TestFilePool.cpp
+++ b/testing/adios2/unit/TestFilePool.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/core/CoreTypes.h"
 #include "adios2/core/IO.h"

--- a/testing/adios2/unit/TestPosixTransport.cpp
+++ b/testing/adios2/unit/TestPosixTransport.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/adios2/unit/TestRemote.cpp
+++ b/testing/adios2/unit/TestRemote.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <adios2/helper/adiosType.h>
 #include <algorithm>
 #include <fstream>

--- a/testing/adios2/xml/CMakeLists.txt
+++ b/testing/adios2/xml/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/xml/TestXMLConfig.cpp
+++ b/testing/adios2/xml/TestXMLConfig.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 
 #include <iostream>

--- a/testing/adios2/xml/TestXMLConfigSerial.cpp
+++ b/testing/adios2/xml/TestXMLConfigSerial.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 
 #include <iostream>

--- a/testing/adios2/yaml/CMakeLists.txt
+++ b/testing/adios2/yaml/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/adios2/yaml/TestYAMLConfig.cpp
+++ b/testing/adios2/yaml/TestYAMLConfig.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 
 #include <iostream>

--- a/testing/adios2/yaml/TestYAMLConfigSerial.cpp
+++ b/testing/adios2/yaml/TestYAMLConfigSerial.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 
 #include <iostream>

--- a/testing/adios2/yaml/TestYAMLTimeSeries.cpp
+++ b/testing/adios2/yaml/TestYAMLTimeSeries.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <cstdint>
 
 #include <iostream>

--- a/testing/adios2/yaml/config1.yaml
+++ b/testing/adios2/yaml/config1.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # adios2 config file in yaml format
 

--- a/testing/adios2/yaml/configOpNullException.yaml
+++ b/testing/adios2/yaml/configOpNullException.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # adios2 config file in yaml format
 - IO: "TestIO"

--- a/testing/adios2/yaml/configOpTypeException.yaml
+++ b/testing/adios2/yaml/configOpTypeException.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # adios2 config file in yaml format
 - IO: "TestIO"

--- a/testing/adios2/yaml/proto.yaml
+++ b/testing/adios2/yaml/proto.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # adios2 config.yaml
 - IO: "SimulationOutput"

--- a/testing/contract/examples/build.sh
+++ b/testing/contract/examples/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/examples/config.sh
+++ b/testing/contract/examples/config.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/examples/depends.sh
+++ b/testing/contract/examples/depends.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 exit 0

--- a/testing/contract/examples/install.sh
+++ b/testing/contract/examples/install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/examples/setup.sh
+++ b/testing/contract/examples/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 source_dir="/opt/adios2/source/examples"
 build_dir=$(readlink -f "${PWD}")/build
 install_dir=$(readlink -f "${PWD}")/install

--- a/testing/contract/examples/test.sh
+++ b/testing/contract/examples/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/lammps/build.sh
+++ b/testing/contract/lammps/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/lammps/check_results.sh
+++ b/testing/contract/lammps/check_results.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Check if output files exists
 if [ ! -d balance_atom.bp ]
 then

--- a/testing/contract/lammps/config.sh
+++ b/testing/contract/lammps/config.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/lammps/depends.sh
+++ b/testing/contract/lammps/depends.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 exit 0

--- a/testing/contract/lammps/install.sh
+++ b/testing/contract/lammps/install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/lammps/setup.sh
+++ b/testing/contract/lammps/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 source_dir=$(readlink -f "${PWD}")/source
 build_dir=$(readlink -f "${PWD}")/build
 install_dir=$(readlink -f "${PWD}")/install

--- a/testing/contract/lammps/test.sh
+++ b/testing/contract/lammps/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/scorpio/build.sh
+++ b/testing/contract/scorpio/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/scorpio/config.sh
+++ b/testing/contract/scorpio/config.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/scorpio/depends.sh
+++ b/testing/contract/scorpio/depends.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/scorpio/install.sh
+++ b/testing/contract/scorpio/install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/scorpio/setup.sh
+++ b/testing/contract/scorpio/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 source_dir=$(readlink -f "${PWD}")/source
 build_dir=$(readlink -f "${PWD}")/build
 install_dir=$(readlink -f "${PWD}")/install

--- a/testing/contract/scorpio/test.sh
+++ b/testing/contract/scorpio/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/tau/build.sh
+++ b/testing/contract/tau/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/tau/config.sh
+++ b/testing/contract/tau/config.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/tau/depends.sh
+++ b/testing/contract/tau/depends.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/tau/install.sh
+++ b/testing/contract/tau/install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/contract/tau/setup.sh
+++ b/testing/contract/tau/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 source_dir="/opt/adios2/source/examples/basics/variablesShapes"
 build_dir=$(readlink -f "${PWD}")/build
 install_dir=$(readlink -f "${PWD}")/install

--- a/testing/contract/tau/test.sh
+++ b/testing/contract/tau/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -x
 set -e
 

--- a/testing/examples/CMakeLists.txt
+++ b/testing/examples/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 if(ADIOS2_HAVE_MPI)
   add_subdirectory(heatTransfer)
 endif()

--- a/testing/examples/heatTransfer/CMakeLists.txt
+++ b/testing/examples/heatTransfer/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestBPFileMx1.cmake
+++ b/testing/examples/heatTransfer/TestBPFileMx1.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestBPFileMx1_zfp.cmake
+++ b/testing/examples/heatTransfer/TestBPFileMx1_zfp.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestBPFileMxM.cmake
+++ b/testing/examples/heatTransfer/TestBPFileMxM.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestBPFileMxN.cmake
+++ b/testing/examples/heatTransfer/TestBPFileMxN.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestInlineMxM.cmake
+++ b/testing/examples/heatTransfer/TestInlineMxM.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestSSCMx1.cmake
+++ b/testing/examples/heatTransfer/TestSSCMx1.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestSSCMxM.cmake
+++ b/testing/examples/heatTransfer/TestSSCMxM.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestSSCMxN.cmake
+++ b/testing/examples/heatTransfer/TestSSCMxN.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestSSTMx1.cmake
+++ b/testing/examples/heatTransfer/TestSSTMx1.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestSSTMxM.cmake
+++ b/testing/examples/heatTransfer/TestSSTMxM.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestSSTMxN.cmake
+++ b/testing/examples/heatTransfer/TestSSTMxN.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/examples/heatTransfer/TestSSTRDMAMxN.cmake
+++ b/testing/examples/heatTransfer/TestSSTRDMAMxN.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/h5vol/CMakeLists.txt
+++ b/testing/h5vol/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/h5vol/TestH5VolWriteReadBPFile.cpp
+++ b/testing/h5vol/TestH5VolWriteReadBPFile.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/install/C/CMakeLists.txt
+++ b/testing/install/C/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/C/Makefile
+++ b/testing/install/C/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/C/main_mpi.c
+++ b/testing/install/C/main_mpi.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/install/C/main_nompi.c
+++ b/testing/install/C/main_nompi.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/install/CMakeLists.txt
+++ b/testing/install/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/CXX/CMakeLists.txt
+++ b/testing/install/CXX/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/CXX/Makefile
+++ b/testing/install/CXX/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/CXX/main_mpi.cxx
+++ b/testing/install/CXX/main_mpi.cxx
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/install/CXX/main_nompi.cxx
+++ b/testing/install/CXX/main_nompi.cxx
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/install/CatalystEnginePlugin/CMakeLists.txt
+++ b/testing/install/CatalystEnginePlugin/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/CatalystEnginePlugin/testCatalystEngine.cpp
+++ b/testing/install/CatalystEnginePlugin/testCatalystEngine.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <iostream>
 #include <vector>
 

--- a/testing/install/EncryptionOperator/CMakeLists.txt
+++ b/testing/install/EncryptionOperator/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/EncryptionOperator/TestSealedOperatorWrongUsage.cpp
+++ b/testing/install/EncryptionOperator/TestSealedOperatorWrongUsage.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/install/EnginePlugin/CMakeLists.txt
+++ b/testing/install/EnginePlugin/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/Fortran/CMakeLists.txt
+++ b/testing/install/Fortran/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/Fortran/Makefile
+++ b/testing/install/Fortran/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/Fortran/main_mpi.f90
+++ b/testing/install/Fortran/main_mpi.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program adios_fortran_test
   use mpi
   use adios2

--- a/testing/install/Fortran/main_mpi_check.F90
+++ b/testing/install/Fortran/main_mpi_check.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 #if !ADIOS2_USE_MPI
 #error "ADIOS2_USE_MPI is not true for source using ADIOS2 MPI bindings"
 #endif

--- a/testing/install/Fortran/main_nompi.f90
+++ b/testing/install/Fortran/main_nompi.f90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 program adios_fortran_test
   use adios2
   integer :: ierr, irank, isize

--- a/testing/install/Fortran/main_nompi_check.F90
+++ b/testing/install/Fortran/main_nompi_check.F90
@@ -1,3 +1,7 @@
+c SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+c
+c SPDX-License-Identifier: Apache-2.0
+
 #if ADIOS2_USE_MPI
 #error "ADIOS2_USE_MPI is true for source not using ADIOS2 MPI bindings"
 #endif

--- a/testing/install/run_cmake.cmake
+++ b/testing/install/run_cmake.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/run_install.cmake
+++ b/testing/install/run_install.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/install/run_make.cmake
+++ b/testing/install/run_make.cmake
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/utils/CMakeLists.txt
+++ b/testing/utils/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/utils/SmallTestData_c.h
+++ b/testing/utils/SmallTestData_c.h
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  */

--- a/testing/utils/bpcmp/CMakeLists.txt
+++ b/testing/utils/bpcmp/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 add_executable(Test.Utils.BPcmp TestUtilsBPcmp.cpp)
 
 target_link_libraries(Test.Utils.BPcmp adios2::cxx)

--- a/testing/utils/bpcmp/TestUtilsBPcmp.cpp
+++ b/testing/utils/bpcmp/TestUtilsBPcmp.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <algorithm>
 #include <ios>
 #include <iostream>

--- a/testing/utils/changingshape/CMakeLists.txt
+++ b/testing/utils/changingshape/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/utils/changingshape/TestUtilsChangingShape.cpp
+++ b/testing/utils/changingshape/TestUtilsChangingShape.cpp
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/utils/cwriter/CMakeLists.txt
+++ b/testing/utils/cwriter/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #------------------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/utils/cwriter/TestUtilsCWriter.c
+++ b/testing/utils/cwriter/TestUtilsCWriter.c
@@ -1,4 +1,10 @@
 /*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Distributed under the OSI-approved Apache License, Version 2.0.  See
  * accompanying file Copyright.txt for details.
  *

--- a/testing/utils/iotest/CMakeLists.txt
+++ b/testing/utils/iotest/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #---------------------------------------------------------------------#
 # Distributed under the OSI-approved Apache License, Version 2.0.  See
 # accompanying file Copyright.txt for details.

--- a/testing/utils/iotest/burstbuffer-BP4-nsub2.yaml
+++ b/testing/utils/iotest/burstbuffer-BP4-nsub2.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 # adios2 config file in yaml format
 


### PR DESCRIPTION
Every file now carries an SPDX copyright and license identifier, either
inline or via .reuse/dep5. This is required by OSSF Scorecards and makes
license info unambiguous for contributors and downstream users.

- LICENSES/ with Apache-2.0, BSD-3-Clause, MIT, CC0-1.0 texts
- .reuse/dep5 for thirdparty libs, binaries, and dotfiles
- SPDX headers in ~600 source files
- CI workflow using fsfe/reuse-action to enforce compliance on PRs
