### PR TITLE
EncryptionOperator: allow key loading via env vars

### DIFF
--- a/docs/user_guide/source/operators/encryption.rst
+++ b/docs/user_guide/source/operators/encryption.rst
@@ -2,55 +2,93 @@
 Encryption
 **********
 
-The Encryption Operator uses the :ref:`Plugins` interface.
-This operator uses `libsodium <https://doc.libsodium.org/>`_ for encrypting and decrypting data.
-If ADIOS can find libsodium at configure time, this plugin will be built.
+The Encryption Operator uses the :ref:`Plugins` interface and requires
+`libsodium <https://doc.libsodium.org/>`_.  If ADIOS2 finds libsodium at
+configure time the plugin is built automatically.
 
-The encryption mode is selected automatically based on the parameters supplied.
+The operator supports two modes.  Mode is selected by which key sources are
+present (parameters or environment variables); asymmetric mode takes priority.
 
 ~~~~~~~~~~~~~~
 Symmetric Mode
 ~~~~~~~~~~~~~~
 
-In symmetric mode, the operator generates a secret key and encrypts the data with the key and a
-nonce as described in the libsodium `secret key cryptography docs
-<https://doc.libsodium.org/secret-key_cryptography/secretbox>`_.
-The key is saved to the specified ``SecretKeyFile`` and will be used for decryption. The key should
-be kept confidential since it is used to both encrypt and decrypt the data.
+Uses **XSalsa20-Poly1305** (``crypto_secretbox``).  A single 32-byte secret
+key is shared between writer and reader.  For each variable chunk a fresh
+random 24-byte nonce is generated; the ciphertext carries a 16-byte Poly1305
+MAC.  On-disk layout::
 
-Symmetric mode is activated when ``SecretKeyFile`` is provided without any public-key parameters.
+    [ uint64 original_size | 24 B nonce | ciphertext + 16 B MAC ]
+
+Key lookup order (first match wins):
+
+1. ``ADIOS2_SECRET_KEY`` environment variable (hex string)
+2. ``SecretKeyFile`` parameter — path to a 32-byte binary key file.
+   On the writer side the file is created if it does not exist.
+3. ``SecretKey`` parameter (hex string)
 
 ============================== ===================== ===========================================================
- **Key**                       **Value Format**       **Explanation**
+ **Parameter**                  **Value**              **Notes**
 ============================== ===================== ===========================================================
- PluginName                     string                Required. Name to refer to plugin, e.g., ``MyOperator``
- PluginLibrary                  string                Required. Name of shared library, ``EncryptionOperator``
- SecretKeyFile                  string                Required. Path to secret key file
+ PluginName                     string                Required
+ PluginLibrary                  ``EncryptionOperator`` Required
+ SecretKeyFile                  file path             Key file (generated if absent on write side)
+ SecretKey                      64-char hex           Alternative to file
 ============================== ===================== ===========================================================
 
 ~~~~~~~~~~~~~~~
 Asymmetric Mode
 ~~~~~~~~~~~~~~~
 
-In asymmetric mode, a random per-write session key is sealed with the recipient's Curve25519 public
-key using ``crypto_box_seal``, and the bulk data is encrypted with that session key via
-``crypto_secretbox``. Only the public key is needed for writing; both the public and secret keys
-are needed for reading.
+Uses a **hybrid** scheme: **Curve25519** key agreement + **XSalsa20-Poly1305**
+bulk cipher.
 
-Asymmetric mode is activated when ``PublicKeyFile`` or ``PublicKey`` is provided. Key pairs can
-be generated with the ``adios2_seal_keygen`` utility.
+For each variable chunk:
 
-The secret key lookup order for reading is: ``SecretKeyFile`` parameter, ``SecretKey`` parameter,
-``ADIOS2_SECRET_KEY_FILE`` environment variable, ``ADIOS2_SECRET_KEY`` environment variable.
-If only the secret key is supplied, the public key is derived automatically via Curve25519.
+1. A random 32-byte **session key** is generated.
+2. The session key is encrypted with ``crypto_box_seal`` — an anonymous ECDH
+   construction using an ephemeral sender keypair.  Only the recipient's public
+   key is required to seal; both keys are required to unseal.
+3. The chunk data is encrypted with the session key via ``crypto_secretbox``.
+4. The session key is wiped from memory.
+
+On-disk layout::
+
+    [ uint64 original_size | 48 B sealed_session_key | 24 B nonce | ciphertext + 16 B MAC ]
+
+The 48-byte sealed session key is ``crypto_box_SEALBYTES (32) + 32``.
+
+**Writer** only needs the **public key**.
+**Reader** needs the **secret key** (public key can be derived automatically).
+
+Key pairs can be generated with the ``adios2_seal_keygen`` utility.
+
+Public key lookup order (first match wins):
+
+1. ``ADIOS2_PUBLIC_KEY_FILE`` environment variable (file path)
+2. ``ADIOS2_PUBLIC_KEY`` environment variable (64-char hex)
+3. ``PublicKeyFile`` parameter
+4. ``PublicKey`` parameter (hex)
+
+Secret key lookup order (first match wins):
+
+1. ``ADIOS2_ASYM_SECRET_KEY_FILE`` environment variable (file path)
+2. ``ADIOS2_ASYM_SECRET_KEY`` environment variable (64-char hex)
+3. ``SecretKeyFile`` parameter
+4. ``SecretKey`` parameter (hex)
+
+If a secret key is provided without a public key, the public key is derived
+automatically via ``crypto_scalarmult_base`` (Curve25519 base-point multiply).
+Setting any of the four asymmetric environment variables activates asymmetric
+mode even when no parameters are passed.
 
 ============================== ===================== ===========================================================
- **Key**                       **Value Format**       **Explanation**
+ **Parameter**                  **Value**              **Notes**
 ============================== ===================== ===========================================================
- PluginName                     string                Required. Name to refer to plugin, e.g., ``MyOperator``
- PluginLibrary                  string                Required. Name of shared library, ``EncryptionOperator``
- PublicKeyFile                  string                Path to a 32-byte Curve25519 public key file
- PublicKey                      string                Hex-encoded public key (64 hex characters)
- SecretKeyFile                  string                Path to a 32-byte Curve25519 secret key file (reading)
- SecretKey                      string                Hex-encoded secret key (64 hex characters, reading only)
+ PluginName                     string                Required
+ PluginLibrary                  ``EncryptionOperator`` Required
+ PublicKeyFile                  file path             32-byte Curve25519 public key (writer / reader)
+ PublicKey                      64-char hex           Alternative to file
+ SecretKeyFile                  file path             32-byte Curve25519 secret key (reader)
+ SecretKey                      64-char hex           Alternative to file
 ============================== ===================== ===========================================================

--- a/plugins/operators/EncryptionOperator.cpp
+++ b/plugins/operators/EncryptionOperator.cpp
@@ -159,6 +159,40 @@ struct EncryptionOperator::EncryptImpl
         }
         this->SecretKeyValid = true;
     }
+
+    // --- Symmetric key helpers (read-only, no generate) ---
+
+    void ReadSymKey(const std::string &filename)
+    {
+        std::ifstream keyFile(filename, std::ios::binary);
+        if (!keyFile)
+        {
+            throw std::runtime_error("EncryptionOperator: could not open symmetric key file: " +
+                                     filename);
+        }
+        keyFile.read(reinterpret_cast<char *>(this->Key), crypto_secretbox_KEYBYTES);
+        if (!keyFile)
+        {
+            throw std::runtime_error("EncryptionOperator: symmetric key file is too short: " +
+                                     filename);
+        }
+        keyFile.close();
+        if (sodium_mlock(this->Key, crypto_secretbox_KEYBYTES) == -1)
+        {
+            throw std::runtime_error("EncryptionOperator: unable to lock memory for symmetric key");
+        }
+        this->KeyValid = true;
+    }
+
+    void SetSymKeyHex(const std::string &hex)
+    {
+        HexDecode(hex, this->Key, crypto_secretbox_KEYBYTES);
+        if (sodium_mlock(this->Key, crypto_secretbox_KEYBYTES) == -1)
+        {
+            throw std::runtime_error("EncryptionOperator: unable to lock memory for symmetric key");
+        }
+        this->KeyValid = true;
+    }
 };
 
 EncryptionOperator::EncryptionOperator(const Params &parameters)
@@ -169,57 +203,56 @@ EncryptionOperator::EncryptionOperator(const Params &parameters)
         throw std::runtime_error("libsodium could not be initialized");
     }
 
