### PR TITLE
Rework derived variable compute functions and type system

### DIFF
--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -970,12 +970,12 @@ VariableDerived &IO::DefineDerivedVariable(const std::string &name, const std::s
                               (itVariable->second)->m_Shape}});
     }
 
-    // Build the expression code stream: GenerateCode -> ResolveTypes -> ConstantFold -> PlanBuffers
+    // Resolve types on tree, then generate code, then run linear passes
+    derived::ResolveTreeTypes(exprTree, name_to_type);
     derived::ExprCodeStream codeStream = derived::GenerateCode(exprTree);
-    derived::ResolveTypes(codeStream, name_to_type);
-    derived::ConstantFold(codeStream);
-    derived::PlanBuffers(codeStream);
     codeStream.ExprString = exp_string;
+    derived::SemanticsPass(codeStream, name_to_type);
+    derived::PlanBuffers(codeStream);
     DataType expressionType = codeStream.OutputType;
 
     {

--- a/source/adios2/toolkit/derived/ExprCodeStream.cpp
+++ b/source/adios2/toolkit/derived/ExprCodeStream.cpp
@@ -27,30 +27,31 @@ namespace derived
 
 // --- Operator dispatch tables (moved from Expression.cpp) ---
 
+// Operator dispatch table: compute function + dimension function per operator.
+// Single source of truth for operator dispatch (PROMOTE handled separately in Execute).
 struct OperatorFunctions
 {
-    std::function<DerivedData(ExprData)> ComputeFct;
+    std::function<DerivedData(const ExprData &)> ComputeFct;
     std::function<std::tuple<Dims, Dims, Dims>(std::vector<std::tuple<Dims, Dims, Dims>>)> DimsFct;
-    std::function<DataType(DataType)> TypeFct;
 };
 
 static const std::map<detail::ExpressionOperator, OperatorFunctions> OpFunctions = {
-    {detail::ExpressionOperator::OP_ADD, {AddFunc, SameDimsWithAgrFunc, SameTypeFunc}},
-    {detail::ExpressionOperator::OP_SUBTRACT, {SubtractFunc, SameDimsFunc, SameTypeFunc}},
-    {detail::ExpressionOperator::OP_NEGATE, {NegateFunc, SameDimsFunc, SameTypeFunc}},
-    {detail::ExpressionOperator::OP_MULT, {MultFunc, SameDimsFunc, SameTypeFunc}},
-    {detail::ExpressionOperator::OP_DIV, {DivFunc, SameDimsFunc, SameTypeFunc}},
-    {detail::ExpressionOperator::OP_POW, {PowFunc, SameDimsFunc, FloatTypeFunc}},
-    {detail::ExpressionOperator::OP_SQRT, {SqrtFunc, SameDimsFunc, FloatTypeFunc}},
-    {detail::ExpressionOperator::OP_SIN, {SinFunc, SameDimsFunc, FloatTypeFunc}},
-    {detail::ExpressionOperator::OP_COS, {CosFunc, SameDimsFunc, FloatTypeFunc}},
-    {detail::ExpressionOperator::OP_TAN, {TanFunc, SameDimsFunc, FloatTypeFunc}},
-    {detail::ExpressionOperator::OP_ASIN, {AsinFunc, SameDimsFunc, FloatTypeFunc}},
-    {detail::ExpressionOperator::OP_ACOS, {AcosFunc, SameDimsFunc, FloatTypeFunc}},
-    {detail::ExpressionOperator::OP_ATAN, {AtanFunc, SameDimsFunc, FloatTypeFunc}},
-    {detail::ExpressionOperator::OP_MAGN, {MagnitudeFunc, SameDimsWithAgrFunc, SameTypeFunc}},
-    {detail::ExpressionOperator::OP_CROSS, {Cross3DFunc, Cross3DDimsFunc, SameTypeFunc}},
-    {detail::ExpressionOperator::OP_CURL, {Curl3DFunc, CurlDimsFunc, SameTypeFunc}}};
+    {detail::ExpressionOperator::OP_ADD, {AddFunc, SameDimsWithAgrFunc}},
+    {detail::ExpressionOperator::OP_SUBTRACT, {SubtractFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_NEGATE, {NegateFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_MULT, {MultFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_DIV, {DivFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_POW, {PowFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_SQRT, {SqrtFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_SIN, {SinFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_COS, {CosFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_TAN, {TanFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_ASIN, {AsinFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_ACOS, {AcosFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_ATAN, {AtanFunc, SameDimsFunc}},
+    {detail::ExpressionOperator::OP_MAGN, {MagnitudeFunc, SameDimsWithAgrFunc}},
+    {detail::ExpressionOperator::OP_CROSS, {Cross3DFunc, Cross3DDimsFunc}},
+    {detail::ExpressionOperator::OP_CURL, {Curl3DFunc, CurlDimsFunc}}};
 
 // --- ExprNode utility functions ---
 
@@ -89,7 +90,8 @@ static const std::map<detail::ExpressionOperator, std::string> OpNameMap = {
     {detail::ExpressionOperator::OP_ATAN, "ATAN"},
     {detail::ExpressionOperator::OP_MAGN, "MAGNITUDE"},
     {detail::ExpressionOperator::OP_CROSS, "CROSS"},
-    {detail::ExpressionOperator::OP_CURL, "CURL"}};
+    {detail::ExpressionOperator::OP_CURL, "CURL"},
+    {detail::ExpressionOperator::OP_PROMOTE, "PROMOTE"}};
 
 std::string ToStringExpr(const ExprNode &node)
 {
@@ -117,6 +119,228 @@ static bool IsIntegerType(DataType type)
     return type == DataType::Int8 || type == DataType::Int16 || type == DataType::Int32 ||
            type == DataType::Int64 || type == DataType::UInt8 || type == DataType::UInt16 ||
            type == DataType::UInt32 || type == DataType::UInt64;
+}
+
+static bool IsUnsignedType(DataType type)
+{
+    return type == DataType::UInt8 || type == DataType::UInt16 || type == DataType::UInt32 ||
+           type == DataType::UInt64;
+}
+
+static bool IsComplexType(DataType type)
+{
+    return type == DataType::FloatComplex || type == DataType::DoubleComplex;
+}
+
+static bool IsFloatOp(detail::ExpressionOperator op)
+{
+    return op == detail::ExpressionOperator::OP_SQRT || op == detail::ExpressionOperator::OP_POW ||
+           op == detail::ExpressionOperator::OP_SIN || op == detail::ExpressionOperator::OP_COS ||
+           op == detail::ExpressionOperator::OP_TAN || op == detail::ExpressionOperator::OP_ASIN ||
+           op == detail::ExpressionOperator::OP_ACOS || op == detail::ExpressionOperator::OP_ATAN;
+}
+
+// C-style type promotion: return the wider of two types.
+static DataType PromoteType(DataType a, DataType b)
+{
+    if (a == b)
+        return a;
+    if (helper::GetDataTypeSize(a) > helper::GetDataTypeSize(b))
+        return a;
+    if (helper::GetDataTypeSize(b) > helper::GetDataTypeSize(a))
+        return b;
+    // Same size: prefer float over int
+    if (!IsIntegerType(a) && IsIntegerType(b))
+        return a;
+    if (!IsIntegerType(b) && IsIntegerType(a))
+        return b;
+    // Same size integers: unsigned wins (C promotion rule)
+    if (IsUnsignedType(a))
+        return a;
+    if (IsUnsignedType(b))
+        return b;
+    return a;
+}
+
+// --- ResolveTreeTypes ---
+
+static void ResolveTreeTypesNode(ExprNode &node, const std::map<std::string, DataType> &varTypes,
+                                 DataType contextType)
+{
+    if (node.IsVar())
+    {
+        auto it = varTypes.find(node.VarName);
+        if (it != varTypes.end())
+            node.Type = it->second;
+        else
+            node.Type = DataType::Double; // unknown variable fallback
+        return;
+    }
+
+    if (node.IsConst())
+    {
+        // Constants take the type of their context (parent's promoted type).
+        // On first pass (contextType==None), stay None so we don't affect promotion.
+        node.Type = contextType;
+        return;
+    }
+
+    // First pass: resolve children (constants don't know context yet, use None)
+    for (auto &child : node.Children)
+        ResolveTreeTypesNode(child, varTypes, DataType::None);
+
+    // Compute promoted type from non-constant children
+    DataType promoted = DataType::None;
+    bool hasComplex = false, hasNonComplex = false;
+    for (auto &child : node.Children)
+    {
+        if (child.IsConst() && child.Type == DataType::None)
+            continue; // unresolved constant, skip
+        if (child.Type == DataType::None)
+            continue;
+        if (IsComplexType(child.Type))
+            hasComplex = true;
+        else
+            hasNonComplex = true;
+        if (promoted == DataType::None)
+            promoted = child.Type;
+        else
+            promoted = PromoteType(promoted, child.Type);
+    }
+    if (promoted == DataType::None)
+        promoted = DataType::Double;
+
+    // For trig/sqrt/pow: integer promotes to double
+    if (IsFloatOp(node.Op) && IsIntegerType(promoted))
+        promoted = DataType::Double;
+
+    // Validation
+    if (hasComplex && hasNonComplex)
+        helper::Throw<std::invalid_argument>("Derived", "ExprNode", "ResolveTreeTypes",
+                                             "Cannot mix complex and non-complex types");
+    if (IsFloatOp(node.Op) && hasComplex)
+        helper::Throw<std::invalid_argument>("Derived", "ExprNode", "ResolveTreeTypes",
+                                             "Transcendental/sqrt/pow not supported on complex");
+    if (IsUnsignedType(promoted) && node.Op == detail::ExpressionOperator::OP_NEGATE)
+        helper::Throw<std::invalid_argument>("Derived", "ExprNode", "ResolveTreeTypes",
+                                             "Negate not valid on unsigned types");
+    if (node.Op == detail::ExpressionOperator::OP_CROSS && node.Children.size() != 6)
+        helper::Throw<std::invalid_argument>("Derived", "ExprNode", "ResolveTreeTypes",
+                                             "Cross product requires exactly 6 inputs");
+    if (node.Op == detail::ExpressionOperator::OP_CURL && node.Children.size() != 1 &&
+        node.Children.size() != 3)
+        helper::Throw<std::invalid_argument>("Derived", "ExprNode", "ResolveTreeTypes",
+                                             "Curl requires 1 or 3 inputs");
+
+    node.Type = promoted;
+
+    // Second pass: re-resolve constants now that we know the promoted type
+    for (auto &child : node.Children)
+    {
+        if (child.IsConst())
+            child.Type = promoted;
+    }
+}
+
+void ResolveTreeTypes(ExprNode &tree, const std::map<std::string, DataType> &varTypes)
+{
+    ResolveTreeTypesNode(tree, varTypes, DataType::None);
+}
+
+// --- ComputeInputSelections ---
+
+std::map<std::string, std::pair<Dims, Dims>>
+ComputeInputSelections(const ExprCodeStream &cs, const Dims &outputStart, const Dims &outputCount)
+{
+    // Per-buffer selection: (start, count). Populated from output backward.
+    std::vector<std::pair<Dims, Dims>> bufSel(cs.Buffers.size());
+    std::vector<bool> bufSelSet(cs.Buffers.size(), false);
+
+    // Seed with the requested output selection
+    bufSel[cs.OutputBufID] = {outputStart, outputCount};
+    bufSelSet[cs.OutputBufID] = true;
+
+    // Walk instructions in reverse order
+    for (int i = static_cast<int>(cs.Instructions.size()) - 1; i >= 0; i--)
+    {
+        const auto &instr = cs.Instructions[i];
+
+        // If this instruction's output doesn't have a selection, skip
+        if (!bufSelSet[instr.OutputBuf])
+            continue;
+
+        const auto &outStart = bufSel[instr.OutputBuf].first;
+        const auto &outCount = bufSel[instr.OutputBuf].second;
+
+        // Propagate selection to input buffers based on SelectionRule
+        for (size_t bufID : instr.InputBufs)
+        {
+            if (cs.Buffers[bufID].IsConstant)
+                continue; // constants don't need selection
+
+            Dims inStart, inCount;
+            switch (instr.SelRule)
+            {
+            case SelectionRule::Identity:
+                // Element-wise: input selection = output selection
+                inStart = outStart;
+                inCount = outCount;
+                break;
+
+            case SelectionRule::ExpandHalo:
+                // Stencil: expand each spatial dimension by halo
+                inStart.resize(outStart.size());
+                inCount.resize(outCount.size());
+                for (size_t d = 0; d < outStart.size(); d++)
+                {
+                    size_t halo = static_cast<size_t>(instr.HaloSize);
+                    inStart[d] = (outStart[d] >= halo) ? outStart[d] - halo : 0;
+                    inCount[d] = outCount[d] + 2 * halo;
+                    // Clamp will happen at read time when actual array bounds are known
+                }
+                break;
+
+            case SelectionRule::Reshape:
+                // Dimension-changing ops (cross, magnitude): pass through spatial dims.
+                // The exact mapping depends on the operator; for now propagate as-is.
+                // Cross adds a trailing dim of 3 to output — input selection is output
+                // without that trailing dim. Magnitude with aggregated input adds the
+                // component dimension back.
+                inStart = outStart;
+                inCount = outCount;
+                break;
+            }
+
+            // If this buffer already has a selection (from another instruction), take the union
+            if (bufSelSet[bufID])
+            {
+                auto &existing = bufSel[bufID];
+                for (size_t d = 0; d < inStart.size() && d < existing.first.size(); d++)
+                {
+                    size_t newEnd =
+                        std::max(existing.first[d] + existing.second[d], inStart[d] + inCount[d]);
+                    existing.first[d] = std::min(existing.first[d], inStart[d]);
+                    existing.second[d] = newEnd - existing.first[d];
+                }
+            }
+            else
+            {
+                bufSel[bufID] = {inStart, inCount};
+                bufSelSet[bufID] = true;
+            }
+        }
+    }
+
+    // Collect selections for input variables
+    std::map<std::string, std::pair<Dims, Dims>> result;
+    for (size_t b = 0; b < cs.Buffers.size(); b++)
+    {
+        if (cs.Buffers[b].IsInput && bufSelSet[b])
+        {
+            result[cs.Buffers[b].VarName] = bufSel[b];
+        }
+    }
+    return result;
 }
 
 // --- DumpCodeStream ---
@@ -180,6 +404,8 @@ std::string DumpCodeStream(const ExprCodeStream &cs)
     return os.str();
 }
 
+static bool IsMixedTypeHandledInline(DataType outType, DataType lhsType, DataType rhsType);
+
 // --- GenerateCode: ExprNode tree -> ExprCodeStream ---
 
 struct GenerateCodeContext
@@ -201,10 +427,10 @@ static size_t GenerateCodeNode(const ExprNode &node, GenerateCodeContext &ctx)
         BufferDescriptor buf;
         buf.IsInput = true;
         buf.VarName = node.VarName;
+        buf.Type = node.Type;
         ctx.cs.Buffers.push_back(buf);
         ctx.varBufMap[node.VarName] = bufID;
 
-        // Track input var names (deduplicated)
         if (std::find(ctx.cs.InputVarNames.begin(), ctx.cs.InputVarNames.end(), node.VarName) ==
             ctx.cs.InputVarNames.end())
         {
@@ -219,20 +445,57 @@ static size_t GenerateCodeNode(const ExprNode &node, GenerateCodeContext &ctx)
         BufferDescriptor buf;
         buf.IsConstant = true;
         buf.ConstVal.StringVal = node.Const;
+        buf.Type = node.Type;
         ctx.cs.Buffers.push_back(buf);
         return bufID;
     }
 
-    // Operator node: generate code for children first (post-order), then emit instruction
+    // Operator node: generate code for children first (post-order)
     std::vector<size_t> inputBufs;
     for (const auto &child : node.Children)
     {
-        inputBufs.push_back(GenerateCodeNode(child, ctx));
+        size_t childBuf = GenerateCodeNode(child, ctx);
+
+        // If child type doesn't match this node's type, may need PROMOTE.
+        // Binary ops: skip if the combo is handled inline by DISPATCH_BINARY.
+        // Unary ops: always promote if types differ.
+        bool needsPromote = false;
+        if (child.Type != DataType::None && child.Type != node.Type)
+        {
+            if (node.Children.size() == 2)
+                needsPromote = !IsMixedTypeHandledInline(node.Type, child.Type, node.Type);
+            else
+                needsPromote = true;
+        }
+        if (needsPromote)
+        {
+            size_t promoteBufID = ctx.cs.Buffers.size();
+            BufferDescriptor promoteBuf;
+            promoteBuf.Type = node.Type;
+            ctx.cs.Buffers.push_back(promoteBuf);
+
+            ExprInstruction promoteInstr;
+            promoteInstr.Op = detail::ExpressionOperator::OP_PROMOTE;
+            promoteInstr.InputBufs = {childBuf};
+            promoteInstr.OutputBuf = promoteBufID;
+            promoteInstr.OutputType = node.Type;
+
+            size_t promoteIdx = ctx.cs.Instructions.size();
+            ctx.cs.Instructions.push_back(promoteInstr);
+            ctx.cs.Buffers[childBuf].LastUse = promoteIdx;
+            ctx.cs.Buffers[promoteBufID].FirstUse = promoteIdx;
+            ctx.cs.Buffers[promoteBufID].LastUse = promoteIdx;
+
+            childBuf = promoteBufID;
+        }
+
+        inputBufs.push_back(childBuf);
     }
 
     // Create output buffer for this instruction
     size_t outBufID = ctx.cs.Buffers.size();
     BufferDescriptor outBuf;
+    outBuf.Type = node.Type;
     ctx.cs.Buffers.push_back(outBuf);
 
     // Create instruction
@@ -240,11 +503,11 @@ static size_t GenerateCodeNode(const ExprNode &node, GenerateCodeContext &ctx)
     instr.Op = node.Op;
     instr.InputBufs = inputBufs;
     instr.OutputBuf = outBufID;
+    instr.OutputType = node.Type;
 
     size_t instrIdx = ctx.cs.Instructions.size();
     ctx.cs.Instructions.push_back(instr);
 
-    // Update buffer use ranges
     for (size_t bufID : inputBufs)
     {
         auto &buf = ctx.cs.Buffers[bufID];
@@ -263,53 +526,182 @@ ExprCodeStream GenerateCode(const ExprNode &root)
     ExprCodeStream cs;
     GenerateCodeContext ctx{cs, {}};
     cs.OutputBufID = GenerateCodeNode(root, ctx);
+    cs.OutputType = root.Type;
     return cs;
 }
 
-// --- ResolveTypes ---
+// --- Constant evaluation helpers (used by SemanticsPass) ---
 
-void ResolveTypes(ExprCodeStream &cs, const std::map<std::string, DataType> &varTypes)
+// Evaluate a binary op on two typed constant values, produce a result TypedConstant
+static TypedConstant EvalConstBinOp(detail::ExpressionOperator op, const TypedConstant &lhs,
+                                    const TypedConstant &rhs, DataType outType)
 {
-    // Set types on input variable buffers
-    for (auto &buf : cs.Buffers)
+    TypedConstant result;
+    result.Type = outType;
+    result.Resolved = true;
+
+    if (IsIntegerType(outType))
     {
-        if (buf.IsInput)
+        int64_t a = lhs.IntVal, b = rhs.IntVal, r = 0;
+        switch (op)
         {
-            auto it = varTypes.find(buf.VarName);
-            if (it != varTypes.end())
-                buf.Type = it->second;
+        case detail::ExpressionOperator::OP_ADD:
+            r = a + b;
+            break;
+        case detail::ExpressionOperator::OP_SUBTRACT:
+            r = a - b;
+            break;
+        case detail::ExpressionOperator::OP_MULT:
+            r = a * b;
+            break;
+        case detail::ExpressionOperator::OP_DIV:
+            r = (b != 0) ? a / b : 0;
+            break;
+        default:
+            r = a;
+            break;
         }
+        result.IntVal = r;
+        result.DoubleVal = static_cast<double>(r);
     }
-
-    // Walk instructions in order
-    for (auto &instr : cs.Instructions)
+    else
     {
-        // Find the first non-constant input type
-        DataType inputType = DataType::None;
-        for (size_t bufID : instr.InputBufs)
+        double a = IsIntegerType(lhs.Type) ? static_cast<double>(lhs.IntVal) : lhs.DoubleVal;
+        double b = IsIntegerType(rhs.Type) ? static_cast<double>(rhs.IntVal) : rhs.DoubleVal;
+        double r = 0;
+        switch (op)
         {
-            auto &buf = cs.Buffers[bufID];
-            if (!buf.IsConstant && buf.Type != DataType::None)
-            {
-                inputType = buf.Type;
-                break;
-            }
+        case detail::ExpressionOperator::OP_ADD:
+            r = a + b;
+            break;
+        case detail::ExpressionOperator::OP_SUBTRACT:
+            r = a - b;
+            break;
+        case detail::ExpressionOperator::OP_MULT:
+            r = a * b;
+            break;
+        case detail::ExpressionOperator::OP_DIV:
+            r = a / b;
+            break;
+        case detail::ExpressionOperator::OP_POW:
+            r = std::pow(a, b);
+            break;
+        default:
+            r = a;
+            break;
         }
+        result.DoubleVal = r;
+        result.IntVal = static_cast<int64_t>(r);
+    }
+    result.StringVal = std::to_string(IsIntegerType(outType) ? static_cast<double>(result.IntVal)
+                                                             : result.DoubleVal);
+    return result;
+}
 
-        if (inputType == DataType::None)
-            inputType = DataType::Double; // all-constant fallback
+// Evaluate a unary op on a typed constant value
+static TypedConstant EvalConstUnaryOp(detail::ExpressionOperator op, const TypedConstant &operand,
+                                      DataType outType)
+{
+    TypedConstant result;
+    result.Type = outType;
+    result.Resolved = true;
 
-        // Resolve constant buffer types based on context
+    if (IsIntegerType(outType) && op == detail::ExpressionOperator::OP_NEGATE)
+    {
+        result.IntVal = -operand.IntVal;
+        result.DoubleVal = static_cast<double>(result.IntVal);
+    }
+    else
+    {
+        double a =
+            IsIntegerType(operand.Type) ? static_cast<double>(operand.IntVal) : operand.DoubleVal;
+        double r = 0;
+        switch (op)
+        {
+        case detail::ExpressionOperator::OP_NEGATE:
+            r = -a;
+            break;
+        case detail::ExpressionOperator::OP_SQRT:
+            r = std::sqrt(a);
+            break;
+        case detail::ExpressionOperator::OP_SIN:
+            r = std::sin(a);
+            break;
+        case detail::ExpressionOperator::OP_COS:
+            r = std::cos(a);
+            break;
+        case detail::ExpressionOperator::OP_TAN:
+            r = std::tan(a);
+            break;
+        case detail::ExpressionOperator::OP_ASIN:
+            r = std::asin(a);
+            break;
+        case detail::ExpressionOperator::OP_ACOS:
+            r = std::acos(a);
+            break;
+        case detail::ExpressionOperator::OP_ATAN:
+            r = std::atan(a);
+            break;
+        default:
+            r = a;
+            break;
+        }
+        result.DoubleVal = r;
+        result.IntVal = static_cast<int64_t>(r);
+    }
+    result.StringVal = std::to_string(result.DoubleVal);
+    return result;
+}
+
+// --- SemanticsPass ---
+
+// Returns true if DISPATCH_BINARY handles this type combination inline (no PROMOTE needed).
+static bool IsMixedTypeHandledInline(DataType outType, DataType lhsType, DataType rhsType)
+{
+    if (lhsType == rhsType)
+        return true; // homogeneous — always handled
+    // Inline mixed combos in DISPATCH_BINARY:
+    if (outType == DataType::Double &&
+        (lhsType == DataType::Float || rhsType == DataType::Float || lhsType == DataType::Int32 ||
+         rhsType == DataType::Int32 || lhsType == DataType::Int64 || rhsType == DataType::Int64))
+        return true;
+    if (outType == DataType::Float && (lhsType == DataType::Int32 || rhsType == DataType::Int32))
+        return true;
+    return false;
+}
+
+static SelectionRule SelectionRuleForOp(detail::ExpressionOperator op)
+{
+    switch (op)
+    {
+    case detail::ExpressionOperator::OP_CURL:
+        return SelectionRule::ExpandHalo;
+    case detail::ExpressionOperator::OP_CROSS:
+    case detail::ExpressionOperator::OP_MAGN:
+        return SelectionRule::Reshape;
+    default:
+        return SelectionRule::Identity;
+    }
+}
+
+void SemanticsPass(ExprCodeStream &cs, const std::map<std::string, DataType> & /*varTypes*/)
+{
+    // Types, validation, and PROMOTE insertion are handled by ResolveTreeTypes + GenerateCode.
+    // This pass handles: constant resolution, constant folding, strength reduction, selection
+    // rules.
+
+    for (size_t instrIdx = 0; instrIdx < cs.Instructions.size(); instrIdx++)
+    {
+        auto &instr = cs.Instructions[instrIdx];
+
+        // Resolve constant buffer string values to numeric values
         for (size_t bufID : instr.InputBufs)
         {
             auto &buf = cs.Buffers[bufID];
             if (buf.IsConstant && !buf.ConstVal.Resolved)
             {
-                buf.Type = inputType;
-                buf.ConstVal.Type = inputType;
-
-                // Parse the string value
-                if (IsIntegerType(inputType))
+                buf.ConstVal.Type = buf.Type;
+                if (IsIntegerType(buf.Type))
                 {
                     std::istringstream iss(buf.ConstVal.StringVal);
                     iss >> buf.ConstVal.IntVal;
@@ -323,204 +715,79 @@ void ResolveTypes(ExprCodeStream &cs, const std::map<std::string, DataType> &var
             }
         }
 
-        // Apply TypeFct to get output type
-        auto opIt = OpFunctions.find(instr.Op);
-        if (opIt == OpFunctions.end())
+        // Set selection rule
+        instr.SelRule = SelectionRuleForOp(instr.Op);
+        if (instr.Op == detail::ExpressionOperator::OP_ADD && instr.InputBufs.size() == 1)
+            instr.SelRule = SelectionRule::Reshape;
+        if (instr.SelRule == SelectionRule::ExpandHalo)
+            instr.HaloSize = 1;
+
+        // Strength reduction: x^2 -> x*x
+        if (instr.Op == detail::ExpressionOperator::OP_POW && instr.InputBufs.size() == 2)
         {
-            helper::Throw<std::invalid_argument>("Derived", "ExprCodeStream", "ResolveTypes",
-                                                 "Unknown operator in expression code stream");
-        }
-        instr.OutputType = opIt->second.TypeFct(inputType);
-        cs.Buffers[instr.OutputBuf].Type = instr.OutputType;
-    }
-
-    cs.OutputType = cs.Buffers[cs.OutputBufID].Type;
-}
-
-// --- ConstantFold ---
-
-// Evaluate a binary op on two typed constant values, produce a result TypedConstant
-static TypedConstant EvalConstBinOp(detail::ExpressionOperator op, const TypedConstant &lhs,
-                                    const TypedConstant &rhs, DataType outType)
-{
-    TypedConstant result;
-    result.Type = outType;
-    result.Resolved = true;
-
-    // Promote both to double for computation
-    double a = IsIntegerType(lhs.Type) ? (double)lhs.IntVal : lhs.DoubleVal;
-    double b = IsIntegerType(rhs.Type) ? (double)rhs.IntVal : rhs.DoubleVal;
-    double r = 0;
-
-    switch (op)
-    {
-    case detail::ExpressionOperator::OP_ADD:
-        r = a + b;
-        break;
-    case detail::ExpressionOperator::OP_SUBTRACT:
-        r = a - b;
-        break;
-    case detail::ExpressionOperator::OP_MULT:
-        r = a * b;
-        break;
-    case detail::ExpressionOperator::OP_DIV:
-        r = a / b;
-        break;
-    case detail::ExpressionOperator::OP_POW:
-        r = std::pow(a, b);
-        break;
-    default:
-        r = a; // fallback — shouldn't happen for binary ops
-        break;
-    }
-
-    if (IsIntegerType(outType))
-    {
-        result.IntVal = (int64_t)r;
-        result.DoubleVal = r;
-    }
-    else
-    {
-        result.DoubleVal = r;
-        result.IntVal = (int64_t)r;
-    }
-    result.StringVal = std::to_string(result.DoubleVal);
-    return result;
-}
-
-// Evaluate a unary op on a typed constant value
-static TypedConstant EvalConstUnaryOp(detail::ExpressionOperator op, const TypedConstant &operand,
-                                      DataType outType)
-{
-    TypedConstant result;
-    result.Type = outType;
-    result.Resolved = true;
-
-    double a = IsIntegerType(operand.Type) ? (double)operand.IntVal : operand.DoubleVal;
-    double r = 0;
-
-    switch (op)
-    {
-    case detail::ExpressionOperator::OP_NEGATE:
-        r = -a;
-        break;
-    case detail::ExpressionOperator::OP_SQRT:
-        r = std::sqrt(a);
-        break;
-    case detail::ExpressionOperator::OP_SIN:
-        r = std::sin(a);
-        break;
-    case detail::ExpressionOperator::OP_COS:
-        r = std::cos(a);
-        break;
-    case detail::ExpressionOperator::OP_TAN:
-        r = std::tan(a);
-        break;
-    case detail::ExpressionOperator::OP_ASIN:
-        r = std::asin(a);
-        break;
-    case detail::ExpressionOperator::OP_ACOS:
-        r = std::acos(a);
-        break;
-    case detail::ExpressionOperator::OP_ATAN:
-        r = std::atan(a);
-        break;
-    default:
-        r = a;
-        break;
-    }
-
-    if (IsIntegerType(outType))
-    {
-        result.IntVal = (int64_t)r;
-        result.DoubleVal = r;
-    }
-    else
-    {
-        result.DoubleVal = r;
-        result.IntVal = (int64_t)r;
-    }
-    result.StringVal = std::to_string(result.DoubleVal);
-    return result;
-}
-
-void ConstantFold(ExprCodeStream &cs)
-{
-    // Iterate until no more folding is possible
-    bool changed = true;
-    while (changed)
-    {
-        changed = false;
-        for (size_t i = 0; i < cs.Instructions.size(); i++)
-        {
-            auto &instr = cs.Instructions[i];
-
-            // Check if all inputs are constants
-            bool allConst = true;
-            for (size_t bufID : instr.InputBufs)
+            auto &expBuf = cs.Buffers[instr.InputBufs[1]];
+            if (expBuf.IsConstant && expBuf.ConstVal.Resolved && expBuf.ConstVal.DoubleVal == 2.0)
             {
-                if (!cs.Buffers[bufID].IsConstant)
-                {
-                    allConst = false;
-                    break;
-                }
+                instr.Op = detail::ExpressionOperator::OP_MULT;
+                instr.InputBufs = {instr.InputBufs[0], instr.InputBufs[0]};
+                instr.OutputType = cs.Buffers[instr.InputBufs[0]].Type;
+                cs.Buffers[instr.OutputBuf].Type = instr.OutputType;
             }
-            if (!allConst)
-                continue;
+        }
 
-            // Evaluate the constant expression
+        // Constant folding
+        bool allConst = true;
+        for (size_t bufID : instr.InputBufs)
+        {
+            if (!cs.Buffers[bufID].IsConstant)
+            {
+                allConst = false;
+                break;
+            }
+        }
+        if (allConst)
+        {
             TypedConstant result;
             if (instr.InputBufs.size() == 1)
-            {
                 result = EvalConstUnaryOp(instr.Op, cs.Buffers[instr.InputBufs[0]].ConstVal,
                                           instr.OutputType);
-            }
             else if (instr.InputBufs.size() == 2)
-            {
                 result = EvalConstBinOp(instr.Op, cs.Buffers[instr.InputBufs[0]].ConstVal,
                                         cs.Buffers[instr.InputBufs[1]].ConstVal, instr.OutputType);
-            }
             else
             {
-                // N-ary (e.g. add(1, 2, 3)) — fold left-to-right
                 result = cs.Buffers[instr.InputBufs[0]].ConstVal;
                 for (size_t j = 1; j < instr.InputBufs.size(); j++)
-                {
                     result =
                         EvalConstBinOp(instr.Op, result, cs.Buffers[instr.InputBufs[j]].ConstVal,
                                        instr.OutputType);
-                }
             }
 
-            // Convert the output buffer to a constant buffer
             auto &outBuf = cs.Buffers[instr.OutputBuf];
             outBuf.IsConstant = true;
             outBuf.ConstVal = result;
             outBuf.Type = instr.OutputType;
 
-            // Remove the instruction
-            cs.Instructions.erase(cs.Instructions.begin() + i);
-            i--; // re-check this index
-
-            // Update FirstUse/LastUse for remaining instructions
-            for (size_t j = 0; j < cs.Instructions.size(); j++)
-            {
-                for (size_t bufID : cs.Instructions[j].InputBufs)
-                {
-                    auto &buf = cs.Buffers[bufID];
-                    if (buf.FirstUse > j)
-                        buf.FirstUse = j;
-                    buf.LastUse = j;
-                }
-                cs.Buffers[cs.Instructions[j].OutputBuf].FirstUse = j;
-                cs.Buffers[cs.Instructions[j].OutputBuf].LastUse = j;
-            }
-
-            changed = true;
+            cs.Instructions.erase(cs.Instructions.begin() + instrIdx);
+            instrIdx--;
+            continue;
         }
     }
 
-    // Mark unreferenced buffers as dead (clear IsConstant so they're not materialized)
+    // Update use ranges and dead code elimination
+    for (size_t j = 0; j < cs.Instructions.size(); j++)
+    {
+        for (size_t bufID : cs.Instructions[j].InputBufs)
+        {
+            auto &buf = cs.Buffers[bufID];
+            if (buf.FirstUse > j)
+                buf.FirstUse = j;
+            buf.LastUse = j;
+        }
+        cs.Buffers[cs.Instructions[j].OutputBuf].FirstUse = j;
+        cs.Buffers[cs.Instructions[j].OutputBuf].LastUse = j;
+    }
+
     std::set<size_t> referenced;
     for (const auto &instr : cs.Instructions)
     {
@@ -535,7 +802,6 @@ void ConstantFold(ExprCodeStream &cs)
             cs.Buffers[i].IsConstant = false;
     }
 
-    // Update OutputType in case the entire expression was folded
     cs.OutputType = cs.Buffers[cs.OutputBufID].Type;
 }
 
@@ -669,8 +935,15 @@ GetDims(const ExprCodeStream &cs,
         {
             inputDims.push_back(bufDims[bufID]);
         }
-        auto opIt = OpFunctions.find(instr.Op);
-        bufDims[instr.OutputBuf] = opIt->second.DimsFct(inputDims);
+        if (instr.Op == detail::ExpressionOperator::OP_PROMOTE)
+        {
+            bufDims[instr.OutputBuf] = inputDims[0]; // PROMOTE doesn't change dims
+        }
+        else
+        {
+            auto opIt = OpFunctions.find(instr.Op);
+            bufDims[instr.OutputBuf] = opIt->second.DimsFct(inputDims);
+        }
     }
 
     return bufDims[cs.OutputBufID];
@@ -762,61 +1035,93 @@ std::vector<DerivedData> Execute(const ExprCodeStream &cs, size_t numBlocks,
                 bufData[i] = {constBufs[i], {}, {}, buf.Type, true};
         }
 
-        // Execute instructions — allocate output from pool, compute writes directly into it
+        // Execute instructions
         for (size_t instrIdx = 0; instrIdx < cs.Instructions.size(); instrIdx++)
         {
             const auto &instr = cs.Instructions[instrIdx];
 
+            // Gather inputs
             std::vector<DerivedData> instrInputs;
+            instrInputs.reserve(instr.InputBufs.size());
             for (size_t bufID : instr.InputBufs)
                 instrInputs.push_back(bufData[bufID]);
 
-            // Compute output dims — use reference dims for scalar constants
-            Dims scalarStart, scalarCount;
-            for (size_t bufID : instr.InputBufs)
+            // Compute output dims: element-wise ops use first non-scalar input dims.
+            // Cross/curl/magnitude use DimsFct (called rarely).
+            Dims outStart, outCount;
+            if (instr.SelRule == SelectionRule::Identity)
             {
-                if (!bufData[bufID].IsScalar)
+                // Element-wise: output dims = first non-scalar input
+                for (size_t bufID : instr.InputBufs)
                 {
-                    scalarStart = bufData[bufID].Start;
-                    scalarCount = bufData[bufID].Count;
-                    break;
+                    if (!bufData[bufID].IsScalar)
+                    {
+                        outStart = bufData[bufID].Start;
+                        outCount = bufData[bufID].Count;
+                        break;
+                    }
                 }
             }
-            std::vector<std::tuple<Dims, Dims, Dims>> instrDims;
-            for (size_t bufID : instr.InputBufs)
+            else
             {
-                if (bufData[bufID].IsScalar)
-                    instrDims.push_back({scalarStart, scalarCount, scalarCount});
-                else
-                    instrDims.push_back(
-                        {bufData[bufID].Start, bufData[bufID].Count, bufData[bufID].Count});
+                // Dimension-changing ops: use DimsFct
+                std::vector<std::tuple<Dims, Dims, Dims>> instrDims;
+                Dims refStart, refCount;
+                for (size_t bufID : instr.InputBufs)
+                {
+                    if (!bufData[bufID].IsScalar)
+                    {
+                        refStart = bufData[bufID].Start;
+                        refCount = bufData[bufID].Count;
+                        break;
+                    }
+                }
+                for (size_t bufID : instr.InputBufs)
+                {
+                    if (bufData[bufID].IsScalar)
+                        instrDims.push_back({refStart, refCount, refCount});
+                    else
+                        instrDims.push_back(
+                            {bufData[bufID].Start, bufData[bufID].Count, bufData[bufID].Count});
+                }
+                auto opIt = OpFunctions.find(instr.Op);
+                auto dims = opIt->second.DimsFct(instrDims);
+                outStart = std::get<0>(dims);
+                outCount = std::get<1>(dims);
             }
 
-            auto opIt = OpFunctions.find(instr.Op);
-            auto outDims = opIt->second.DimsFct(instrDims);
-            Dims outCount = std::get<1>(outDims);
             size_t outSize = std::accumulate(outCount.begin(), outCount.end(), (size_t)1,
                                              std::multiplies<size_t>());
 
-            // Allocate output from pool, pass to compute function
+            // Allocate output: final instruction writes directly to caller buffer
             size_t outBytes = outSize * ElementSize(instr.OutputType);
-            size_t slot = cs.Buffers[instr.OutputBuf].PhysicalSlot;
-            void *outBuf = PoolAlloc(pool, slot, outBytes);
+            bool isFinal = (instr.OutputBuf == cs.OutputBufID);
+            void *outBuf;
+            if (isFinal)
+                outBuf = malloc(outBytes);
+            else
+                outBuf = PoolAlloc(pool, cs.Buffers[instr.OutputBuf].PhysicalSlot, outBytes);
 
-            ExprData exprInputData({instrInputs, instr.OutputType, outBuf, outSize});
-            opIt->second.ComputeFct(exprInputData);
+            const ExprData exprInputData({instrInputs, instr.OutputType, outBuf, outSize});
+            if (instr.Op == detail::ExpressionOperator::OP_PROMOTE)
+            {
+                PromoteArray(instr.OutputType, instrInputs[0].Type, outBuf, instrInputs[0].Data,
+                             outSize);
+            }
+            else
+            {
+                auto opIt = OpFunctions.find(instr.Op);
+                if (opIt == OpFunctions.end())
+                    helper::Throw<std::invalid_argument>("Derived", "ExprCodeStream", "Execute",
+                                                         "Unknown operator");
+                opIt->second.ComputeFct(exprInputData);
+            }
 
-            bufData[instr.OutputBuf] = {outBuf, std::get<0>(outDims), outCount, instr.OutputType};
+            bufData[instr.OutputBuf] = {outBuf, outStart, outCount, instr.OutputType};
         }
 
-        // Copy final output out of pool for caller (caller will free it)
         DerivedData &finalBuf = bufData[cs.OutputBufID];
-        size_t finalBytes = std::accumulate(finalBuf.Count.begin(), finalBuf.Count.end(), (size_t)1,
-                                            std::multiplies<size_t>()) *
-                            ElementSize(finalBuf.Type);
-        void *callerBuf = malloc(finalBytes);
-        memcpy(callerBuf, finalBuf.Data, finalBytes);
-        outputData[blk] = {callerBuf, finalBuf.Start, finalBuf.Count, finalBuf.Type};
+        outputData[blk] = {finalBuf.Data, finalBuf.Start, finalBuf.Count, finalBuf.Type};
     }
 
     // Free scalar constants and pool

--- a/source/adios2/toolkit/derived/ExprCodeStream.h
+++ b/source/adios2/toolkit/derived/ExprCodeStream.h
@@ -28,12 +28,21 @@ struct TypedConstant
     bool Resolved = false; // true after ResolveTypes
 };
 
+enum class SelectionRule
+{
+    Identity,   // element-wise: output region = input region
+    ExpandHalo, // stencil op (curl): expand spatial dims by HaloSize
+    Reshape     // dimension-changing op (cross, aggregated magnitude)
+};
+
 struct ExprInstruction
 {
     detail::ExpressionOperator Op;
     std::vector<size_t> InputBufs; // buffer IDs for operands
     size_t OutputBuf;              // buffer ID for result
     DataType OutputType = DataType::None;
+    SelectionRule SelRule = SelectionRule::Identity;
+    int HaloSize = 0; // only used with ExpandHalo
 };
 
 struct BufferDescriptor
@@ -61,14 +70,17 @@ struct ExprCodeStream
 
 // Pipeline passes — free functions
 
-/** GenerateCode: convert ExprNode tree to linear ExprCodeStream. Types not yet resolved. */
+/** Resolve types bottom-up on the expression tree. Sets Type on every node.
+    Validates type combinations. Must be called before GenerateCode. */
+void ResolveTreeTypes(ExprNode &tree, const std::map<std::string, DataType> &varTypes);
+
+/** GenerateCode: convert ExprNode tree to linear ExprCodeStream. Tree must have types resolved.
+    Emits PROMOTE instructions for mixed-type combinations not handled inline. */
 ExprCodeStream GenerateCode(const ExprNode &root);
 
-/** ResolveTypes: propagate types from input variables, resolve constants. */
-void ResolveTypes(ExprCodeStream &cs, const std::map<std::string, DataType> &varTypes);
-
-/** ConstantFold: evaluate instructions whose inputs are all constants. Run after ResolveTypes. */
-void ConstantFold(ExprCodeStream &cs);
+/** SemanticsPass: type propagation, constant resolution/folding, strength reduction,
+    validation, selection rules. Replaces ResolveTypes + ConstantFold. */
+void SemanticsPass(ExprCodeStream &cs, const std::map<std::string, DataType> &varTypes);
 
 /** PlanBuffers: assign physical buffer slots for temp reuse. */
 void PlanBuffers(ExprCodeStream &cs);
@@ -83,6 +95,12 @@ GetDims(const ExprCodeStream &cs,
 /** Execute the code stream over numBlocks of data. */
 std::vector<DerivedData> Execute(const ExprCodeStream &cs, size_t numBlocks,
                                  std::map<std::string, std::vector<DerivedData>> &nameToData);
+
+/** Compute input selections needed for a given output selection.
+    Walks instructions backward, applying each SelectionRule.
+    Returns a map from input variable name to (start, count). */
+std::map<std::string, std::pair<Dims, Dims>>
+ComputeInputSelections(const ExprCodeStream &cs, const Dims &outputStart, const Dims &outputCount);
 
 /** Dump the compiled code stream for debugging. */
 std::string DumpCodeStream(const ExprCodeStream &cs);

--- a/source/adios2/toolkit/derived/ExprNode.h
+++ b/source/adios2/toolkit/derived/ExprNode.h
@@ -7,8 +7,16 @@
 #ifndef ADIOS2_DERIVED_ExprNode_H_
 #define ADIOS2_DERIVED_ExprNode_H_
 
+#include <map>
 #include <string>
 #include <vector>
+
+namespace adios2
+{
+// Forward-declare DataType so ExprNode can store it without pulling in ADIOSTypes.h
+// (ExprNode.h is used by the parser library which doesn't have the full ADIOS includes)
+enum class DataType;
+}
 
 namespace adios2
 {
@@ -37,7 +45,8 @@ enum ExpressionOperator
     OP_ATAN,
     OP_MAGN,
     OP_CROSS,
-    OP_CURL
+    OP_CURL,
+    OP_PROMOTE
 };
 
 }
@@ -56,6 +65,7 @@ struct ExprNode
     std::vector<ExprNode> Children;
     std::string VarName; // set for variable leaves
     std::string Const;   // set for numeric constant leaves
+    DataType Type{};     // resolved by ResolveTreeTypes (default: DataType::None = 0)
 
     bool IsLeaf() const { return Children.empty(); }
     bool IsVar() const { return IsLeaf() && !VarName.empty(); }

--- a/source/adios2/toolkit/derived/Function.cpp
+++ b/source/adios2/toolkit/derived/Function.cpp
@@ -17,28 +17,368 @@ namespace adios2
 {
 namespace detail
 {
-template <class T, class Op, class Iterator>
-void ApplyOneToOne(T *outValues, Iterator inputBegin, Iterator inputEnd, size_t dataSize, Op op,
-                   T initVal = (T)0)
+
+// --- Typed element-wise operations ---
+// Each Do* function: casts void pointers, handles scalar broadcast, contains the loop.
+// Two levels only: *Func → DISPATCH_TYPE → Do*.
+
+// Binary op with per-element type promotion. When LhsT==RhsT==OutT (homogeneous),
+// the static_casts are no-ops and the compiler optimizes them away.
+template <typename OutT, typename LhsT, typename RhsT>
+void DoAdd(void *out, const derived::DerivedData &lhs, const derived::DerivedData &rhs, size_t N)
 {
-    for (size_t i = 0; i < dataSize; i++)
-        outValues[i] = initVal;
-    for (Iterator variable = inputBegin; variable != inputEnd; ++variable)
+    OutT *o = reinterpret_cast<OutT *>(out);
+    LhsT *l = reinterpret_cast<LhsT *>(lhs.Data);
+    RhsT *r = reinterpret_cast<RhsT *>(rhs.Data);
+    if (lhs.IsScalar)
     {
-        T *src = reinterpret_cast<T *>((*variable).Data);
-        if ((*variable).IsScalar)
+        OutT val = static_cast<OutT>(l[0]);
+        for (size_t i = 0; i < N; i++)
+            o[i] = val + static_cast<OutT>(r[i]);
+    }
+    else if (rhs.IsScalar)
+    {
+        OutT val = static_cast<OutT>(r[0]);
+        for (size_t i = 0; i < N; i++)
+            o[i] = static_cast<OutT>(l[i]) + val;
+    }
+    else
+    {
+        for (size_t i = 0; i < N; i++)
+            o[i] = static_cast<OutT>(l[i]) + static_cast<OutT>(r[i]);
+    }
+}
+
+template <typename OutT, typename LhsT, typename RhsT>
+void DoSub(void *out, const derived::DerivedData &lhs, const derived::DerivedData &rhs, size_t N)
+{
+    OutT *o = reinterpret_cast<OutT *>(out);
+    LhsT *l = reinterpret_cast<LhsT *>(lhs.Data);
+    RhsT *r = reinterpret_cast<RhsT *>(rhs.Data);
+    if (lhs.IsScalar)
+    {
+        OutT val = static_cast<OutT>(l[0]);
+        for (size_t i = 0; i < N; i++)
+            o[i] = val - static_cast<OutT>(r[i]);
+    }
+    else if (rhs.IsScalar)
+    {
+        OutT val = static_cast<OutT>(r[0]);
+        for (size_t i = 0; i < N; i++)
+            o[i] = static_cast<OutT>(l[i]) - val;
+    }
+    else
+    {
+        for (size_t i = 0; i < N; i++)
+            o[i] = static_cast<OutT>(l[i]) - static_cast<OutT>(r[i]);
+    }
+}
+
+template <typename OutT, typename LhsT, typename RhsT>
+void DoMul(void *out, const derived::DerivedData &lhs, const derived::DerivedData &rhs, size_t N)
+{
+    OutT *o = reinterpret_cast<OutT *>(out);
+    LhsT *l = reinterpret_cast<LhsT *>(lhs.Data);
+    RhsT *r = reinterpret_cast<RhsT *>(rhs.Data);
+    if (lhs.IsScalar)
+    {
+        OutT val = static_cast<OutT>(l[0]);
+        for (size_t i = 0; i < N; i++)
+            o[i] = val * static_cast<OutT>(r[i]);
+    }
+    else if (rhs.IsScalar)
+    {
+        OutT val = static_cast<OutT>(r[0]);
+        for (size_t i = 0; i < N; i++)
+            o[i] = static_cast<OutT>(l[i]) * val;
+    }
+    else
+    {
+        for (size_t i = 0; i < N; i++)
+            o[i] = static_cast<OutT>(l[i]) * static_cast<OutT>(r[i]);
+    }
+}
+
+template <typename OutT, typename LhsT, typename RhsT>
+void DoDiv(void *out, const derived::DerivedData &lhs, const derived::DerivedData &rhs, size_t N)
+{
+    OutT *o = reinterpret_cast<OutT *>(out);
+    LhsT *l = reinterpret_cast<LhsT *>(lhs.Data);
+    RhsT *r = reinterpret_cast<RhsT *>(rhs.Data);
+    if (lhs.IsScalar)
+    {
+        OutT val = static_cast<OutT>(l[0]);
+        for (size_t i = 0; i < N; i++)
+            o[i] = val / static_cast<OutT>(r[i]);
+    }
+    else if (rhs.IsScalar)
+    {
+        OutT val = static_cast<OutT>(r[0]);
+        for (size_t i = 0; i < N; i++)
+            o[i] = static_cast<OutT>(l[i]) / val;
+    }
+    else
+    {
+        for (size_t i = 0; i < N; i++)
+            o[i] = static_cast<OutT>(l[i]) / static_cast<OutT>(r[i]);
+    }
+}
+
+template <typename T>
+void DoPow(void *out, const derived::DerivedData &base, const derived::DerivedData &exp, size_t N)
+{
+    T *o = reinterpret_cast<T *>(out);
+    T *b = reinterpret_cast<T *>(base.Data);
+    T *e = reinterpret_cast<T *>(exp.Data);
+    if (exp.IsScalar)
+    {
+        T ev = e[0];
+        if (ev == static_cast<T>(2))
         {
-            T val = src[0];
-            for (size_t i = 0; i < dataSize; i++)
-                outValues[i] = op(outValues[i], val);
+            for (size_t i = 0; i < N; i++)
+                o[i] = b[i] * b[i];
         }
         else
         {
-            for (size_t i = 0; i < dataSize; i++)
-                outValues[i] = op(outValues[i], src[i]);
+            for (size_t i = 0; i < N; i++)
+                o[i] = std::pow(b[i], ev);
         }
     }
+    else
+    {
+        for (size_t i = 0; i < N; i++)
+            o[i] = std::pow(b[i], e[i]);
+    }
 }
+
+// Promote: convert array from one type to another, element by element.
+template <typename OutT, typename InT>
+void DoPromoteTyped(void *out, void *in, size_t N)
+{
+    OutT *o = reinterpret_cast<OutT *>(out);
+    const InT *src = reinterpret_cast<const InT *>(in);
+    for (size_t i = 0; i < N; i++)
+        o[i] = static_cast<OutT>(src[i]);
+}
+
+template <typename T>
+void DoNegate(void *out, void *in, size_t N)
+{
+    T *o = reinterpret_cast<T *>(out);
+    const T *src = reinterpret_cast<const T *>(in);
+    for (size_t i = 0; i < N; i++)
+        o[i] = static_cast<T>(0) - src[i];
+}
+
+template <typename T>
+void DoSqrt(void *out, void *in, size_t N)
+{
+    T *o = reinterpret_cast<T *>(out);
+    const T *src = reinterpret_cast<const T *>(in);
+    for (size_t i = 0; i < N; i++)
+        o[i] = std::sqrt(src[i]);
+}
+
+#define DEFINE_UNARY_MATH(Name, func)                                                              \
+    template <typename T>                                                                          \
+    void Do##Name(void *out, void *in, size_t N)                                                   \
+    {                                                                                              \
+        T *o = reinterpret_cast<T *>(out);                                                         \
+        const T *src = reinterpret_cast<const T *>(in);                                            \
+        for (size_t i = 0; i < N; i++)                                                             \
+            o[i] = std::func(src[i]);                                                              \
+    }
+DEFINE_UNARY_MATH(Sin, sin)
+DEFINE_UNARY_MATH(Cos, cos)
+DEFINE_UNARY_MATH(Tan, tan)
+DEFINE_UNARY_MATH(Asin, asin)
+DEFINE_UNARY_MATH(Acos, acos)
+DEFINE_UNARY_MATH(Atan, atan)
+#undef DEFINE_UNARY_MATH
+
+template <typename T>
+void DoMagnitude3(void *out, void *a, void *b, void *c, size_t N)
+{
+    T *o = reinterpret_cast<T *>(out);
+    const T *aa = reinterpret_cast<const T *>(a);
+    const T *bb = reinterpret_cast<const T *>(b);
+    const T *cc = reinterpret_cast<const T *>(c);
+    for (size_t i = 0; i < N; i++)
+        o[i] = std::sqrt(aa[i] * aa[i] + bb[i] * bb[i] + cc[i] * cc[i]);
+}
+
+// General N-component magnitude: out[i] = sqrt(sum of comp[k][i]^2)
+template <typename T>
+void DoMagnitudeN(void *out, const std::vector<derived::DerivedData> &inputs, size_t N)
+{
+    T *o = reinterpret_cast<T *>(out);
+    // Initialize with first component squared
+    const T *c0 = reinterpret_cast<const T *>(inputs[0].Data);
+    for (size_t i = 0; i < N; i++)
+        o[i] = c0[i] * c0[i];
+    // Accumulate remaining components
+    for (size_t k = 1; k < inputs.size(); k++)
+    {
+        const T *ck = reinterpret_cast<const T *>(inputs[k].Data);
+        for (size_t i = 0; i < N; i++)
+            o[i] += ck[i] * ck[i];
+    }
+    // Sqrt
+    for (size_t i = 0; i < N; i++)
+        o[i] = std::sqrt(o[i]);
+}
+
+// Dispatch a binary op, handling mixed float/double inline.
+// FUNC must take three type params: FUNC<OutT, LhsT, RhsT>(out, lhs, rhs, N).
+// For homogeneous types, all three are the same. For float/double mixes, uses actual types.
+#define DISPATCH_BINARY(outType, lhsType, rhsType, FUNC, ...)                                      \
+    do                                                                                             \
+    {                                                                                              \
+        if (lhsType == rhsType)                                                                    \
+        {                                                                                          \
+            /* Homogeneous — single type for all three params */                                 \
+            switch (outType)                                                                       \
+            {                                                                                      \
+            case DataType::Float:                                                                  \
+                FUNC<float, float, float>(__VA_ARGS__);                                            \
+                break;                                                                             \
+            case DataType::Double:                                                                 \
+                FUNC<double, double, double>(__VA_ARGS__);                                         \
+                break;                                                                             \
+            case DataType::LongDouble:                                                             \
+                FUNC<long double, long double, long double>(__VA_ARGS__);                          \
+                break;                                                                             \
+            case DataType::Int32:                                                                  \
+                FUNC<int32_t, int32_t, int32_t>(__VA_ARGS__);                                      \
+                break;                                                                             \
+            case DataType::Int64:                                                                  \
+                FUNC<int64_t, int64_t, int64_t>(__VA_ARGS__);                                      \
+                break;                                                                             \
+            case DataType::FloatComplex:                                                           \
+                FUNC<std::complex<float>, std::complex<float>, std::complex<float>>(__VA_ARGS__);  \
+                break;                                                                             \
+            case DataType::DoubleComplex:                                                          \
+                FUNC<std::complex<double>, std::complex<double>, std::complex<double>>(            \
+                    __VA_ARGS__);                                                                  \
+                break;                                                                             \
+            case DataType::Int8:                                                                   \
+                FUNC<int8_t, int8_t, int8_t>(__VA_ARGS__);                                         \
+                break;                                                                             \
+            case DataType::Int16:                                                                  \
+                FUNC<int16_t, int16_t, int16_t>(__VA_ARGS__);                                      \
+                break;                                                                             \
+            case DataType::UInt8:                                                                  \
+                FUNC<uint8_t, uint8_t, uint8_t>(__VA_ARGS__);                                      \
+                break;                                                                             \
+            case DataType::UInt16:                                                                 \
+                FUNC<uint16_t, uint16_t, uint16_t>(__VA_ARGS__);                                   \
+                break;                                                                             \
+            case DataType::UInt32:                                                                 \
+                FUNC<uint32_t, uint32_t, uint32_t>(__VA_ARGS__);                                   \
+                break;                                                                             \
+            case DataType::UInt64:                                                                 \
+                FUNC<uint64_t, uint64_t, uint64_t>(__VA_ARGS__);                                   \
+                break;                                                                             \
+            default:                                                                               \
+                helper::Throw<std::invalid_argument>("Derived", "Function", "dispatch",            \
+                                                     "Unsupported type");                          \
+                break;                                                                             \
+            }                                                                                      \
+        }                                                                                          \
+        else if (outType == DataType::Double && lhsType == DataType::Float)                        \
+            FUNC<double, float, double>(__VA_ARGS__);                                              \
+        else if (outType == DataType::Double && rhsType == DataType::Float)                        \
+            FUNC<double, double, float>(__VA_ARGS__);                                              \
+        else if (outType == DataType::Double && lhsType == DataType::Int32)                        \
+            FUNC<double, int32_t, double>(__VA_ARGS__);                                            \
+        else if (outType == DataType::Double && rhsType == DataType::Int32)                        \
+            FUNC<double, double, int32_t>(__VA_ARGS__);                                            \
+        else if (outType == DataType::Double && lhsType == DataType::Int64)                        \
+            FUNC<double, int64_t, double>(__VA_ARGS__);                                            \
+        else if (outType == DataType::Double && rhsType == DataType::Int64)                        \
+            FUNC<double, double, int64_t>(__VA_ARGS__);                                            \
+        else if (outType == DataType::Float && lhsType == DataType::Int32)                         \
+            FUNC<float, int32_t, float>(__VA_ARGS__);                                              \
+        else if (outType == DataType::Float && rhsType == DataType::Int32)                         \
+            FUNC<float, float, int32_t>(__VA_ARGS__);                                              \
+        else                                                                                       \
+            helper::Throw<std::invalid_argument>(                                                  \
+                "Derived", "Function", "dispatch",                                                 \
+                "Unsupported type combination — use PROMOTE instruction");                         \
+    } while (0)
+
+// Float-only type dispatch (for sqrt, pow, trig — not valid on integer or complex)
+#define DISPATCH_FLOAT_TYPE(dtype, FUNC, ...)                                                      \
+    do                                                                                             \
+    {                                                                                              \
+        switch (dtype)                                                                             \
+        {                                                                                          \
+        case DataType::Float:                                                                      \
+            FUNC<float>(__VA_ARGS__);                                                              \
+            break;                                                                                 \
+        case DataType::Double:                                                                     \
+            FUNC<double>(__VA_ARGS__);                                                             \
+            break;                                                                                 \
+        case DataType::LongDouble:                                                                 \
+            FUNC<long double>(__VA_ARGS__);                                                        \
+            break;                                                                                 \
+        default:                                                                                   \
+            helper::Throw<std::invalid_argument>("Derived", "Function", "dispatch",                \
+                                                 "Operation requires floating-point type");        \
+        }                                                                                          \
+    } while (0)
+
+// Full type dispatch for homogeneous operations: calls Func<T,T,T>(args...) for binary ops
+// or Func<T>(args...) for unary ops.
+#define DISPATCH_TYPE(dtype, FUNC, ...)                                                            \
+    do                                                                                             \
+    {                                                                                              \
+        switch (dtype)                                                                             \
+        {                                                                                          \
+        case DataType::Float:                                                                      \
+            FUNC<float>(__VA_ARGS__);                                                              \
+            break;                                                                                 \
+        case DataType::Double:                                                                     \
+            FUNC<double>(__VA_ARGS__);                                                             \
+            break;                                                                                 \
+        case DataType::LongDouble:                                                                 \
+            FUNC<long double>(__VA_ARGS__);                                                        \
+            break;                                                                                 \
+        case DataType::Int8:                                                                       \
+            FUNC<int8_t>(__VA_ARGS__);                                                             \
+            break;                                                                                 \
+        case DataType::Int16:                                                                      \
+            FUNC<int16_t>(__VA_ARGS__);                                                            \
+            break;                                                                                 \
+        case DataType::Int32:                                                                      \
+            FUNC<int32_t>(__VA_ARGS__);                                                            \
+            break;                                                                                 \
+        case DataType::Int64:                                                                      \
+            FUNC<int64_t>(__VA_ARGS__);                                                            \
+            break;                                                                                 \
+        case DataType::UInt8:                                                                      \
+            FUNC<uint8_t>(__VA_ARGS__);                                                            \
+            break;                                                                                 \
+        case DataType::UInt16:                                                                     \
+            FUNC<uint16_t>(__VA_ARGS__);                                                           \
+            break;                                                                                 \
+        case DataType::UInt32:                                                                     \
+            FUNC<uint32_t>(__VA_ARGS__);                                                           \
+            break;                                                                                 \
+        case DataType::UInt64:                                                                     \
+            FUNC<uint64_t>(__VA_ARGS__);                                                           \
+            break;                                                                                 \
+        case DataType::FloatComplex:                                                               \
+            FUNC<std::complex<float>>(__VA_ARGS__);                                                \
+            break;                                                                                 \
+        case DataType::DoubleComplex:                                                              \
+            FUNC<std::complex<double>>(__VA_ARGS__);                                               \
+            break;                                                                                 \
+        default:                                                                                   \
+            helper::Throw<std::invalid_argument>("Derived", "Function", "dispatch",                \
+                                                 "Unsupported type");                              \
+        }                                                                                          \
+    } while (0)
 
 template <class T, class Op>
 void AggregateOnLastDim(T *outValues, T *data, size_t dataSize, size_t nVariables, Op op)
@@ -134,489 +474,184 @@ DerivedData AddAggregatedFunc(void *output, DerivedData inputData, DataType type
     return DerivedData();
 }
 
-DerivedData AddFunc(ExprData exprData)
+DerivedData AddFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::AddFunc");
-    auto inputData = exprData.Data;
+    auto &inputData = exprData.Data;
     auto type = exprData.OutType;
-    // if there is only one element return the aggregate result
     if (inputData.size() == 1)
         return AddAggregatedFunc(exprData.Output, inputData[0], type);
 
-    size_t dataSize = exprData.OutputSize;
-#define declare_type_add(T)                                                                        \
-    if (type == helper::GetDataType<T>())                                                          \
-    {                                                                                              \
-        T *addValues = reinterpret_cast<T *>(exprData.Output);                                     \
-        detail::ApplyOneToOne<T>(addValues, inputData.begin(), inputData.end(), dataSize,          \
-                                 [](auto a, auto b) { return a + b; });                            \
-        return DerivedData({exprData.Output});                                                     \
+    size_t N = exprData.OutputSize;
+    // First two inputs
+    DISPATCH_BINARY(type, inputData[0].Type, inputData[1].Type, detail::DoAdd, exprData.Output,
+                    inputData[0], inputData[1], N);
+    // Accumulate additional inputs (n-ary sum)
+    for (size_t k = 2; k < inputData.size(); k++)
+    {
+        DerivedData outAsDerived = {exprData.Output, {}, {}, type};
+        DISPATCH_BINARY(type, type, inputData[k].Type, detail::DoAdd, exprData.Output, outAsDerived,
+                        inputData[k], N);
     }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_add)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "AddFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    return DerivedData({exprData.Output});
 }
 
-// Perform a subtraction from the first variable of all other variables in the std::vector
-DerivedData SubtractFunc(ExprData exprData)
+DerivedData SubtractFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::SubtractFunc");
-    auto inputData = exprData.Data;
+    auto &inputData = exprData.Data;
     auto type = exprData.OutType;
-    size_t dataSize = exprData.OutputSize;
-
-// Perform a reduce sum over all variables in the std::vector except the first one
-// and remove this sum from the first buffer
-#define declare_type_subtract(T)                                                                   \
-    if (type == helper::GetDataType<T>())                                                          \
-    {                                                                                              \
-        T *out = reinterpret_cast<T *>(exprData.Output);                                           \
-        detail::ApplyOneToOne<T>(out, inputData.begin() + 1, inputData.end(), dataSize,            \
-                                 [](auto a, auto b) { return a + b; });                            \
-        T *lhs = reinterpret_cast<T *>(inputData[0].Data);                                         \
-        if (inputData[0].IsScalar)                                                                 \
-        {                                                                                          \
-            T val = lhs[0];                                                                        \
-            for (size_t i = 0; i < dataSize; i++)                                                  \
-                out[i] = val - out[i];                                                             \
-        }                                                                                          \
-        else                                                                                       \
-        {                                                                                          \
-            for (size_t i = 0; i < dataSize; i++)                                                  \
-                out[i] = lhs[i] - out[i];                                                          \
-        }                                                                                          \
-        return DerivedData({exprData.Output});                                                     \
+    size_t N = exprData.OutputSize;
+    if (inputData.size() == 2)
+    {
+        DISPATCH_BINARY(type, inputData[0].Type, inputData[1].Type, detail::DoSub, exprData.Output,
+                        inputData[0], inputData[1], N);
     }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_subtract)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "SubtractFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    else
+    {
+        // subtract(x, y, z) = x - y - z: first add y+z+..., then subtract from x
+        DISPATCH_BINARY(type, inputData[1].Type, inputData[2].Type, detail::DoAdd, exprData.Output,
+                        inputData[1], inputData[2], N);
+        for (size_t k = 3; k < inputData.size(); k++)
+        {
+            DerivedData outAsDerived = {exprData.Output, {}, {}, type};
+            DISPATCH_BINARY(type, type, inputData[k].Type, detail::DoAdd, exprData.Output,
+                            outAsDerived, inputData[k], N);
+        }
+        DerivedData outAsDerived = {exprData.Output, {}, {}, type};
+        DISPATCH_BINARY(type, inputData[0].Type, type, detail::DoSub, exprData.Output, inputData[0],
+                        outAsDerived, N);
+    }
+    return DerivedData({exprData.Output});
 }
 
-// Negate all elements in the variable
-DerivedData NegateFunc(ExprData exprData)
+DerivedData NegateFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::NegateFunc");
-    auto inputData = exprData.Data;
-    if (inputData.size() != 1)
-    {
-        helper::Throw<std::invalid_argument>("Derived", "Function", "NegateFunc",
-                                             "Invalid number of arguments passed to NegateFunc");
-    }
-    size_t dataSize = exprData.OutputSize;
-    DataType inputType = inputData[0].Type;
-
-#define declare_type_negate(T)                                                                     \
-    if (inputType == helper::GetDataType<T>())                                                     \
-    {                                                                                              \
-        T *negValues = reinterpret_cast<T *>(exprData.Output);                                     \
-        T *src = reinterpret_cast<T *>(inputData[0].Data);                                         \
-        for (size_t i = 0; i < dataSize; i++)                                                      \
-            negValues[i] = static_cast<T>(0) - src[i];                                             \
-        return DerivedData({exprData.Output});                                                     \
-    }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_negate)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "NegateFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    DISPATCH_TYPE(exprData.OutType, detail::DoNegate, exprData.Output, exprData.Data[0].Data,
+                  exprData.OutputSize);
+    return DerivedData({exprData.Output});
 }
 
-// Perform a reduce multiply over all variables in the std::vector
-DerivedData MultFunc(ExprData exprData)
+DerivedData MultFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::MultFunc");
-    auto inputData = exprData.Data;
+    auto &inputData = exprData.Data;
     auto type = exprData.OutType;
-    size_t dataSize = exprData.OutputSize;
-
-#define declare_type_mult(T)                                                                       \
-    if (type == helper::GetDataType<T>())                                                          \
-    {                                                                                              \
-        T *multValues = reinterpret_cast<T *>(exprData.Output);                                    \
-        detail::ApplyOneToOne<T>(                                                                  \
-            multValues, inputData.begin(), inputData.end(), dataSize,                              \
-            [](auto a, auto b) { return a * b; }, (T)1);                                           \
-        return DerivedData({exprData.Output});                                                     \
+    size_t N = exprData.OutputSize;
+    DISPATCH_BINARY(type, inputData[0].Type, inputData[1].Type, detail::DoMul, exprData.Output,
+                    inputData[0], inputData[1], N);
+    for (size_t k = 2; k < inputData.size(); k++)
+    {
+        DerivedData outAsDerived = {exprData.Output, {}, {}, type};
+        DISPATCH_BINARY(type, type, inputData[k].Type, detail::DoMul, exprData.Output, outAsDerived,
+                        inputData[k], N);
     }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_mult)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "MultFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    return DerivedData({exprData.Output});
 }
 
-// Perform a division from the first variable of all other variables in the std::vector
-DerivedData DivFunc(ExprData exprData)
+DerivedData DivFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::DivFunc");
-    auto inputData = exprData.Data;
+    auto &inputData = exprData.Data;
     auto type = exprData.OutType;
-    size_t dataSize = exprData.OutputSize;
-
-// Perform a reduce multiply over all variables in the std::vector except the first one
-// and divide this value from the first buffer
-#define declare_type_div(T)                                                                        \
-    if (type == helper::GetDataType<T>())                                                          \
-    {                                                                                              \
-        T *out = reinterpret_cast<T *>(exprData.Output);                                           \
-        detail::ApplyOneToOne<T>(                                                                  \
-            out, inputData.begin() + 1, inputData.end(), dataSize,                                 \
-            [](auto a, auto b) { return a * b; }, (T)1);                                           \
-        T *lhs = reinterpret_cast<T *>(inputData[0].Data);                                         \
-        if (inputData[0].IsScalar)                                                                 \
-        {                                                                                          \
-            T val = lhs[0];                                                                        \
-            for (size_t i = 0; i < dataSize; i++)                                                  \
-                out[i] = val / out[i];                                                             \
-        }                                                                                          \
-        else                                                                                       \
-        {                                                                                          \
-            for (size_t i = 0; i < dataSize; i++)                                                  \
-                out[i] = lhs[i] / out[i];                                                          \
-        }                                                                                          \
-        return DerivedData({exprData.Output});                                                     \
+    size_t N = exprData.OutputSize;
+    if (inputData.size() == 2)
+    {
+        DISPATCH_BINARY(type, inputData[0].Type, inputData[1].Type, detail::DoDiv, exprData.Output,
+                        inputData[0], inputData[1], N);
     }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_div)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "DivFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    else
+    {
+        // divide(x, y, z) = x / y / z: multiply y*z*..., then divide x by result
+        DISPATCH_BINARY(type, inputData[1].Type, inputData[2].Type, detail::DoMul, exprData.Output,
+                        inputData[1], inputData[2], N);
+        for (size_t k = 3; k < inputData.size(); k++)
+        {
+            DerivedData outAsDerived = {exprData.Output, {}, {}, type};
+            DISPATCH_BINARY(type, type, inputData[k].Type, detail::DoMul, exprData.Output,
+                            outAsDerived, inputData[k], N);
+        }
+        DerivedData outAsDerived = {exprData.Output, {}, {}, type};
+        DISPATCH_BINARY(type, inputData[0].Type, type, detail::DoDiv, exprData.Output, inputData[0],
+                        outAsDerived, N);
+    }
+    return DerivedData({exprData.Output});
 }
 
-// Apply Sqrt over all elements in the variable
-DerivedData SqrtFunc(ExprData exprData)
+DerivedData SqrtFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::SqrtFunc");
-    auto inputData = exprData.Data;
-    if (inputData.size() != 1)
-    {
-        helper::Throw<std::invalid_argument>("Derived", "Function", "SqrtFunc",
-                                             "Invalid number of arguments passed to SqrtFunc");
-    }
-    size_t dataSize = exprData.OutputSize;
-    DataType inputType = inputData[0].Type;
-
-    if (inputType == DataType::LongDouble)
-    {
-        long double *sqrtValues = reinterpret_cast<long double *>(exprData.Output);
-        std::transform(reinterpret_cast<long double *>(inputData[0].Data),
-                       reinterpret_cast<long double *>(inputData[0].Data) + dataSize, sqrtValues,
-                       [](auto &a) { return std::sqrt(a); });
-        return DerivedData({exprData.Output});
-    }
-#define declare_type_sqrt(T)                                                                       \
-    else if (inputType == helper::GetDataType<T>())                                                \
-    {                                                                                              \
-        double *sqrtValues = reinterpret_cast<double *>(exprData.Output);                          \
-        std::transform(reinterpret_cast<T *>(inputData[0].Data),                                   \
-                       reinterpret_cast<T *>(inputData[0].Data) + dataSize, sqrtValues,            \
-                       [](auto &a) { return std::sqrt(a); });                                      \
-        return DerivedData({exprData.Output});                                                     \
-    }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_sqrt)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "SqrtFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    DISPATCH_FLOAT_TYPE(exprData.OutType, detail::DoSqrt, exprData.Output, exprData.Data[0].Data,
+                        exprData.OutputSize);
+    return DerivedData({exprData.Output});
 }
 
-// Apply Pow over all elements: base array raised to exponent array element-wise
-// With 1 operand, defaults to squaring; with 2 operands, uses second as exponent
-DerivedData PowFunc(ExprData exprData)
+DerivedData PowFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::PowFunc");
-    auto inputData = exprData.Data;
-    if (inputData.size() < 1 || inputData.size() > 2)
+    auto &inputData = exprData.Data;
+    size_t N = exprData.OutputSize;
+    if (inputData.size() == 1)
     {
-        helper::Throw<std::invalid_argument>("Derived", "Function", "PowFunc",
-                                             "Invalid number of arguments passed to PowFunc");
+        // Default: squaring
+        DISPATCH_BINARY(exprData.OutType, inputData[0].Type, inputData[0].Type, detail::DoMul,
+                        exprData.Output, inputData[0], inputData[0], N);
     }
-    size_t dataSize = exprData.OutputSize;
-    DataType inputType = inputData[0].Type;
-
-    if (inputType == DataType::LongDouble)
+    else
     {
-        long double *out = reinterpret_cast<long double *>(exprData.Output);
-        long double *base = reinterpret_cast<long double *>(inputData[0].Data);
-        if (inputData.size() == 2)
-        {
-            long double *expData = reinterpret_cast<long double *>(inputData[1].Data);
-            if (inputData[1].IsScalar)
-            {
-                long double exp = expData[0];
-                if (exp == 2.0L)
-                    for (size_t i = 0; i < dataSize; i++)
-                        out[i] = base[i] * base[i];
-                else
-                    for (size_t i = 0; i < dataSize; i++)
-                        out[i] = std::pow(base[i], exp);
-            }
-            else
-                for (size_t i = 0; i < dataSize; i++)
-                    out[i] = std::pow(base[i], expData[i]);
-        }
-        else
-            for (size_t i = 0; i < dataSize; i++)
-                out[i] = base[i] * base[i];
-        return DerivedData({exprData.Output});
+        DISPATCH_FLOAT_TYPE(exprData.OutType, detail::DoPow, exprData.Output, inputData[0],
+                            inputData[1], N);
     }
-#define declare_type_pow(T)                                                                        \
-    else if (inputType == helper::GetDataType<T>())                                                \
-    {                                                                                              \
-        double *out = reinterpret_cast<double *>(exprData.Output);                                 \
-        T *base = reinterpret_cast<T *>(inputData[0].Data);                                        \
-        if (inputData.size() == 2)                                                                 \
-        {                                                                                          \
-            T *expData = reinterpret_cast<T *>(inputData[1].Data);                                 \
-            if (inputData[1].IsScalar)                                                             \
-            {                                                                                      \
-                double exp = (double)expData[0];                                                   \
-                if (exp == 2.0)                                                                    \
-                    for (size_t i = 0; i < dataSize; i++)                                          \
-                        out[i] = (double)base[i] * (double)base[i];                                \
-                else                                                                               \
-                    for (size_t i = 0; i < dataSize; i++)                                          \
-                        out[i] = std::pow((double)base[i], exp);                                   \
-            }                                                                                      \
-            else                                                                                   \
-                for (size_t i = 0; i < dataSize; i++)                                              \
-                    out[i] = std::pow((double)base[i], (double)expData[i]);                        \
-        }                                                                                          \
-        else                                                                                       \
-            for (size_t i = 0; i < dataSize; i++)                                                  \
-                out[i] = (double)base[i] * (double)base[i];                                        \
-        return DerivedData({exprData.Output});                                                     \
-    }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_pow)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "PowFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    return DerivedData({exprData.Output});
 }
 
