### PR TITLE
Add MPI barrier before test file cleanup to prevent race conditions

### DIFF
--- a/testing/adios2/bindings/C/TestBPWriteReadMultiblock.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteReadMultiblock.cpp
@@ -254,14 +254,11 @@ TEST_F(BPWriteReadMultiblockCC, ZeroSizeBlocks)
     adios2_finalize(adiosH);
 
     // Cleanup generated files
-    if (rank == 0)
-    {
 #if ADIOS2_USE_MPI
-        CleanupTestFiles("cmblocks_MPI.bp");
+    CleanupTestFilesMPI("cmblocks_MPI.bp", MPI_COMM_WORLD);
 #else
-        CleanupTestFiles("cmblocks.bp");
+    CleanupTestFiles("cmblocks.bp");
 #endif
-    }
 }
 
 //******************************************************************************

--- a/testing/adios2/bindings/C/TestBPWriteTypes.cpp
+++ b/testing/adios2/bindings/C/TestBPWriteTypes.cpp
@@ -424,10 +424,11 @@ TEST_F(ADIOS2_C_API, ADIOS2BPWriteTypes)
     }
 
     // Cleanup generated files
-    if (rank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class ADIOS2_C_API_IO : public ADIOS2_C_API
@@ -503,10 +504,11 @@ TEST_F(ADIOS2_C_API_IO, Engine)
     adios2_close(engineH);
 
     // Cleanup generated files
-    if (rank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(ADIOS2_C_API_IO, EngineDefault)
@@ -530,10 +532,11 @@ TEST_F(ADIOS2_C_API_IO, EngineDefault)
     adios2_close(engineH);
 
     // Cleanup generated files
-    if (rank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(ADIOS2_C_API_IO, ReturnedStrings)

--- a/testing/adios2/engine/TestHelpers.h
+++ b/testing/adios2/engine/TestHelpers.h
@@ -21,6 +21,10 @@
 #define NOMINMAX
 #endif
 
+#if ADIOS2_USE_MPI
+#include <mpi.h>
+#endif
+
 // Include appropriate headers based on the operating system
 #ifdef _WIN32
 #include <direct.h>
@@ -76,6 +80,21 @@ inline void CleanupTestFiles(const std::string &path)
         exit(EXIT_FAILURE);
     }
 }
+
+// MPI-aware cleanup: barrier ensures all ranks are done before rank 0 deletes files.
+// Without this, rank 0 can rm -rf test files while other ranks still have them open.
+#if ADIOS2_USE_MPI
+inline void CleanupTestFilesMPI(const std::string &path, MPI_Comm comm)
+{
+    MPI_Barrier(comm);
+    int rank;
+    MPI_Comm_rank(comm, &rank);
+    if (rank == 0)
+    {
+        CleanupTestFiles(path);
+    }
+}
+#endif
 
 // Test data for each type.  Make sure our values exceed the range of the
 // previous size to make sure we all bytes for each element

--- a/testing/adios2/engine/bp/TestBPAccuracyDefaults.cpp
+++ b/testing/adios2/engine/bp/TestBPAccuracyDefaults.cpp
@@ -123,11 +123,11 @@ TEST_F(AccuracyTests, DefaultAccuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPAppendAfterSteps.cpp
+++ b/testing/adios2/engine/bp/TestBPAppendAfterSteps.cpp
@@ -190,11 +190,11 @@ TEST_P(BPAppendAfterStepsP, Test)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(filename);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(filename, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(filename);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(BPAppendAfterSteps, BPAppendAfterStepsP,

--- a/testing/adios2/engine/bp/TestBPBufferSize.cpp
+++ b/testing/adios2/engine/bp/TestBPBufferSize.cpp
@@ -258,12 +258,15 @@ TEST_F(BPBufferSizeTest, SyncDeferredIdenticalUsage)
         }
 
         // Cleanup generated files
-        if (mpiRank == 0)
-        {
-            CleanupTestFiles(fnameSync);
-            CleanupTestFiles(fnameDeferred);
-            CleanupTestFiles(fnameDeferredPP);
-        }
+#if ADIOS2_USE_MPI
+        CleanupTestFilesMPI(fnameSync, MPI_COMM_WORLD);
+        CleanupTestFilesMPI(fnameDeferred, MPI_COMM_WORLD);
+        CleanupTestFilesMPI(fnameDeferredPP, MPI_COMM_WORLD);
+#else
+        CleanupTestFiles(fnameSync);
+        CleanupTestFiles(fnameDeferred);
+        CleanupTestFiles(fnameDeferredPP);
+#endif
     }
 }
 

--- a/testing/adios2/engine/bp/TestBPChangingShape.cpp
+++ b/testing/adios2/engine/bp/TestBPChangingShape.cpp
@@ -171,10 +171,11 @@ TEST_F(BPChangingShape, BPWriteReadShape2D)
     }
 
     // Cleanup generated files
-    if (rank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPChangingShapeWithinStep.cpp
+++ b/testing/adios2/engine/bp/TestBPChangingShapeWithinStep.cpp
@@ -235,10 +235,11 @@ TEST_P(BPChangingShapeWithinStep, MultiBlock)
     }
 
     // Cleanup generated files
-    if (rank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 adios2::Params paccuracy = {{"accuracy", "0.001"}};

--- a/testing/adios2/engine/bp/TestBPDataSizeAggregate.cpp
+++ b/testing/adios2/engine/bp/TestBPDataSizeAggregate.cpp
@@ -196,10 +196,11 @@ TEST_F(DSATest, TestWriteUnbalancedData)
     }
 
     // Cleanup generated files
