### PR TITLE
XRootD HTTP: more path-encode changes

### DIFF
--- a/scripts/docker/spin-xrootd/Dockerfile
+++ b/scripts/docker/spin-xrootd/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=linux/amd64 fedora:latest@sha256:781b7642e8bf256e9cf75d2aa58d86f5cc695fd2df113517614e181a5eee9138
+FROM --platform=linux/amd64 fedora:latest
 
 # Install development tools
 RUN dnf update -y && \

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
@@ -265,26 +265,38 @@ XrootdHttpRemote::XrootdHttpRemote(const adios2::HostOptions &hostOptions) : Rem
 
 XrootdHttpRemote::~XrootdHttpRemote() { Close(); }
 
-std::string XrootdHttpRemote::UrlEncode(const std::string &str)
+// Base64url encoding (RFC 4648 §5).  Uses only A-Za-z0-9, '-', '_' —
+// all path-safe characters that no HTTP intermediary will mangle.
+// No padding ('=') is emitted; the decoder infers it from length.
+std::string XrootdHttpRemote::Base64urlEncode(const std::string &str)
 {
-#ifdef ADIOS2_HAVE_CURL
-    if (str.empty())
-        return str;
-
-    CURL *curl = curl_easy_init();
-    if (!curl)
-        return str;
-
-    char *encoded = curl_easy_escape(curl, str.c_str(), static_cast<int>(str.length()));
-    std::string result = encoded ? std::string(encoded) : str;
-
-    if (encoded)
-        curl_free(encoded);
-    curl_easy_cleanup(curl);
-    return result;
-#else
-    return str;
-#endif
+    static const char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    std::string out;
+    const auto *src = reinterpret_cast<const unsigned char *>(str.data());
+    size_t len = str.size();
+    out.reserve((len * 4 + 2) / 3);
+    size_t i = 0;
+    for (; i + 2 < len; i += 3)
+    {
+        out += table[(src[i] >> 2) & 0x3F];
+        out += table[((src[i] & 0x03) << 4) | (src[i + 1] >> 4)];
+        out += table[((src[i + 1] & 0x0F) << 2) | (src[i + 2] >> 6)];
+        out += table[src[i + 2] & 0x3F];
+    }
+    if (i < len)
+    {
+        out += table[(src[i] >> 2) & 0x3F];
+        if (i + 1 < len)
+        {
+            out += table[((src[i] & 0x03) << 4) | (src[i + 1] >> 4)];
+            out += table[(src[i + 1] & 0x0F) << 2];
+        }
+        else
+        {
+            out += table[(src[i] & 0x03) << 4];
+        }
+    }
+    return out;
 }
 
 void XrootdHttpRemote::Open(const std::string hostname, const int32_t port,
@@ -348,71 +360,20 @@ void XrootdHttpRemote::Open(const std::string hostname, const int32_t port,
     }
 
     std::ostringstream urlStream;
-    urlStream << (m_UseHttps ? "https" : "http") << "://" << hostname << ":" << port << "/adios/"
-              << UrlEncode(m_Filename);
+    urlStream << (m_UseHttps ? "https" : "http") << "://" << hostname << ":" << port << "/adios"
+              << m_Filename;
     m_BaseUrl = urlStream.str();
+
+    // Per-engine constants (RMOrder + EngineParams) are packed once into
+    // the file-config path segment and reused on every request.
+    m_FileConfigSegment = BuildFileConfigSegment();
 
     m_OpenSuccess = true;
 }
 
 void XrootdHttpRemote::Close() { m_OpenSuccess = false; }
 