-DerivedData SinFunc(ExprData exprData)
+DerivedData SinFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::SinFunc");
-    auto inputData = exprData.Data;
-    if (inputData.size() != 1)
-    {
-        helper::Throw<std::invalid_argument>("Derived", "Function", "SinFunc",
-                                             "Invalid number of arguments passed to SinFunc");
-    }
-    size_t dataSize = exprData.OutputSize;
-    DataType inputType = inputData[0].Type;
-
-    if (inputType == DataType::LongDouble)
-    {
-        long double *sinValues = reinterpret_cast<long double *>(exprData.Output);
-        std::transform(reinterpret_cast<long double *>(inputData[0].Data),
-                       reinterpret_cast<long double *>(inputData[0].Data) + dataSize, sinValues,
-                       [](auto &a) { return std::sin(a); });
-        return DerivedData({exprData.Output});
-    }
-#define declare_type_sin(T)                                                                        \
-    if (inputType == helper::GetDataType<T>())                                                     \
-    {                                                                                              \
-        if (inputType != DataType::LongDouble)                                                     \
-        {                                                                                          \
-            double *sinValues = reinterpret_cast<double *>(exprData.Output);                       \
-            std::transform(reinterpret_cast<T *>(inputData[0].Data),                               \
-                           reinterpret_cast<T *>(inputData[0].Data) + dataSize, sinValues,         \
-                           [](T &a) { return std::sin(a); });                                      \
-            return DerivedData({exprData.Output});                                                 \
-        }                                                                                          \
-    }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_sin)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "SinFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    DISPATCH_FLOAT_TYPE(exprData.OutType, detail::DoSin, exprData.Output, exprData.Data[0].Data,
+                        exprData.OutputSize);
+    return DerivedData({exprData.Output});
 }
 