-    if (worldRank == 0)
-    {
-        CleanupTestFiles("unbalanced_output.bp");
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI("unbalanced_output.bp", MPI_COMM_WORLD);
+#else
+    CleanupTestFiles("unbalanced_output.bp");
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPDirectIO.cpp
+++ b/testing/adios2/engine/bp/TestBPDirectIO.cpp
@@ -130,11 +130,11 @@ TEST_F(ADIOSReadDirectIOTest, BufferResize)
         engine_s.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(filename);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(filename, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(filename);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPFStreamWriteReadHighLevelAPI.cpp
+++ b/testing/adios2/engine/bp/TestBPFStreamWriteReadHighLevelAPI.cpp
@@ -409,11 +409,11 @@ TEST_F(StreamWriteReadHighLevelAPI, ADIOS2BPWriteRead1D8)
         iStream.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -537,11 +537,11 @@ TEST_F(StreamWriteReadHighLevelAPI, ADIOS2BPwriteRead2D2x4)
         iStream.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -667,22 +667,17 @@ TEST_F(StreamWriteReadHighLevelAPI, ADIOS2BPwriteRead2D4x2)
         iStream.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(StreamWriteReadHighLevelAPI, DoubleOpenException)
 {
     // Each process would write a 1x8 array and all processes would
     // form a mpiSize * Nx 1D array
-
-    int mpiRank = 0;
-#if ADIOS2_USE_MPI
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
-#endif
 
     {
 #if ADIOS2_USE_MPI
@@ -707,10 +702,11 @@ TEST_F(StreamWriteReadHighLevelAPI, DoubleOpenException)
 #else
     const std::string fname("ADIOS2BP_hl_exception.bp");
 #endif
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPFortranToCppReader.cpp
+++ b/testing/adios2/engine/bp/TestBPFortranToCppReader.cpp
@@ -128,11 +128,11 @@ TEST_F(BPFortranToCppRead, ADIOS2BPFortranToCppRead)
     EXPECT_EQ(step, 3);
     bpReader.Close();
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPInquireDefine.cpp
+++ b/testing/adios2/engine/bp/TestBPInquireDefine.cpp
@@ -231,11 +231,11 @@ TEST_F(ADIOSInquireDefineTest, Read)
         }
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(filename);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(filename, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(filename);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPInquireVariableException.cpp
+++ b/testing/adios2/engine/bp/TestBPInquireVariableException.cpp
@@ -82,10 +82,11 @@ TEST_F(ADIOSInquireVariableException, Read)
     }
 
     // Cleanup generated files
-    if (rank == 0)
-    {
-        CleanupTestFiles(filename);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(filename, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(filename);
+#endif
 }
 int main(int argc, char **argv)
 {

--- a/testing/adios2/engine/bp/TestBPJoinedArray.cpp
+++ b/testing/adios2/engine/bp/TestBPJoinedArray.cpp
@@ -188,10 +188,11 @@ TEST_F(BPJoinedArray, MultiBlock)
     }
 
     // Cleanup generated files
-    if (!rank)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPLargeMetadata.cpp
+++ b/testing/adios2/engine/bp/TestBPLargeMetadata.cpp
@@ -94,11 +94,11 @@ TEST_F(BPLargeMetadata, BPWrite1D_LargeMetadata)
         bpWriter.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPLargeMetadata, ManyLongStrings)
@@ -159,17 +159,10 @@ TEST_F(BPLargeMetadata, ManyLongStrings)
     }
 
 #if ADIOS2_USE_MPI
-    int mpiRank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
 #else
-    int mpiRank = 0;
+    CleanupTestFiles(fname);
 #endif
-
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPParameterSelectSteps.cpp
+++ b/testing/adios2/engine/bp/TestBPParameterSelectSteps.cpp
@@ -178,11 +178,11 @@ TEST_P(BPParameterSelectStepsP, Read)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(filename);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(filename, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(filename);
+#endif
 }
 
 TEST_P(BPParameterSelectStepsP, Stream)
@@ -290,11 +290,11 @@ TEST_P(BPParameterSelectStepsP, Stream)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(filename);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(filename, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(filename);
+#endif
 }
 
 const std::vector<size_t> s_0n1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};

--- a/testing/adios2/engine/bp/TestBPReadMultithreaded.cpp
+++ b/testing/adios2/engine/bp/TestBPReadMultithreaded.cpp
@@ -207,11 +207,11 @@ TEST_P(BPReadMultithreadedTestP, ReadFile)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(filename);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(filename, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(filename);
+#endif
 }
 
 TEST_P(BPReadMultithreadedTestP, ReadStream)
@@ -282,11 +282,11 @@ TEST_P(BPReadMultithreadedTestP, ReadStream)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(filename);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(filename, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(filename);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(BPReadMultithreadedTest, BPReadMultithreadedTestP,

--- a/testing/adios2/engine/bp/TestBPStepsFileGlobalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsFileGlobalArray.cpp
@@ -352,11 +352,11 @@ TEST_P(BPStepsFileGlobalArrayReaders, EveryStep)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // Variable written every other step from 2nd step
@@ -624,11 +624,11 @@ TEST_P(BPStepsFileGlobalArrayReaders, NewVarPerStep)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(BPStepsFileGlobalArray, BPStepsFileGlobalArrayReaders,
@@ -923,11 +923,11 @@ TEST_P(BPStepsFileGlobalArrayParameters, EveryOtherStep)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/testing/adios2/engine/bp/TestBPStepsFileLocalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsFileLocalArray.cpp
@@ -232,11 +232,11 @@ TEST_P(BPStepsFileLocalArrayReaders, EveryStep)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // Variable written every other step from 2nd step
@@ -390,11 +390,11 @@ TEST_P(BPStepsFileLocalArrayReaders, NewVarPerStep)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(BPStepsFileLocalArray, BPStepsFileLocalArrayReaders,
@@ -579,11 +579,11 @@ TEST_P(BPStepsFileLocalArrayParameters, EveryOtherStep)
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/testing/adios2/engine/bp/TestBPStepsInSituGlobalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsInSituGlobalArray.cpp
@@ -275,11 +275,11 @@ TEST_P(BPStepsInSituGlobalArrayReaders, EveryStep)
     writer.Close();
     reader.Close();
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // A new variable is created and written every step
@@ -435,11 +435,11 @@ TEST_P(BPStepsInSituGlobalArrayReaders, NewVarPerStep)
     writer.Close();
     reader.Close();
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(BPStepsInSituGlobalArray, BPStepsInSituGlobalArrayReaders,
@@ -638,11 +638,11 @@ TEST_P(BPStepsInSituGlobalArrayParameters, EveryOtherStep)
     writer.Close();
     reader.Close();
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/testing/adios2/engine/bp/TestBPStepsInSituLocalArray.cpp
+++ b/testing/adios2/engine/bp/TestBPStepsInSituLocalArray.cpp
@@ -225,11 +225,11 @@ TEST_P(BPStepsInSituLocalArrayReaders, EveryStep)
     writer.Close();
     reader.Close();
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // A new variable is created and written every step
@@ -357,11 +357,11 @@ TEST_P(BPStepsInSituLocalArrayReaders, NewVarPerStep)
     writer.Close();
     reader.Close();
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(BPStepsInSituLocalArray, BPStepsInSituLocalArrayReaders,
@@ -515,11 +515,11 @@ TEST_P(BPStepsInSituLocalArrayParameters, EveryOtherStep)
     writer.Close();
     reader.Close();
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(BPStepsInSituLocalArray, BPStepsInSituLocalArrayParameters,

--- a/testing/adios2/engine/bp/TestBPTimeAggregation.cpp
+++ b/testing/adios2/engine/bp/TestBPTimeAggregation.cpp
@@ -342,11 +342,11 @@ void TimeAggregation1D8(const std::string flushstepscount)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void TimeAggregation2D4x2(const std::string flushstepscount)
@@ -680,11 +680,11 @@ void TimeAggregation2D4x2(const std::string flushstepscount)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPTestTimeAggregation : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/TestBPWriteAggregateRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteAggregateRead.cpp
@@ -330,11 +330,11 @@ void WriteAggRead1D8(const std::string substreams)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void WriteAggRead2D4x2(const std::string substreams)
@@ -650,11 +650,11 @@ void WriteAggRead2D4x2(const std::string substreams)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void WriteAggRead2D2x4(const std::string substreams)
@@ -957,11 +957,11 @@ void WriteAggRead2D2x4(const std::string substreams)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteAggregateReadTest : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/TestBPWriteAppendReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteAppendReadADIOS2.cpp
@@ -643,11 +643,11 @@ TEST_F(BPWriteAppendReadTestADIOS2, ADIOS2BPWriteAppendRead2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // Write with append combined with aggregation, same aggregation ratio
@@ -748,11 +748,11 @@ TEST_F(BPWriteAppendReadTestADIOS2, ADIOS2BPWriteAppendReadAggregate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // Write with append combined with aggregation, same aggregation ratio
@@ -870,11 +870,11 @@ TEST_F(BPWriteAppendReadTestADIOS2, ADIOS2BPWriteAppendReadVaryingAggregation)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************

--- a/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteFlushRead.cpp
@@ -480,16 +480,13 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2D)
     }
 
     // Cleanup generated files
-    if (mpiRank == 0)
-    {
 #if ADIOS2_USE_MPI
-        CleanupTestFiles("Flush1D_MPI.bp");
-        CleanupTestFiles("Flush2D_MPI.bp");
+    CleanupTestFilesMPI("Flush1D_MPI.bp", MPI_COMM_WORLD);
+    CleanupTestFilesMPI("Flush2D_MPI.bp", MPI_COMM_WORLD);
 #else
-        CleanupTestFiles("Flush1D.bp");
-        CleanupTestFiles("Flush2D.bp");
+    CleanupTestFiles("Flush1D.bp");
+    CleanupTestFiles("Flush2D.bp");
 #endif
-    }
 }
 
 TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dstdio)
@@ -946,16 +943,13 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dstdio)
     }
 
     // Cleanup generated files
-    if (mpiRank == 0)
-    {
 #if ADIOS2_USE_MPI
-        CleanupTestFiles("Flush1Dstdio_MPI.bp");
-        CleanupTestFiles("Flush2Dstdio_MPI.bp");
+    CleanupTestFilesMPI("Flush1Dstdio_MPI.bp", MPI_COMM_WORLD);
+    CleanupTestFilesMPI("Flush2Dstdio_MPI.bp", MPI_COMM_WORLD);
 #else
-        CleanupTestFiles("Flush1Dstdio.bp");
-        CleanupTestFiles("Flush2Dstdio.bp");
+    CleanupTestFiles("Flush1Dstdio.bp");
+    CleanupTestFiles("Flush2Dstdio.bp");
 #endif
-    }
 }
 
 TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dfstream)
@@ -1413,16 +1407,13 @@ TEST_F(BPWriteFlushRead, ADIOS2BPWrite1D2Dfstream)
     }
 
     // Cleanup generated files
-    if (mpiRank == 0)
-    {
 #if ADIOS2_USE_MPI
-        CleanupTestFiles("Flush1Dfstream_MPI.bp");
-        CleanupTestFiles("Flush2Dfstream_MPI.bp");
+    CleanupTestFilesMPI("Flush1Dfstream_MPI.bp", MPI_COMM_WORLD);
+    CleanupTestFilesMPI("Flush2Dfstream_MPI.bp", MPI_COMM_WORLD);
 #else
-        CleanupTestFiles("Flush1Dfstream.bp");
-        CleanupTestFiles("Flush2Dfstream.bp");
+    CleanupTestFiles("Flush1Dfstream.bp");
+    CleanupTestFiles("Flush2Dfstream.bp");
 #endif
-    }
 }
 
 //******************************************************************************

