### PR TITLE
Improve SST ctest time

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -8,7 +8,16 @@
 # ------------------------------------------------------------------------------#
 
 if(ADIOS2_HAVE_MPI)
-  set(MPIEXEC_EXTRA_FLAGS "" CACHE STRING
+  # Default to yielding idle MPI ranks for OpenMPI to avoid 100% CPU spin
+  # in collectives when some ranks are waiting (e.g. StagingMPMD tests).
+  set(_default_mpiexec_extra_flags "")
+  execute_process(
+    COMMAND ${MPIEXEC_EXECUTABLE} --version
+    OUTPUT_VARIABLE _mpiexec_version ERROR_VARIABLE _mpiexec_version)
+  if(_mpiexec_version MATCHES "Open MPI")
+    set(_default_mpiexec_extra_flags "--mca;mpi_yield_when_idle;1")
+  endif()
+  set(MPIEXEC_EXTRA_FLAGS "${_default_mpiexec_extra_flags}" CACHE STRING
     "Extra flags to set after mpiexec and before the num_procs flag"
   )
   mark_as_advanced(MPIEXEC_EXTRA_FLAGS)

--- a/testing/adios2/engine/common/CMakeLists.txt
+++ b/testing/adios2/engine/common/CMakeLists.txt
@@ -33,11 +33,8 @@ if(ADIOS2_HAVE_HDF5 AND HDF5_IS_PARALLEL)
 endif()
 
 if(ADIOS2_HAVE_SST)
-  gtest_add_tests_helper(Common MPI_ONLY "" Engine. .SST.FFS
-    EXTRA_ARGS "SST" "0" "MarshalMethod=FFS"
-  )
-  gtest_add_tests_helper(Common MPI_ONLY "" Engine. .SST.BP
-    EXTRA_ARGS "SST" "0" "MarshalMethod=BP"
+  gtest_add_tests_helper(Common MPI_ONLY "" Engine. .SST
+    EXTRA_ARGS "SST" "0"
   )
 endif()
 

--- a/testing/adios2/engine/staging-common/CMakeLists.txt
+++ b/testing/adios2/engine/staging-common/CMakeLists.txt
@@ -10,11 +10,9 @@
 find_package(Threads REQUIRED)
 
 if(ADIOS2_HAVE_SST)
-  gtest_add_tests_helper(StagingMPMD MPI_ONLY "" Engine.Staging. ".SST.FFS" EXTRA_ARGS "SST" "MarshalMethod=FFS")
-  gtest_add_tests_helper(StagingMPMD MPI_ONLY "" Engine.Staging. ".SST.BP" EXTRA_ARGS "SST" "MarshalMethod=BP")
+  gtest_add_tests_helper(StagingMPMD MPI_ONLY "" Engine.Staging. ".SST" EXTRA_ARGS "SST")
   gtest_add_tests_helper(OnDemandMPI MPI_ONLY "" Engine.Staging. ".SST" EXTRA_ARGS "SST" "OnDemandContact")
-  gtest_add_tests_helper(Threads MPI_NONE "" Engine.Staging. ".SST.FFS" EXTRA_ARGS "SST"  "--engine_params" "MarshalMethod=FFS")
-  gtest_add_tests_helper(Threads MPI_NONE "" Engine.Staging. ".SST.BP" EXTRA_ARGS "SST"  "--engine_params" "MarshalMethod=BP")
+  gtest_add_tests_helper(Threads MPI_NONE "" Engine.Staging. ".SST" EXTRA_ARGS "SST")
   gtest_add_tests_helper(Threads MPI_NONE "" Engine.Staging. ".BP4_stream" EXTRA_ARGS "BP4"  "--engine_params" "OpenTimeoutSecs=5")
   gtest_add_tests_helper(Threads MPI_NONE "" Engine.Staging. ".FileStream" EXTRA_ARGS "FileStream")
 endif()
@@ -215,20 +213,7 @@ MutateTestSet( COMM_MIN_SST_TESTS "CommMin" writer "CPCommPattern=Min" "${BASIC_
 # temporarily remove PreciousTimestep CommPeer tests
 list (REMOVE_ITEM COMM_PEER_SST_TESTS "PreciousTimestep")
 
-MutateTestSet( BP5_SST_TESTS "BP5" writer "MarshalMethod=BP5" "${COMM_MIN_SST_TESTS};${COMM_PEER_SST_TESTS}" )
-MutateTestSet( BP_SST_TESTS "BP" writer "MarshalMethod=BP" "${COMM_MIN_SST_TESTS};${COMM_PEER_SST_TESTS}" )
-
-# no SSE engine does Joined
-list (FILTER BP_SST_TESTS EXCLUDE REGEX "Joined*")
-
-set (SST_TESTS "")
-LIST (APPEND SST_TESTS ${BP5_SST_TESTS} ${BP_SST_TESTS})
-
-# Zero Data tests are unreliable with SST and BP marshaling
-list (FILTER SST_TESTS EXCLUDE REGEX "2x1ZeroData.*BP")
-
-# BP Marshalling doesn't support Struct data
-list (FILTER SST_TESTS EXCLUDE REGEX "1x1Struct.*BP$")
+MutateTestSet( SST_TESTS "BP5" writer "MarshalMethod=BP5" "${COMM_MIN_SST_TESTS};${COMM_PEER_SST_TESTS}" )
 
 foreach(test ${SST_TESTS})
     add_common_test(${test} SST)


### PR DESCRIPTION
OpenMPI does a spin wait in some circumstances with very ugly consequences if you're not on a dedicated HPC resource.  Some of our MPI tests run with fewer ranks than the default, with the result that those "idle" ranks (sitting in MPI_Barrier) spin at 100% cpu usage until the test complete, which of course takes much longer when they're preventing the actual working ranks from doing anything.  For CI only, this change detects OpenMPI and adds a flag that converts that spin wait to a yield with much better results for laptop testing.  While we're at it, this also stops testing the BP variant of SST marshalling.  BP5 marshalling has been the default since it was created and I can't imagine that the ancient BP version is of any use.  Not removing that code yet, but I think we can at least stop testing it.