### PR TITLE
Fix printing double values in bpls min/max and the Min and Max string…

### DIFF
--- a/source/adios2/helper/adiosType.inl
+++ b/source/adios2/helper/adiosType.inl
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
 #ifndef ADIOS2_HELPER_ADIOSTYPE_INL_
 #define ADIOS2_HELPER_ADIOSTYPE_INL_
 #ifndef ADIOS2_HELPER_ADIOSTYPE_H_
 #error "Inline file should only be included from it's header, never on it's own"
 #endif
 
-#include <algorithm> //std::transform
-#include <sstream>   //std::ostringstream
+#include <algorithm>   //std::transform
+#include <sstream>     //std::ostringstream
+#include <type_traits> //std::is_floating_point_v
 
 #include "adios2/common/ADIOSMacros.h"
 #include "adiosLog.h"
@@ -110,8 +110,7 @@ template <class T, class U>
 std::vector<U> NewVectorTypeFromArray(const T *in, const size_t inSize)
 {
     std::vector<U> out(inSize);
-    std::transform(in, in + inSize, out.begin(),
-                   [](T value) { return static_cast<U>(value); });
+    std::transform(in, in + inSize, out.begin(), [](T value) { return static_cast<U>(value); });
     return out;
 }
 
@@ -149,12 +148,12 @@ inline std::string ValueToString(const std::string value) noexcept
     return "\"" + value + "\"";
 }
 