--- a/testing/adios2/engine/bp/TestBPWriteMemorySelectionRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteMemorySelectionRead.cpp
@@ -388,11 +388,11 @@ void BPSteps1D(const size_t ghostCells)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BPSteps2D4x2(const size_t ghostCells)
@@ -622,11 +622,11 @@ void BPSteps2D4x2(const size_t ghostCells)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BPSteps3D8x2x4(const size_t ghostCells)
@@ -893,11 +893,11 @@ void BPSteps3D8x2x4(const size_t ghostCells)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteMemSelReadVector : public ::testing::TestWithParam<size_t>

--- a/testing/adios2/engine/bp/TestBPWriteMultiblockRead.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteMultiblockRead.cpp
@@ -364,11 +364,11 @@ TEST_F(BPWriteMultiblockReadTest, ADIOS2BPWriteMultiblockRead1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -714,11 +714,11 @@ TEST_F(BPWriteMultiblockReadTest, ADIOS2BPWriteMultiblockRead2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -1396,11 +1396,11 @@ TEST_F(BPWriteMultiblockReadTest, ADIOS2BPWriteRead1D8ZeroBlock)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPWriteNull.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteNull.cpp
@@ -170,11 +170,11 @@ TEST_F(BPWriteNullTest, BPWrite1D1x8)
         bpWriter.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -318,11 +318,11 @@ TEST_F(BPWriteNullTest, BPWrite2D2x4)
         bpWriter.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -462,11 +462,11 @@ TEST_F(BPWriteNullTest, BPWrite2D4x2)
         bpWriter.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteNullTest, BPWrite2D4x2_MultiSteps)
@@ -598,11 +598,11 @@ TEST_F(BPWriteNullTest, BPWrite2D4x2_MultiSteps)
         bpWriter.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteProfilingJSON.cpp
@@ -173,11 +173,11 @@ TEST_F(BPWriteProfilingJSONTest, DISABLED_ADIOS2BPWriteProfilingJSON)
         ASSERT_EQ(transportType, "File_POSIX");
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteProfilingJSONTest, ADIOS2BPWriteProfilingJSON_Off)
@@ -299,11 +299,11 @@ TEST_F(BPWriteProfilingJSONTest, ADIOS2BPWriteProfilingJSON_Off)
         EXPECT_EQ(profilingJSONFile.good(), false);
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2.cpp
@@ -417,11 +417,11 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -746,11 +746,11 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -1064,11 +1064,11 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead10D2x2)
@@ -1254,11 +1254,11 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead10D2x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2_ReadMultiSteps)
@@ -1569,11 +1569,11 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2_ReadMultiSteps)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2_MultiStepsOverflow)
@@ -1794,11 +1794,11 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteRead2D4x2_MultiStepsOverflow)
         EXPECT_THROW(bpReader.Get(var_r64, R64.data()), std::invalid_argument);
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadTestADIOS2, OpenEngineTwice)
@@ -1807,9 +1807,7 @@ TEST_F(BPWriteReadTestADIOS2, OpenEngineTwice)
     // form a 2D 4 * (NumberOfProcess * Nx) matrix where Nx is 2 here
     const std::string fname("OpenTwice.bp");
 