-DerivedData CosFunc(ExprData exprData)
+DerivedData CosFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::CosFunc");
-    auto inputData = exprData.Data;
-    if (inputData.size() != 1)
-    {
-        helper::Throw<std::invalid_argument>("Derived", "Function", "CosFunc",
-                                             "Invalid number of arguments passed to CosFunc");
-    }
-    size_t dataSize = exprData.OutputSize;
-    DataType inputType = inputData[0].Type;
-
-    if (inputType == DataType::LongDouble)
-    {
-        long double *cosValues = reinterpret_cast<long double *>(exprData.Output);
-        std::transform(reinterpret_cast<long double *>(inputData[0].Data),
-                       reinterpret_cast<long double *>(inputData[0].Data) + dataSize, cosValues,
-                       [](auto &a) { return std::cos(a); });
-        return DerivedData({exprData.Output});
-    }
-#define declare_type_cos(T)                                                                        \
-    if (inputType == helper::GetDataType<T>())                                                     \
-    {                                                                                              \
-        if (inputType != DataType::LongDouble)                                                     \
-        {                                                                                          \
-            double *cosValues = reinterpret_cast<double *>(exprData.Output);                       \
-            std::transform(reinterpret_cast<T *>(inputData[0].Data),                               \
-                           reinterpret_cast<T *>(inputData[0].Data) + dataSize, cosValues,         \
-                           [](T &a) { return std::cos(a); });                                      \
-            return DerivedData({exprData.Output});                                                 \
-        }                                                                                          \
-    }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_cos)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "CosFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    DISPATCH_FLOAT_TYPE(exprData.OutType, detail::DoCos, exprData.Output, exprData.Data[0].Data,
+                        exprData.OutputSize);
+    return DerivedData({exprData.Output});
 }
 