-    // Detect mode: asymmetric when any public-key param is present.
+    // Env vars for key loading (read once for both mode detection and loading).
+    // Asymmetric public key:  ADIOS2_PUBLIC_KEY_FILE (file) / ADIOS2_PUBLIC_KEY (hex).
+    // Asymmetric secret key:  ADIOS2_ASYM_SECRET_KEY_FILE (file) / ADIOS2_ASYM_SECRET_KEY (hex).
+    //   Setting any asymmetric env var triggers asymmetric mode.
+    //   If no public key is provided the public key is derived from the secret key.
+    // Symmetric: ADIOS2_SECRET_KEY (hex).
+    const char *envPKFile = std::getenv("ADIOS2_PUBLIC_KEY_FILE");
+    const char *envPKHex = std::getenv("ADIOS2_PUBLIC_KEY");
+    const char *envASKFile = std::getenv("ADIOS2_ASYM_SECRET_KEY_FILE");
+    const char *envASKHex = std::getenv("ADIOS2_ASYM_SECRET_KEY");
+    const char *envSKHex = std::getenv("ADIOS2_SECRET_KEY");
+
     auto pkFileIt = m_Parameters.find("publickeyfile");
     auto pkHexIt = m_Parameters.find("publickey");
-    bool hasAsymParam = (pkFileIt != m_Parameters.end() || pkHexIt != m_Parameters.end());
+    auto skFileIt = m_Parameters.find("secretkeyfile");
+    auto skHexIt = m_Parameters.find("secretkey");
+    auto modeParamIt = m_Parameters.find("mode");
 
-    if (hasAsymParam)
+    // Mode detection: any asym env var → mode param → public key param presence.
+    bool hasAsymEnv = (envPKFile && envPKFile[0] != '\0') || (envPKHex && envPKHex[0] != '\0') ||
+                      (envASKFile && envASKFile[0] != '\0') || (envASKHex && envASKHex[0] != '\0');
+    bool hasPKParam = pkFileIt != m_Parameters.end() || pkHexIt != m_Parameters.end();
+    bool hasModeParam = modeParamIt != m_Parameters.end() && modeParamIt->second == "asymmetric";
+    bool isAsymmetric = hasAsymEnv || hasPKParam || hasModeParam;
+
+    if (isAsymmetric)
     {
         Impl->EncryptionMode = EncryptImpl::Mode::Asymmetric;
 
-        // Load public key: file param takes priority, then hex param.
-        if (pkFileIt != m_Parameters.end())
-        {
+        // Load public key: env file → env hex → param file → param hex.
+        if (envPKFile && envPKFile[0] != '\0')
+            Impl->ReadPublicKey(std::string(envPKFile));
+        else if (envPKHex && envPKHex[0] != '\0')
+            Impl->SetPublicKeyHex(std::string(envPKHex));
+        else if (pkFileIt != m_Parameters.end())
             Impl->ReadPublicKey(pkFileIt->second);
-        }
-        else
-        {
+        else if (pkHexIt != m_Parameters.end())
             Impl->SetPublicKeyHex(pkHexIt->second);
-        }
 
-        // Load secret key for decryption.
-        // Lookup order: SecretKeyFile param, SecretKey param (hex),
-        //   ADIOS2_SECRET_KEY_FILE env var, ADIOS2_SECRET_KEY env var (hex).
-        auto skFileIt = m_Parameters.find("secretkeyfile");
-        auto skHexIt = m_Parameters.find("secretkey");
-        if (skFileIt != m_Parameters.end())
-        {
+        // Load secret key: env file → env hex → param file → param hex.
+        if (envASKFile && envASKFile[0] != '\0')
+            Impl->ReadSecretKey(std::string(envASKFile));
+        else if (envASKHex && envASKHex[0] != '\0')
+            Impl->SetSecretKeyHex(std::string(envASKHex));
+        else if (skFileIt != m_Parameters.end())
             Impl->ReadSecretKey(skFileIt->second);
-        }
         else if (skHexIt != m_Parameters.end())
-        {
             Impl->SetSecretKeyHex(skHexIt->second);
-        }
-        else
-        {
-            const char *envSKFile = std::getenv("ADIOS2_SECRET_KEY_FILE");
-            if (envSKFile && envSKFile[0] != '\0')
-            {
-                Impl->ReadSecretKey(std::string(envSKFile));
-            }
-            else
-            {
-                const char *envSKHex = std::getenv("ADIOS2_SECRET_KEY");
-                if (envSKHex && envSKHex[0] != '\0')
-                {
-                    Impl->SetSecretKeyHex(std::string(envSKHex));
-                }
-            }
-        }
 
-        // If we have a secret key but no public key, derive the public key
-        // from the secret key (Curve25519: pk = sk * basepoint).
+        // Derive public key from secret key when only the secret key was provided.
         if (Impl->SecretKeyValid && !Impl->PublicKeyValid)
         {
             if (crypto_scalarmult_base(Impl->PublicKey, Impl->SecretKey) != 0)
@@ -237,16 +270,16 @@ EncryptionOperator::EncryptionOperator(const Params &parameters)
     }
     else
     {
-        // Symmetric mode: in the case "secretkeyfile" is found, so we know
-        // the operator should be calling Operate(). If "secretkeyfile" is not
-        // found, then the operator should be calling InverseOperate(), due to
-        // ADIOS calling InverseOperate() not allowing Parameters to be passed.
-        auto skFileIt = m_Parameters.find("secretkeyfile");
-        if (skFileIt != m_Parameters.end())
+        // Symmetric mode: env hex → param file (with generate) → param hex.
+        if (envSKHex && envSKHex[0] != '\0')
+            Impl->SetSymKeyHex(std::string(envSKHex));
+        else if (skFileIt != m_Parameters.end())
         {
             Impl->KeyFilename = skFileIt->second;
             Impl->GenerateOrReadKey();
         }
+        else if (skHexIt != m_Parameters.end())
+            Impl->SetSymKeyHex(skHexIt->second);
     }
 }
 