-    int mpiRank = 0;
 #if ADIOS2_USE_MPI
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     adios2::ADIOS adios(MPI_COMM_WORLD);
 #else
     adios2::ADIOS adios;
@@ -1842,11 +1840,11 @@ TEST_F(BPWriteReadTestADIOS2, OpenEngineTwice)
         bpWriter2.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadTestADIOS2, ReadStartCount)
@@ -1931,11 +1929,11 @@ TEST_F(BPWriteReadTestADIOS2, ReadStartCount)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //***************************************************
@@ -2091,11 +2089,11 @@ TEST_F(BPWriteReadTestADIOS2, ADIOS2BPWriteReadEmptyProcess)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 #else
     return;
 #endif
@@ -2170,11 +2168,11 @@ TEST_F(BPWriteReadTestADIOS2, GetDeferredInClose)
         }
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadTestADIOS2, GetDeferredInEndStep)
@@ -2247,11 +2245,11 @@ TEST_F(BPWriteReadTestADIOS2, GetDeferredInEndStep)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadTestADIOS2, GetDeferredWithoutEndStep)
@@ -2325,11 +2323,11 @@ TEST_F(BPWriteReadTestADIOS2, GetDeferredWithoutEndStep)
         }
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************

--- a/testing/adios2/engine/bp/TestBPWriteReadADIOS2Transport.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadADIOS2Transport.cpp
@@ -367,11 +367,11 @@ TEST_P(BPWriteReadTestADIOS2Transport, ADIOS2BPWriteRead1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -717,11 +717,11 @@ TEST_P(BPWriteReadTestADIOS2Transport, ADIOS2BPWriteRead2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -1055,11 +1055,11 @@ TEST_P(BPWriteReadTestADIOS2Transport, ADIOS2BPWriteRead2D4x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_P(BPWriteReadTestADIOS2Transport, ADIOS2BPWriteRead2D4x2_ReadMultiSteps)
@@ -1390,11 +1390,11 @@ TEST_P(BPWriteReadTestADIOS2Transport, ADIOS2BPWriteRead2D4x2_ReadMultiSteps)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_P(BPWriteReadTestADIOS2Transport, ADIOS2BPWriteRead2D4x2_MultiStepsOverflow)
@@ -1600,11 +1600,11 @@ TEST_P(BPWriteReadTestADIOS2Transport, ADIOS2BPWriteRead2D4x2_MultiStepsOverflow
         EXPECT_THROW(bpReader.Get(var_r64, R64.data()), std::invalid_argument);
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_P(BPWriteReadTestADIOS2Transport, OpenEngineTwice)

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2.cpp
@@ -382,11 +382,11 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D2x4)
@@ -631,11 +631,11 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D4x2)
@@ -886,11 +886,11 @@ TEST_F(BPWriteReadAsStreamTestADIOS2, ADIOS2BPWriteRead2D4x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadAsStreamTestADIOS2, ReaderWriterDefineVariable)

--- a/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAsStreamADIOS2_Threads.cpp
@@ -261,11 +261,11 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -516,11 +516,11 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -775,11 +775,11 @@ TEST_F(BPWriteReadAsStreamTestADIOS2_Threads, ADIOS2BPWriteRead2D4x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 /* This test fails with BP5

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributes.cpp
@@ -229,13 +229,10 @@ TEST_F(BPWriteReadAttributes, WriteReadSingleTypes)
 
     // Cleanup generated files
 #if ADIOS2_USE_MPI
-    int mpiRank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
-    if (mpiRank == 0)
+    CleanupTestFilesMPI(fName, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fName);
 #endif
-    {
-        CleanupTestFiles(fName);
-    }
 }
 
 // ADIOS2 write read for array attributes
@@ -655,13 +652,10 @@ TEST_F(BPWriteReadAttributes, BPWriteReadSingleTypesVar)
 
     // Cleanup generated files
 #if ADIOS2_USE_MPI
-    int mpiRank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
-    if (mpiRank == 0)
+    CleanupTestFilesMPI(fName, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fName);
 #endif
-    {
-        CleanupTestFiles(fName);
-    }
 }
 
 // ADIOS2 write read for array attributes

--- a/testing/adios2/engine/bp/TestBPWriteReadAttributesMultirank.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadAttributesMultirank.cpp
@@ -110,11 +110,11 @@ TEST_F(BPWriteReadAttributeTestMultirank, ADIOS2BPWriteReadArrayTypes)
         bpRead.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fName);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fName, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fName);
+#endif
 }
 
 //******************************************************************************

--- a/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
@@ -449,11 +449,11 @@ TEST_F(BPWriteReadBlockInfo, BPWriteReadBlockInfo1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadBlockInfo, BPWriteReadBlockInfo2D2x4)
@@ -719,11 +719,11 @@ TEST_F(BPWriteReadBlockInfo, BPWriteReadBlockInfo2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadBlockInfo, BPWriteReadBlockInfo1D8_C)
@@ -904,11 +904,11 @@ TEST_F(BPWriteReadBlockInfo, BPWriteReadBlockInfo1D8_C)
         adios2_finalize(adiosH);
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPWriteReadFlatten.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadFlatten.cpp
@@ -349,11 +349,11 @@ TEST_F(BPWriteReadTestFlatten, FlattenBPWriteRead1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -677,11 +677,11 @@ TEST_F(BPWriteReadTestFlatten, FlattenBPWriteRead2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -996,11 +996,11 @@ TEST_F(BPWriteReadTestFlatten, FlattenBPWriteRead2D4x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadTestFlatten, FlattenBPWriteRead10D2x2)
@@ -1191,11 +1191,11 @@ TEST_F(BPWriteReadTestFlatten, FlattenBPWriteRead10D2x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // ADIOS2 BP write and read 1D arrays
@@ -1331,11 +1331,11 @@ TEST_F(BPWriteReadTestFlatten, FlattenBPWriteReadEmptyProcess)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 #else
     return;
 #endif

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariables.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariables.cpp
@@ -417,11 +417,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1D)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D2x4)
@@ -800,11 +800,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D4x2)
@@ -1184,11 +1184,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D4x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DAllSteps)
@@ -1466,11 +1466,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DAllSteps)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DBlockInfo)
@@ -1646,11 +1646,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DBlockInfo)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DSubFile)
@@ -1759,11 +1759,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DSubFile)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2DChangeCount)
@@ -1840,11 +1840,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2DChangeCount)
         }
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 template <class T>
@@ -2047,10 +2047,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocalVaryingNumberOfBlocks)
 #if ADIOS2_USE_MPI
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSel.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSel.cpp
@@ -439,11 +439,11 @@ TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal1DSel)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal2D2x4Sel)
@@ -906,11 +906,11 @@ TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal2D2x4Sel)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal2D4x2Sel)
@@ -1372,11 +1372,11 @@ TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal2D4x2Sel)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal1DAllStepsSel)
@@ -1681,11 +1681,11 @@ TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal1DAllStepsSel)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSelHighLevel.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSelHighLevel.cpp
@@ -169,11 +169,11 @@ TEST_F(BPWriteReadLocalVariablesSelHighLevel, BPWriteReadLocal1DSel)
         } // step
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariablesSelHighLevel, BPWriteReadLocal2D2x4Sel)
@@ -339,11 +339,11 @@ TEST_F(BPWriteReadLocalVariablesSelHighLevel, BPWriteReadLocal2D2x4Sel)
         } // step
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariablesSelHighLevel, BPWriteReadLocal1DAllStepsSel)
@@ -488,11 +488,11 @@ TEST_F(BPWriteReadLocalVariablesSelHighLevel, BPWriteReadLocal1DAllStepsSel)
         } // selection
     }     // blockID
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPWriteReadMultiblock.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadMultiblock.cpp
@@ -768,11 +768,11 @@ TEST_F(BPWriteReadMultiblockTest, ADIOS2BPWriteReadMultiblock1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -1185,11 +1185,11 @@ TEST_F(BPWriteReadMultiblockTest, ADIOS2BPWriteReadMultiblock2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -1976,11 +1976,11 @@ TEST_F(BPWriteReadMultiblockTest, ADIOS2BPWriteReadMultiblock2D4x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -2119,11 +2119,11 @@ TEST_F(BPWriteReadMultiblockTest, MultiblockPerformDataWrite)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -2260,11 +2260,11 @@ TEST_F(BPWriteReadMultiblockTest, MultiblockNullBlocks)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************

--- a/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVariableSpan.cpp
@@ -316,11 +316,11 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadSpan, BPWriteRead2D2x4)
@@ -637,11 +637,11 @@ TEST_F(BPWriteReadSpan, BPWriteRead2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadSpan, BPWriteRead1D8Local)
@@ -892,11 +892,11 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8Local)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadSpan, BPWriteRead2D2x4Local)
@@ -1179,11 +1179,11 @@ TEST_F(BPWriteReadSpan, BPWriteRead2D2x4Local)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadSpan, BPWriteRead1D8FillValue)
@@ -1501,11 +1501,11 @@ TEST_F(BPWriteReadSpan, BPWriteRead1D8FillValue)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 #ifdef ADIOS2_HAVE_BZIP2
@@ -1581,11 +1581,11 @@ TEST_F(BPWriteReadSpan, BPWriteSpanOperatorException)
         bpWriter.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 #endif
 

--- a/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadVector.cpp
@@ -337,11 +337,11 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead1D8)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -658,11 +658,11 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -967,11 +967,11 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteRead2D4x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadVector, ADIOS2BPWriteReadVector2D4x2_MultiSteps)
@@ -1273,11 +1273,11 @@ TEST_F(BPWriteReadVector, ADIOS2BPWriteReadVector2D4x2_MultiSteps)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************

--- a/testing/adios2/engine/bp/TestBPWriteStatsOnly.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteStatsOnly.cpp
@@ -84,11 +84,11 @@ TEST_F(BPWriteStatsOnly, BPReadException)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadBZIP2.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadBZIP2.cpp
@@ -153,11 +153,11 @@ void BZIP2Accuracy1D(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BZIP2Accuracy1DLocal(const std::string accuracy)
@@ -289,11 +289,11 @@ void BZIP2Accuracy1DLocal(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BZIP2Accuracy2D(const std::string accuracy)
@@ -431,11 +431,11 @@ void BZIP2Accuracy2D(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BZIP2Accuracy3D(const std::string accuracy)
@@ -576,11 +576,11 @@ void BZIP2Accuracy3D(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BZIP2Accuracy1DSel(const std::string accuracy)
@@ -715,11 +715,11 @@ void BZIP2Accuracy1DSel(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BZIP2Accuracy2DSel(const std::string accuracy)
@@ -857,11 +857,11 @@ void BZIP2Accuracy2DSel(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BZIP2Accuracy3DSel(const std::string accuracy)
@@ -1002,11 +1002,11 @@ void BZIP2Accuracy3DSel(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteReadBZIP2 : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc.cpp
@@ -161,11 +161,11 @@ void BloscAccuracy1D(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BloscAccuracy2D(const std::string accuracy, const std::string threshold,
@@ -310,11 +310,11 @@ void BloscAccuracy2D(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BloscAccuracy3D(const std::string accuracy, const std::string threshold,
@@ -462,11 +462,11 @@ void BloscAccuracy3D(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BloscAccuracy1DSel(const std::string accuracy, const std::string threshold,
@@ -608,11 +608,11 @@ void BloscAccuracy1DSel(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BloscAccuracy2DSel(const std::string accuracy, const std::string threshold,
@@ -757,11 +757,11 @@ void BloscAccuracy2DSel(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void BloscAccuracy3DSel(const std::string accuracy, const std::string threshold,
@@ -909,11 +909,11 @@ void BloscAccuracy3DSel(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteReadBlosc

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc2.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadBlosc2.cpp
@@ -161,11 +161,11 @@ void Blosc2Accuracy1D(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void Blosc2Accuracy2D(const std::string accuracy, const std::string threshold,
@@ -310,11 +310,11 @@ void Blosc2Accuracy2D(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void Blosc2Accuracy3D(const std::string accuracy, const std::string threshold,
@@ -462,11 +462,11 @@ void Blosc2Accuracy3D(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void Blosc2Accuracy1DSel(const std::string accuracy, const std::string threshold,
@@ -608,11 +608,11 @@ void Blosc2Accuracy1DSel(const std::string accuracy, const std::string threshold
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void Blosc2Accuracy2DSel(const std::string accuracy, const std::string threshold,
@@ -757,11 +757,11 @@ void Blosc2Accuracy2DSel(const std::string accuracy, const std::string threshold
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void Blosc2Accuracy3DSel(const std::string accuracy, const std::string threshold,
@@ -1026,11 +1026,11 @@ void Blosc2NullBlocks(const std::string accuracy, const std::string threshold,
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 class BPWriteReadBlosc2
 : public ::testing::TestWithParam<std::tuple<std::string, std::string, std::string>>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadLocalVariables.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadLocalVariables.cpp
@@ -374,11 +374,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1D)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D2x4)
@@ -737,11 +737,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D2x4)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D4x2)
@@ -1101,11 +1101,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D4x2)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DAllSteps)
@@ -1347,11 +1347,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DAllSteps)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DBlockInfo)
@@ -1502,11 +1502,11 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DBlockInfo)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadMGARD.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadMGARD.cpp
@@ -176,11 +176,11 @@ void MGARDAccuracy1D(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy2D(const std::string tolerance)
@@ -345,11 +345,11 @@ void MGARDAccuracy2D(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy3D(const std::string tolerance)
@@ -515,11 +515,11 @@ void MGARDAccuracy3D(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy1DSel(const std::string tolerance)
@@ -652,11 +652,11 @@ void MGARDAccuracy1DSel(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy2DSel(const std::string tolerance)
@@ -792,11 +792,11 @@ void MGARDAccuracy2DSel(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy3DSel(const std::string tolerance)
@@ -936,11 +936,11 @@ void MGARDAccuracy3DSel(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDNullBlocks(const std::string tolerance)
@@ -1058,11 +1058,11 @@ void MGARDNullBlocks(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteReadMGARD : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDCuda.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDCuda.cpp
@@ -140,11 +140,11 @@ void MGARDAccuracy2D(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracySmall(const std::string tolerance)
@@ -272,11 +272,11 @@ void MGARDAccuracySmall(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteReadMGARD : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDMDR.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDMDR.cpp
@@ -207,11 +207,11 @@ TEST_F(BPWriteReadMGARDMDR, BPWRMGARD1D)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDPlus.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadMGARDPlus.cpp
@@ -152,11 +152,11 @@ void MGARDAccuracy1D(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy2D(const std::string tolerance)
@@ -293,11 +293,11 @@ void MGARDAccuracy2D(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy3D(const std::string tolerance)
@@ -437,11 +437,11 @@ void MGARDAccuracy3D(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy1DSel(const std::string tolerance)
@@ -566,11 +566,11 @@ void MGARDAccuracy1DSel(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy2DSel(const std::string tolerance)
@@ -699,11 +699,11 @@ void MGARDAccuracy2DSel(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy3DSel(const std::string tolerance)
@@ -845,11 +845,11 @@ void MGARDAccuracy3DSel(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void MGARDAccuracy2DSmallSel(const std::string tolerance)
@@ -975,11 +975,11 @@ void MGARDAccuracy2DSmallSel(const std::string tolerance)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteReadMGARDPlus : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadPNG.cpp
@@ -276,11 +276,11 @@ void PNGAccuracy2D(const std::string compressionLevel)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void PNGAccuracy2DSel(const std::string accuracy)
@@ -416,11 +416,11 @@ void PNGAccuracy2DSel(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWRPNG : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadProDM.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadProDM.cpp
@@ -207,11 +207,11 @@ TEST_F(BPWriteReadProDM, BPWRProDM1D)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadSZ.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadSZ.cpp
@@ -152,11 +152,11 @@ void SZAccuracy1D(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void SZAccuracy2D(const std::string accuracy)
@@ -293,11 +293,11 @@ void SZAccuracy2D(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void SZAccuracy3D(const std::string accuracy)
@@ -437,11 +437,11 @@ void SZAccuracy3D(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void SZAccuracy1DSel(const std::string accuracy)
@@ -577,11 +577,11 @@ void SZAccuracy1DSel(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void SZAccuracy2DSel(const std::string accuracy)
@@ -722,11 +722,11 @@ void SZAccuracy2DSel(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void SZAccuracy3DSel(const std::string accuracy)
@@ -870,11 +870,11 @@ void SZAccuracy3DSel(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void SZAccuracy2DSmallSel(const std::string accuracy)
@@ -1013,11 +1013,11 @@ void SZAccuracy2DSmallSel(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteReadSZ : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadSZ3.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadSZ3.cpp
@@ -200,11 +200,11 @@ void SZ3Accuracy1D(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void SZ3Accuracy2D(const std::string accuracy)
@@ -381,11 +381,11 @@ void SZ3Accuracy2D(const std::string accuracy)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteReadSZ3 : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadSzComplex.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadSzComplex.cpp
@@ -192,9 +192,7 @@ void Writer(const Dims &shape, const Dims &start, const Dims &count, const size_
 
 void Reader(const Dims &shape, const Dims &start, const Dims &count, const size_t steps)
 {
-    int mpiRank = 0;
 #if ADIOS2_USE_MPI
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
     adios2::ADIOS adios(MPI_COMM_WORLD);
 #else
     adios2::ADIOS adios;
@@ -306,11 +304,11 @@ void Reader(const Dims &shape, const Dims &start, const Dims &count, const size_
     ASSERT_EQ(dcomplexCompressed, true);
     readerEngine.Close();
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fileName);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fileName, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fileName);
+#endif
 }
 
 TEST_F(BPEngineTest, SzComplex)

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfp.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfp.cpp
@@ -152,11 +152,11 @@ void ZFPRate1D(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZFPRate2D(const std::string rate)
@@ -290,11 +290,11 @@ void ZFPRate2D(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZFPRate3D(const std::string rate)
@@ -431,11 +431,11 @@ void ZFPRate3D(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZFPRate1DSel(const std::string rate)
@@ -565,11 +565,11 @@ void ZFPRate1DSel(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZFPRate2DSel(const std::string rate)
@@ -697,11 +697,11 @@ void ZFPRate2DSel(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZFPRate3DSel(const std::string rate)
@@ -831,11 +831,11 @@ void ZFPRate3DSel(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZFPRate2DSmallSel(const std::string rate)
@@ -965,11 +965,11 @@ void ZFPRate2DSmallSel(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWRZFP : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpComplex.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpComplex.cpp
@@ -320,11 +320,11 @@ TEST_F(BPEngineTest, ZfpComplex)
 #endif
     Reader(shape, start, count, steps);
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fileName);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fileName, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fileName);
+#endif
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpConfig.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpConfig.cpp
@@ -142,11 +142,11 @@ void ZfpRate1D(const std::string configFile)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate2D(const std::string configFile)
@@ -269,11 +269,11 @@ void ZfpRate2D(const std::string configFile)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate3D(const std::string configFile)
@@ -399,11 +399,11 @@ void ZfpRate3D(const std::string configFile)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate1DSel(const std::string configFile)
@@ -526,11 +526,11 @@ void ZfpRate1DSel(const std::string configFile)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate2DSel(const std::string configFile)
@@ -653,11 +653,11 @@ void ZfpRate2DSel(const std::string configFile)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate3DSel(const std::string configFile)
@@ -783,11 +783,11 @@ void ZfpRate3DSel(const std::string configFile)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate2DSmallSel(const std::string configFile)
@@ -912,11 +912,11 @@ void ZfpRate2DSmallSel(const std::string configFile)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteReadZfpConfig : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpCuda.cpp
@@ -141,11 +141,11 @@ void ZFPRateCUDA(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWRZFPCUDA : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpHighLevelAPI.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpHighLevelAPI.cpp
@@ -103,11 +103,11 @@ void ZfpRate1D(const double rate)
         fr.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate2D(const double rate)
@@ -191,11 +191,11 @@ void ZfpRate2D(const double rate)
         fr.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate3D(const double rate)
@@ -280,11 +280,11 @@ void ZfpRate3D(const double rate)
         fr.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate1DSel(const double rate)
@@ -374,11 +374,11 @@ void ZfpRate1DSel(const double rate)
         fr.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate2DSel(const double rate)
@@ -469,11 +469,11 @@ void ZfpRate2DSel(const double rate)
         fr.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate3DSel(const double rate)
@@ -565,11 +565,11 @@ void ZfpRate3DSel(const double rate)
         fr.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZfpRate2DSmallSel(const double rate)
@@ -663,11 +663,11 @@ void ZfpRate2DSmallSel(const double rate)
         fr.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWriteReadZfpHighLevelAPI : public ::testing::TestWithParam<double>

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadZfpRemoveOperations.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadZfpRemoveOperations.cpp
@@ -170,11 +170,11 @@ void ZFPRate1D(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZFPRate2D(const std::string rate)
@@ -327,11 +327,11 @@ void ZFPRate2D(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void ZFPRate3D(const std::string rate)
@@ -484,11 +484,11 @@ void ZFPRate3D(const std::string rate)
         bpReader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class BPWRZFPODD : public ::testing::TestWithParam<std::string>

--- a/testing/adios2/engine/common/TestEngineCommon.cpp
+++ b/testing/adios2/engine/common/TestEngineCommon.cpp
@@ -226,11 +226,7 @@ TEST_F(Common, NewAttributeEveryStep)
     }
 
     // Cleanup generated files
-    MPI_Barrier(MPI_COMM_WORLD);
-    if (wrank == 0)
-    {
-        CleanupTestFiles(streamName);
-    }
+    CleanupTestFilesMPI(streamName, MPI_COMM_WORLD);
 
     // Separate each individual test with a big gap in time
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/testing/adios2/engine/hdf5/TestHDF5Append.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5Append.cpp
@@ -369,11 +369,11 @@ TEST_F(AppendTimeStepTest, ADIOS2HDF5WriteAppendRead)
         reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************

--- a/testing/adios2/engine/hdf5/TestHDF5StreamWriteReadHighLevelAPI.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5StreamWriteReadHighLevelAPI.cpp
@@ -249,11 +249,11 @@ TEST_F(StreamWriteReadHighLevelAPI_HDF5, ADIOS2H5writeRead1D8)
         iStream.close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 #ifdef NEVER

--- a/testing/adios2/engine/hdf5/TestHDF5WriteMemorySelectionRead.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteMemorySelectionRead.cpp
@@ -333,11 +333,11 @@ void HDF5Steps1D(const size_t ghostCells)
         h5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void HDF5Steps2D4x2(const size_t ghostCells)
@@ -571,11 +571,11 @@ void HDF5Steps2D4x2(const size_t ghostCells)
         h5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 void HDF5Steps3D8x2x4(const size_t ghostCells)
@@ -852,11 +852,11 @@ void HDF5Steps3D8x2x4(const size_t ghostCells)
         h5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 class HDF5WriteMemSelReadVector : public ::testing::TestWithParam<size_t>

--- a/testing/adios2/engine/hdf5/TestHDF5WriteReadAsStream.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteReadAsStream.cpp
@@ -394,11 +394,11 @@ TEST_F(HDF5WriteReadAsStreamTestADIOS2, ADIOS2HDF5WriteRead1D8)
         h5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(HDF5WriteReadAsStreamTestADIOS2, ADIOS2HDF5WriteRead2D2x4)
@@ -641,11 +641,11 @@ TEST_F(HDF5WriteReadAsStreamTestADIOS2, ADIOS2HDF5WriteRead2D2x4)
         h5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(HDF5WriteReadAsStreamTestADIOS2, ADIOS2HDF5WriteRead2D4x2)
@@ -891,11 +891,11 @@ TEST_F(HDF5WriteReadAsStreamTestADIOS2, ADIOS2HDF5WriteRead2D4x2)
         h5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(HDF5WriteReadAsStreamTestADIOS2, ReaderWriterDefineVariable)

--- a/testing/adios2/engine/hdf5/TestHDF5WriteReadAttributesADIOS2.cpp
+++ b/testing/adios2/engine/hdf5/TestHDF5WriteReadAttributesADIOS2.cpp
@@ -188,13 +188,10 @@ TEST_F(BPWriteReadAttributeTestADIOS2, ADIOS2BPWriteReadSingleTypes)
 
     // Cleanup generated files
 #if ADIOS2_USE_MPI
-    int mpiRank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
-    if (mpiRank == 0)
+    CleanupTestFilesMPI(fName, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fName);
 #endif
-    {
-        CleanupTestFiles(fName);
-    }
 }
 
 // ADIOS2 write read for array attributes
@@ -538,13 +535,10 @@ TEST_F(BPWriteReadAttributeTestADIOS2, BPWriteReadSingleTypesVar)
 
     // Cleanup generated files
 #if ADIOS2_USE_MPI
-    int mpiRank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
-    if (mpiRank == 0)
+    CleanupTestFilesMPI(fName, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fName);
 #endif
-    {
-        CleanupTestFiles(fName);
-    }
 }
 
 // ADIOS2 write read for array attributes

--- a/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
+++ b/testing/adios2/engine/hdf5/TestNativeHDF5WriteRead.cpp
@@ -701,11 +701,11 @@ TEST_F(HDF5WriteReadTest, ADIOS2HDF5WriteHDF5Read1D8)
         }
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // ADIOS2 write, ADIOS2 read
@@ -991,11 +991,11 @@ TEST_F(HDF5WriteReadTest, ADIOS2HDF5WriteADIOS2HDF5Read1D8)
         hdf5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // Native HDF5 write, ADIOS2 read
@@ -1251,11 +1251,11 @@ TEST_F(HDF5WriteReadTest, HDF5WriteADIOS2HDF5Read1D8)
         hdf5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -1537,11 +1537,11 @@ TEST_F(HDF5WriteReadTest, ADIOS2HDF5WriteHDF5Read2D2x4)
         }
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // ADIOS2 write, ADIOS2 read
@@ -1844,11 +1844,11 @@ TEST_F(HDF5WriteReadTest, ADIOS2HDF5WriteADIOS2HDF5Read2D2x4)
         hdf5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // Native HDF5 write, ADIOS2 read
@@ -2099,11 +2099,11 @@ TEST_F(HDF5WriteReadTest, HDF5WriteADIOS2HDF5Read2D2x4)
         hdf5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 //******************************************************************************
@@ -2382,11 +2382,11 @@ TEST_F(HDF5WriteReadTest, ADIOS2HDF5WriteHDF5Read2D4x2)
         }
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // ADIOS2 write, ADIOS2 read
@@ -2686,11 +2686,11 @@ TEST_F(HDF5WriteReadTest, ADIOS2HDF5WriteADIOS2HDF5Read2D4x2)
         hdf5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 // Native HDF5 write, ADIOS2 read
@@ -2941,11 +2941,11 @@ TEST_F(HDF5WriteReadTest, HDF5WriteADIOS2HDF5Read2D4x2)
         hdf5Reader.Close();
     }
 
-    // Cleanup generated files
-    if (mpiRank == 0)
-    {
-        CleanupTestFiles(fname);
-    }
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
 }
 
 TEST_F(HDF5WriteReadTest, /*DISABLE_*/ ATTRTESTADIOS2vsHDF5)

--- a/testing/adios2/engine/staging-common/TestCommonRead.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonRead.cpp
@@ -466,10 +466,13 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
         EXPECT_FALSE(io.InquireVariable<std::complex<float>>("c32"));
     }
 
-    // Cleanup generated files (only for file engines, not streaming engines)
-    if (mpiRank == 0 && Cleanup)
+    if (Cleanup)
     {
+#if ADIOS2_USE_MPI
+        CleanupTestFilesMPI(fname, testComm);
+#else
         CleanupTestFiles(fname);
+#endif
     }
 }
 