-std::string XrootdHttpRemote::BuildRequestString(const char *VarName, size_t Step, size_t StepCount,
-                                                 size_t BlockID, const Dims &Count,
-                                                 const Dims &Start, const Accuracy &accuracy)
-{
-    std::ostringstream reqStream;
-    std::string encodedVarName = UrlEncode(std::string(VarName));
-
-    reqStream << "get&Varname=" << encodedVarName;
-    if (m_RowMajorOrdering)
-    {
-        reqStream << "&RMOrder=1";
-    }
-    if (Step != 0)
-    {
-        reqStream << "&StepStart=" << Step;
-    }
-    if (StepCount != 1)
-    {
-        reqStream << "&StepCount=" << StepCount;
-    }
-    if (BlockID != static_cast<size_t>(-1))
-    {
-        reqStream << "&Block=" << BlockID;
-    }
-    if (!Count.empty())
-    {
-        reqStream << "&Count=" << Count[0];
-        for (size_t i = 1; i < Count.size(); i++)
-        {
-            reqStream << "," << Count[i];
-        }
-    }
-    if (!Start.empty())
-    {
-        reqStream << "&Start=" << Start[0];
-        for (size_t i = 1; i < Start.size(); i++)
-        {
-            reqStream << "," << Start[i];
-        }
-    }
-    if (accuracy.error != 0.0 || accuracy.norm != 0.0 || accuracy.relative)
-    {
-        reqStream << "&AccuracyError=" << accuracy.error;
-        reqStream << "&AccuracyNorm=" << accuracy.norm;
-        reqStream << "&AccuracyRelative=" << (accuracy.relative ? 1 : 0);
-    }
-    if (!m_EngineParams.empty())
-    {
-        reqStream << "&EngineParams=" << UrlEncode(m_EngineParams);
-    }
-
-    return reqStream.str();
-}
-
-CURL *XrootdHttpRemote::CreateEasyHandle(AsyncGet *asyncOp, const std::string &url,
-                                         const std::string &queryData)
+CURL *XrootdHttpRemote::CreateEasyHandle(AsyncGet *asyncOp, const std::string &url)
 {
 #ifdef ADIOS2_HAVE_CURL
     CURL *easy = curl_easy_init();
@@ -422,8 +383,7 @@ CURL *XrootdHttpRemote::CreateEasyHandle(AsyncGet *asyncOp, const std::string &u
     curl_easy_setopt(easy, CURLOPT_PRIVATE, asyncOp);
     asyncOp->easyHandle = easy;
 
-    std::string fullUrl = url + "?" + queryData;
-    curl_easy_setopt(easy, CURLOPT_URL, fullUrl.c_str());
+    curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
     curl_easy_setopt(easy, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, WriteCallback);
     curl_easy_setopt(easy, CURLOPT_WRITEDATA, &asyncOp->responseData);
@@ -454,61 +414,103 @@ CURL *XrootdHttpRemote::CreateEasyHandle(AsyncGet *asyncOp, const std::string &u
 #endif
 }
 
-std::string XrootdHttpRemote::BuildBatchRequestString(const std::vector<BatchGetRequest> &requests)
+// ---------------------------------------------------------------------
+// Path-encoded URL builders (Pelican/XCache-friendly form).
+//
+// Full URL: <scheme>://<host>:<port>/adios<filename>/<file-config>/<request>
+//
+// The filename keeps its literal slashes (it is not URL-encoded), so
+// it occupies multiple path segments.  The server identifies the last
+// two segments as file-config and request and rejoins everything
+// before them as the filename.
+//
+// Per-segment grammar:
+//   file-config:   r<digit>(p<base64url-EP>)?       (always at least r0/r1)
+//   single get:    g~<base64url-var>~<paramstring>  (`_` if no params)
+//   batch get:     b~N~<v1>~<p1>~<v2>~<p2>~...~<vN>~<pN>
+//
+// Variable names and EngineParams are base64url-encoded (RFC 4648 §5)
+// so they never collide with our delimiters and so HTTP intermediaries
+// can't normalize them in transit.  Paramstring fields are letter-
+// prefixed and self-delimiting; vector elements use `,` (e.g.
+// `c4,8,12`); outer delimiter is `~`; floats keep `.` as decimal
+// separator without colliding with anything.
+// ---------------------------------------------------------------------
+
+std::string XrootdHttpRemote::BuildFileConfigSegment()
 {
-    std::ostringstream reqStream;
-
-    reqStream << "batchget&NVars=" << requests.size();
-    if (m_RowMajorOrdering)
-    {
-        reqStream << "&RMOrder=1";
-    }
+    std::ostringstream s;
+    // Always emit RMOrder so the server doesn't have to guess the default.
+    s << "r" << (m_RowMajorOrdering ? "1" : "0");
     if (!m_EngineParams.empty())
-    {
-        reqStream << "&EngineParams=" << UrlEncode(m_EngineParams);
-    }
+        s << "p" << Base64urlEncode(m_EngineParams);
+    std::string out = s.str();
+    // Empty file-config gets a placeholder so the path segment is non-
+    // empty; some intermediaries normalize empty segments away.
+    return out.empty() ? std::string("_") : out;
+}
 
-    for (const auto &req : requests)
+std::string XrootdHttpRemote::BuildPerRequestParamString(size_t Step, size_t StepCount,
+                                                         size_t BlockID, const Dims &Count,
+                                                         const Dims &Start,
+                                                         const Accuracy &accuracy)
+{
+    std::ostringstream s;
+    if (BlockID != static_cast<size_t>(-1))
+        s << "b" << BlockID;
+    if (Step != 0)
+        s << "s" << Step;
+    if (StepCount != 1)
+        s << "S" << StepCount;
+    if (!Count.empty())
     {
-        std::string encodedVarName = UrlEncode(std::string(req.VarName));
-        reqStream << "&Varname=" << encodedVarName;
-        if (req.Step != 0)
-        {
-            reqStream << "&StepStart=" << req.Step;
-        }
-        if (req.StepCount != 1)
-        {
-            reqStream << "&StepCount=" << req.StepCount;
-        }
-        if (req.BlockID != static_cast<size_t>(-1))
-        {
-            reqStream << "&Block=" << req.BlockID;
-        }
-        if (!req.Count.empty())
-        {
-            reqStream << "&Count=" << req.Count[0];
-            for (size_t i = 1; i < req.Count.size(); i++)
-            {
-                reqStream << "," << req.Count[i];
-            }
-        }
-        if (!req.Start.empty())
-        {
-            reqStream << "&Start=" << req.Start[0];
-            for (size_t i = 1; i < req.Start.size(); i++)
-            {
-                reqStream << "," << req.Start[i];
-            }
-        }
-        if (req.accuracy.error != 0.0 || req.accuracy.norm != 0.0 || req.accuracy.relative)
-        {
-            reqStream << "&AccuracyError=" << req.accuracy.error;
-            reqStream << "&AccuracyNorm=" << req.accuracy.norm;
-            reqStream << "&AccuracyRelative=" << (req.accuracy.relative ? 1 : 0);
-        }
+        s << "c" << Count[0];
+        for (size_t i = 1; i < Count.size(); ++i)
+            s << "," << Count[i];
     }
+    if (!Start.empty())
+    {
+        s << "o" << Start[0];
+        for (size_t i = 1; i < Start.size(); ++i)
+            s << "," << Start[i];
+    }
+    // `a`/`N` (not `e`/`n`) so the letters don't collide with characters
+    // that appear in float formatting: `e` in scientific notation
+    // (`1e-5`), `n` in `nan`/`inf`.  None of {a, N, R} appear in float
+    // output, so a value is always self-delimiting.
+    if (accuracy.error != 0.0)
+        s << "a" << accuracy.error;
+    if (accuracy.norm != 0.0)
+        s << "N" << accuracy.norm;
+    if (accuracy.relative)
+        s << "R1";
+    std::string out = s.str();
+    // Same `_` placeholder convention as file-config: an all-default
+    // request is the empty string and would collapse adjacent `~`s in
+    // batch sub-requests.
+    return out.empty() ? std::string("_") : out;
+}
 
-    return reqStream.str();
+std::string XrootdHttpRemote::BuildSingleGetSegment(const char *VarName, size_t Step,
+                                                    size_t StepCount, size_t BlockID,
+                                                    const Dims &Count, const Dims &Start,
+                                                    const Accuracy &accuracy)
+{
+    return "g~" + Base64urlEncode(std::string(VarName)) + "~" +
+           BuildPerRequestParamString(Step, StepCount, BlockID, Count, Start, accuracy);
+}
+
+std::string XrootdHttpRemote::BuildBatchGetSegment(const std::vector<BatchGetRequest> &requests)
+{
+    std::ostringstream s;
+    s << "b~" << requests.size();
+    for (const auto &r : requests)
+    {
+        s << "~" << Base64urlEncode(std::string(r.VarName)) << "~"
+          << BuildPerRequestParamString(r.Step, r.StepCount, r.BlockID, r.Count, r.Start,
+                                        r.accuracy);
+    }
+    return s.str();
 }
 
 bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
@@ -551,10 +553,11 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
 
         std::vector<BatchGetRequest> subRequests(requests.begin() + startIdx,
                                                  requests.begin() + startIdx + count);
-        std::string postData = BuildBatchRequestString(subRequests);
+        std::string url =
+            m_BaseUrl + "/" + m_FileConfigSegment + "/" + BuildBatchGetSegment(subRequests);
 
         AsyncGet *asyncOp = new AsyncGet();
-        CURL *easy = CreateEasyHandle(asyncOp, m_BaseUrl, postData);
+        CURL *easy = CreateEasyHandle(asyncOp, url);
         if (!easy)
         {
             delete asyncOp;
@@ -597,9 +600,11 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
 
                 std::vector<BatchGetRequest> subRequests(requests.begin() + sb.startIdx,
                                                          requests.begin() + sb.startIdx + sb.count);
-                std::string postData = BuildBatchRequestString(subRequests);
+                std::string url =
+                    m_BaseUrl + "/" + m_FileConfigSegment + "/" + BuildBatchGetSegment(subRequests);
+
                 AsyncGet *retryOp = new AsyncGet();
-                CURL *easy = CreateEasyHandle(retryOp, m_BaseUrl, postData);
+                CURL *easy = CreateEasyHandle(retryOp, url);
                 if (!easy)
                 {
                     delete retryOp;
@@ -703,9 +708,10 @@ Remote::GetHandle XrootdHttpRemote::Get(const char *VarName, size_t Step, size_t
     AsyncGet *asyncOp = new AsyncGet();
     asyncOp->destBuffer = dest;
 
-    std::string postData =
-        BuildRequestString(VarName, Step, StepCount, BlockID, Count, Start, accuracy);
-    CURL *easy = CreateEasyHandle(asyncOp, m_BaseUrl, postData);
+    std::string url =
+        m_BaseUrl + "/" + m_FileConfigSegment + "/" +
+        BuildSingleGetSegment(VarName, Step, StepCount, BlockID, Count, Start, accuracy);
+    CURL *easy = CreateEasyHandle(asyncOp, url);
     if (!easy)
     {
         delete asyncOp;

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.h
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.h
@@ -124,16 +124,32 @@ public:
     void SetVerifySSL(bool verify) { m_VerifySSL = verify; }
 
 private:
-    std::string BuildRequestString(const char *VarName, size_t Step, size_t StepCount,
-                                   size_t BlockID, const Dims &Count, const Dims &Start,
-                                   const Accuracy &accuracy);
-    std::string BuildBatchRequestString(const std::vector<BatchGetRequest> &requests);
-    std::string UrlEncode(const std::string &str);
-    CURL *CreateEasyHandle(AsyncGet *asyncOp, const std::string &url, const std::string &postData);
+    /** Path-encoded request builders.  Each produces one URL path segment.
+     *  See developer notes for the wire grammar; summary:
+     *    file-config:  r0?p<base64url-EP>?    (`_` placeholder if empty)
+     *    single get:   g~<base64url-var>~<paramstring>     (`_` if no params)
+     *    batch get:    b~N~<v1>~<p1>~…~<vN>~<pN>
+     *  Varnames and EngineParams are base64url-encoded (RFC 4648 §5).
+     *  Paramstring fields are letter-prefixed and self-delimiting; vector
+     *  elements use `,`; outer delimiter is `~`; floats use `.` as decimal. */
+    std::string BuildFileConfigSegment();
+    std::string BuildPerRequestParamString(size_t Step, size_t StepCount, size_t BlockID,
+                                           const Dims &Count, const Dims &Start,
+                                           const Accuracy &accuracy);
+    std::string BuildSingleGetSegment(const char *VarName, size_t Step, size_t StepCount,
+                                      size_t BlockID, const Dims &Count, const Dims &Start,
+                                      const Accuracy &accuracy);
+    std::string BuildBatchGetSegment(const std::vector<BatchGetRequest> &requests);
+
+    static std::string Base64urlEncode(const std::string &str);
+    CURL *CreateEasyHandle(AsyncGet *asyncOp, const std::string &url);
 
     std::string m_BaseUrl;
     std::string m_Filename;
     std::string m_EngineParams;
+    /** Per-engine `<file-config>` path segment, computed once at Open()
+     *  from RMOrder + EngineParams.  Reused on every request. */
+    std::string m_FileConfigSegment;
     Mode m_Mode;
     bool m_RowMajorOrdering;
     bool m_OpenSuccess = false;

--- a/source/utils/xrootd-plugin/XrdHttpSsiHandler.cpp
+++ b/source/utils/xrootd-plugin/XrdHttpSsiHandler.cpp
@@ -23,6 +23,7 @@
 #include <dlfcn.h>
 #include <iostream>
 #include <sstream>
+#include <vector>
 
 namespace
 {
@@ -45,6 +46,313 @@ std::string UrlEncode(const std::string &s)
         }
     }
     return out;
+}
+
+// ---------------------------------------------------------------------
+// Path-encoded URL decoder.
+//
+// Wire grammar matches the client encoder in
+// source/adios2/toolkit/remote/XrootdHttpRemote.cpp:
+//
+//   /adios/<urlenc-filename>/<file-config>/<request>
+//
+//   file-config:   r<digit>?p<base64url-EP>?    (or `_` placeholder)
+//   single get:    g~<base64url-var>~<paramstring>     (or `_` if no params)
+//   batch get:     b~N~<v1>~<p1>~<v2>~<p2>~...~<vN>~<pN>
+//
+//   Variable names and EngineParams are base64url-encoded (RFC 4648 §5)
+//   because they may contain '/' which HTTP intermediaries decode from
+//   percent-encoding, breaking path-segment parsing.
+//
+//   paramstring:   letter-prefixed fields, no internal delimiter; fields
+//                  self-delimit because the next field's letter ends the
+//                  previous value.  Vector elements separated by `,`.
+//
+// Letter codes (single get / batch sub-request):
+//   b Block            s StepStart        S StepCount
+//   c Count            o Start            a AccuracyError
+//   N AccuracyNorm     R AccuracyRelative
+//
+// File-config codes:
+//   r RMOrder (single digit)               p EngineParams (rest of segment)
+//
+// The decoder builds a legacy "verb Filename=...&key=val&..." string for
+// the inner SSI parser, which is unchanged.
+// ---------------------------------------------------------------------
+
+// Base64url decoding (RFC 4648 §5).  Inverse of the client's
+// Base64urlEncode — uses '-' and '_' instead of '+' and '/',
+// no padding required.
+std::string Base64urlDecode(const std::string &in)
+{
+    // Lookup: ASCII value → 6-bit index (64 = invalid).
+    // Covers 0x00–0xFF (256 entries).  Indices:
+    //   A-Z = 0-25, a-z = 26-51, 0-9 = 52-61, '-' = 62, '_' = 63
+    auto decodeCh = [](unsigned char c) -> unsigned char {
+        if (c >= 'A' && c <= 'Z')
+            return c - 'A';
+        if (c >= 'a' && c <= 'z')
+            return c - 'a' + 26;
+        if (c >= '0' && c <= '9')
+            return c - '0' + 52;
+        if (c == '-')
+            return 62;
+        if (c == '_')
+            return 63;
+        return 64;
+    };
+    std::string out;
+    out.reserve(in.size() * 3 / 4);
+    unsigned int buf = 0;
+    int bits = 0;
+    for (unsigned char c : in)
+    {
+        if (c == '=')
+            break;
+        unsigned char v = decodeCh(c);
+        if (v == 64)
+            continue; // skip unknown chars
+        buf = (buf << 6) | v;
+        bits += 6;
+        if (bits >= 8)
+        {
+            bits -= 8;
+            out += static_cast<char>((buf >> bits) & 0xFF);
+        }
+    }
+    return out;
+}
+
+std::vector<std::string> SplitOn(const std::string &s, char delim)
+{
+    std::vector<std::string> out;
+    size_t start = 0;
+    while (true)
+    {
+        size_t pos = s.find(delim, start);
+        if (pos == std::string::npos)
+        {
+            out.push_back(s.substr(start));
+            return out;
+        }
+        out.push_back(s.substr(start, pos - start));
+        start = pos + 1;
+    }
+}
+
+// Map a per-request paramstring letter to the legacy field name.  Returns
+// nullptr if the character isn't a known field letter, which doubles as
+// the "this character belongs in the value, not a new field" test.
+const char *PerRequestKey(char letter)
+{
+    switch (letter)
+    {
+    case 'b':
+        return "Block";
+    case 's':
+        return "StepStart";
+    case 'S':
+        return "StepCount";
+    case 'c':
+        return "Count";
+    case 'o':
+        return "Start";
+    case 'a':
+        return "AccuracyError";
+    case 'N':
+        return "AccuracyNorm";
+    case 'R':
+        return "AccuracyRelative";
+    default:
+        return nullptr;
+    }
+}
+
+// Append `&Key=Value` pairs for each field in a per-request paramstring.
+// `_` placeholder produces no output.  Returns false on malformed input.
+bool DecodePerRequestParamString(const std::string &paramstring, std::ostringstream &out)
+{
+    if (paramstring == "_")
+        return true;
+    size_t i = 0;
+    const size_t n = paramstring.size();
+    while (i < n)
+    {
+        const char *key = PerRequestKey(paramstring[i]);
+        if (!key)
+            return false;
+        ++i;
+        const size_t valStart = i;
+        while (i < n && PerRequestKey(paramstring[i]) == nullptr)
+            ++i;
+        if (i == valStart)
+            return false;
+        out << "&" << key << "=" << paramstring.substr(valStart, i - valStart);
+    }
+    return true;
+}
+
+// Decode the file-config segment.  Strict order: optional `r<digit>`,
+// then optional `p<rest>`.  `_` placeholder is empty.
+bool DecodeFileConfigSegment(const std::string &fileConfig, std::ostringstream &out)
+{
+    if (fileConfig == "_")
+        return true;
+    size_t i = 0;
+    const size_t n = fileConfig.size();
+    if (i < n && fileConfig[i] == 'r')
+    {
+        ++i;
+        if (i >= n)
+            return false;
+        char d = fileConfig[i++];
+        if (d != '0' && d != '1')
+            return false;
+        out << "&RMOrder=" << d;
+    }
+    if (i < n && fileConfig[i] == 'p')
+    {
+        ++i;
+        out << "&EngineParams=" << UrlEncode(Base64urlDecode(fileConfig.substr(i)));
+        return true;
+    }
+    return i == n;
+}
+
+// Top-level decoder.  Strips the route prefix, splits the path, and
+// composes the legacy ssiCommand from the three segments.  On parse
+// error returns false with an explanation in `errorOut`.
+bool DecodePathEncodedRequest(const std::string &fullresource, const std::string &pathPrefix,
+                              std::string &ssiCommandOut, std::string &resourceOut,
+                              std::string &errorOut)
+{
+    // Strip query string defensively (path-encoded form puts everything
+    // in the path; any `?…` is an artifact and we ignore it).
+    std::string path = fullresource;
+    size_t qpos = path.find('?');
+    if (qpos != std::string::npos)
+        path = path.substr(0, qpos);
+
+    const std::string fullPrefix = pathPrefix + "/";
+    if (path.compare(0, fullPrefix.size(), fullPrefix) != 0)
+    {
+        errorOut = "URL does not start with " + fullPrefix;
+        return false;
+    }
+    path = path.substr(fullPrefix.size());
+
+    // Three segments after the prefix: filename, file-config, request.
+    // The filename's slashes are literal path separators (not encoded),
+    // so it spans multiple segments.  The last two are file-config and
+    // request; everything before them is the filename.
+    std::vector<std::string> segments = SplitOn(path, '/');
+    if (segments.size() < 3)
+    {
+        errorOut = "URL must have filename, file-config, and request segments";
+        return false;
+    }
+    const std::string requestSeg = segments.back();
+    segments.pop_back();
+    const std::string fileConfigSeg = segments.back();
+    segments.pop_back();
+    std::string encodedFilename;
+    for (size_t i = 0; i < segments.size(); ++i)
+    {
+        if (i > 0)
+            encodedFilename += "/";
+        encodedFilename += segments[i];
+    }
+
+    // Ensure leading '/' so the resource matches the legacy form
+    // (XRootD SSI uses it for tar-archive resolution and caching).
+    if (encodedFilename.empty() || encodedFilename[0] != '/')
+        resourceOut = "/" + encodedFilename;
+    else
+        resourceOut = encodedFilename;
+
+    if (requestSeg.size() < 2 || requestSeg[1] != '~')
+    {
+        errorOut = "Request segment missing op marker";
+        return false;
+    }
+    const char op = requestSeg[0];
+    std::string verb;
+    if (op == 'g')
+        verb = "get";
+    else if (op == 'b')
+        verb = "batchget";
+    else
+    {
+        errorOut = std::string("Unknown op marker '") + op + "' in request segment";
+        return false;
+    }
+
+    std::ostringstream cmd;
+    cmd << verb << " Filename=" << resourceOut;
+
+    if (!DecodeFileConfigSegment(fileConfigSeg, cmd))
+    {
+        errorOut = "Malformed file-config segment '" + fileConfigSeg + "'";
+        return false;
+    }
+
+    if (op == 'g')
+    {
+        // g~<varname>~<paramstring>
+        std::vector<std::string> parts = SplitOn(requestSeg.substr(2), '~');
+        if (parts.size() != 2)
+        {
+            errorOut = "Single-get request must be 'g~<varname>~<params>'";
+            return false;
+        }
+        cmd << "&Varname=" << UrlEncode(Base64urlDecode(parts[0]));
+        if (!DecodePerRequestParamString(parts[1], cmd))
+        {
+            errorOut = "Malformed paramstring '" + parts[1] + "'";
+            return false;
+        }
+    }
+    else // op == 'b'
+    {
+        // b~N~<v1>~<p1>~<v2>~<p2>~...~<vN>~<pN>
+        std::vector<std::string> parts = SplitOn(requestSeg.substr(2), '~');
+        if (parts.empty())
+        {
+            errorOut = "Batch request missing sub-request count";
+            return false;
+        }
+        size_t expected = 0;
+        try
+        {
+            expected = std::stoul(parts[0]);
+        }
+        catch (...)
+        {
+            errorOut = "Batch sub-request count is not a number";
+            return false;
+        }
+        cmd << "&NVars=" << parts[0];
+        if (parts.size() != 1 + 2 * expected)
+        {
+            errorOut = "Batch sub-request count mismatch";
+            return false;
+        }
+        for (size_t s = 0; s < expected; ++s)
+        {
+            const std::string &v = parts[1 + s * 2];
+            const std::string &p = parts[2 + s * 2];
+            cmd << "&Varname=" << UrlEncode(Base64urlDecode(v));
+            if (!DecodePerRequestParamString(p, cmd))
+            {
+                errorOut =
+                    "Malformed paramstring '" + p + "' in batch sub-request " + std::to_string(s);
+                return false;
+            }
+        }
+    }
+
+    ssiCommandOut = cmd.str();
+    return true;
 }
 } // namespace
 
@@ -381,48 +689,67 @@ int XrdHttpSsiHandler::ProcessReq(XrdHttpExtReq &req)
         resource = "/";
     }
 
-    // For GET requests, the command and parameters are in the query string.
-    // For POST requests, the command is in the request body.
-    // Both produce the same ssiCommand format: "verb key=val&key=val..."
-    std::string ssiCommand;
-
-    if (req.verb == "GET")
+    // The handler accepts two GET wire forms while old clients are
+    // still being phased out:
+    //   - path-encoded GET (new, cache-friendly):
+    //       /adios/<filename>/<file-config>/<request>
+    //     Distinguished by the absence of any '?' in the URL.
+    //   - legacy query-string GET (old client form):
+    //       /adios/<filename>?<verb>&<key>=<val>&...
+    // POST is no longer supported (legacy POST builds are out of
+    // circulation).
+    if (req.verb != "GET")
     {
-        // Use xrd-http-fullresource which has the raw resource+opaque,
-        // unprocessed by XrdOucEnv (which mangles bare tokens without '=')
-        auto it = req.headers.find("xrd-http-fullresource");
-        if (it == req.headers.end() || it->second.empty())
+        return SendError(req, 405, "Only GET is supported");
+    }
+
+    // Use xrd-http-fullresource (the raw URI, unprocessed by XrdOucEnv)
+    // so percent-encoded slashes in the filename segment survive intact
+    // for path-encoded splits, and bare query tokens (e.g. `get` with
+    // no `=`) survive for legacy parsing.
+    auto it = req.headers.find("xrd-http-fullresource");
+    if (it == req.headers.end() || it->second.empty())
+    {
+        return SendError(req, 400, "GET request missing xrd-http-fullresource");
+    }
+
+    std::string ssiCommand;
+    if (it->second.find('?') == std::string::npos)
+    {
+        // No query string → new path-encoded form.
+        std::string err;
+        std::string pathResource;
+        if (!DecodePathEncodedRequest(it->second, m_pathPrefix, ssiCommand, pathResource, err))
+        {
+            return SendError(req, 400, err.c_str());
+        }
+        // Use the filename from the path as the SSI resource so that
+        // tar-archive resolution and caching key on the right path.
+        resource = pathResource;
+    }
+    else
+    {
+        // Legacy query-string form.  The full URI has the shape
+        // "<prefix>/<filename>?<verb>&<key>=<val>&...".  Split at '?'
+        // to get verb-and-args; inject Filename= from the (decoded)
+        // resource path.
+        const std::string &raw = it->second;
+        size_t qpos = raw.find('?');
+        std::string query = raw.substr(qpos + 1);
+        if (query.empty())
         {
             return SendError(req, 400, "GET request requires query parameters");
         }
-
-        // fullresource is "/adios/path/to/file?get&Varname=..."
-        // Extract the query string after '?'
-        std::string query;
-        size_t qpos = it->second.find('?');
-        if (qpos == std::string::npos || qpos + 1 >= it->second.size())
-        {
-            return SendError(req, 400, "GET request requires query parameters");
-        }
-        query = it->second.substr(qpos + 1);
-
-        // The query string is "verb&key=val&..." (e.g. "batchget&RMOrder=1&...")
-        // The SSI tokenizer expects "verb key=val&..." (space after verb).
-        // Split at the first '&' and rejoin with a space.
         size_t ampPos = query.find('&');
         if (ampPos == std::string::npos)
         {
-            // Just a verb, no parameters
-            ssiCommand = query;
+            ssiCommand = query; // verb only, no args
         }
         else
         {
             std::string verb = query.substr(0, ampPos);
             std::string args = query.substr(ampPos + 1);
-
-            // If the filename is in the URL path (not in query params),
-            // inject Filename= from the resource path
-            if (args.find("Filename=") == std::string::npos && resource != "/")
+            if (resource != "/")
             {
                 ssiCommand = verb + " Filename=" + UrlEncode(resource) + "&" + args;
             }
@@ -431,23 +758,6 @@ int XrdHttpSsiHandler::ProcessReq(XrdHttpExtReq &req)
                 ssiCommand = verb + " " + args;
             }
         }
-    }
-    else
-    {
-        // POST - read the request body
-        if (req.length <= 0)
-        {
-            return SendError(req, 400, "POST request requires body");
-        }
-
-        // Read the request body
-        char *bodyData = nullptr;
-        int bytesRead = req.BuffgetData(req.length, &bodyData, true);
-        if (bytesRead <= 0 || !bodyData)
-        {
-            return SendError(req, 400, "Failed to read request body");
-        }
-        ssiCommand = std::string(bodyData, bytesRead);
     }
 
     // Create the SSI resource

--- a/source/utils/xrootd-plugin/XrdSsiSvService.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvService.cpp
@@ -496,7 +496,7 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
 
         std::string Filename;
         std::string EngineParams;
-        bool ArrayOrder = false;
+        bool ArrayOrder = true;
         size_t NVars = 0;
 
         struct VarRequest
@@ -739,9 +739,9 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
         std::string VarName;
         std::string EngineParams;
         adios2::Dims Start, Count;
-        size_t BlockID, DimCount, StepStart;
+        size_t BlockID = (size_t)-1, DimCount = 0, StepStart = 0;
         size_t StepCount = 1;
-        bool ArrayOrder = false;
+        bool ArrayOrder = true;
         // Accuracy parameters
         double AccuracyError = 0.0;
         double AccuracyNorm = 0.0;


### PR DESCRIPTION
This mod completely gets rid of query arguments in favor of encoding everything in a couple of trailing (dummy) filespecs. That is, the URLs now look like this:
`/adios<filename>/<file-config>/<request>`
where file-config encodes the rowmajor order and any engine params:
```
 - r<digit> — RMOrder.  r0 = column-major, r1 = row-major.                                                                                   
 - p<base64url-blob> 
```
The request segment is:
  Single get: `g~<base64url-varname>~<paramstring>`
         where paramstring is something like "b0" for block 0, or "c4,8,12,o0,0,0" for a count and offset spec.
-or-
  Batch get: `b~N~<v1>~<p1>~<v2>~<p2>~...~<vN>~<pN>` 
         where each vi is base64url-encoded and each pi is a paramstring