@@ -403,6 +436,15 @@ EncryptionOperator::InverseOperate(const char *bufferIn, const size_t sizeIn, ch
     }
     else
     {
+        if (!Impl->KeyValid)
+        {
+            throw std::runtime_error(
+                "EncryptionOperator::InverseOperate (symmetric) was called, but"
+                " a valid secret key has not been loaded. "
+                "Set SecretKeyFile/SecretKey param, or set"
+                " ADIOS2_SECRET_KEY_FILE or ADIOS2_SECRET_KEY env var.");
+        }
+
         size_t offset = 0;
 
         // need to grab any parameter(s) we saved in Operate()

--- a/plugins/operators/EncryptionOperator.cpp
+++ b/plugins/operators/EncryptionOperator.cpp
@@ -9,7 +9,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <optional>
 #include <string>
+#include <string_view>
 
 #include <sodium.h>
 
@@ -18,20 +20,50 @@ namespace adios2
 namespace plugin
 {
 
-/// Decode a hex string (2*len chars) into a byte buffer of length len.
+// Wraps a C-string env var: returns nullopt when the pointer is null or the
+// string is empty (checked via strlen, not just the first byte).
+static std::optional<std::string_view> Env(const char *s)
+{
+    if (s != nullptr && std::strlen(s) != 0)
+        return std::string_view(s);
+    return std::nullopt;
+}
+
 static void HexDecode(const std::string &hex, unsigned char *out, size_t len)
 {
     if (hex.size() != 2 * len)
-    {
-        throw std::runtime_error("EncryptionOperator: hex string has wrong length. Expected " +
-                                 std::to_string(2 * len) + " chars, got " +
-                                 std::to_string(hex.size()));
-    }
+        throw std::runtime_error("EncryptionOperator: hex string length " +
+                                 std::to_string(hex.size()) + " expected " +
+                                 std::to_string(2 * len));
     if (sodium_hex2bin(out, len, hex.c_str(), hex.size(), nullptr, nullptr, nullptr) != 0)
-    {
         throw std::runtime_error("EncryptionOperator: invalid hex string");
-    }
 }
+
+static void LoadKeyFromFile(unsigned char *buf, size_t len, bool &valid, const std::string &path,
+                            const std::string &label)
+{
+    std::ifstream f(path, std::ios::binary);
+    if (!f)
+        throw std::runtime_error("EncryptionOperator: cannot open " + label + ": " + path);
+    f.read(reinterpret_cast<char *>(buf), static_cast<std::streamsize>(len));
+    if (!f)
+        throw std::runtime_error("EncryptionOperator: " + label + " file too short: " + path);
+    if (sodium_mlock(buf, len) == -1)
+        throw std::runtime_error("EncryptionOperator: cannot lock memory for " + label);
+    valid = true;
+}
+
+static void LoadKeyFromHex(unsigned char *buf, size_t len, bool &valid, const std::string &hex,
+                           const std::string &label)
+{
+    HexDecode(hex, buf, len);
+    if (sodium_mlock(buf, len) == -1)
+        throw std::runtime_error("EncryptionOperator: cannot lock memory for " + label);
+    valid = true;
+}
+
+// Sealed session key: ephemeral public key (32 B) + encrypted key (32 B) + MAC (16 B).
+static constexpr size_t kSealedKeySize = crypto_box_SEALBYTES + crypto_secretbox_KEYBYTES;
 
 struct EncryptionOperator::EncryptImpl
 {
@@ -42,156 +74,39 @@ struct EncryptionOperator::EncryptImpl
     };
     Mode EncryptionMode = Mode::Symmetric;
 
-    // --- Symmetric mode ---
-    std::string KeyFilename;
-    unsigned char Key[crypto_secretbox_KEYBYTES] = {0};
+    unsigned char Key[crypto_secretbox_KEYBYTES] = {};
+    unsigned char PublicKey[crypto_box_PUBLICKEYBYTES] = {};
+    unsigned char SecretKey[crypto_box_SECRETKEYBYTES] = {};
     bool KeyValid = false;
-
-    // --- Asymmetric mode ---
-    unsigned char PublicKey[crypto_box_PUBLICKEYBYTES] = {0};
-    unsigned char SecretKey[crypto_box_SECRETKEYBYTES] = {0};
     bool PublicKeyValid = false;
     bool SecretKeyValid = false;
 
     ~EncryptImpl()
     {
-        sodium_munlock(this->Key, crypto_secretbox_KEYBYTES);
-        sodium_munlock(this->PublicKey, crypto_box_PUBLICKEYBYTES);
-        sodium_munlock(this->SecretKey, crypto_box_SECRETKEYBYTES);
+        sodium_munlock(Key, crypto_secretbox_KEYBYTES);
+        sodium_munlock(PublicKey, crypto_box_PUBLICKEYBYTES);
+        sodium_munlock(SecretKey, crypto_box_SECRETKEYBYTES);
     }
 
-    // --- Symmetric helpers ---
-
-    void GenerateOrReadKey()
+    // Read or generate the symmetric key at `filename` (generates if absent).
+    void GenerateOrReadKey(const std::string &filename)
     {
-        // if the key file already exists, we'll use that key,
-        // otherwise we'll generate one and write it out
-        std::fstream keyFile(this->KeyFilename.c_str());
-        if (keyFile)
+        std::fstream f(filename);
+        if (f)
         {
-            keyFile.read(reinterpret_cast<char *>(&this->Key), crypto_secretbox_KEYBYTES);
-            keyFile.close();
+            f.read(reinterpret_cast<char *>(Key), crypto_secretbox_KEYBYTES);
         }
         else
         {
-            keyFile.open(this->KeyFilename.c_str(), std::fstream::out);
-            if (!keyFile)
-            {
-                throw std::runtime_error("couldn't open file to write key");
-            }
-            crypto_secretbox_keygen(this->Key);
-            keyFile.write(reinterpret_cast<char *>(&this->Key), crypto_secretbox_KEYBYTES);
-            keyFile.close();
+            f.open(filename, std::fstream::out);
+            if (!f)
+                throw std::runtime_error("EncryptionOperator: cannot create key file: " + filename);
+            crypto_secretbox_keygen(Key);
+            f.write(reinterpret_cast<char *>(Key), crypto_secretbox_KEYBYTES);
         }
-
-        // lock the key to avoid swapping to disk
-        if (sodium_mlock(this->Key, crypto_secretbox_KEYBYTES) == -1)
-        {
-            throw std::runtime_error("Unable to lock memory location of secret key,"
-                                     " due to system limit on amount of memory that can be locked "
-                                     "by a process.");
-        }
-        this->KeyValid = true;
-    }
-
-    // --- Asymmetric helpers ---
-
-    void ReadPublicKey(const std::string &filename)
-    {
-        std::ifstream keyFile(filename, std::ios::binary);
-        if (!keyFile)
-        {
-            throw std::runtime_error("EncryptionOperator: could not open public key file: " +
-                                     filename);
-        }
-        keyFile.read(reinterpret_cast<char *>(this->PublicKey), crypto_box_PUBLICKEYBYTES);
-        if (!keyFile)
-        {
-            throw std::runtime_error("EncryptionOperator: public key file is too short: " +
-                                     filename);
-        }
-        keyFile.close();
-        if (sodium_mlock(this->PublicKey, crypto_box_PUBLICKEYBYTES) == -1)
-        {
-            throw std::runtime_error("EncryptionOperator: unable to lock memory for public key");
-        }
-        this->PublicKeyValid = true;
-    }
-
-    void SetPublicKeyHex(const std::string &hex)
-    {
-        HexDecode(hex, this->PublicKey, crypto_box_PUBLICKEYBYTES);
-        if (sodium_mlock(this->PublicKey, crypto_box_PUBLICKEYBYTES) == -1)
-        {
-            throw std::runtime_error("EncryptionOperator: unable to lock memory for public key");
-        }
-        this->PublicKeyValid = true;
-    }
-
-    void ReadSecretKey(const std::string &filename)
-    {
-        std::ifstream keyFile(filename, std::ios::binary);
-        if (!keyFile)
-        {
-            throw std::runtime_error("EncryptionOperator: could not open secret key file: " +
-                                     filename);
-        }
-        keyFile.read(reinterpret_cast<char *>(this->SecretKey), crypto_box_SECRETKEYBYTES);
-        if (!keyFile)
-        {
-            throw std::runtime_error("EncryptionOperator: secret key file is too short: " +
-                                     filename);
-        }
-        keyFile.close();
-        if (sodium_mlock(this->SecretKey, crypto_box_SECRETKEYBYTES) == -1)
-        {
-            throw std::runtime_error("EncryptionOperator: unable to lock memory for secret key");
-        }
-        this->SecretKeyValid = true;
-    }
-
-    void SetSecretKeyHex(const std::string &hex)
-    {
-        HexDecode(hex, this->SecretKey, crypto_box_SECRETKEYBYTES);
-        if (sodium_mlock(this->SecretKey, crypto_box_SECRETKEYBYTES) == -1)
-        {
-            throw std::runtime_error("EncryptionOperator: unable to lock memory for secret key");
-        }
-        this->SecretKeyValid = true;
-    }
-
-    // --- Symmetric key helpers (read-only, no generate) ---
-
-    void ReadSymKey(const std::string &filename)
-    {
-        std::ifstream keyFile(filename, std::ios::binary);
-        if (!keyFile)
-        {
-            throw std::runtime_error("EncryptionOperator: could not open symmetric key file: " +
-                                     filename);
-        }
-        keyFile.read(reinterpret_cast<char *>(this->Key), crypto_secretbox_KEYBYTES);
-        if (!keyFile)
-        {
-            throw std::runtime_error("EncryptionOperator: symmetric key file is too short: " +
-                                     filename);
-        }
-        keyFile.close();
-        if (sodium_mlock(this->Key, crypto_secretbox_KEYBYTES) == -1)
-        {
-            throw std::runtime_error("EncryptionOperator: unable to lock memory for symmetric key");
-        }
-        this->KeyValid = true;
-    }
-
-    void SetSymKeyHex(const std::string &hex)
-    {
-        HexDecode(hex, this->Key, crypto_secretbox_KEYBYTES);
-        if (sodium_mlock(this->Key, crypto_secretbox_KEYBYTES) == -1)
-        {
-            throw std::runtime_error("EncryptionOperator: unable to lock memory for symmetric key");
-        }
-        this->KeyValid = true;
+        if (sodium_mlock(Key, crypto_secretbox_KEYBYTES) == -1)
+            throw std::runtime_error("EncryptionOperator: cannot lock memory for symmetric key");
+        KeyValid = true;
     }
 };
 
@@ -199,87 +114,78 @@ EncryptionOperator::EncryptionOperator(const Params &parameters)
 : PluginOperatorInterface(parameters), Impl(new EncryptImpl)
 {
     if (sodium_init() < 0)
-    {
-        throw std::runtime_error("libsodium could not be initialized");
-    }
+        throw std::runtime_error("EncryptionOperator: libsodium initialization failed");
 
-    // Env vars for key loading (read once for both mode detection and loading).
-    // Asymmetric public key:  ADIOS2_PUBLIC_KEY_FILE (file) / ADIOS2_PUBLIC_KEY (hex).
-    // Asymmetric secret key:  ADIOS2_ASYM_SECRET_KEY_FILE (file) / ADIOS2_ASYM_SECRET_KEY (hex).
-    //   Setting any asymmetric env var triggers asymmetric mode.
-    //   If no public key is provided the public key is derived from the secret key.
-    // Symmetric: ADIOS2_SECRET_KEY (hex).
-    const char *envPKFile = std::getenv("ADIOS2_PUBLIC_KEY_FILE");
-    const char *envPKHex = std::getenv("ADIOS2_PUBLIC_KEY");
-    const char *envASKFile = std::getenv("ADIOS2_ASYM_SECRET_KEY_FILE");
-    const char *envASKHex = std::getenv("ADIOS2_ASYM_SECRET_KEY");
-    const char *envSKHex = std::getenv("ADIOS2_SECRET_KEY");
+    const auto envPKFile = Env(std::getenv("ADIOS2_PUBLIC_KEY_FILE"));
+    const auto envPKHex = Env(std::getenv("ADIOS2_PUBLIC_KEY"));
+    const auto envASKFile = Env(std::getenv("ADIOS2_ASYM_SECRET_KEY_FILE"));
+    const auto envASKHex = Env(std::getenv("ADIOS2_ASYM_SECRET_KEY"));
+    const auto envSKHex = Env(std::getenv("ADIOS2_SECRET_KEY"));
 
-    auto pkFileIt = m_Parameters.find("publickeyfile");
-    auto pkHexIt = m_Parameters.find("publickey");
-    auto skFileIt = m_Parameters.find("secretkeyfile");
-    auto skHexIt = m_Parameters.find("secretkey");
-    auto modeParamIt = m_Parameters.find("mode");
+    const auto end = m_Parameters.end();
+    const auto pkFile = m_Parameters.find("publickeyfile");
+    const auto pkHex = m_Parameters.find("publickey");
+    const auto skFile = m_Parameters.find("secretkeyfile");
+    const auto skHex = m_Parameters.find("secretkey");
+    const auto modeIt = m_Parameters.find("mode");
 
-    // Mode detection: any asym env var → mode param → public key param presence.
-    bool hasAsymEnv = (envPKFile && envPKFile[0] != '\0') || (envPKHex && envPKHex[0] != '\0') ||
-                      (envASKFile && envASKFile[0] != '\0') || (envASKHex && envASKHex[0] != '\0');
-    bool hasPKParam = pkFileIt != m_Parameters.end() || pkHexIt != m_Parameters.end();
-    bool hasModeParam = modeParamIt != m_Parameters.end() && modeParamIt->second == "asymmetric";
-    bool isAsymmetric = hasAsymEnv || hasPKParam || hasModeParam;
+    const bool hasAsymEnv = envPKFile || envPKHex || envASKFile || envASKHex;
+    const bool isAsymmetric = hasAsymEnv || pkFile != end || pkHex != end ||
+                              (modeIt != end && modeIt->second == "asymmetric");
 
     if (isAsymmetric)
     {
         Impl->EncryptionMode = EncryptImpl::Mode::Asymmetric;
 
-        // Load public key: env file → env hex → param file → param hex.
-        if (envPKFile && envPKFile[0] != '\0')
-            Impl->ReadPublicKey(std::string(envPKFile));
-        else if (envPKHex && envPKHex[0] != '\0')
-            Impl->SetPublicKeyHex(std::string(envPKHex));
-        else if (pkFileIt != m_Parameters.end())
-            Impl->ReadPublicKey(pkFileIt->second);
-        else if (pkHexIt != m_Parameters.end())
-            Impl->SetPublicKeyHex(pkHexIt->second);
+        // Public key: env file → env hex → param file → param hex.
+        if (envPKFile)
+            LoadKeyFromFile(Impl->PublicKey, crypto_box_PUBLICKEYBYTES, Impl->PublicKeyValid,
+                            std::string(*envPKFile), "public key");
+        else if (envPKHex)
+            LoadKeyFromHex(Impl->PublicKey, crypto_box_PUBLICKEYBYTES, Impl->PublicKeyValid,
+                           std::string(*envPKHex), "public key");
+        else if (pkFile != end)
+            LoadKeyFromFile(Impl->PublicKey, crypto_box_PUBLICKEYBYTES, Impl->PublicKeyValid,
+                            pkFile->second, "public key");
+        else if (pkHex != end)
+            LoadKeyFromHex(Impl->PublicKey, crypto_box_PUBLICKEYBYTES, Impl->PublicKeyValid,
+                           pkHex->second, "public key");
 
-        // Load secret key: env file → env hex → param file → param hex.
-        if (envASKFile && envASKFile[0] != '\0')
-            Impl->ReadSecretKey(std::string(envASKFile));
-        else if (envASKHex && envASKHex[0] != '\0')
-            Impl->SetSecretKeyHex(std::string(envASKHex));
-        else if (skFileIt != m_Parameters.end())
-            Impl->ReadSecretKey(skFileIt->second);
-        else if (skHexIt != m_Parameters.end())
-            Impl->SetSecretKeyHex(skHexIt->second);
+        // Secret key: env file → env hex → param file → param hex.
+        if (envASKFile)
+            LoadKeyFromFile(Impl->SecretKey, crypto_box_SECRETKEYBYTES, Impl->SecretKeyValid,
+                            std::string(*envASKFile), "secret key");
+        else if (envASKHex)
+            LoadKeyFromHex(Impl->SecretKey, crypto_box_SECRETKEYBYTES, Impl->SecretKeyValid,
+                           std::string(*envASKHex), "secret key");
+        else if (skFile != end)
+            LoadKeyFromFile(Impl->SecretKey, crypto_box_SECRETKEYBYTES, Impl->SecretKeyValid,
+                            skFile->second, "secret key");
+        else if (skHex != end)
+            LoadKeyFromHex(Impl->SecretKey, crypto_box_SECRETKEYBYTES, Impl->SecretKeyValid,
+                           skHex->second, "secret key");
 
         // Derive public key from secret key when only the secret key was provided.
         if (Impl->SecretKeyValid && !Impl->PublicKeyValid)
         {
             if (crypto_scalarmult_base(Impl->PublicKey, Impl->SecretKey) != 0)
-            {
-                throw std::runtime_error(
-                    "EncryptionOperator: failed to derive public key from secret key");
-            }
+                throw std::runtime_error("EncryptionOperator: public key derivation failed");
             if (sodium_mlock(Impl->PublicKey, crypto_box_PUBLICKEYBYTES) == -1)
-            {
-                throw std::runtime_error(
-                    "EncryptionOperator: unable to lock memory for public key");
-            }
+                throw std::runtime_error("EncryptionOperator: cannot lock memory for public key");
             Impl->PublicKeyValid = true;
         }
     }
     else
     {
-        // Symmetric mode: env hex → param file (with generate) → param hex.
-        if (envSKHex && envSKHex[0] != '\0')
-            Impl->SetSymKeyHex(std::string(envSKHex));
-        else if (skFileIt != m_Parameters.end())
-        {
-            Impl->KeyFilename = skFileIt->second;
-            Impl->GenerateOrReadKey();
-        }
-        else if (skHexIt != m_Parameters.end())
-            Impl->SetSymKeyHex(skHexIt->second);
+        // Symmetric: env hex → param file (generates if absent) → param hex.
+        if (envSKHex)
+            LoadKeyFromHex(Impl->Key, crypto_secretbox_KEYBYTES, Impl->KeyValid,
+                           std::string(*envSKHex), "symmetric key");
+        else if (skFile != end)
+            Impl->GenerateOrReadKey(skFile->second);
+        else if (skHex != end)
+            LoadKeyFromHex(Impl->Key, crypto_secretbox_KEYBYTES, Impl->KeyValid, skHex->second,
+                           "symmetric key");
     }
 }
 
@@ -287,7 +193,6 @@ EncryptionOperator::~EncryptionOperator() {}
 
 #if defined(__clang__)
 #if __has_feature(memory_sanitizer)
-// Memory Sanitizer has an issue with some libsodium calls.
 __attribute__((no_sanitize("memory")))
 #endif
 #endif
@@ -295,181 +200,109 @@ size_t
 EncryptionOperator::Operate(const char *dataIn, const Dims &blockStart, const Dims &blockCount,
                             const DataType type, char *bufferOut)
 {
+    size_t offset = 0;
+    const size_t sizeIn = GetTotalSize(blockCount, GetDataTypeSize(type));
+    PutParameter(bufferOut, offset, sizeIn);
+
     if (Impl->EncryptionMode == EncryptImpl::Mode::Asymmetric)
     {
         if (!Impl->PublicKeyValid)
-        {
-            throw std::runtime_error("EncryptionOperator::Operate (asymmetric) was called, but"
-                                     " a valid public key has not been loaded. "
-                                     "Did you add the PublicKeyFile"
-                                     " param when setting up the operator?");
-        }
+            throw std::runtime_error(
+                "EncryptionOperator: no public key for encryption. "
+                "Set ADIOS2_PUBLIC_KEY_FILE, ADIOS2_PUBLIC_KEY, or PublicKeyFile param.");
 
-        size_t offset = 0;
-
-        // 1. Write original data size.
-        size_t sizeIn = GetTotalSize(blockCount, GetDataTypeSize(type));
-        PutParameter(bufferOut, offset, sizeIn);
-
-        // 2. Generate random session key and seal it with the public key.
         unsigned char sessionKey[crypto_secretbox_KEYBYTES];
         crypto_secretbox_keygen(sessionKey);
 
-        const size_t sealedKeySize = crypto_box_SEALBYTES + crypto_secretbox_KEYBYTES;
-        unsigned char *sealedKey = reinterpret_cast<unsigned char *>(bufferOut + offset);
-        crypto_box_seal(sealedKey, sessionKey, crypto_secretbox_KEYBYTES, Impl->PublicKey);
-        offset += sealedKeySize;
+        crypto_box_seal(reinterpret_cast<unsigned char *>(bufferOut + offset), sessionKey,
+                        crypto_secretbox_KEYBYTES, Impl->PublicKey);
+        offset += kSealedKeySize;
 
-        // 3. Generate random nonce.
-        unsigned char *nonce = reinterpret_cast<unsigned char *>(bufferOut + offset);
+        auto *nonce = reinterpret_cast<unsigned char *>(bufferOut + offset);
         randombytes_buf(nonce, crypto_secretbox_NONCEBYTES);
         offset += crypto_secretbox_NONCEBYTES;
 
-        // 4. Encrypt data with session key.
-        size_t cipherTextSize = sizeIn + crypto_secretbox_MACBYTES;
-        unsigned char *cipherText = reinterpret_cast<unsigned char *>(bufferOut + offset);
-        crypto_secretbox_easy(cipherText, reinterpret_cast<const unsigned char *>(dataIn), sizeIn,
-                              nonce, sessionKey);
-        offset += cipherTextSize;
-
-        // 5. Wipe session key from memory.
+        crypto_secretbox_easy(reinterpret_cast<unsigned char *>(bufferOut + offset),
+                              reinterpret_cast<const unsigned char *>(dataIn), sizeIn, nonce,
+                              sessionKey);
+        offset += sizeIn + crypto_secretbox_MACBYTES;
         sodium_memzero(sessionKey, crypto_secretbox_KEYBYTES);
-
-        return offset;
     }
     else
     {
         if (!Impl->KeyValid)
-        {
-            throw std::runtime_error("EncryptionOperator::Operate was called, but"
-                                     " a valid secret key has not been generated. "
-                                     "Did you add the SecretKeyFile"
-                                     " param when setting up the operator?");
-        }
+            throw std::runtime_error("EncryptionOperator: no symmetric key for encryption. "
+                                     "Set ADIOS2_SECRET_KEY or SecretKeyFile param.");
 
-        // offset for writing into bufferOut
-        size_t offset = 0;
-
-        // write any parameters we need to save for the InverseOperate() call
-        // In this case, we just write out the size of the data
-        size_t sizeIn = GetTotalSize(blockCount, GetDataTypeSize(type));
-        PutParameter(bufferOut, offset, sizeIn);
-
-        // create the nonce directly in the output buffer, since we'll need it for
-        // decryption
-        unsigned char *nonce = reinterpret_cast<unsigned char *>(bufferOut + offset);
+        auto *nonce = reinterpret_cast<unsigned char *>(bufferOut + offset);
         randombytes_buf(nonce, crypto_secretbox_NONCEBYTES);
         offset += crypto_secretbox_NONCEBYTES;
 
-        // encrypt data directly into the output buffer
-        size_t cipherTextSize = sizeIn + crypto_secretbox_MACBYTES;
-        unsigned char *cipherText = reinterpret_cast<unsigned char *>(bufferOut + offset);
-        crypto_secretbox_easy(cipherText, reinterpret_cast<const unsigned char *>(dataIn), sizeIn,
-                              nonce, Impl->Key);
-        offset += cipherTextSize;
-
-        // need to return the size of data in the buffer
-        return offset;
+        crypto_secretbox_easy(reinterpret_cast<unsigned char *>(bufferOut + offset),
+                              reinterpret_cast<const unsigned char *>(dataIn), sizeIn, nonce,
+                              Impl->Key);
+        offset += sizeIn + crypto_secretbox_MACBYTES;
     }
+
+    return offset;
 }
 
 #if defined(__clang__)
 #if __has_feature(memory_sanitizer)
-// Memory Sanitizer has an issue with some libsodium calls.
 __attribute__((no_sanitize("memory")))
 #endif
 #endif
 size_t
 EncryptionOperator::InverseOperate(const char *bufferIn, const size_t sizeIn, char *dataOut)
 {
+    size_t offset = 0;
+    const size_t dataBytes = GetParameter<size_t>(bufferIn, offset);
+
     if (Impl->EncryptionMode == EncryptImpl::Mode::Asymmetric)
     {
         if (!Impl->PublicKeyValid || !Impl->SecretKeyValid)
-        {
-            throw std::runtime_error(
-                "EncryptionOperator::InverseOperate (asymmetric) was called, but"
-                " valid public and secret keys have not been loaded. "
-                "Set PublicKeyFile/SecretKeyFile params, or set"
-                " ADIOS2_SECRET_KEY_FILE or ADIOS2_SECRET_KEY env var.");
-        }
+            throw std::runtime_error("EncryptionOperator: no key pair for decryption. "
+                                     "Set ADIOS2_ASYM_SECRET_KEY_FILE or ADIOS2_ASYM_SECRET_KEY.");
 
-        size_t offset = 0;
-
-        // 1. Read original data size.
-        const size_t dataBytes = GetParameter<size_t>(bufferIn, offset);
-
-        // 2. Unseal the session key.
-        const size_t sealedKeySize = crypto_box_SEALBYTES + crypto_secretbox_KEYBYTES;
-        const unsigned char *sealedKey = reinterpret_cast<const unsigned char *>(bufferIn + offset);
-        offset += sealedKeySize;
+        const auto *sealedKey = reinterpret_cast<const unsigned char *>(bufferIn + offset);
+        offset += kSealedKeySize;
 
         unsigned char sessionKey[crypto_secretbox_KEYBYTES];
-        if (crypto_box_seal_open(sessionKey, sealedKey, sealedKeySize, Impl->PublicKey,
+        if (crypto_box_seal_open(sessionKey, sealedKey, kSealedKeySize, Impl->PublicKey,
                                  Impl->SecretKey) != 0)
-        {
             throw std::runtime_error("EncryptionOperator: failed to unseal session key. "
                                      "Wrong key pair?");
-        }
 
-        // 3. Read nonce.
-        const unsigned char *nonce = reinterpret_cast<const unsigned char *>(bufferIn + offset);
+        const auto *nonce = reinterpret_cast<const unsigned char *>(bufferIn + offset);
         offset += crypto_secretbox_NONCEBYTES;
 
-        // 4. Decrypt data.
-        size_t cipherTextSize = dataBytes + crypto_secretbox_MACBYTES;
-        const unsigned char *cipherText =
-            reinterpret_cast<const unsigned char *>(bufferIn + offset);
-        offset += cipherTextSize;
-
-        if (crypto_secretbox_open_easy(reinterpret_cast<unsigned char *>(dataOut), cipherText,
+        const size_t cipherTextSize = dataBytes + crypto_secretbox_MACBYTES;
+        if (crypto_secretbox_open_easy(reinterpret_cast<unsigned char *>(dataOut),
+                                       reinterpret_cast<const unsigned char *>(bufferIn + offset),
                                        cipherTextSize, nonce, sessionKey) != 0)
         {
             sodium_memzero(sessionKey, crypto_secretbox_KEYBYTES);
-            throw std::runtime_error(
-                "EncryptionOperator: asymmetric decryption failed, message forged!");
+            throw std::runtime_error("message forged!");
         }
-
-        // 5. Wipe session key.
         sodium_memzero(sessionKey, crypto_secretbox_KEYBYTES);
-
-        return dataBytes;
     }
     else
     {
         if (!Impl->KeyValid)
-        {
-            throw std::runtime_error(
-                "EncryptionOperator::InverseOperate (symmetric) was called, but"
-                " a valid secret key has not been loaded. "
-                "Set SecretKeyFile/SecretKey param, or set"
-                " ADIOS2_SECRET_KEY_FILE or ADIOS2_SECRET_KEY env var.");
-        }
+            throw std::runtime_error("EncryptionOperator: no symmetric key for decryption. "
+                                     "Set ADIOS2_SECRET_KEY or SecretKeyFile param.");
 
-        size_t offset = 0;
-
-        // need to grab any parameter(s) we saved in Operate()
-        const size_t dataBytes = GetParameter<size_t>(bufferIn, offset);
-
-        // grab the nonce ptr
-        const unsigned char *nonce = reinterpret_cast<const unsigned char *>(bufferIn + offset);
+        const auto *nonce = reinterpret_cast<const unsigned char *>(bufferIn + offset);
         offset += crypto_secretbox_NONCEBYTES;
 
-        // grab the cipher text ptr
-        size_t cipherTextSize = dataBytes + crypto_secretbox_MACBYTES;
-        const unsigned char *cipherText =
-            reinterpret_cast<const unsigned char *>(bufferIn + offset);
-        offset += cipherTextSize;
-
-        // decrypt directly into dataOut buffer
-        if (crypto_secretbox_open_easy(reinterpret_cast<unsigned char *>(dataOut), cipherText,
+        const size_t cipherTextSize = dataBytes + crypto_secretbox_MACBYTES;
+        if (crypto_secretbox_open_easy(reinterpret_cast<unsigned char *>(dataOut),
+                                       reinterpret_cast<const unsigned char *>(bufferIn + offset),
                                        cipherTextSize, nonce, Impl->Key) != 0)
-        {
             throw std::runtime_error("message forged!");
-        }
-
-        // return the size of the data
-        return dataBytes;
     }
+
+    return dataBytes;
 }
 
 bool EncryptionOperator::IsDataTypeValid(const DataType type) const { return true; }
@@ -477,25 +310,16 @@ bool EncryptionOperator::IsDataTypeValid(const DataType type) const { return tru
 size_t EncryptionOperator::GetEstimatedSize(const size_t ElemCount, const size_t ElemSize,
                                             const size_t ndims, const size_t *dims) const
 {
-    size_t sizeIn = ElemCount * ElemSize;
+    const size_t sizeIn = ElemCount * ElemSize;
     if (Impl->EncryptionMode == EncryptImpl::Mode::Asymmetric)
     {
-        return (sizeof(size_t)                                       // Data size
-                + (crypto_box_SEALBYTES + crypto_secretbox_KEYBYTES) // Sealed session key
-                + crypto_secretbox_NONCEBYTES                        // Nonce
-                + sizeIn                                             // Data
-                + crypto_secretbox_MACBYTES                          // MAC
-        );
+        return (sizeof(size_t)   // original data size
+                + kSealedKeySize // sealed session key
+                + crypto_secretbox_NONCEBYTES + sizeIn + crypto_secretbox_MACBYTES);
     }
-    else
-    {
-        return (sizeof(size_t)                // Data size
-                + crypto_secretbox_NONCEBYTES // Nonce
-                + sizeIn                      // Data
-                + crypto_secretbox_MACBYTES   // MAC
-        );
-    }
+    return (sizeof(size_t) + crypto_secretbox_NONCEBYTES + sizeIn + crypto_secretbox_MACBYTES);
 }
+
 } // end namespace plugin
 } // end namespace adios2
 

--- a/plugins/operators/EncryptionOperator.h
+++ b/plugins/operators/EncryptionOperator.h
@@ -16,33 +16,23 @@ namespace adios2
 namespace plugin
 {
 
-/** EncryptionOperator that uses libsodium. The encryption mode is determined
- * automatically by the parameters supplied.
+/** EncryptionOperator: libsodium-based encryption plugin.
  *
- * --- Symmetric mode (crypto_secretbox) ---
- * Activated when 'SecretKeyFile' is provided without any public-key params.
- * Both writer and reader must share the same secret key file.
+ * Mode is selected automatically. Setting any asymmetric env var or public-key
+ * parameter activates asymmetric mode; otherwise symmetric mode is used.
  *
- *   SecretKeyFile  - path to the secret key file; if the file does not exist
- *                    a new key is generated and written there.
+ * Symmetric (XSalsa20-Poly1305 / crypto_secretbox):
+ *   Key lookup: ADIOS2_SECRET_KEY env (hex) → SecretKeyFile param → SecretKey param.
+ *   SecretKeyFile generates a new key on first write if the file does not exist.
  *
- * --- Asymmetric mode (hybrid crypto_box_seal) ---
- * Activated when 'PublicKeyFile' or 'PublicKey' is provided. A random session
- * key is sealed with the recipient's Curve25519 public key; bulk data is
- * encrypted with that session key via crypto_secretbox. Only the public key
- * is needed for writing; both keys are needed for reading.
+ * Asymmetric (Curve25519 + XSalsa20-Poly1305 hybrid):
+ *   Writer needs the public key; reader needs the secret key.
+ *   Public key lookup:  ADIOS2_PUBLIC_KEY_FILE → ADIOS2_PUBLIC_KEY → PublicKeyFile → PublicKey
+ *   Secret key lookup:  ADIOS2_ASYM_SECRET_KEY_FILE → ADIOS2_ASYM_SECRET_KEY
+ *                       → SecretKeyFile → SecretKey
+ *   If only the secret key is supplied, the public key is derived automatically.
  *
- *   PublicKeyFile  - path to a 32-byte Curve25519 public key file
- *   PublicKey      - hex-encoded public key (64 hex chars)
- *   SecretKeyFile  - path to a 32-byte secret key file (reading only)
- *   SecretKey      - hex-encoded secret key (64 hex chars, reading only)
- *
- * Secret key lookup order (asymmetric): SecretKeyFile param, SecretKey param,
- *   ADIOS2_SECRET_KEY_FILE env var, ADIOS2_SECRET_KEY env var.
- * When only the secret key is supplied, the public key is derived automatically
- * via Curve25519 (sk * basepoint).
- *
- * Use adios2_seal_keygen to generate asymmetric key pairs.
+ * Use adios2_seal_keygen to generate Curve25519 key pairs.
  */
 class EncryptionOperator : public PluginOperatorInterface
 {

--- a/testing/install/EncryptionOperator/CMakeLists.txt
+++ b/testing/install/EncryptionOperator/CMakeLists.txt
@@ -77,3 +77,25 @@ add_test(NAME adios_plugin_sealed_operator_wrong_usage_test
 )
 set_tests_properties(adios_plugin_sealed_operator_wrong_usage_test PROPERTIES
   DEPENDS adios_plugin_sealed_keygen_fixture)
+
+# Step 5: env var key loading tests (no key params on reader side)
+add_executable(adios_plugin_env_var_keys_test
+  TestEnvVarKeys.cpp
+)
+target_link_libraries(adios_plugin_env_var_keys_test adios2::cxx)
+add_test(NAME adios_plugin_env_var_keys_test
+  COMMAND adios_plugin_env_var_keys_test
+)
+set_tests_properties(adios_plugin_env_var_keys_test PROPERTIES
+  DEPENDS adios_plugin_sealed_keygen_fixture)
+
+# Step 6: reader mode selection from env vars
+add_executable(adios_plugin_reader_mode_from_env_test
+  TestReaderModeFromEnv.cpp
+)
+target_link_libraries(adios_plugin_reader_mode_from_env_test adios2::cxx)
+add_test(NAME adios_plugin_reader_mode_from_env_test
+  COMMAND adios_plugin_reader_mode_from_env_test
+)
+set_tests_properties(adios_plugin_reader_mode_from_env_test PROPERTIES
+  DEPENDS adios_plugin_sealed_keygen_fixture)

--- a/testing/install/EncryptionOperator/TestEnvVarKeys.cpp
+++ b/testing/install/EncryptionOperator/TestEnvVarKeys.cpp
@@ -1,0 +1,173 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Tests that EncryptionOperator loads keys via environment variables with no
+ * key parameters on the reader side.
+ *
+ * Env vars exercised:
+ *   ADIOS2_ASYM_SECRET_KEY_FILE  — asymmetric secret key, file path
+ *   ADIOS2_ASYM_SECRET_KEY       — asymmetric secret key, hex string
+ *   ADIOS2_SECRET_KEY            — symmetric secret key, hex string
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "adios2.h"
+
+// RAII: set env vars for the duration of a scope, then unset them.
+struct EnvGuard
+{
+    std::vector<std::string> Keys;
+    EnvGuard(std::initializer_list<std::pair<std::string, std::string>> vars)
+    {
+        for (auto &kv : vars)
+        {
+            setenv(kv.first.c_str(), kv.second.c_str(), 1);
+            Keys.push_back(kv.first);
+        }
+    }
+    ~EnvGuard()
+    {
+        for (auto &k : Keys)
+            unsetenv(k.c_str());
+    }
+};
+
+template <typename Fn>
+static bool Expect(const std::string &label, Fn fn)
+{
+    try
+    {
+        fn();
+        std::cout << "PASS [" << label << "]\n";
+        return true;
+    }
+    catch (std::exception &e)
+    {
+        std::cout << "FAIL [" << label << "]: " << e.what() << "\n";
+        return false;
+    }
+}
+
+static const std::vector<double> kData = []() {
+    std::vector<double> v(20);
+    std::iota(v.begin(), v.end(), 0.0);
+    return v;
+}();
+
+static adios2::Params PluginParams(const adios2::Params &extra = {})
+{
+    adios2::Params p;
+    p["PluginName"] = "Encryption";
+    p["PluginLibrary"] = "EncryptionOperator";
+    for (auto &kv : extra)
+        p[kv.first] = kv.second;
+    return p;
+}
+
+static void WriteWith(const std::string &bp, const adios2::Params &params)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("w_" + bp);
+    io.SetEngine("BPFile");
+    auto var = io.DefineVariable<double>("data", {}, {}, {kData.size()}, adios2::ConstantDims);
+    var.AddOperation("plugin", params);
+    auto eng = io.Open(bp, adios2::Mode::Write);
+    eng.BeginStep();
+    eng.Put<double>(var, kData.data());
+    eng.EndStep();
+    eng.Close();
+}
+
+// Read without providing any key parameters — relies entirely on env vars.
+static void ReadNoKeyParams(const std::string &bp)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("r_" + bp);
+    auto eng = io.Open(bp, adios2::Mode::Read);
+    eng.BeginStep();
+    auto var = io.InquireVariable<double>("data");
+    std::vector<double> result;
+    eng.Get<double>(var, result);
+    eng.PerformGets();
+    eng.EndStep();
+    eng.Close();
+    if (result != kData)
+        throw std::runtime_error("data mismatch after decryption");
+}
+
+int main()
+{
+    int failures = 0;
+
+    // -----------------------------------------------------------------------
+    // Symmetric: write with SecretKeyFile param, read with ADIOS2_SECRET_KEY
+    // -----------------------------------------------------------------------
+    // Use a sodium hex key (64 zeros = all-zero 32-byte key) just for the test.
+    // The writer uses the param to generate/store the key file; the env var
+    // provides the same key to the reader as a hex string.
+    const std::string kSymKeyHex(64, '0'); // 32 zero bytes in hex
+
+    failures += !Expect("SymWrite", [&] {
+        // Write with an explicit hex key via param.
+        WriteWith("testSymEnvVar.bp", PluginParams({{"SecretKey", kSymKeyHex}}));
+    });
+    failures += !Expect("SymReadEnvHex", [&] {
+        EnvGuard env{{"ADIOS2_SECRET_KEY", kSymKeyHex}};
+        ReadNoKeyParams("testSymEnvVar.bp");
+    });
+
+    // -----------------------------------------------------------------------
+    // Asymmetric: write with PublicKeyFile param, read with
+    // ADIOS2_ASYM_SECRET_KEY_FILE (no public key param needed on reader side)
+    // -----------------------------------------------------------------------
+    failures += !Expect("AsymWrite", [&] {
+        WriteWith("testAsymEnvFile.bp", PluginParams({{"PublicKeyFile", "test-public.key"}}));
+    });
+    failures += !Expect("AsymReadEnvFile", [&] {
+        EnvGuard env{{"ADIOS2_ASYM_SECRET_KEY_FILE", "test-secret.key"}};
+        ReadNoKeyParams("testAsymEnvFile.bp");
+    });
+
+    // -----------------------------------------------------------------------
+    // Asymmetric: writer uses ADIOS2_PUBLIC_KEY_FILE env var (no param),
+    // reader uses ADIOS2_ASYM_SECRET_KEY_FILE env var (no param)
+    // -----------------------------------------------------------------------
+    failures += !Expect("AsymWriteEnvPKFile", [&] {
+        EnvGuard env{{"ADIOS2_PUBLIC_KEY_FILE", "test-public.key"}};
+        WriteWith("testAsymWriteEnvPK.bp", PluginParams());
+    });
+    failures += !Expect("AsymReadEnvSKFile", [&] {
+        EnvGuard env{{"ADIOS2_ASYM_SECRET_KEY_FILE", "test-secret.key"}};
+        ReadNoKeyParams("testAsymWriteEnvPK.bp");
+    });
+
+    // -----------------------------------------------------------------------
+    // Asymmetric: write and read using ADIOS2_ASYM_SECRET_KEY_FILE only —
+    // the public key is derived from the secret key on both sides.
+    // -----------------------------------------------------------------------
+    failures += !Expect("AsymWriteDerivedPK", [&] {
+        EnvGuard env{{"ADIOS2_ASYM_SECRET_KEY_FILE", "test-secret.key"}};
+        WriteWith("testAsymDerived.bp", PluginParams());
+    });
+    failures += !Expect("AsymReadDerivedPK", [&] {
+        EnvGuard env{{"ADIOS2_ASYM_SECRET_KEY_FILE", "test-secret.key"}};
+        ReadNoKeyParams("testAsymDerived.bp");
+    });
+
+    if (failures == 0)
+    {
+        std::cout << "All env-var key tests passed.\n";
+        return EXIT_SUCCESS;
+    }
+    std::cout << failures << " env-var key test(s) failed.\n";
+    return EXIT_FAILURE;
+}

--- a/testing/install/EncryptionOperator/TestReaderModeFromEnv.cpp
+++ b/testing/install/EncryptionOperator/TestReaderModeFromEnv.cpp
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Verifies that the reader selects asymmetric or symmetric mode purely from
+ * env vars when no operator parameters are given on the read side.
+ *
+ * Setting ADIOS2_ASYM_* triggers asymmetric mode.
+ * Setting only ADIOS2_SECRET_KEY with no asym indicators triggers symmetric.
+ * Using the wrong mode's env vars causes a decryption failure.
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "adios2.h"
+
+struct EnvGuard
+{
+    std::vector<std::string> Keys;
+    EnvGuard(std::initializer_list<std::pair<std::string, std::string>> vars)
+    {
+        for (auto &kv : vars)
+        {
+            setenv(kv.first.c_str(), kv.second.c_str(), 1);
+            Keys.push_back(kv.first);
+        }
+    }
+    ~EnvGuard()
+    {
+        for (auto &k : Keys)
+            unsetenv(k.c_str());
+    }
+};
+
+template <typename Fn>
+static bool Expect(const std::string &label, bool shouldPass, Fn fn)
+{
+    try
+    {
+        fn();
+        if (shouldPass)
+        {
+            std::cout << "PASS [" << label << "]\n";
+            return true;
+        }
+        std::cout << "FAIL [" << label << "]: expected exception but none thrown\n";
+        return false;
+    }
+    catch (std::exception &e)
+    {
+        if (!shouldPass)
+        {
+            std::cout << "PASS [" << label << "]: " << e.what() << "\n";
+            return true;
+        }
+        std::cout << "FAIL [" << label << "]: unexpected exception: " << e.what() << "\n";
+        return false;
+    }
+}
+
+static const std::vector<double> kData = []() {
+    std::vector<double> v(20);
+    std::iota(v.begin(), v.end(), 0.0);
+    return v;
+}();
+
+static void WriteWith(const std::string &bp, const adios2::Params &params)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("w_" + bp);
+    io.SetEngine("BPFile");
+    auto var = io.DefineVariable<double>("data", {}, {}, {kData.size()}, adios2::ConstantDims);
+    var.AddOperation("plugin", params);
+    auto eng = io.Open(bp, adios2::Mode::Write);
+    eng.BeginStep();
+    eng.Put<double>(var, kData.data());
+    eng.EndStep();
+    eng.Close();
+}
+
+// Read with no operator params — relies on stored metadata + env vars.
+static void ReadNoKeyParams(const std::string &bp)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("r_" + bp);
+    auto eng = io.Open(bp, adios2::Mode::Read);
+    eng.BeginStep();
+    auto var = io.InquireVariable<double>("data");
+    std::vector<double> result;
+    eng.Get<double>(var, result);
+    eng.PerformGets();
+    eng.EndStep();
+    eng.Close();
+    if (result != kData)
+        throw std::runtime_error("data mismatch after decryption");
+}
+
+int main()
+{
+    int failures = 0;
+    const std::string kSymKeyHex(64, 'a'); // 32 x 0xaa bytes
+
+    // Setup: write a sym file and an asym file.
+    adios2::Params symWriteParams;
+    symWriteParams["PluginName"] = "Encryption";
+    symWriteParams["PluginLibrary"] = "EncryptionOperator";
+    symWriteParams["SecretKey"] = kSymKeyHex;
+
+    adios2::Params asymWriteParams;
+    asymWriteParams["PluginName"] = "Encryption";
+    asymWriteParams["PluginLibrary"] = "EncryptionOperator";
+    asymWriteParams["PublicKeyFile"] = "test-public.key";
+
+    try
+    {
+        WriteWith("testModeSelectSym.bp", symWriteParams);
+        WriteWith("testModeSelectAsym.bp", asymWriteParams);
+    }
+    catch (std::exception &e)
+    {
+        std::cout << "FATAL (write): " << e.what() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    // PASS: sym data, sym env var → sym mode selected, decryption succeeds.
+    failures += !Expect("SymDataEnvSym", true, [&] {
+        EnvGuard env{{"ADIOS2_SECRET_KEY", kSymKeyHex}};
+        ReadNoKeyParams("testModeSelectSym.bp");
+    });
+
+    // PASS: asym data, asym env var → asym mode selected, decryption succeeds.
+    failures += !Expect("AsymDataEnvAsym", true, [&] {
+        EnvGuard env{{"ADIOS2_ASYM_SECRET_KEY_FILE", "test-secret.key"}};
+        ReadNoKeyParams("testModeSelectAsym.bp");
+    });
+
+    // FAIL: sym data, asym env var → asym mode selected, sym data format mismatch.
+    failures += !Expect("SymDataEnvAsym", false, [&] {
+        EnvGuard env{{"ADIOS2_ASYM_SECRET_KEY_FILE", "test-secret.key"}};
+        ReadNoKeyParams("testModeSelectSym.bp");
+    });
+
+    // FAIL: asym data, sym env var → asym mode from stored metadata (PublicKeyFile),
+    //       sym env var not used for asym secret key → no secret key loaded.
+    failures += !Expect("AsymDataEnvSym", false, [&] {
+        EnvGuard env{{"ADIOS2_SECRET_KEY", kSymKeyHex}};
+        ReadNoKeyParams("testModeSelectAsym.bp");
+    });
+
+    if (failures == 0)
+    {
+        std::cout << "All reader-mode-from-env tests passed.\n";
+        return EXIT_SUCCESS;
+    }
+    std::cout << failures << " reader-mode-from-env test(s) failed.\n";
+    return EXIT_FAILURE;
+}

--- a/testing/install/EncryptionOperator/TestSealedOperatorWrongUsage.cpp
+++ b/testing/install/EncryptionOperator/TestSealedOperatorWrongUsage.cpp
@@ -4,12 +4,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <numeric>
 #include <string>
 #include <vector>
 
 #include "adios2.h"
+
+// RAII: set env vars for the duration of a scope, then unset them.
+struct EnvGuard
+{
+    std::vector<std::string> Keys;
+    EnvGuard(std::initializer_list<std::pair<std::string, std::string>> vars)
+    {
+        for (auto &kv : vars)
+        {
+            setenv(kv.first.c_str(), kv.second.c_str(), 1);
+            Keys.push_back(kv.first);
+        }
+    }
+    ~EnvGuard()
+    {
+        for (auto &k : Keys)
+            unsetenv(k.c_str());
+    }
+};
 
 template <typename Fn>
 static bool ExpectThrow(const std::string &label, Fn fn)
@@ -39,6 +61,16 @@ static adios2::Params AsymParams(const std::string &pk_file = "", const std::str
         p["PublicKey"] = pk_hex;
     if (!sk_file.empty())
         p["SecretKeyFile"] = sk_file;
+    if (!sk_hex.empty())
+        p["SecretKey"] = sk_hex;
+    return p;
+}
+
+static adios2::Params SymParams(const std::string &sk_hex = "")
+{
+    adios2::Params p;
+    p["PluginName"] = "Encryption";
+    p["PluginLibrary"] = "EncryptionOperator";
     if (!sk_hex.empty())
         p["SecretKey"] = sk_hex;
     return p;
@@ -104,23 +136,70 @@ static void ReadEncrypted(const std::string &file, const adios2::Params &params)
     reader.Close();
 }
 
+// Read a 32-byte binary key file and return its hex representation (64 chars).
+static std::string KeyFileToHex(const std::string &path)
+{
+    std::ifstream f(path, std::ios::binary);
+    if (!f)
+        throw std::runtime_error("KeyFileToHex: cannot open " + path);
+    std::vector<unsigned char> b(32);
+    f.read(reinterpret_cast<char *>(b.data()), 32);
+    std::string hex;
+    char buf[3];
+    for (auto byte : b)
+    {
+        snprintf(buf, sizeof(buf), "%02x", byte);
+        hex += buf;
+    }
+    return hex;
+}
+
 int main()
 {
     int failures = 0;
     const std::string kValidBP = "testSealedWrongUsage.bp";
+    const std::string kValidSymBP = "testSymWrongUsage.bp";
     const std::string kZeros64(64, '0');
+    const std::string kSymKeyHex(64, 'a'); // 32 x 0xaa bytes
 
+    // Setup: write an asym-encrypted file and a sym-encrypted file.
     try
     {
         WriteEncrypted(kValidBP, AsymParams("test-public.key"));
     }
     catch (std::exception &e)
     {
-        std::cout << "FATAL: " << e.what() << "\n";
+        std::cout << "FATAL (asym write): " << e.what() << "\n";
+        return EXIT_FAILURE;
+    }
+    try
+    {
+        WriteEncrypted(kValidSymBP, SymParams(kSymKeyHex));
+    }
+    catch (std::exception &e)
+    {
+        std::cout << "FATAL (sym write): " << e.what() << "\n";
         return EXIT_FAILURE;
     }
 
-    // Read-side decryption errors (exceptions from InverseOperate, not constructor)
+    // Read the test keys as hex for priority ordering tests.
+    // Priority tests work by supplying a WRONG value at a higher-priority source
+    // and a CORRECT value at a lower-priority source; decryption must fail,
+    // proving the higher-priority source was used.
+    std::string correctSKHex, correctPKHex;
+    try
+    {
+        correctSKHex = KeyFileToHex("test-secret.key");
+        correctPKHex = KeyFileToHex("test-public.key");
+    }
+    catch (std::exception &e)
+    {
+        std::cout << "FATAL (key hex): " << e.what() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    // --- Existing wrong-usage tests ---
+
     failures += !ExpectThrow("ReadWithNoSecretKey", [&] { ReadEncrypted(kValidBP, {}); });
 
     failures += !ExpectThrow("ReadWithWrongSecretKey", [&] {
@@ -129,6 +208,62 @@ int main()
 
     failures += !ExpectThrow("ReadWithWrongPublicKey", [&] {
         ReadEncrypted(kValidBP, AsymParams("", kZeros64, "test-secret.key"));
+    });
+
+    // --- Priority order: env file > env hex > param ---
+    //
+    // For wrong-file tests we use an existing but wrong-content file to avoid
+    // constructor throws (which do not propagate cleanly through ADIOS2):
+    //   wrong SK file = "test-public.key"  (32 bytes, wrong value as secret key)
+    //   wrong PK file = "test-secret.key"  (32 bytes, wrong value as public key)
+
+    // Asym SK: env file beats env hex
+    failures += !ExpectThrow("PriorityAsymSKEnvFileOverEnvHex", [&] {
+        // Wrong SK file at env, correct SK at env hex → env file wins → decrypt fails.
+        EnvGuard env{{"ADIOS2_ASYM_SECRET_KEY_FILE", "test-public.key"},
+                     {"ADIOS2_ASYM_SECRET_KEY", correctSKHex}};
+        ReadEncrypted(kValidBP, AsymParams("test-public.key"));
+    });
+
+    // Asym SK: env file beats param
+    failures += !ExpectThrow("PriorityAsymSKEnvFileOverParam", [&] {
+        EnvGuard env{{"ADIOS2_ASYM_SECRET_KEY_FILE", "test-public.key"}};
+        ReadEncrypted(kValidBP, AsymParams("test-public.key", "", "test-secret.key"));
+    });
+
+    // Asym SK: env hex beats param
+    failures += !ExpectThrow("PriorityAsymSKEnvHexOverParam", [&] {
+        EnvGuard env{{"ADIOS2_ASYM_SECRET_KEY", kZeros64}};
+        ReadEncrypted(kValidBP, AsymParams("test-public.key", "", "test-secret.key"));
+    });
+
+    // Asym PK: env file beats env hex
+    failures += !ExpectThrow("PriorityAsymPKEnvFileOverEnvHex", [&] {
+        // Wrong PK file at env, correct PK at env hex → env file wins → decrypt fails.
+        EnvGuard env{{"ADIOS2_PUBLIC_KEY_FILE", "test-secret.key"},
+                     {"ADIOS2_PUBLIC_KEY", correctPKHex},
+                     {"ADIOS2_ASYM_SECRET_KEY_FILE", "test-secret.key"}};
+        ReadEncrypted(kValidBP, {});
+    });
+
+    // Asym PK: env file beats param
+    failures += !ExpectThrow("PriorityAsymPKEnvFileOverParam", [&] {
+        EnvGuard env{{"ADIOS2_PUBLIC_KEY_FILE", "test-secret.key"},
+                     {"ADIOS2_ASYM_SECRET_KEY_FILE", "test-secret.key"}};
+        ReadEncrypted(kValidBP, AsymParams("test-public.key"));
+    });
+
+    // Asym PK: env hex beats param
+    failures += !ExpectThrow("PriorityAsymPKEnvHexOverParam", [&] {
+        EnvGuard env{{"ADIOS2_PUBLIC_KEY", kZeros64},
+                     {"ADIOS2_ASYM_SECRET_KEY_FILE", "test-secret.key"}};
+        ReadEncrypted(kValidBP, AsymParams("test-public.key"));
+    });
+
+    // Sym key: env hex beats param
+    failures += !ExpectThrow("PrioritySymEnvHexOverParam", [&] {
+        EnvGuard env{{"ADIOS2_SECRET_KEY", kZeros64}};
+        ReadEncrypted(kValidSymBP, SymParams(kSymKeyHex));
     });
 
     if (failures == 0)


### PR DESCRIPTION
## Summary

- Add five env vars for key provision without operator params on the reader side:
  - `ADIOS2_PUBLIC_KEY_FILE` / `ADIOS2_PUBLIC_KEY` — asym public key (activates asym mode)
  - `ADIOS2_ASYM_SECRET_KEY_FILE` / `ADIOS2_ASYM_SECRET_KEY` — asym secret key
  - `ADIOS2_SECRET_KEY` — symmetric key (hex)
- Priority order: env file > env hex > param for all key slots
- Asym mode is activated by any asym env var; public key is derived from the secret key when not provided
- Refactor: six near-identical key-loading methods replaced by two generic helpers; minor cleanups

## Tests

- `TestEnvVarKeys` — reads with no key params, keys come entirely from env vars
- `TestSealedOperatorWrongUsage` — priority-order tests verifying env var beats param for each key slot
- `TestReaderModeFromEnv` — reader selects asym or sym mode purely from env vars

## Docs

`docs/user_guide/source/operators/encryption.rst` updated with algorithms (XSalsa20-Poly1305 / Curve25519 hybrid), on-disk layouts, and full env var reference.