--- a/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadAttrs.cpp
@@ -354,10 +354,13 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
     // Close the file
     engine.Close();
 
-    // Cleanup generated files (only for file engines, not streaming engines)
-    if (mpiRank == 0 && Cleanup)
+    if (Cleanup)
     {
+#if ADIOS2_USE_MPI
+        CleanupTestFilesMPI(fname, testComm);
+#else
         CleanupTestFiles(fname);
+#endif
     }
 }
 

--- a/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadLocal.cpp
@@ -159,10 +159,13 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
     // Close the file
     engine.Close();
 
-    // Cleanup generated files (only for file engines, not streaming engines)
-    if (mpiRank == 0 && Cleanup)
+    if (Cleanup)
     {
+#if ADIOS2_USE_MPI
+        CleanupTestFilesMPI(fname, testComm);
+#else
         CleanupTestFiles(fname);
+#endif
     }
 }
 

--- a/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonReadShared.cpp
@@ -136,10 +136,15 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
     engine2.Close();
 
     // Cleanup generated files (only for file engines, not streaming engines)
-    if (mpiRank == 0 && Cleanup)
+    if (Cleanup)
     {
+#if ADIOS2_USE_MPI
+        CleanupTestFilesMPI(fname1, testComm);
+        CleanupTestFilesMPI(fname2, testComm);
+#else
         CleanupTestFiles(fname1);
         CleanupTestFiles(fname2);
+#endif
     }
 }
 