-DerivedData TanFunc(ExprData exprData)
+DerivedData TanFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::TanFunc");
-    auto inputData = exprData.Data;
-    if (inputData.size() != 1)
-    {
-        helper::Throw<std::invalid_argument>("Derived", "Function", "TanFunc",
-                                             "Invalid number of arguments passed to TanFunc");
-    }
-    size_t dataSize = exprData.OutputSize;
-    DataType inputType = inputData[0].Type;
-
-    if (inputType == DataType::LongDouble)
-    {
-        long double *tanValues = reinterpret_cast<long double *>(exprData.Output);
-        std::transform(reinterpret_cast<long double *>(inputData[0].Data),
-                       reinterpret_cast<long double *>(inputData[0].Data) + dataSize, tanValues,
-                       [](auto &a) { return std::tan(a); });
-        return DerivedData({exprData.Output});
-    }
-#define declare_type_tan(T)                                                                        \
-    if (inputType == helper::GetDataType<T>())                                                     \
-    {                                                                                              \
-        if (inputType != DataType::LongDouble)                                                     \
-        {                                                                                          \
-            double *tanValues = reinterpret_cast<double *>(exprData.Output);                       \
-            std::transform(reinterpret_cast<T *>(inputData[0].Data),                               \
-                           reinterpret_cast<T *>(inputData[0].Data) + dataSize, tanValues,         \
-                           [](T &a) { return std::tan(a); });                                      \
-            return DerivedData({exprData.Output});                                                 \
-        }                                                                                          \
-    }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_tan)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "TanFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    DISPATCH_FLOAT_TYPE(exprData.OutType, detail::DoTan, exprData.Output, exprData.Data[0].Data,
+                        exprData.OutputSize);
+    return DerivedData({exprData.Output});
 }
 