-#define declare_template_instantiation(C)                                      \
-    template <>                                                                \
-    inline std::string ValueToString(const C value) noexcept                   \
-    {                                                                          \
-        const int valueInt = static_cast<int>(value);                          \
-        return std::to_string(valueInt);                                       \
+#define declare_template_instantiation(C)                                                          \
+    template <>                                                                                    \
+    inline std::string ValueToString(const C value) noexcept                                       \
+    {                                                                                              \
+        const int valueInt = static_cast<int>(value);                                              \
+        return std::to_string(valueInt);                                                           \
     }
 ADIOS2_FOREACH_CHAR_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
@@ -163,6 +162,10 @@ template <class T>
 inline std::string ValueToString(const T value) noexcept
 {
     std::ostringstream valueSS;
+    if constexpr (std::is_floating_point_v<T>)
+    {
+        valueSS << std::scientific;
+    }
     valueSS << value;
     const std::string valueStr(valueSS.str());
     return valueStr;
@@ -188,26 +191,26 @@ inline std::string VectorToCSV(const std::vector<std::string> &input) noexcept
     return csv;
 }
 
-#define declare_template_instantiation(C)                                      \
-    template <>                                                                \
-    inline std::string VectorToCSV(const std::vector<C> &input) noexcept       \
-    {                                                                          \
-        if (input.empty())                                                     \
-        {                                                                      \
-            return std::string();                                              \
-        }                                                                      \
-                                                                               \
-        std::ostringstream valueSS;                                            \
-        for (const auto &value : input)                                        \
-        {                                                                      \
-            const int valueInt = static_cast<int>(value);                      \
-            valueSS << valueInt << ", ";                                       \
-        }                                                                      \
-        std::string csv(valueSS.str());                                        \
-        csv.pop_back();                                                        \
-        csv.pop_back();                                                        \
-                                                                               \
-        return csv;                                                            \
+#define declare_template_instantiation(C)                                                          \
+    template <>                                                                                    \
+    inline std::string VectorToCSV(const std::vector<C> &input) noexcept                           \
+    {                                                                                              \
+        if (input.empty())                                                                         \
+        {                                                                                          \
+            return std::string();                                                                  \
+        }                                                                                          \
+                                                                                                   \
+        std::ostringstream valueSS;                                                                \
+        for (const auto &value : input)                                                            \
+        {                                                                                          \
+            const int valueInt = static_cast<int>(value);                                          \
+            valueSS << valueInt << ", ";                                                           \
+        }                                                                                          \
+        std::string csv(valueSS.str());                                                            \
+        csv.pop_back();                                                                            \
+        csv.pop_back();                                                                            \
+                                                                                                   \
+        return csv;                                                                                \
     }
 ADIOS2_FOREACH_CHAR_TYPE_1ARG(declare_template_instantiation)
 #undef declare_template_instantiation
@@ -237,8 +240,7 @@ void CheckForNullptr(T *pointer, const std::string hint)
 {
     if (pointer == nullptr)
     {
-        helper::Throw<std::invalid_argument>("Helper", "adiosType",
-                                             "CheckForNullPtr",
+        helper::Throw<std::invalid_argument>("Helper", "adiosType", "CheckForNullPtr",
                                              "found null pointer " + hint);
     }
 }

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -918,7 +918,7 @@ int printAttributeValue(core::Engine *fp, core::IO *io, core::Attribute<T> *attr
     DataType adiosvartype = attribute->m_Type;
     if (attribute->m_IsSingleValue)
     {
-        print_data((void *)&attribute->m_DataSingleValue, 0, adiosvartype, true);
+        print_data((void *)&attribute->m_DataSingleValue, 0, adiosvartype, false);
     }
     else
     {
@@ -926,7 +926,7 @@ int printAttributeValue(core::Engine *fp, core::IO *io, core::Attribute<T> *attr
         size_t nelems = attribute->m_DataArray.size();
         for (size_t j = 0; j < nelems; j++)
         {
-            print_data((void *)&attribute->m_DataArray[j], 0, adiosvartype, true);
+            print_data((void *)&attribute->m_DataArray[j], 0, adiosvartype, false);
             if (j < nelems - 1)
             {
                 fprintf(outf, ", ");
@@ -953,7 +953,7 @@ int printAttributeValue(core::Engine *fp, core::IO *io, core::Attribute<std::str
         }
         if (printDataAnyway)
         {
-            print_data((void *)&attribute->m_DataSingleValue, 0, adiosvartype, true);
+            print_data((void *)&attribute->m_DataSingleValue, 0, adiosvartype, false);
         }
     }
     else
@@ -969,7 +969,7 @@ int printAttributeValue(core::Engine *fp, core::IO *io, core::Attribute<std::str
             }
             if (printDataAnyway)
             {
-                print_data((void *)&attribute->m_DataArray[j], 0, adiosvartype, true);
+                print_data((void *)&attribute->m_DataArray[j], 0, adiosvartype, false);
             }
             if (j < nelems - 1)
             {
@@ -3072,18 +3072,47 @@ int print_data(const void *data, int item, DataType adiosvartype, bool allowform
         fprintf(outf, (f ? fmt : "%lld"), ((signed long long *)data)[item]);
         break;
 
-    case DataType::Float:
-        fprintf(outf, (f ? fmt : "%g"), ((float *)data)[item]);
+    case DataType::Float: {
+        float v = ((float *)data)[item];
+        if (allowformat)
+            fprintf(outf, (f ? fmt : "%g"), v);
+        else
+        {
+            if (-10000.0 < v && v < 100000.0)
+                fprintf(outf, "%g", v);
+            else
+                fprintf(outf, "%e", v);
+        }
         break;
+    }
 
-    case DataType::Double:
-        fprintf(outf, (f ? fmt : "%g"), ((double *)data)[item]);
+    case DataType::Double: {
+        double v = ((double *)data)[item];
+        if (allowformat)
+            fprintf(outf, (f ? fmt : "%g"), v);
+        else
+        {
+            if (-10000.0 < v && v < 100000.0)
+                fprintf(outf, "%g", v);
+            else
+                fprintf(outf, "%e", v);
+        }
         break;
+    }
 
-    case DataType::LongDouble:
-        fprintf(outf, (f ? fmt : "%Lg"), ((long double *)data)[item]);
-        // fprintf(outf,(f ? fmt : "????????"));
+    case DataType::LongDouble: {
+        long double v = ((long double *)data)[item];
+        if (allowformat)
+            fprintf(outf, (f ? fmt : "%Lg"), v);
+        else
+        {
+            if (-10000.0 < v && v < 100000.0)
+                fprintf(outf, "%Lg", v);
+            else
+                fprintf(outf, "%Le", v);
+        }
         break;
+    }
 
     case DataType::FloatComplex:
         fprintf(outf, (f ? fmt : "(%g,i%g)"), ((float *)data)[2 * item],

--- a/testing/utils/bpcmp/TestUtilsBPcmp.stats.expected.txt
+++ b/testing/utils/bpcmp/TestUtilsBPcmp.stats.expected.txt
@@ -1,7 +1,7 @@
 COMPARE : FILE : TestBPcmp_set1.bp : FILE : TestBPcmp_set2.bp
 DIFFER : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : MIN : 4 <> 6 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
-DIFFER : VARIABLE : bpFloats : MAX : 10 <> 11 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : MIN : 4.000000e+00 <> 6.000000e+00 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
+DIFFER : VARIABLE : bpFloats : MAX : 1.000000e+01 <> 1.100000e+01 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
 DIFFER : VARIABLE : bpFloats : STEP : 0 : VALUES_SUMMARY : 6 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
 DIFFER : VARIABLE : bpFloats : STEP : 1 : VALUES_SUMMARY : 6 : TestBPcmp_set1.bp : TestBPcmp_set2.bp
 DIFFER : VARIABLE : bpStep : NUM_STEPS : 2 <> 3 : TestBPcmp_set1.bp : TestBPcmp_set2.bp


### PR DESCRIPTION
…s of the io.AvailableVariables() result map/dictionary.

Note: %g in printf and cout << doublevar in C++ renders 6 significant digits by default and a value like 130255.32345 is printed as 130255, looking like an integer. Now we print 1.302553e+05. In case of bpls, min/max for small values (-10000, 10000) are still printed with %g, but outside that they are printed with %e.