--- a/testing/adios2/engine/staging-common/TestCommonSpanRead.cpp
+++ b/testing/adios2/engine/staging-common/TestCommonSpanRead.cpp
@@ -114,10 +114,13 @@ TEST_F(CommonReadTest, ADIOS2CommonRead1D8)
     // Close the file
     engine.Close();
 
-    // Cleanup generated files (only for file engines, not streaming engines)
-    if (mpiRank == 0 && Cleanup)
+    if (Cleanup)
     {
+#if ADIOS2_USE_MPI
+        CleanupTestFilesMPI(fname, testComm);
+#else
         CleanupTestFiles(fname);
+#endif
     }
 }
 

--- a/testing/adios2/engine/time-series/TestTimeSeries.cpp
+++ b/testing/adios2/engine/time-series/TestTimeSeries.cpp
@@ -237,12 +237,23 @@ TEST_F(TimeSeries, WriteReadShape2D)
     }
 
     // Cleanup generated files
-    if (rank == 0)
     {
-        CleanupTestFiles(fname + ".ats");
-
-        // Clean up all numbered .bp or .h5 files
         size_t numFiles = (nsteps + stepsPerFile - 1) / stepsPerFile;
+#if ADIOS2_USE_MPI
+        CleanupTestFilesMPI(fname + ".ats", MPI_COMM_WORLD);
+        for (size_t i = 0; i < numFiles; i++)
+        {
+            if (engineName == "HDF5")
+            {
+                CleanupTestFilesMPI(fname + "_" + std::to_string(i) + ".h5", MPI_COMM_WORLD);
+            }
+            else
+            {
+                CleanupTestFilesMPI(fname + "_" + std::to_string(i) + ".bp", MPI_COMM_WORLD);
+            }
+        }
+#else
+        CleanupTestFiles(fname + ".ats");
         for (size_t i = 0; i < numFiles; i++)
         {
             if (engineName == "HDF5")
@@ -254,6 +265,7 @@ TEST_F(TimeSeries, WriteReadShape2D)
                 CleanupTestFiles(fname + "_" + std::to_string(i) + ".bp");
             }
         }
+#endif
     }
 }
 


### PR DESCRIPTION
It turns out that after the initial Open(), most of the file engines proceed through the typical BeginStep/Get/EndStep loop without any MPI collectives.  This means that if rank 0 deletes all the files when it's done, it's possible that some other ranks haven't actually opened those files yet causing an exception in a non-zero rank.  This is rare, but it happens in CI now and then.  This change touches a lot of files, but it's basically the same pattern, rather than something like "if (mpiRank==0) CleanupGeneratedFiles()", we move the MPI logic into CleanupGeneratedFiles so that we can have a barrier before we do cleanup, ensuring that we never delete before everyone is finished.