-DerivedData AsinFunc(ExprData exprData)
+DerivedData AsinFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::AsinFunc");
-    auto inputData = exprData.Data;
-    if (inputData.size() != 1)
-    {
-        helper::Throw<std::invalid_argument>("Derived", "Function", "AsinFunc",
-                                             "Invalid number of arguments passed to AsinFunc");
-    }
-    size_t dataSize = exprData.OutputSize;
-    DataType inputType = inputData[0].Type;
-
-    if (inputType == DataType::LongDouble)
-    {
-        long double *asinValues = reinterpret_cast<long double *>(exprData.Output);
-        std::transform(reinterpret_cast<long double *>(inputData[0].Data),
-                       reinterpret_cast<long double *>(inputData[0].Data) + dataSize, asinValues,
-                       [](auto &a) { return std::asin(a); });
-        return DerivedData({exprData.Output});
-    }
-#define declare_type_asin(T)                                                                       \
-    if (inputType == helper::GetDataType<T>())                                                     \
-    {                                                                                              \
-        if (inputType != DataType::LongDouble)                                                     \
-        {                                                                                          \
-            double *asinValues = reinterpret_cast<double *>(exprData.Output);                      \
-            std::transform(reinterpret_cast<T *>(inputData[0].Data),                               \
-                           reinterpret_cast<T *>(inputData[0].Data) + dataSize, asinValues,        \
-                           [](T &a) { return std::asin(a); });                                     \
-            return DerivedData({exprData.Output});                                                 \
-        }                                                                                          \
-    }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_asin)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "AsinFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    DISPATCH_FLOAT_TYPE(exprData.OutType, detail::DoAsin, exprData.Output, exprData.Data[0].Data,
+                        exprData.OutputSize);
+    return DerivedData({exprData.Output});
 }
 
