### PR TITLE
Use access/secret keys in AWS explicitly only if they are not empty, …

### DIFF
--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -593,8 +593,6 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
                     {
                         io.AddTransport("File", p);
                         io.SetParameter("UUID", ds.uuid);
-                        io.SetParameter("DataTransport", "awssdk");
-                        io.SetParameter("S3Endpoint", endpointURL);
                         io.SetEngine("BP5");
                     }
                     newLocalPath = remotePath;

--- a/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
@@ -239,9 +239,18 @@ void FileAWSSDK::SetParameters(const Params &params)
     {
         aws_credentials = {m_accessKeyID, m_secretKey};
     }
-    s3Client =
-        new Aws::S3::S3Client(aws_credentials, *s3ClientConfig,
-                              Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+
+    if (m_accessKeyID.empty() && m_secretKey.empty() && m_sessionToken.empty())
+    {
+        // last hope user set AWS_PROFILE (CampaignReader does this)
+        s3Client = new Aws::S3::S3Client(*s3ClientConfig);
+    }
+    else
+    {
+        s3Client =
+            new Aws::S3::S3Client(aws_credentials, *s3ClientConfig,
+                                  Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+    }
     if (m_Verbose > 0)
     {
         std::cout << "FileAWSSDK::SetParameters: AWS Transport created with endpoint = '"


### PR DESCRIPTION
…otherwise rely on S3Client() do its thing, and use profile from environment or no access keys. CampaignReader sets profile in environment.