-DerivedData AcosFunc(ExprData exprData)
+DerivedData AcosFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::AcosFunc");
-    auto inputData = exprData.Data;
-    if (inputData.size() != 1)
-    {
-        helper::Throw<std::invalid_argument>("Derived", "Function", "AcosFunc",
-                                             "Invalid number of arguments passed to AcosFunc");
-    }
-    size_t dataSize = exprData.OutputSize;
-    DataType inputType = inputData[0].Type;
-
-    if (inputType == DataType::LongDouble)
-    {
-        long double *acosValues = reinterpret_cast<long double *>(exprData.Output);
-        std::transform(reinterpret_cast<long double *>(inputData[0].Data),
-                       reinterpret_cast<long double *>(inputData[0].Data) + dataSize, acosValues,
-                       [](auto &a) { return std::acos(a); });
-        return DerivedData({exprData.Output});
-    }
-#define declare_type_acos(T)                                                                       \
-    if (inputType == helper::GetDataType<T>())                                                     \
-    {                                                                                              \
-        if (inputType != DataType::LongDouble)                                                     \
-        {                                                                                          \
-            double *acosValues = reinterpret_cast<double *>(exprData.Output);                      \
-            std::transform(reinterpret_cast<T *>(inputData[0].Data),                               \
-                           reinterpret_cast<T *>(inputData[0].Data) + dataSize, acosValues,        \
-                           [](T &a) { return std::acos(a); });                                     \
-            return DerivedData({exprData.Output});                                                 \
-        }                                                                                          \
-    }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_acos)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "AcosFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    DISPATCH_FLOAT_TYPE(exprData.OutType, detail::DoAcos, exprData.Output, exprData.Data[0].Data,
+                        exprData.OutputSize);
+    return DerivedData({exprData.Output});
 }
 
-DerivedData AtanFunc(ExprData exprData)
+DerivedData AtanFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::AtanFunc");
-    auto inputData = exprData.Data;
-    if (inputData.size() != 1)
-    {
-        helper::Throw<std::invalid_argument>("Derived", "Function", "AtanFunc",
-                                             "Invalid number of arguments passed to AtanFunc");
-    }
-    size_t dataSize = exprData.OutputSize;
-    DataType inputType = inputData[0].Type;
-
-    if (inputType == DataType::LongDouble)
-    {
-        long double *atanValues = reinterpret_cast<long double *>(exprData.Output);
-        std::transform(reinterpret_cast<long double *>(inputData[0].Data),
-                       reinterpret_cast<long double *>(inputData[0].Data) + dataSize, atanValues,
-                       [](auto &a) { return std::atan(a); });
-        return DerivedData({exprData.Output});
-    }
-#define declare_type_atan(T)                                                                       \
-    if (inputType == helper::GetDataType<T>())                                                     \
-    {                                                                                              \
-        if (inputType != DataType::LongDouble)                                                     \
-        {                                                                                          \
-            double *atanValues = reinterpret_cast<double *>(exprData.Output);                      \
-            std::transform(reinterpret_cast<T *>(inputData[0].Data),                               \
-                           reinterpret_cast<T *>(inputData[0].Data) + dataSize, atanValues,        \
-                           [](T &a) { return std::atan(a); });                                     \
-            return DerivedData({exprData.Output});                                                 \
-        }                                                                                          \
-    }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_atan)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "AtanFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    DISPATCH_FLOAT_TYPE(exprData.OutType, detail::DoAtan, exprData.Output, exprData.Data[0].Data,
+                        exprData.OutputSize);
+    return DerivedData({exprData.Output});
 }
 
 /* Magnitude can work on aggregated or separated  vectors*/
@@ -645,34 +680,31 @@ DerivedData MagAggregatedFunc(void *output, DerivedData inputData, DataType type
     return DerivedData();
 }
 
-DerivedData MagnitudeFunc(ExprData exprData)
+DerivedData MagnitudeFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::MagnitudeFunc");
-    auto inputData = exprData.Data;
+    auto &inputData = exprData.Data;
     auto type = exprData.OutType;
-    // if there is only one element return the aggregate result
     if (inputData.size() == 1)
         return MagAggregatedFunc(exprData.Output, inputData[0], type);
-    size_t dataSize = exprData.OutputSize;
-#define declare_type_mag(T)                                                                        \
-    if (type == helper::GetDataType<T>())                                                          \
-    {                                                                                              \
-        T *magValues = reinterpret_cast<T *>(exprData.Output);                                     \
-        detail::ApplyOneToOne<T>(magValues, inputData.begin(), inputData.end(), dataSize,          \
-                                 [](auto a, auto b) { return a + b * b; });                        \
-        for (size_t i = 0; i < dataSize; i++)                                                      \
-        {                                                                                          \
-            magValues[i] = (T)std::sqrt(magValues[i]);                                             \
-        }                                                                                          \
-        return DerivedData({exprData.Output});                                                     \
+
+    size_t N = exprData.OutputSize;
+    if (inputData.size() == 3 && !inputData[0].IsScalar && !inputData[1].IsScalar &&
+        !inputData[2].IsScalar)
+    {
+        // Fast path for 3-component magnitude
+        DISPATCH_FLOAT_TYPE(type, detail::DoMagnitude3, exprData.Output, inputData[0].Data,
+                            inputData[1].Data, inputData[2].Data, N);
     }
-    ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(declare_type_mag)
-    helper::Throw<std::invalid_argument>("Derived", "Function", "MagnitudeFunc",
-                                         "Invalid variable types");
-    return DerivedData();
+    else
+    {
+        // General N-component magnitude: out[i] = sqrt(sum of comp[k][i]^2)
+        DISPATCH_FLOAT_TYPE(type, detail::DoMagnitudeN, exprData.Output, inputData, N);
+    }
+    return DerivedData({exprData.Output});
 }
 
-DerivedData Cross3DFunc(const ExprData exprData)
+DerivedData Cross3DFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::Cross3DFunc");
     auto inputData = exprData.Data;
@@ -722,7 +754,7 @@ DerivedData Cross3DFunc(const ExprData exprData)
  *         (ex: partial derivatives in x direction at point (0,0,0)
  *              only use data from (1,0,0), etc )
  */
-DerivedData Curl3DFunc(const ExprData exprData)
+DerivedData Curl3DFunc(const ExprData &exprData)
 {
     PERFSTUBS_SCOPED_TIMER("derived::Function::Curl3DFunc");
     auto inputData = exprData.Data;
@@ -908,16 +940,44 @@ std::tuple<Dims, Dims, Dims> CurlDimsFunc(std::vector<std::tuple<Dims, Dims, Dim
     return output;
 }
 
-DataType SameTypeFunc(DataType input) { return input; }
-
-DataType FloatTypeFunc(DataType input)
+void PromoteArray(DataType outType, DataType inType, void *out, void *in, size_t N)
 {
-    if (input == DataType::LongDouble)
-        return input;
-    if ((input == DataType::FloatComplex) || (input == DataType::DoubleComplex))
-        return input;
-    return DataType::Double;
+#define PROMOTE_CASE(OT, OC, IT, IC)                                                               \
+    if (outType == OT && inType == IT)                                                             \
+    {                                                                                              \
+        detail::DoPromoteTyped<OC, IC>(out, in, N);                                                \
+        return;                                                                                    \
+    }
+    PROMOTE_CASE(DataType::Double, double, DataType::Float, float)
+    PROMOTE_CASE(DataType::Double, double, DataType::Int32, int32_t)
+    PROMOTE_CASE(DataType::Double, double, DataType::Int64, int64_t)
+    PROMOTE_CASE(DataType::Double, double, DataType::Int16, int16_t)
+    PROMOTE_CASE(DataType::Double, double, DataType::Int8, int8_t)
+    PROMOTE_CASE(DataType::Double, double, DataType::UInt8, uint8_t)
+    PROMOTE_CASE(DataType::Double, double, DataType::UInt16, uint16_t)
+    PROMOTE_CASE(DataType::Double, double, DataType::UInt32, uint32_t)
+    PROMOTE_CASE(DataType::Double, double, DataType::UInt64, uint64_t)
+    PROMOTE_CASE(DataType::Float, float, DataType::Int32, int32_t)
+    PROMOTE_CASE(DataType::Float, float, DataType::Int16, int16_t)
+    PROMOTE_CASE(DataType::Float, float, DataType::Int8, int8_t)
+    PROMOTE_CASE(DataType::Float, float, DataType::UInt8, uint8_t)
+    PROMOTE_CASE(DataType::Float, float, DataType::UInt16, uint16_t)
+    PROMOTE_CASE(DataType::Float, float, DataType::Int64, int64_t)
+    PROMOTE_CASE(DataType::Float, float, DataType::UInt32, uint32_t)
+    PROMOTE_CASE(DataType::LongDouble, long double, DataType::Double, double)
+    PROMOTE_CASE(DataType::LongDouble, long double, DataType::Float, float)
+    PROMOTE_CASE(DataType::Int64, int64_t, DataType::Int32, int32_t)
+    PROMOTE_CASE(DataType::Int64, int64_t, DataType::Int16, int16_t)
+    PROMOTE_CASE(DataType::Int64, int64_t, DataType::Int8, int8_t)
+    PROMOTE_CASE(DataType::Int32, int32_t, DataType::Int16, int16_t)
+    PROMOTE_CASE(DataType::Int32, int32_t, DataType::Int8, int8_t)
+    PROMOTE_CASE(DataType::DoubleComplex, std::complex<double>, DataType::FloatComplex,
+                 std::complex<float>)
+#undef PROMOTE_CASE
+    helper::Throw<std::invalid_argument>("Derived", "Function", "PromoteArray",
+                                         "Unsupported type promotion");
 }
+
 }
 } // namespace adios2
 #endif

--- a/source/adios2/toolkit/derived/Function.h
+++ b/source/adios2/toolkit/derived/Function.h
@@ -13,30 +13,31 @@ namespace adios2
 {
 namespace derived
 {
-DerivedData AddFunc(ExprData input);
-DerivedData SubtractFunc(ExprData input);
-DerivedData NegateFunc(ExprData input);
-DerivedData SinFunc(ExprData input);
-DerivedData CosFunc(ExprData input);
-DerivedData TanFunc(ExprData input);
-DerivedData AsinFunc(ExprData input);
-DerivedData AcosFunc(ExprData input);
-DerivedData AtanFunc(ExprData input);
-DerivedData MultFunc(ExprData input);
-DerivedData DivFunc(ExprData input);
-DerivedData SqrtFunc(ExprData input);
-DerivedData PowFunc(ExprData input);
-DerivedData MagnitudeFunc(ExprData input);
-DerivedData Cross3DFunc(ExprData input);
-DerivedData Curl3DFunc(ExprData input);
+DerivedData AddFunc(const ExprData &input);
+DerivedData SubtractFunc(const ExprData &input);
+DerivedData NegateFunc(const ExprData &input);
+DerivedData SinFunc(const ExprData &input);
+DerivedData CosFunc(const ExprData &input);
+DerivedData TanFunc(const ExprData &input);
+DerivedData AsinFunc(const ExprData &input);
+DerivedData AcosFunc(const ExprData &input);
+DerivedData AtanFunc(const ExprData &input);
+DerivedData MultFunc(const ExprData &input);
+DerivedData DivFunc(const ExprData &input);
+DerivedData SqrtFunc(const ExprData &input);
+DerivedData PowFunc(const ExprData &input);
+DerivedData MagnitudeFunc(const ExprData &input);
+DerivedData Cross3DFunc(const ExprData &input);
+DerivedData Curl3DFunc(const ExprData &input);
 
 std::tuple<Dims, Dims, Dims> SameDimsFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
 std::tuple<Dims, Dims, Dims> SameDimsWithAgrFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
 std::tuple<Dims, Dims, Dims> Cross3DDimsFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
 std::tuple<Dims, Dims, Dims> CurlDimsFunc(std::vector<std::tuple<Dims, Dims, Dims>> input);
 
-DataType SameTypeFunc(DataType input);
-DataType FloatTypeFunc(DataType input);
+/** Promote (type-convert) an array element by element. */
+void PromoteArray(DataType outType, DataType inType, void *out, void *in, size_t N);
+
 }
 }
 #endif

--- a/source/adios2/toolkit/derived/parser/ASTDriver.cpp
+++ b/source/adios2/toolkit/derived/parser/ASTDriver.cpp
@@ -29,8 +29,10 @@ ASTDriver::~ASTDriver()
 
 ASTNode *ASTDriver::getAST()
 {
+    if (hasError)
+        throw std::invalid_argument("Failed to parse derived expression: " + errorMessage);
     if (holding.size() == 0)
-        throw std::runtime_error("ERROR: the derived expression is null");
+        throw std::invalid_argument("Derived expression is empty");
     resolve(holding.top());
     return holding.top();
 }

--- a/source/adios2/toolkit/derived/parser/ASTDriver.h
+++ b/source/adios2/toolkit/derived/parser/ASTDriver.h
@@ -58,6 +58,10 @@ public:
     // The token's location used by the scanner.
     adios2::detail::location location;
 
+    // Parser error state — set by parser::error callback
+    bool hasError = false;
+    std::string errorMessage;
+
 private:
     // While parsing, holds ASTNodes until parent node is created
     // (since root node is created last from bottom up design)

--- a/source/adios2/toolkit/derived/parser/ASTToExprNode.cpp
+++ b/source/adios2/toolkit/derived/parser/ASTToExprNode.cpp
@@ -38,7 +38,7 @@ static ExpressionOperator ConvertOp(const std::string &opname)
     auto it = string_to_op_new.find(upper);
     if (it == string_to_op_new.end())
     {
-        throw std::invalid_argument("Parser cannot recognize operator '" + opname + "'");
+        throw std::invalid_argument("Unrecognized operator '" + opname + "' in derived expression");
     }
     return it->second;
 }

--- a/source/adios2/toolkit/derived/parser/parser.y
+++ b/source/adios2/toolkit/derived/parser/parser.y
@@ -39,6 +39,7 @@
 %code {
 #include "ASTDriver.h"
 #include "ASTNode.h"
+#include <sstream>
 #include <string>
 }
 
@@ -132,5 +133,8 @@ list:
 void
 adios2::detail::parser::error (const location_type& l, const std::string& m)
 {
-  std::cerr << l << ": " << m << '\n';
+  std::ostringstream os;
+  os << l << ": " << m;
+  drv.hasError = true;
+  drv.errorMessage = os.str();
 }

--- a/source/adios2/toolkit/derived/parser/pregen-source/parser.cpp
+++ b/source/adios2/toolkit/derived/parser/pregen-source/parser.cpp
@@ -38,7 +38,7 @@
 
 
 
-#include "parser.h"
+#include "pregen-source/parser.h"
 
 
 // Unqualified %code blocks.
@@ -46,9 +46,10 @@
 
 #include "ASTDriver.h"
 #include "ASTNode.h"
+#include <sstream>
 #include <string>
 
-#line 52 "pregen-source/parser.cpp"
+#line 53 "pregen-source/parser.cpp"
 
 
 #ifndef YY_
@@ -141,7 +142,7 @@
 
 #line 12 "parser.y"
 namespace adios2 { namespace detail {
-#line 145 "pregen-source/parser.cpp"
+#line 146 "pregen-source/parser.cpp"
 
   /// Build a parser object.
   parser::parser (ASTDriver& drv_yyarg)
@@ -629,139 +630,139 @@ namespace adios2 { namespace detail {
           switch (yyn)
             {
   case 2: // lines: assignment lines
-#line 76 "parser.y"
+#line 77 "parser.y"
                    {}
-#line 635 "pregen-source/parser.cpp"
+#line 636 "pregen-source/parser.cpp"
     break;
 
   case 3: // lines: exp
-#line 77 "parser.y"
+#line 78 "parser.y"
       {}
-#line 641 "pregen-source/parser.cpp"
+#line 642 "pregen-source/parser.cpp"
     break;
 
   case 4: // assignment: "identifier" "=" VARNAME
-#line 81 "parser.y"
+#line 82 "parser.y"
                             { drv.add_lookup_entry(yystack_[2].value.as < std::string > (),  yystack_[0].value.as < std::string > ()); }
-#line 647 "pregen-source/parser.cpp"
+#line 648 "pregen-source/parser.cpp"
     break;
 
   case 5: // assignment: "identifier" "=" "identifier"
-#line 82 "parser.y"
+#line 83 "parser.y"
                                { drv.add_lookup_entry(yystack_[2].value.as < std::string > (),  yystack_[0].value.as < std::string > ()); }
-#line 653 "pregen-source/parser.cpp"
+#line 654 "pregen-source/parser.cpp"
     break;
 
   case 6: // assignment: "identifier" "=" VARNAME "[" indices_list "]"
-#line 83 "parser.y"
+#line 84 "parser.y"
                                                          { drv.add_lookup_entry(yystack_[5].value.as < std::string > (), yystack_[3].value.as < std::string > (), yystack_[1].value.as < std::vector<std::tuple<int, int, int>> > ()); }
-#line 659 "pregen-source/parser.cpp"
+#line 660 "pregen-source/parser.cpp"
     break;
 
   case 7: // assignment: "identifier" "=" "identifier" "[" indices_list "]"
-#line 84 "parser.y"
+#line 85 "parser.y"
                                                             { drv.add_lookup_entry(yystack_[5].value.as < std::string > (), yystack_[3].value.as < std::string > (), yystack_[1].value.as < std::vector<std::tuple<int, int, int>> > ()); }
-#line 665 "pregen-source/parser.cpp"
+#line 666 "pregen-source/parser.cpp"
     break;
 
   case 8: // exp: NUM
-#line 88 "parser.y"
+#line 89 "parser.y"
       { drv.add_number(yystack_[0].value.as < double > ()); }
-#line 671 "pregen-source/parser.cpp"
+#line 672 "pregen-source/parser.cpp"
     break;
 
   case 9: // exp: exp "+" exp
-#line 89 "parser.y"
+#line 90 "parser.y"
                 { drv.createNode("ADD", 2); }
-#line 677 "pregen-source/parser.cpp"
+#line 678 "pregen-source/parser.cpp"
     break;
 
   case 10: // exp: exp "-" exp
-#line 90 "parser.y"
+#line 91 "parser.y"
                 { drv.createNode("SUBTRACT", 2); }
-#line 683 "pregen-source/parser.cpp"
+#line 684 "pregen-source/parser.cpp"
     break;
 
   case 11: // exp: exp "*" exp
-#line 91 "parser.y"
+#line 92 "parser.y"
                 { drv.createNode("MULT", 2); }
-#line 689 "pregen-source/parser.cpp"
+#line 690 "pregen-source/parser.cpp"
     break;
 
   case 12: // exp: exp "/" exp
-#line 92 "parser.y"
+#line 93 "parser.y"
                 { drv.createNode("DIV", 2); }
-#line 695 "pregen-source/parser.cpp"
+#line 696 "pregen-source/parser.cpp"
     break;
 
   case 13: // exp: exp "^" exp
-#line 93 "parser.y"
+#line 94 "parser.y"
                 { drv.createNode("POW", 2); }
-#line 701 "pregen-source/parser.cpp"
+#line 702 "pregen-source/parser.cpp"
     break;
 
   case 14: // exp: "-" exp
-#line 94 "parser.y"
+#line 95 "parser.y"
                         { drv.createNode("NEGATE", 1); }
-#line 707 "pregen-source/parser.cpp"
+#line 708 "pregen-source/parser.cpp"
     break;
 
   case 15: // exp: "(" exp ")"
-#line 95 "parser.y"
+#line 96 "parser.y"
               {  }
-#line 713 "pregen-source/parser.cpp"
+#line 714 "pregen-source/parser.cpp"
     break;
 
   case 16: // exp: "identifier" "(" list ")"
-#line 96 "parser.y"
+#line 97 "parser.y"
                           { drv.createNode(yystack_[3].value.as < std::string > (), yystack_[1].value.as < int > ()); }
-#line 719 "pregen-source/parser.cpp"
+#line 720 "pregen-source/parser.cpp"
     break;
 
   case 17: // exp: "identifier" "[" indices_list "]"
-#line 97 "parser.y"
+#line 98 "parser.y"
                                   { drv.createNode(yystack_[3].value.as < std::string > (), yystack_[1].value.as < std::vector<std::tuple<int, int, int>> > ()); }
-#line 725 "pregen-source/parser.cpp"
+#line 726 "pregen-source/parser.cpp"
     break;
 
   case 18: // exp: "identifier"
-#line 98 "parser.y"
+#line 99 "parser.y"
               { drv.createNode(yystack_[0].value.as < std::string > ()); }
-#line 731 "pregen-source/parser.cpp"
+#line 732 "pregen-source/parser.cpp"
     break;
 
   case 19: // exp: VARNAME
-#line 99 "parser.y"
+#line 100 "parser.y"
            { drv.createNode(yystack_[0].value.as < std::string > ()); }
-#line 737 "pregen-source/parser.cpp"
+#line 738 "pregen-source/parser.cpp"
     break;
 
   case 20: // indices_list: %empty
-#line 104 "parser.y"
+#line 105 "parser.y"
          { yylhs.value.as < std::vector<std::tuple<int, int, int>> > () = {}; }
-#line 743 "pregen-source/parser.cpp"
+#line 744 "pregen-source/parser.cpp"
     break;
 
   case 21: // list: %empty
-#line 127 "parser.y"
+#line 128 "parser.y"
          { yylhs.value.as < int > () = 0; }
-#line 749 "pregen-source/parser.cpp"
+#line 750 "pregen-source/parser.cpp"
     break;
 
   case 22: // list: exp "," list
-#line 128 "parser.y"
+#line 129 "parser.y"
                  { yylhs.value.as < int > () = yystack_[0].value.as < int > () + 1; }
-#line 755 "pregen-source/parser.cpp"
+#line 756 "pregen-source/parser.cpp"
     break;
 
   case 23: // list: exp
-#line 129 "parser.y"
+#line 130 "parser.y"
       { yylhs.value.as < int > () = 1; }
-#line 761 "pregen-source/parser.cpp"
+#line 762 "pregen-source/parser.cpp"
     break;
 
 
-#line 765 "pregen-source/parser.cpp"
+#line 766 "pregen-source/parser.cpp"
 
             default:
               break;
@@ -1307,9 +1308,9 @@ namespace adios2 { namespace detail {
   const unsigned char
   parser::yyrline_[] =
   {
-       0,    76,    76,    77,    81,    82,    83,    84,    88,    89,
-      90,    91,    92,    93,    94,    95,    96,    97,    98,    99,
-     104,   127,   128,   129
+       0,    77,    77,    78,    82,    83,    84,    85,    89,    90,
+      91,    92,    93,    94,    95,    96,    97,    98,    99,   100,
+     105,   128,   129,   130
   };
 
   void
@@ -1342,13 +1343,16 @@ namespace adios2 { namespace detail {
 
 #line 12 "parser.y"
 } } // adios2::detail
-#line 1346 "pregen-source/parser.cpp"
+#line 1347 "pregen-source/parser.cpp"
 
-#line 130 "parser.y"
+#line 131 "parser.y"
 
 
 void
 adios2::detail::parser::error (const location_type& l, const std::string& m)
 {
-  std::cerr << l << ": " << m << '\n';
+  std::ostringstream os;
+  os << l << ": " << m;
+  drv.hasError = true;
+  drv.errorMessage = os.str();
 }

--- a/source/adios2/toolkit/derived/parser/pregen-source/parser.h
+++ b/source/adios2/toolkit/derived/parser/pregen-source/parser.h
@@ -103,7 +103,7 @@
 #else
 # define YY_CONSTEXPR
 #endif
-# include "location.hh"
+# include "pregen-source/location.hh"
 #include <typeinfo>
 #ifndef YY_ASSERT
 # include <cassert>

--- a/testing/adios2/derived/TestBPDerivedCorrectness.cpp
+++ b/testing/adios2/derived/TestBPDerivedCorrectness.cpp
@@ -854,6 +854,74 @@ TEST_P(DerivedCorrectnessP, ConstantFoldingTest)
     reader.Close();
 }
 
+TEST_P(DerivedCorrectnessP, MixedTypeTest)
+{
+    adios2::DerivedVarType mode = GetParam();
+    adios2::ADIOS adios;
+    adios2::IO bpOut = adios.DeclareIO("BPMixedTypeWrite");
+
+    const size_t N = 10;
+    std::vector<float> floatData(N);
+    std::vector<double> doubleData(N);
+    for (size_t i = 0; i < N; ++i)
+    {
+        floatData[i] = static_cast<float>(i) * 1.5f;
+        doubleData[i] = static_cast<double>(i) * 2.5;
+    }
+
+    std::vector<int16_t> intData(N);
+    for (size_t i = 0; i < N; ++i)
+        intData[i] = static_cast<int16_t>(i * 3);
+
+    auto varF = bpOut.DefineVariable<float>("F", {N}, {0}, {N});
+    auto varD = bpOut.DefineVariable<double>("D", {N}, {0}, {N});
+    auto varI = bpOut.DefineVariable<int16_t>("I", {N}, {0}, {N});
+    // float + double => double output (inline mixed-type dispatch)
+    bpOut.DefineDerivedVariable("derAdd", "F + D", mode);
+    // float * double => double output (inline mixed-type dispatch)
+    bpOut.DefineDerivedVariable("derMul", "F * D", mode);
+    // int16 + double => double output (exercises PROMOTE path)
+    bpOut.DefineDerivedVariable("derPromote", "I + D", mode);
+
+    adios2::Engine bpFileWriter = bpOut.Open("BPMixedType.bp", adios2::Mode::Write);
+    bpFileWriter.BeginStep();
+    bpFileWriter.Put(varF, floatData.data());
+    bpFileWriter.Put(varD, doubleData.data());
+    bpFileWriter.Put(varI, intData.data());
+    bpFileWriter.EndStep();
+    bpFileWriter.Close();
+
+    {
+        adios2::IO bpIn = adios.DeclareIO("BPMixedTypeRead");
+        adios2::Engine bpFileReader = bpIn.Open("BPMixedType.bp", adios2::Mode::Read);
+        bpFileReader.BeginStep();
+        auto varAdd = bpIn.InquireVariable<double>("derAdd");
+        auto varMul = bpIn.InquireVariable<double>("derMul");
+        auto varProm = bpIn.InquireVariable<double>("derPromote");
+        ASSERT_TRUE(varAdd);
+        ASSERT_TRUE(varMul);
+        ASSERT_TRUE(varProm);
+
+        std::vector<double> readAdd(N), readMul(N), readProm(N);
+        bpFileReader.Get(varAdd, readAdd);
+        bpFileReader.Get(varMul, readMul);
+        bpFileReader.Get(varProm, readProm);
+        bpFileReader.EndStep();
+
+        double epsilon = 0.01;
+        for (size_t i = 0; i < N; ++i)
+        {
+            double expectedAdd = static_cast<double>(floatData[i]) + doubleData[i];
+            double expectedMul = static_cast<double>(floatData[i]) * doubleData[i];
+            double expectedProm = static_cast<double>(intData[i]) + doubleData[i];
+            EXPECT_NEAR(readAdd[i], expectedAdd, epsilon);
+            EXPECT_NEAR(readMul[i], expectedMul, epsilon);
+            EXPECT_NEAR(readProm[i], expectedProm, epsilon);
+        }
+        bpFileReader.Close();
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(DerivedCorrectness, DerivedCorrectnessP,
                          ::testing::Values(adios2::DerivedVarType::StatsOnly,
                                            adios2::DerivedVarType::ExpressionString,

--- a/testing/adios2/derived/TestBPDerivedCorrectnessMPI.cpp
+++ b/testing/adios2/derived/TestBPDerivedCorrectnessMPI.cpp
@@ -218,12 +218,11 @@ TEST_P(DerivedCorrectnessMPIP, ScalarFunctionsCorrectnessTest)
         std::vector<float> readMult(mpiSize * Nx * Ny * Nz);
         std::vector<float> readConstMult(mpiSize * Nx * Ny * Nz);
         std::vector<float> readDiv(mpiSize * Nx * Ny * Nz);
-        std::vector<double> readPow(mpiSize * Nx * Ny * Nz);
-        std::vector<double> readPow3(mpiSize * Nx * Ny * Nz);
-        std::vector<double> readSqrt(mpiSize * Nx * Ny * Nz);
+        std::vector<float> readPow(mpiSize * Nx * Ny * Nz);
+        std::vector<float> readPow3(mpiSize * Nx * Ny * Nz);
+        std::vector<float> readSqrt(mpiSize * Nx * Ny * Nz);
 
         float calcFloat;
-        double calcDouble;
         float epsilon = (float)0.01;
         bpFileReader.BeginStep();
         auto varUx = bpIn.InquireVariable<float>(varname[0]);
@@ -236,9 +235,9 @@ TEST_P(DerivedCorrectnessMPIP, ScalarFunctionsCorrectnessTest)
         auto varMult = bpIn.InquireVariable<float>(derMultName);
         auto varConstMult = bpIn.InquireVariable<float>(derConstMult);
         auto varDiv = bpIn.InquireVariable<float>(derDivName);
-        auto varPow = bpIn.InquireVariable<double>(derPowName);
-        auto varPow3 = bpIn.InquireVariable<double>(derPow3Name);
-        auto varSqrt = bpIn.InquireVariable<double>(derSqrtName);
+        auto varPow = bpIn.InquireVariable<float>(derPowName);
+        auto varPow3 = bpIn.InquireVariable<float>(derPow3Name);
+        auto varSqrt = bpIn.InquireVariable<float>(derSqrtName);
 
         bpFileReader.Get(varUx, readUx);
         bpFileReader.Get(varUy, readUy);
@@ -276,14 +275,14 @@ TEST_P(DerivedCorrectnessMPIP, ScalarFunctionsCorrectnessTest)
             calcFloat = readUx[ind] / readUy[ind] / readUz[ind];
             EXPECT_TRUE(fabs(calcFloat - readDiv[ind]) < epsilon);
 
-            calcDouble = std::pow(readUx[ind], 2);
-            EXPECT_TRUE(fabs(calcDouble - readPow[ind]) < epsilon);
+            calcFloat = static_cast<float>(std::pow(readUx[ind], 2));
+            EXPECT_TRUE(fabs(calcFloat - readPow[ind]) < epsilon);
 
-            calcDouble = std::pow(readUx[ind], 3);
-            EXPECT_TRUE(fabs(calcDouble - readPow3[ind]) < epsilon);
+            calcFloat = static_cast<float>(std::pow(readUx[ind], 3));
+            EXPECT_TRUE(fabs(calcFloat - readPow3[ind]) < epsilon);
 
-            calcDouble = std::sqrt(readUx[ind]);
-            EXPECT_TRUE(fabs(calcDouble - readSqrt[ind]) < epsilon);
+            calcFloat = std::sqrt(readUx[ind]);
+            EXPECT_TRUE(fabs(calcFloat - readSqrt[ind]) < epsilon);
         }
 
         for (size_t ind = 0; ind < Nx * Ny; ++ind)


### PR DESCRIPTION
Rewrote the operator stuff entirely with the idea of having vectorizable loops for both type-uniform operations and some common mixed-type operations (mixing float, double and long for example). This rewrite also directly handles constants in the express with vectorizable loops (not expanding constants to an array).  We also added a unified semantics pass that does C-style type promotion, constant folding strength reduction (x^2 → x*x), and validation.  More unusual type combinations work (uint_8 + double), but there is an additional type conversion pass inserted.

sqrt/trig/pow can now stay float, rather than always promoted float to double. Eliminated extra memory passes in the compute functions (old code zero-initialized then accumulated per-input) and removed the pool-to-caller memcpy in Execute.

This PR also adds sub-selection infrastructure (I.E. the ability to back-propagate read selections to the input selections that we'd need to produce it), but does not yet employ it to optimize read-side derived expressions.                                                                                            
