### PR TITLE
DAOS engine: per-rank metadata, engine autodetect, and scaling fixes

### DIFF
--- a/docs/user_guide/source/engines/daos.rst
+++ b/docs/user_guide/source/engines/daos.rst
@@ -52,6 +52,38 @@ The engine **does** require:
 The pool and container must already exist before the writer opens the
 engine; the engine does not create them.
 
+.. note::
+
+   HPC sites that ship a DAOS client module (for example
+   ``daos/base`` on ALCF Aurora) typically use it to export
+   libfabric and Mercury tuning environment variables — on
+   Slingshot fabrics these include ``FI_CXI_DEFAULT_CQ_SIZE``,
+   ``FI_CXI_RX_MATCH_MODE``, ``FI_MR_CACHE_MAX_COUNT``, and
+   ``NA_OFI_CXI_PROTO_RNR``.  These are needed for the DAOS client
+   to sustain the network load of many concurrent ranks.
+
+   ``module load`` sets these in the launching shell, but they are
+   **not** automatically propagated to ranks by every MPI launcher.
+   Propagate them explicitly:
+
+   * MPICH / PALS ``mpiexec``: ``-genvall``, or specific variables
+     via ``--env NAME=VALUE``.
+   * SLURM ``srun``: ``--export=ALL`` (or list specific variables).
+   * OpenMPI ``mpirun``: typically propagates by default; ``-x NAME``
+     to be explicit.
+
+   Without propagation the ranks run with libfabric defaults that
+   are too small for high-rank-count concurrent DAOS reads.  The
+   visible symptom is ``DER_HG`` (Mercury transport error) followed
+   by ``DER_TIMEDOUT`` after ~120 s during multi-node reads; the
+   workload completes but read throughput drops by one to two
+   orders of magnitude.
+
+   On Aurora specifically, propagating the full module env to BP5
+   ranks running on Lustre has been observed to break MPICH/Lustre
+   I/O.  When a single submit script runs both DAOS and BP5 phases,
+   apply ``-genvall`` only to the DAOS-phase ``mpiexec`` line.
+
 Usage
 =====
 

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -619,6 +619,13 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm, co
             {
                 engineTypeLC = lf_GuessEngineFromTAR(it->second);
             }
+            else if (helper::IsDAOSDataset(name))
+            {
+                // Must precede the generic directory branch: a DAOS
+                // dataset is also a directory and contains an mmd.0,
+                // so BPVersion would otherwise mis-detect it as BP5.
+                engineTypeLC = "daos";
+            }
             else if (adios2sys::SystemTools::FileIsDirectory(name))
             {
                 char v = helper::BPVersion(name, comm, m_TransportsParameters);
@@ -666,6 +673,10 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm, co
         if (helper::EndsWith(name, ".ats", false))
         {
             engineTypeLC = "timeseries";
+        }
+        else if (helper::IsDAOSDataset(name))
+        {
+            engineTypeLC = "daos";
         }
         else
         {

--- a/source/adios2/engine/daos/DaosEngine.h
+++ b/source/adios2/engine/daos/DaosEngine.h
@@ -24,12 +24,10 @@ class DaosEngine
 {
 public:
     int m_RankMPI = 0;
-    /* metadata index table
+    /* metadata index table (Phase-1 layout)
             0: pos in memory for step (after filtered read)
             1: size of metadata
-            2: flush count
-            3: pos in index where data offsets are enumerated
-            4: abs. pos in metadata File for step
+            2: abs. pos in metadata File for step
     */
     std::unordered_map<uint64_t, std::vector<uint64_t>> m_MetadataIndexTable;
 
@@ -53,6 +51,10 @@ public:
     static constexpr size_t m_BPMinorVersionPosition = 38;
     static constexpr size_t m_ActiveFlagPosition = 39;
     static constexpr size_t m_ColumnMajorFlagPosition = 40;
+    /// Phase-2: 0 = aggregated metadata (Phase 1 / default), 1 = per-rank
+    /// metadata (each rank carries its own MetaMetaBlocks + Attribute
+    /// content in its metadata blob; rank 0 does no aggregation).
+    static constexpr size_t m_PerRankMetadataFlagPosition = 41;
     static constexpr size_t m_VersionTagPosition = 0;
     static constexpr size_t m_VersionTagLength = 32;
 

--- a/source/adios2/engine/daos/DaosReader.cpp
+++ b/source/adios2/engine/daos/DaosReader.cpp
@@ -11,7 +11,11 @@
 #include <adios2-perfstubs-interface.h>
 
 #include <chrono>
+#include <cstdio>  // fprintf (DAOS_MD_DEBUG)
+#include <cstdlib> // getenv
+#include <cstring> // memcpy
 #include <errno.h>
+#include <exception> // std::exception (DAOS_MD_DEBUG)
 #include <fstream>
 #include <iomanip>
 #include <mutex>
@@ -163,12 +167,17 @@ void DaosReader::DaosKVReadMetadata(size_t Step, uint64_t WriterCount)
     for (int j = 0; j < WriterCount; j++)
         total_mdsize += list_writer_mdsize[j];
 
-    // Reading total size of attribute includes vector of sizes of attributes and also the attribute
-    // buffers
+    // In per-rank mode the attributes ride in each rank's blob (no md.0
+    // aggregate writes), so skip the md.0 reads and the attribute-size
+    // layer in the buffer.
     size_t total_attr_size = 0;
-    size_t off_attr = m_MetadataIndexTable[Step][4];
-    m_MDFileManager.ReadFile((char *)&total_attr_size, sizeof(size_t), off_attr);
-    off_attr = off_attr + sizeof(size_t);
+    size_t off_attr = 0;
+    if (!m_PerRankMetadata)
+    {
+        off_attr = m_MetadataIndexTable[Step][2];
+        m_MDFileManager.ReadFile((char *)&total_attr_size, sizeof(size_t), off_attr);
+        off_attr = off_attr + sizeof(size_t);
+    }
 
     // Allocate memory for m_Metadata
     buffer_size = sizeof(uint64_t) * (WriterCount + 1) + total_mdsize + total_attr_size;
@@ -184,11 +193,13 @@ void DaosReader::DaosKVReadMetadata(size_t Step, uint64_t WriterCount)
         ptr[index] = list_writer_mdsize[WriterRank];
         index++;
     }
-    m_MDFileManager.ReadFile((char *)&ptr[index], sizeof(uint64_t) * WriterCount, off_attr);
-    off_attr = off_attr + sizeof(uint64_t) * WriterCount;
-
-    // Skip over the already read attribute sizes
-    index += WriterCount;
+    if (!m_PerRankMetadata)
+    {
+        m_MDFileManager.ReadFile((char *)&ptr[index], sizeof(uint64_t) * WriterCount, off_attr);
+        off_attr = off_attr + sizeof(uint64_t) * WriterCount;
+        // Skip over the already read attribute sizes
+        index += WriterCount;
+    }
 
     char *meta_buff = (char *)&ptr[index];
     index = 0;
@@ -251,9 +262,13 @@ void DaosReader::DaosKVReadMetadata(size_t Step, uint64_t WriterCount)
     }
     CALI_MARK_END("DaosReader::loop-get");
 
-    // Read in attributes
-    size_t att_readin_size = total_attr_size - (WriterCount * sizeof(uint64_t));
-    m_MDFileManager.ReadFile((char *)&meta_buff[index], att_readin_size, off_attr);
+    if (!m_PerRankMetadata)
+    {
+        // Read in attributes (aggregated mode only — per-rank carries attrs
+        // inline in the per-rank blob).
+        size_t att_readin_size = total_attr_size - (WriterCount * sizeof(uint64_t));
+        m_MDFileManager.ReadFile((char *)&meta_buff[index], att_readin_size, off_attr);
+    }
 }
 
 void DaosReader::DaosArrayReadMetadata(size_t Step, uint64_t WriterCount)
@@ -291,12 +306,15 @@ void DaosReader::DaosArrayReadMetadata(size_t Step, uint64_t WriterCount)
         total_mdsize += list_writer_mdsize[WriterRank];
     }
 
-    // Reading total size of attribute includes vector of sizes of attributes and also the attribute
-    // buffers
+    // In per-rank mode attributes ride in each rank's blob — skip md.0.
     size_t total_attr_size = 0;
-    size_t off_attr = m_MetadataIndexTable[Step][4];
-    m_MDFileManager.ReadFile((char *)&total_attr_size, sizeof(size_t), off_attr);
-    off_attr = off_attr + sizeof(size_t);
+    size_t off_attr = 0;
+    if (!m_PerRankMetadata)
+    {
+        off_attr = m_MetadataIndexTable[Step][2];
+        m_MDFileManager.ReadFile((char *)&total_attr_size, sizeof(size_t), off_attr);
+        off_attr = off_attr + sizeof(size_t);
+    }
 
     // Allocate memory for m_Metadata
     buffer_size = sizeof(uint64_t) * (WriterCount + 1) + total_mdsize + total_attr_size;
@@ -319,10 +337,12 @@ void DaosReader::DaosArrayReadMetadata(size_t Step, uint64_t WriterCount)
         index++;
     }
 
-    m_MDFileManager.ReadFile((char *)&ptr[index], sizeof(uint64_t) * WriterCount, off_attr);
-    off_attr = off_attr + sizeof(uint64_t) * WriterCount;
-
-    index += WriterCount;
+    if (!m_PerRankMetadata)
+    {
+        m_MDFileManager.ReadFile((char *)&ptr[index], sizeof(uint64_t) * WriterCount, off_attr);
+        off_attr = off_attr + sizeof(uint64_t) * WriterCount;
+        index += WriterCount;
+    }
 
     char *meta_buff = (char *)&ptr[index];
     index = 0;
@@ -358,15 +378,54 @@ void DaosReader::DaosArrayReadMetadata(size_t Step, uint64_t WriterCount)
     }
     CALI_MARK_END("DaosReader::daos_array_read");
 
+    if (std::getenv("DAOS_MD_DEBUG") && Step == 0)
+    {
+        const unsigned char *mb = (const unsigned char *)meta_buff;
+        fprintf(stderr,
+                "[DAOS_MD_DEBUG] ArrayReadMD step=%zu layout=%d WriterCount=%zu "
+                "total_mdsize=%zu total_attr_size=%zu buffer_size=%zu m_step_offset=%zu\n",
+                Step, (int)metadataLayout, (size_t)WriterCount, total_mdsize, total_attr_size,
+                buffer_size, m_step_offset);
+        // Print a spread of blobs so the *shape* of any buffer corruption is
+        // visible right after the array read: which ranks carry a valid FFS
+        // id (first bytes 02 00 00 92 for EFFIS-XG) and which are garbage.
+        const size_t probes[] = {0,  1,   2,   3,   4,    5,    8,    16,  32,
+                                 64, 128, 256, 512, 1024, 2048, 3072, 4000};
+        for (size_t pi = 0; pi < sizeof(probes) / sizeof(probes[0]); ++pi)
+        {
+            size_t w = probes[pi];
+            if (w >= WriterCount)
+                continue;
+            size_t cum = 0;
+            for (size_t j = 0; j < w; ++j)
+                cum += list_writer_mdsize[j];
+            const unsigned char *bp = mb + cum;
+            fprintf(stderr,
+                    "[DAOS_MD_DEBUG]   blob[%zu] mdsize=%llu off=%zu first=%02x%02x%02x%02x\n", w,
+                    (unsigned long long)list_writer_mdsize[w], cum, bp[0], bp[1], bp[2], bp[3]);
+        }
+        size_t lastw = WriterCount - 1, lastcum = 0;
+        for (size_t j = 0; j < lastw; ++j)
+            lastcum += list_writer_mdsize[j];
+        const unsigned char *lp = mb + lastcum;
+        fprintf(stderr,
+                "[DAOS_MD_DEBUG]   blob[%zu](last) mdsize=%llu off=%zu first=%02x%02x%02x%02x\n",
+                lastw, (unsigned long long)list_writer_mdsize[lastw], lastcum, lp[0], lp[1], lp[2],
+                lp[3]);
+    }
+
     m_step_offset += MAX_AGGREGATE_METADATA_SIZE;
     if (metadataLayout == MetadataLayout::ARRAY_1MB_ALIGNED)
         free(list_rg);
 
     index += total_mdsize;
 
-    // Read in attributes
-    size_t att_readin_size = total_attr_size - (WriterCount * sizeof(uint64_t));
-    m_MDFileManager.ReadFile((char *)&meta_buff[index], att_readin_size, off_attr);
+    if (!m_PerRankMetadata)
+    {
+        // Read in attributes (aggregated mode only).
+        size_t att_readin_size = total_attr_size - (WriterCount * sizeof(uint64_t));
+        m_MDFileManager.ReadFile((char *)&meta_buff[index], att_readin_size, off_attr);
+    }
     free(list_writer_mdsize);
 }
 
@@ -376,36 +435,157 @@ void DaosReader::InstallMetadataForTimestep(size_t Step)
     size_t pgstart = m_MetadataIndexTable[0][0];
     size_t Position = pgstart + sizeof(uint64_t); // skip total data size
     const uint64_t WriterCount = m_WriterMap[m_WriterMapIndex[0]].WriterCount;
-    // m_WriterMap[m_WriterMapIndex[Step]].WriterCount;
-    size_t MDPosition = Position + 2 * sizeof(uint64_t) * WriterCount;
+    auto &stepStarts = m_RankStartDataPos[Step];
+    stepStarts.resize(WriterCount);
+
+    const bool mdDebug = std::getenv("DAOS_MD_DEBUG") != nullptr;
+    if (mdDebug)
+        fprintf(stderr,
+                "[DAOS_MD_DEBUG] InstallMDForTimestep Step=%zu pgstart=%zu Position=%zu "
+                "WriterCount=%zu perRank=%d\n",
+                Step, pgstart, Position, (size_t)WriterCount, (int)m_PerRankMetadata);
+
+    if (!m_PerRankMetadata)
+    {
+        // ---- aggregated mode (Phase 1): blob = [MetaEncode][step_start u64] ----
+        // m_Metadata layout: [total_mdsize][mdsize×N][attr_size×N][meta][attr]
+        size_t MDPosition = Position + 2 * sizeof(uint64_t) * WriterCount;
+        for (size_t WriterRank = 0; WriterRank < WriterCount; WriterRank++)
+        {
+            size_t ThisMDSizeFull = helper::ReadValue<uint64_t>(m_Metadata.m_Buffer, Position,
+                                                                m_Minifooter.IsLittleEndian);
+            size_t ThisMDSize = ThisMDSizeFull - sizeof(uint64_t);
+            char *ThisMD = m_Metadata.m_Buffer.data() + MDPosition;
+            uint64_t stepStart = 0;
+            std::memcpy(&stepStart, ThisMD + ThisMDSize, sizeof(uint64_t));
+            stepStarts[WriterRank] = stepStart;
+            if (mdDebug && Step == 0 && (WriterRank < 4 || WriterRank + 1 == WriterCount))
+                fprintf(stderr,
+                        "[DAOS_MD_DEBUG]   agg rank=%zu MDPosition=%zu ThisMDSizeFull=%zu "
+                        "ThisMDSize=%zu first=%02x%02x%02x%02x\n",
+                        WriterRank, MDPosition, ThisMDSizeFull, ThisMDSize,
+                        (unsigned char)ThisMD[0], (unsigned char)ThisMD[1],
+                        (unsigned char)ThisMD[2], (unsigned char)ThisMD[3]);
+            try
+            {
+                if (m_OpenMode == Mode::ReadRandomAccess)
+                {
+                    m_BP5Deserializer->InstallMetaData(ThisMD, ThisMDSize, WriterRank, Step);
+                }
+                else
+                {
+                    CALI_MARK_BEGIN("DaosReader::InstallMetaData");
+                    m_BP5Deserializer->InstallMetaData(ThisMD, ThisMDSize, WriterRank);
+                    CALI_MARK_END("DaosReader::InstallMetaData");
+                }
+            }
+            catch (const std::exception &)
+            {
+                // Pinpoint exactly which rank's blob the deserializer rejects
+                // and dump its leading bytes -- distinguishes a garbage blob
+                // (bad first bytes) from a deserializer-state bug (valid id,
+                // still thrown).
+                if (mdDebug)
+                    fprintf(stderr,
+                            "[DAOS_MD_DEBUG]   *** InstallMetaData THREW at rank=%zu "
+                            "MDPosition=%zu ThisMDSizeFull=%zu ThisMDSize=%zu "
+                            "first8=%02x%02x%02x%02x%02x%02x%02x%02x\n",
+                            WriterRank, MDPosition, ThisMDSizeFull, ThisMDSize,
+                            (unsigned char)ThisMD[0], (unsigned char)ThisMD[1],
+                            (unsigned char)ThisMD[2], (unsigned char)ThisMD[3],
+                            (unsigned char)ThisMD[4], (unsigned char)ThisMD[5],
+                            (unsigned char)ThisMD[6], (unsigned char)ThisMD[7]);
+                throw;
+            }
+            MDPosition += ThisMDSizeFull;
+        }
+
+        for (size_t WriterRank = 0; WriterRank < WriterCount; WriterRank++)
+        {
+            // attribute metadata for timestep
+            size_t ThisADSize = helper::ReadValue<uint64_t>(m_Metadata.m_Buffer, Position,
+                                                            m_Minifooter.IsLittleEndian);
+            char *ThisAD = m_Metadata.m_Buffer.data() + MDPosition;
+            if (ThisADSize > 0)
+                m_BP5Deserializer->InstallAttributeData(ThisAD, ThisADSize);
+            MDPosition += ThisADSize;
+        }
+        return;
+    }
+
+    // ---- per-rank mode (Phase 2): blob = [MetaEncode][MetaMeta][Attr][24B footer] ----
+    // m_Metadata layout (no attr-size layer): [total_mdsize][mdsize×N][blobs]
+    size_t MDPosition = Position + sizeof(uint64_t) * WriterCount;
+    constexpr size_t footerSize = 3 * sizeof(uint64_t);
     for (size_t WriterRank = 0; WriterRank < WriterCount; WriterRank++)
     {
-        // variable metadata for timestep
-        size_t ThisMDSize =
+        const size_t ThisBlobSize =
             helper::ReadValue<uint64_t>(m_Metadata.m_Buffer, Position, m_Minifooter.IsLittleEndian);
-        char *ThisMD = m_Metadata.m_Buffer.data() + MDPosition;
+        char *blob = m_Metadata.m_Buffer.data() + MDPosition;
+        // Read footer from the tail of the blob.
+        uint64_t mmbSize = 0, attrSize = 0, stepStart = 0;
+        std::memcpy(&mmbSize, blob + ThisBlobSize - footerSize, sizeof(uint64_t));
+        std::memcpy(&attrSize, blob + ThisBlobSize - 2 * sizeof(uint64_t), sizeof(uint64_t));
+        std::memcpy(&stepStart, blob + ThisBlobSize - sizeof(uint64_t), sizeof(uint64_t));
+        stepStarts[WriterRank] = stepStart;
+        const size_t metaSize = ThisBlobSize - mmbSize - attrSize - footerSize;
+
+        if (mdDebug && Step == 0 && (WriterRank < 4 || WriterRank + 1 == WriterCount))
+            fprintf(stderr,
+                    "[DAOS_MD_DEBUG]   prr rank=%zu MDPosition=%zu ThisBlobSize=%zu metaSize=%zu "
+                    "mmbSize=%llu attrSize=%llu first=%02x%02x%02x%02x\n",
+                    WriterRank, MDPosition, ThisBlobSize, metaSize, (unsigned long long)mmbSize,
+                    (unsigned long long)attrSize, (unsigned char)blob[0], (unsigned char)blob[1],
+                    (unsigned char)blob[2], (unsigned char)blob[3]);
+
+        // Install MetaMetaBlocks for this rank (count + (idLen,infoLen,id,info)+).
+        if (mmbSize > 0)
+        {
+            char *mmbStart = blob + metaSize;
+            size_t mp = 0;
+            uint64_t mmbCount = 0;
+            std::memcpy(&mmbCount, mmbStart + mp, sizeof(uint64_t));
+            mp += sizeof(uint64_t);
+            for (uint64_t k = 0; k < mmbCount; ++k)
+            {
+                format::BP5Base::MetaMetaInfoBlock MMI;
+                std::memcpy(&MMI.MetaMetaIDLen, mmbStart + mp, sizeof(uint64_t));
+                mp += sizeof(uint64_t);
+                std::memcpy(&MMI.MetaMetaInfoLen, mmbStart + mp, sizeof(uint64_t));
+                mp += sizeof(uint64_t);
+                MMI.MetaMetaID = mmbStart + mp;
+                mp += MMI.MetaMetaIDLen;
+                MMI.MetaMetaInfo = mmbStart + mp;
+                mp += MMI.MetaMetaInfoLen;
+                // Each rank carries its own copy of the MMBs; with N ranks
+                // defining the same variables that is N duplicates of each
+                // format ID.  Install each unique ID exactly once.
+                std::string idKey(MMI.MetaMetaID, MMI.MetaMetaIDLen);
+                if (m_InstalledMetaMetaIDs.insert(std::move(idKey)).second)
+                    m_BP5Deserializer->InstallMetaMetaData(MMI);
+            }
+        }
+
+        // Install per-rank attribute block (if any).
+        if (attrSize > 0)
+        {
+            char *attrStart = blob + metaSize + mmbSize;
+            m_BP5Deserializer->InstallAttributeData(attrStart, attrSize);
+        }
+
+        // Install variable metadata.
         if (m_OpenMode == Mode::ReadRandomAccess)
         {
-            m_BP5Deserializer->InstallMetaData(ThisMD, ThisMDSize, WriterRank, Step);
+            m_BP5Deserializer->InstallMetaData(blob, metaSize, WriterRank, Step);
         }
         else
         {
             CALI_MARK_BEGIN("DaosReader::InstallMetaData");
-            m_BP5Deserializer->InstallMetaData(ThisMD, ThisMDSize, WriterRank);
+            m_BP5Deserializer->InstallMetaData(blob, metaSize, WriterRank);
             CALI_MARK_END("DaosReader::InstallMetaData");
         }
-        MDPosition += ThisMDSize;
-    }
 
-    for (size_t WriterRank = 0; WriterRank < WriterCount; WriterRank++)
-    {
-        // attribute metadata for timestep
-        size_t ThisADSize =
-            helper::ReadValue<uint64_t>(m_Metadata.m_Buffer, Position, m_Minifooter.IsLittleEndian);
-        char *ThisAD = m_Metadata.m_Buffer.data() + MDPosition;
-        if (ThisADSize > 0)
-            m_BP5Deserializer->InstallAttributeData(ThisAD, ThisADSize);
-        MDPosition += ThisADSize;
+        MDPosition += ThisBlobSize;
     }
 }
 
@@ -537,14 +717,10 @@ std::pair<double, double> DaosReader::ReadData(adios2::transportman::TransportMa
     /*
      * Warning: this function is called by multiple threads
      */
-    size_t FlushCount = m_MetadataIndexTable[Timestep][2];
-    size_t DataPosPos = m_MetadataIndexTable[Timestep][3];
-
-    // Read directly from the writer rank's per-rank DAOS array.  We still
-    // walk the flush table because a single step may include data from
-    // multiple flushes; for each flush, ThisDataPos is the byte offset
-    // within the writer rank's array (since the writer set m_StartDataPos
-    // = its array cursor before each flush's data was committed).
+    // Phase-1: each rank's data is contiguous in its own per-rank DAOS
+    // array, so the read offset is simply step_start + StartOffset.  The
+    // step_start was extracted from the rank's metadata-blob trailer in
+    // InstallMetadataForTimestep.
     if (WriterRank >= m_DataArrayHandles.size())
     {
         helper::Throw<std::runtime_error>("Engine", "DaosReader", "ReadData",
@@ -552,33 +728,17 @@ std::pair<double, double> DaosReader::ReadData(adios2::transportman::TransportMa
                                               " has no entry in OID index (size=" +
                                               std::to_string(m_DataArrayHandles.size()) + ")");
     }
+    auto it = m_RankStartDataPos.find(Timestep);
+    if (it == m_RankStartDataPos.end() || WriterRank >= it->second.size())
+    {
+        helper::Throw<std::runtime_error>(
+            "Engine", "DaosReader", "ReadData",
+            "missing step-start for Timestep=" + std::to_string(Timestep) +
+                " WriterRank=" + std::to_string(WriterRank));
+    }
     daos_handle_t aoh = m_DataArrayHandles[WriterRank];
     TP startRead = NOW();
-    size_t InfoStartPos = DataPosPos + (WriterRank * (2 * FlushCount + 1) * sizeof(uint64_t));
-    size_t SumDataSize = 0;
-    size_t arrayOffset = 0;
-    bool found = false;
-    for (size_t flush = 0; flush < FlushCount && !found; ++flush)
-    {
-        size_t ThisDataPos = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
-                                                         m_Minifooter.IsLittleEndian);
-        size_t ThisDataSize = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
-                                                          m_Minifooter.IsLittleEndian);
-        if (StartOffset < SumDataSize + ThisDataSize)
-        {
-            arrayOffset = ThisDataPos + (StartOffset - SumDataSize);
-            found = true;
-            break;
-        }
-        SumDataSize += ThisDataSize;
-    }
-    if (!found)
-    {
-        // last (post-last-flush) record
-        size_t ThisDataPos = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
-                                                         m_Minifooter.IsLittleEndian);
-        arrayOffset = ThisDataPos + (StartOffset - SumDataSize);
-    }
+    size_t arrayOffset = it->second[WriterRank] + StartOffset;
 
     daos_range_t rgr;
     rgr.rg_idx = arrayOffset;
@@ -1550,6 +1710,15 @@ size_t DaosReader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t
         const uint8_t val =
             helper::ReadValue<uint8_t>(buffer, position, m_Minifooter.IsLittleEndian);
         m_WriterIsRowMajor = val == 'n';
+
+        // Phase-2 mode flag (byte 41).  0 = aggregated (Phase 1), 1 =
+        // per-rank metadata layout.  Used by ReadMetadata /
+        // InstallMetadataForTimestep to dispatch.
+        position = m_PerRankMetadataFlagPosition;
+        const uint8_t perRankFlag =
+            helper::ReadValue<uint8_t>(buffer, position, m_Minifooter.IsLittleEndian);
+        m_PerRankMetadata = (perRankFlag == 1);
+
         // move position to first row
         position = m_IndexHeaderSize;
     }
@@ -1609,8 +1778,9 @@ size_t DaosReader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t
                 helper::ReadValue<uint64_t>(buffer, position, m_Minifooter.IsLittleEndian);
             const uint64_t MetadataSize =
                 helper::ReadValue<uint64_t>(buffer, position, m_Minifooter.IsLittleEndian);
-            const uint64_t FlushCount =
-                helper::ReadValue<uint64_t>(buffer, position, m_Minifooter.IsLittleEndian);
+            // Phase-1: no FlushCount, no per-writer block.  Each rank's
+            // step-start data offset lives in its own metadata-blob
+            // trailer in DAOS, not in md.idx.
 
             if (!n)
             {
@@ -1625,8 +1795,6 @@ size_t DaosReader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t
                 // pos in metadata in memory
                 ptrs.push_back(MetadataPos - MetadataPosTotalSkip);
                 ptrs.push_back(MetadataSize);
-                ptrs.push_back(FlushCount);
-                ptrs.push_back(position);
                 // absolute pos in file before read
                 ptrs.push_back(MetadataPos);
                 m_MetadataIndexTable[m_StepsCount] = ptrs;
@@ -1645,8 +1813,6 @@ size_t DaosReader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t
                 minfo_size = 0;
             }
 
-            // skip over the writer -> data file offset records
-            position += sizeof(uint64_t) * m_LastWriterCount * ((2 * FlushCount) + 1);
             ++m_AbsStepsInFile;
             ++n;
             break;

--- a/source/adios2/engine/daos/DaosReader.h
+++ b/source/adios2/engine/daos/DaosReader.h
@@ -21,6 +21,9 @@
 #include <daos.h>
 #include <daos_obj.h>
 #include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #if defined(ADIOS2_HAVE_Caliper)
@@ -310,6 +313,26 @@ private:
 
     void InstallMetaMetaData(format::BufferSTL MetaMetadata);
     void InstallMetadataForTimestep(size_t Step);
+
+    /// Per-rank step-start array offsets, extracted from each rank's
+    /// metadata-blob trailer.  Indexed by [Step][WriterRank].  Populated
+    /// in InstallMetadataForTimestep; consumed in ReadData as the base
+    /// for arrayOffset = step_start + StartOffset.
+    std::unordered_map<size_t, std::vector<uint64_t>> m_RankStartDataPos;
+
+    /// Phase-2 gating, read from md.idx header byte 41 by
+    /// ParseMetadataIndex.  When true, the writer used the per-rank
+    /// metadata layout (MetaMetaBlocks + Attr packed in each rank's
+    /// blob, no md.0/mmd.0 aggregate writes).
+    bool m_PerRankMetadata = false;
+
+    /// Per-rank-metadata mode only: format IDs already handed to
+    /// InstallMetaMetaData.  Every writer rank packs its own copy of the
+    /// MetaMetaBlocks into its blob, so N ranks defining the same
+    /// variables carry N duplicates of each format ID.  Keyed on the raw
+    /// format-ID bytes; install each unique ID exactly once for the
+    /// lifetime of the reader.
+    std::unordered_set<std::string> m_InstalledMetaMetaIDs;
     std::pair<double, double> ReadData(adios2::transportman::TransportMan &FileManager,
                                        const size_t maxOpenFiles, const size_t WriterRank,
                                        const size_t Timestep, const size_t StartOffset,

--- a/source/adios2/engine/daos/DaosWriter.cpp
+++ b/source/adios2/engine/daos/DaosWriter.cpp
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <cstdlib> // getenv
+#include <cstring> // memcpy
 #include <ctime>
 #include <fstream>
 #include <iomanip> // setw
@@ -113,6 +114,10 @@ StepStatus DaosWriter::BeginStep(StepMode mode, const float timeoutSeconds)
     }
     m_BP5Serializer.InitStep(m_DataBuf.get());
     m_ThisTimestepDataSize = 0;
+    // Snapshot the cursor at step begin.  Phase-1 design: each rank's
+    // metadata blob carries its own step-start array offset as a trailer,
+    // so the reader can compute arrayOffset = step_start + StartOffset.
+    m_StepStartDataPos = m_DataArrayCursor;
 
     return StepStatus::OK;
 }
@@ -235,10 +240,6 @@ void DaosWriter::WriteData(format::BufferV *Data)
         }
     }
 
-    // Record the array offset where this step's data begins so the
-    // BP5 metadata index records the right "data position" for readers.
-    m_StartDataPos = m_DataArrayCursor;
-    m_DataPos = m_DataArrayCursor + Data->Size();
     m_Profiler.AddBytes("totalBytes", Data->Size());
     m_DataArrayCursor += Data->Size();
     // DON'T delete Data: with chunk recycling, Data == m_DataBuf.get()
@@ -251,23 +252,27 @@ void DaosWriter::WriteMetadataFileIndex(uint64_t MetaDataPos, uint64_t MetaDataS
     m_FileMetadataManager.FlushFiles();
 
     const uint64_t writerCount = static_cast<uint64_t>(m_Comm.Size());
-    const uint64_t flushCount = static_cast<uint64_t>(FlushPosSizeInfo.size());
 
+    // Phase-1 StepRecord layout: only (MetaDataPos, MetaDataSize).  Each
+    // rank's step-start data offset rides on its own metadata-blob
+    // trailer in DAOS, so md.idx no longer carries any per-writer block.
+    //
     // First-call layout:
     //   header (m_IndexHeaderSize bytes)
     //   WriterMapRecord (1 + 8 + (3 + writerCount) * 8 bytes)
-    //   StepRecord      (1 + 8 + stepBody)
+    //   StepRecord      (1 + 8 + 16 bytes)
     // Subsequent calls: just StepRecord.
     //
-    // The WriterMapRecord populates the reader's m_WriterMap so its
+    // The WriterMapRecord still populates the reader's m_WriterMap so
     // m_WriterMap[step].WriterCount is non-zero — without this,
     // DaosArrayReadMetadata's daos_kv_get for the per-step metadata
     // sizes is called with writer_count=0 and deadlocks.  The subfile
     // indices in the map are nominal (every rank "owns" its own
     // subfile slot); the actual data is reached via data_oids.txt.
-    const size_t stepBodyBytes = (3 + writerCount * (2 * flushCount + 1)) * sizeof(uint64_t);
+    const size_t stepBodyBytes = 2 * sizeof(uint64_t);
     size_t bufsize = 1 + sizeof(uint64_t) + stepBodyBytes;
-    if (MetaDataPos == 0)
+    const bool isFirstCall = m_FirstIndexCall;
+    if (isFirstCall)
     {
         bufsize += m_IndexHeaderSize;
         bufsize += 1 + sizeof(uint64_t) + (3 + writerCount) * sizeof(uint64_t);
@@ -278,7 +283,7 @@ void DaosWriter::WriteMetadataFileIndex(uint64_t MetaDataPos, uint64_t MetaDataS
     uint64_t d;
     unsigned char record;
 
-    if (MetaDataPos == 0)
+    if (isFirstCall)
     {
         MakeHeader(buf, pos, "Index Table", true);
 
@@ -294,6 +299,7 @@ void DaosWriter::WriteMetadataFileIndex(uint64_t MetaDataPos, uint64_t MetaDataS
         {
             helper::CopyToBuffer(buf, pos, &i, 1); // RankToSubfile[i] = i
         }
+        m_FirstIndexCall = false;
     }
 
     // StepRecord
@@ -303,28 +309,8 @@ void DaosWriter::WriteMetadataFileIndex(uint64_t MetaDataPos, uint64_t MetaDataS
     helper::CopyToBuffer(buf, pos, &d, 1); // record length
     helper::CopyToBuffer(buf, pos, &MetaDataPos, 1);
     helper::CopyToBuffer(buf, pos, &MetaDataSize, 1);
-    helper::CopyToBuffer(buf, pos, &flushCount, 1);
-
-    // Per-writer block: for each writer, FlushCount (pos,size) pairs +
-    // m_WriterDataPos[writer].  data_oids.txt locates the per-rank array;
-    // m_WriterDataPos[writer] is the byte offset within that array where
-    // this step's data begins.  The reader's ReadData walks this block
-    // (2*FlushCount+1 uint64s per writer) to compute the read offset --
-    // the trailing m_WriterDataPos[writer] becomes ThisDataPos when
-    // FlushCount==0, which is the steady-state case.
-    for (uint64_t writer = 0; writer < writerCount; ++writer)
-    {
-        for (uint64_t f = 0; f < flushCount; ++f)
-        {
-            helper::CopyToBuffer(buf, pos, &FlushPosSizeInfo[f][2 * writer], 2);
-        }
-        helper::CopyToBuffer(buf, pos, &m_WriterDataPos[writer], 1);
-    }
 
     m_FileMetadataIndexManager.WriteFiles((char *)buf.data(), buf.size());
-
-    /* reset for next timestep */
-    FlushPosSizeInfo.clear();
 }
 
 void DaosWriter::NotifyEngineAttribute(std::string name, DataType type) noexcept
@@ -415,13 +401,84 @@ void DaosWriter::MarshalAttributes()
     }
 }
 
+std::vector<char> DaosWriter::BuildMetadataBlob(format::BP5Serializer::TimestepInfo &TSInfo)
+{
+    const size_t metaSize = TSInfo.MetaEncodeBuffer ? TSInfo.MetaEncodeBuffer->m_FixedSize : 0;
+
+    if (!m_PerRankMetadata)
+    {
+        // Aggregated mode (Phase 1): [MetaEncode][step_start u64].
+        std::vector<char> buf(metaSize + sizeof(uint64_t));
+        if (metaSize > 0)
+            std::memcpy(buf.data(), TSInfo.MetaEncodeBuffer->Data(), metaSize);
+        std::memcpy(buf.data() + metaSize, &m_StepStartDataPos, sizeof(uint64_t));
+        return buf;
+    }
+
+    // Per-rank mode (Phase 2): pack MetaEncode + MetaMetaBlocks +
+    // AttributeEncodeBuffer + 24-byte footer.  Footer is
+    // (mmb_size, attr_size, step_start) — sizes count only the
+    // serialized body bytes, not the footer itself.
+    const auto &mmbs = TSInfo.NewMetaMetaBlocks;
+    uint64_t mmbBodySize = sizeof(uint64_t); // count prefix
+    for (const auto &m : mmbs)
+        mmbBodySize += 2 * sizeof(uint64_t) + m.MetaMetaIDLen + m.MetaMetaInfoLen;
+
+    const uint64_t attrSize =
+        (TSInfo.AttributeEncodeBuffer && TSInfo.AttributeEncodeBuffer->m_FixedSize > 0)
+            ? static_cast<uint64_t>(TSInfo.AttributeEncodeBuffer->m_FixedSize)
+            : 0;
+    const size_t footerSize = 3 * sizeof(uint64_t);
+    const size_t total = metaSize + mmbBodySize + attrSize + footerSize;
+
+    std::vector<char> buf(total);
+    size_t pos = 0;
+    if (metaSize > 0)
+    {
+        std::memcpy(buf.data() + pos, TSInfo.MetaEncodeBuffer->Data(), metaSize);
+        pos += metaSize;
+    }
+    // MetaMetaBlocks body: count + (idLen, infoLen, id, info)+
+    const uint64_t mmbCount = static_cast<uint64_t>(mmbs.size());
+    std::memcpy(buf.data() + pos, &mmbCount, sizeof(uint64_t));
+    pos += sizeof(uint64_t);
+    for (const auto &m : mmbs)
+    {
+        const uint64_t idLen = m.MetaMetaIDLen;
+        const uint64_t infoLen = m.MetaMetaInfoLen;
+        std::memcpy(buf.data() + pos, &idLen, sizeof(uint64_t));
+        pos += sizeof(uint64_t);
+        std::memcpy(buf.data() + pos, &infoLen, sizeof(uint64_t));
+        pos += sizeof(uint64_t);
+        std::memcpy(buf.data() + pos, m.MetaMetaID, idLen);
+        pos += idLen;
+        std::memcpy(buf.data() + pos, m.MetaMetaInfo, infoLen);
+        pos += infoLen;
+    }
+    // AttributeEncodeBuffer
+    if (attrSize > 0)
+    {
+        std::memcpy(buf.data() + pos, TSInfo.AttributeEncodeBuffer->Data(), attrSize);
+        pos += attrSize;
+    }
+    // Footer
+    std::memcpy(buf.data() + pos, &mmbBodySize, sizeof(uint64_t));
+    pos += sizeof(uint64_t);
+    std::memcpy(buf.data() + pos, &attrSize, sizeof(uint64_t));
+    pos += sizeof(uint64_t);
+    std::memcpy(buf.data() + pos, &m_StepStartDataPos, sizeof(uint64_t));
+    pos += sizeof(uint64_t);
+    return buf;
+}
+
 void DaosWriter::DaosArrayWriteMetadata(format::BP5Serializer::TimestepInfo &TSInfo)
 {
     /* Allgather metadata sizes from all processes; absorbs cross-rank
        skew left by the no-Barrier-after-SelAgg decision in EndStep. */
+    std::vector<char> blob = BuildMetadataBlob(TSInfo);
+    const uint64_t myMetaTotal = static_cast<uint64_t>(blob.size());
     std::vector<uint64_t> list_metadata_size(m_Comm.Size());
-    m_Comm.Allgather((uint64_t *)&TSInfo.MetaEncodeBuffer->m_FixedSize, 1,
-                     list_metadata_size.data(), 1);
+    m_Comm.Allgather(&myMetaTotal, 1, list_metadata_size.data(), 1);
 
     size_t offset = 0;
     if (metadataLayout == MetadataLayout::ARRAY)
@@ -431,18 +488,23 @@ void DaosWriter::DaosArrayWriteMetadata(format::BP5Serializer::TimestepInfo &TSI
     }
     else if (metadataLayout == MetadataLayout::ARRAY_1MB_ALIGNED)
     {
-        offset = m_Comm.Rank() * chunk_size_1mb;
+        // 64-bit multiply: chunk_size_1mb and Comm::Rank() are both int, so
+        // an int*int product overflows at rank 2048 (2048 * 1 MiB == 2^31).
+        // The reader computes this offset in size_t and reads the correct
+        // location, so an overflow here silently strands every blob from
+        // rank 2048 on.  Cast the rank to widen the whole expression.
+        offset = static_cast<size_t>(m_Comm.Rank()) * chunk_size_1mb;
     }
 
     // Setup I/O Descriptor
     iod.arr_nr = 1;
-    rg.rg_len = list_metadata_size[m_Comm.Rank()];
+    rg.rg_len = myMetaTotal;
     rg.rg_idx = m_step_offset + offset;
     iod.arr_rgs = &rg;
 
-    /** set memory location */
+    /** memory location: single contiguous blob */
+    d_iov_set(&iov, blob.data(), myMetaTotal);
     sgl.sg_nr = 1;
-    d_iov_set(&iov, TSInfo.MetaEncodeBuffer->Data(), TSInfo.MetaEncodeBuffer->m_FixedSize);
     sgl.sg_iovs = &iov;
 
     // Write Metadata
@@ -481,9 +543,14 @@ void DaosWriter::DaosKVWriteMetadata(format::BP5Serializer::TimestepInfo &TSInfo
     char key[1000];
     int rc;
     sprintf(key, "step%zu-rank%d", m_WriterStep, m_Comm.Rank());
+
+    // Value = composite blob (see BuildMetadataBlob).  Either Phase-1
+    // (MetaEncode + 8-byte trailer) or Phase-2 (MetaEncode + MetaMeta
+    // + Attr + 24-byte footer) depending on m_PerRankMetadata.
+    std::vector<char> blob = BuildMetadataBlob(TSInfo);
+
     CALI_MARK_BEGIN("DaosWriter::daos_kv_put");
-    rc = daos_kv_put(oh, DAOS_TX_NONE, 0, key, TSInfo.MetaEncodeBuffer->m_FixedSize,
-                     TSInfo.MetaEncodeBuffer->Data(), NULL);
+    rc = daos_kv_put(oh, DAOS_TX_NONE, 0, key, blob.size(), blob.data(), NULL);
     if (rc)
     {
         helper::Throw<std::runtime_error>("Engine", "DaosWriter", "DaosKVWriteMetadata",
@@ -546,7 +613,7 @@ void DaosWriter::EndStep()
      *
      * Rank 0 also emits a step record to md.idx every step (even when
      * the gate says no new content) — the reader's attribute path
-     * uses m_MetadataIndexTable[Step][4] to locate attributes in md.0,
+     * uses m_MetadataIndexTable[Step][2] to locate attributes in md.0,
      * so an entry per step is required for attribute reads to work.
      *
      * Cheap collective gate: blocking Allreduce of a 1-byte "anyone has
@@ -556,76 +623,78 @@ void DaosWriter::EndStep()
      * the cost is ~80-100 ms/step at 32 ranks, which is the floor for
      * one MPI collective at scale on this network.
      */
-    unsigned char localHasContent =
-        (!TSInfo.NewMetaMetaBlocks.empty() ||
-         (TSInfo.AttributeEncodeBuffer && TSInfo.AttributeEncodeBuffer->m_FixedSize > 0))
-            ? 1
-            : 0;
-    unsigned char anyHasContent = 0;
-    m_Profiler.Start("ES_Gate");
-    m_Comm.Allreduce(&localHasContent, &anyHasContent, 1, helper::Comm::Op::Max);
-    m_Profiler.Stop("ES_Gate");
-
     std::vector<core::iovec> AttributeBlocks;
-    if (anyHasContent)
+    if (!m_PerRankMetadata)
     {
-        profiling::ProfilerGuard g(m_Profiler, "ES_SelAgg");
+        // ---- aggregated mode (Phase 1 / default) ----
+        unsigned char localHasContent =
+            (!TSInfo.NewMetaMetaBlocks.empty() ||
+             (TSInfo.AttributeEncodeBuffer && TSInfo.AttributeEncodeBuffer->m_FixedSize > 0))
+                ? 1
+                : 0;
+        unsigned char anyHasContent = 0;
+        m_Profiler.Start("ES_Gate");
+        m_Comm.Allreduce(&localHasContent, &anyHasContent, 1, helper::Comm::Op::Max);
+        m_Profiler.Stop("ES_Gate");
 
-        std::vector<format::BP5Base::MetaMetaInfoBlock> UniqueMetaMetaBlocks =
-            TSInfo.NewMetaMetaBlocks;
-        if (TSInfo.AttributeEncodeBuffer)
+        if (anyHasContent)
         {
-            AttributeBlocks.push_back(
-                {TSInfo.AttributeEncodeBuffer->Data(), TSInfo.AttributeEncodeBuffer->m_FixedSize});
-        }
-        std::vector<size_t> MetaEncodeSize{
-            TSInfo.MetaEncodeBuffer ? TSInfo.MetaEncodeBuffer->m_FixedSize : 0};
-        std::vector<uint64_t> WriterDataPos{m_StartDataPos};
+            profiling::ProfilerGuard g(m_Profiler, "ES_SelAgg");
 
-        format::BP5Helper::BP5AggregateInformation(m_Comm, m_Profiler, UniqueMetaMetaBlocks,
-                                                   AttributeBlocks, MetaEncodeSize, WriterDataPos);
-
-        if (m_Comm.Rank() == 0 && !UniqueMetaMetaBlocks.empty())
-        {
-            WriteMetaMetadata(UniqueMetaMetaBlocks);
-            for (auto &mm : UniqueMetaMetaBlocks)
+            std::vector<format::BP5Base::MetaMetaInfoBlock> UniqueMetaMetaBlocks =
+                TSInfo.NewMetaMetaBlocks;
+            if (TSInfo.AttributeEncodeBuffer)
             {
-                free((void *)mm.MetaMetaInfo);
-                free((void *)mm.MetaMetaID);
+                AttributeBlocks.push_back({TSInfo.AttributeEncodeBuffer->Data(),
+                                           TSInfo.AttributeEncodeBuffer->m_FixedSize});
             }
-        }
-        // No trailing Barrier — the next collective is the Allgather
-        // inside DaosArrayWriteMetadata, which itself synchronizes and
-        // will absorb cross-rank skew.
-    }
+            std::vector<size_t> MetaEncodeSize{
+                TSInfo.MetaEncodeBuffer ? TSInfo.MetaEncodeBuffer->m_FixedSize : 0};
+            // Aggregated WriterDataPositions output is no longer used —
+            // each rank carries its own step-start position in its
+            // metadata trailer.  Pass m_StepStartDataPos as input only
+            // because BP5Helper's fixed-node-contrib packet requires it.
+            std::vector<uint64_t> WriterDataPos{m_StepStartDataPos};
 
-    // Always gather per-rank data start offsets into m_WriterDataPos so
-    // WriteMetadataFileIndex emits the right offsets every step.
-    // BP5AggregateInformation only runs when anyHasContent is true, so
-    // we can't rely on its WriterDataPos vector for steady-state steps.
-    {
-        profiling::ProfilerGuard gw(m_Profiler, "ES_GatherPos");
-        std::vector<uint64_t> tmp;
+            format::BP5Helper::BP5AggregateInformation(m_Comm, m_Profiler, UniqueMetaMetaBlocks,
+                                                       AttributeBlocks, MetaEncodeSize,
+                                                       WriterDataPos);
+
+            if (m_Comm.Rank() == 0 && !UniqueMetaMetaBlocks.empty())
+            {
+                WriteMetaMetadata(UniqueMetaMetaBlocks);
+                for (auto &mm : UniqueMetaMetaBlocks)
+                {
+                    free((void *)mm.MetaMetaInfo);
+                    free((void *)mm.MetaMetaID);
+                }
+            }
+            // No trailing Barrier — the next collective is the Allgather
+            // inside DaosArrayWriteMetadata, which absorbs cross-rank skew.
+        }
+
+        // Rank 0 always emits an attribute record to md.0 (even when empty —
+        // WriteAttributes pads AttrSizeVector to writerCount zeros).
         if (m_Comm.Rank() == 0)
         {
-            tmp.resize(m_Comm.Size());
-        }
-        m_Comm.GatherArrays(&m_StartDataPos, 1, tmp.data(), 0);
-        if (m_Comm.Rank() == 0)
-        {
-            m_WriterDataPos = std::move(tmp);
+            m_LatestMetaDataPos = m_MetaDataPos;
+            m_LatestMetaDataSize = WriteAttributes(AttributeBlocks);
+            WriteMetadataFileIndex(m_LatestMetaDataPos, m_LatestMetaDataSize);
         }
     }
-
-    // Rank 0 always emits an attribute record to md.0 (even when empty —
-    // WriteAttributes pads AttrSizeVector to writerCount zeros).  This
-    // keeps the reader's per-step bookkeeping consistent every step.
-    // Then emits the corresponding md.idx step record.
-    if (m_Comm.Rank() == 0)
+    else
     {
-        m_LatestMetaDataPos = m_MetaDataPos;
-        m_LatestMetaDataSize = WriteAttributes(AttributeBlocks);
-        WriteMetadataFileIndex(m_LatestMetaDataPos, m_LatestMetaDataSize);
+        // ---- per-rank mode (Phase 2) ----
+        // No ES_Gate, no ES_SelAgg.  Each rank's NewMetaMetaBlocks and
+        // AttributeEncodeBuffer are serialized into its own metadata
+        // blob inside WriteMetadata below.  Rank 0 still emits a step
+        // record to md.idx (degenerate: MetaDataPos/Size = 0) so the
+        // reader's step-count machinery still works.  mmd.0 / md.0
+        // stay empty in this mode.
+        if (m_Comm.Rank() == 0)
+        {
+            WriteMetadataFileIndex(0, 0);
+        }
     }
 
     CALI_MARK_BEGIN("DaosWriter::metadata-stabilization");
@@ -793,6 +862,36 @@ void DaosWriter::SetMetadataLayout()
     }
 }
 
+/// Pick the per-rank-metadata mode from DAOS_PER_RANK_METADATA.  When
+/// unset or 0, the Phase-1 default (aggregated mmd / attrs via ES_Gate
+/// + ES_SelAgg) runs.  When 1, each rank serializes its own
+/// NewMetaMetaBlocks + AttributeEncodeBuffer into its metadata blob.
+void DaosWriter::SetPerRankMetadata()
+{
+    const char *env = std::getenv("DAOS_PER_RANK_METADATA");
+    if (!env)
+    {
+        m_PerRankMetadata = false;
+        return;
+    }
+    std::string v(env);
+    std::transform(v.begin(), v.end(), v.begin(), ::tolower);
+    if (v == "0" || v == "false" || v == "off")
+    {
+        m_PerRankMetadata = false;
+    }
+    else if (v == "1" || v == "true" || v == "on")
+    {
+        m_PerRankMetadata = true;
+    }
+    else
+    {
+        helper::Throw<std::invalid_argument>("Engine", "DaosWriter", "SetPerRankMetadata",
+                                             "DAOS_PER_RANK_METADATA='" + v +
+                                                 "' is not recognized; expected 0/1");
+    }
+}
+
 // Set m_PoolName and m_ContName from the environment variables DAOS_POOL and DAOS_CONT
 void DaosWriter::SetPoolAndContName()
 {
@@ -832,6 +931,7 @@ void DaosWriter::InitDAOS()
     }
 
     SetMetadataLayout();
+    SetPerRankMetadata();
     SetPoolAndContName();
 
     CALI_MARK_BEGIN("DaosWriter::daos_pool_connect");
@@ -1115,8 +1215,21 @@ void DaosWriter::MakeHeader(std::vector<char> &buffer, size_t &position, const s
     const uint8_t columnMajor = (m_IO.m_ArrayOrder == ArrayOrdering::ColumnMajor) ? 'y' : 'n';
     helper::CopyToBuffer(buffer, position, &columnMajor);
 
-    // byte 41-63: unused
-    position += 23;
+    // byte 41: per-rank-metadata mode flag (Phase 2 gating).  0 =
+    // aggregated (Phase 1), 1 = per-rank attributes/MetaMetaBlocks
+    // packed in each rank's blob.  Reader uses this byte to dispatch.
+    if (position != m_PerRankMetadataFlagPosition)
+    {
+        helper::Throw<std::runtime_error>(
+            "Engine", "DaosWriter", "MakeHeader",
+            "ADIOS Coding ERROR in DaosWriter::MakeHeader. PerRankMetadata "
+            "flag position mismatch");
+    }
+    const uint8_t perRankFlag = (m_PerRankMetadata ? 1 : 0);
+    helper::CopyToBuffer(buffer, position, &perRankFlag);
+
+    // byte 42-63: unused
+    position += 22;
     // absolutePosition = position;
 }
 
@@ -1137,15 +1250,14 @@ void DaosWriter::InitBPBuffer()
                                              "(each Open allocates a new per-rank DAOS array)");
     }
 
-    /* New file: prepare metadata streams and a slot per writer for
-     * the per-step data position (legacy WriterMap is not emitted —
-     * DaosReader locates per-rank arrays via data_oids.txt). */
+    /* New file: prepare metadata streams.  Per-step data positions are
+     * now carried in each rank's metadata blob trailer, not gathered to
+     * rank 0; DaosReader locates per-rank arrays via data_oids.txt. */
     if (m_Comm.Rank() == 0)
     {
         m_FileMetadataIndexManager.SeekToFileBegin();
         m_FileMetadataManager.SeekToFileBegin();
         m_FileMetaMetadataManager.SeekToFileBegin();
-        m_WriterDataPos.resize(m_Comm.Size());
     }
 }
 
@@ -1162,25 +1274,11 @@ void DaosWriter::FlushData(const bool isFinal)
     DataBuf = nullptr;
 
     m_ThisTimestepDataSize += databufsize;
-
-    if (!isFinal)
-    {
-        size_t tmp[2];
-        // aggregate start pos and data size to rank 0
-        tmp[0] = m_StartDataPos;
-        tmp[1] = databufsize;
-
-        std::vector<size_t> RecvBuffer;
-        if (m_Comm.Rank() == 0)
-        {
-            RecvBuffer.resize(m_Comm.Size() * 2);
-        }
-        m_Comm.GatherArrays(tmp, 2, RecvBuffer.data(), 0);
-        if (m_Comm.Rank() == 0)
-        {
-            FlushPosSizeInfo.push_back(RecvBuffer);
-        }
-    }
+    // Phase-1: no per-flush (pos, size) gather.  BP5's flush-list
+    // machinery is structurally dead in DAOS — each rank writes its own
+    // per-rank array, so all flush segments within a step are physically
+    // contiguous and the reader only needs the step-start offset (carried
+    // in the per-rank metadata trailer).
 }
 
 void DaosWriter::Flush(const int transportIndex) {}
@@ -1546,8 +1644,19 @@ void DaosWriter::CreateDaosArrayObject()
     /** Open a DAOS array object */
     daos_size_t cell_size = 1;
     daos_size_t chunk_size = 1048576;
+    // Server-allocated OIDs avoid PID-derived collisions when multiple
+    // runs reuse the same container (DER_EXIST -1004).  Allocate two
+    // contiguous OIDs: base+0 for the metadata array, base+1 for the
+    // mdsize KV.
+    uint64_t base_oid_lo = 0;
+    rc = daos_cont_alloc_oids(coh, 2, &base_oid_lo, NULL);
+    if (rc)
+    {
+        helper::Throw<std::runtime_error>("Engine", "DaosWriter", "CreateDaosArrayObject",
+                                          "daos_cont_alloc_oids failed rc=" + std::to_string(rc));
+    }
     oid.hi = 0;
-    oid.lo = getpid();
+    oid.lo = base_oid_lo;
     rc = daos_array_generate_oid(coh, &oid, true, 0, 0, 0);
     if (rc)
     {
@@ -1565,7 +1674,7 @@ void DaosWriter::CreateDaosArrayObject()
 
     /** Create a DAOS KV object to store metadata sizes */
     mdsize_oid.hi = 0;
-    mdsize_oid.lo = getpid() + 1;
+    mdsize_oid.lo = base_oid_lo + 1;
     // cid=0 (OC_UNKNOWN) so DAOS picks an object class consistent with the
     // container's rd_fac.  Aurora's pool requires rd_fac>=3 and rejects
     // OC_SX (single, no replica) with DER_INVAL.
@@ -1592,6 +1701,17 @@ void DaosWriter::CreateDaosKVObject()
 {
     /** Open a DAOS KV object */
     int rc;
+    // Server-allocated OID — avoids DER_EXIST collisions when the same
+    // container is reused across runs.
+    uint64_t kv_oid_lo = 0;
+    rc = daos_cont_alloc_oids(coh, 1, &kv_oid_lo, NULL);
+    if (rc)
+    {
+        helper::Throw<std::runtime_error>("Engine", "DaosWriter", "CreateDaosKVObject",
+                                          "daos_cont_alloc_oids failed rc=" + std::to_string(rc));
+    }
+    oid.hi = 0;
+    oid.lo = kv_oid_lo;
     // cid=0 (OC_UNKNOWN) so DAOS picks an object class consistent with the
     // container's rd_fac (Aurora pool requires rd_fac>=3 and rejects OC_SX).
     rc = daos_obj_generate_oid(coh, &oid, DAOS_OT_KV_HASHED, 0, 0, 0);

--- a/source/adios2/engine/daos/DaosWriter.h
+++ b/source/adios2/engine/daos/DaosWriter.h
@@ -144,12 +144,27 @@ private:
     void SetMetadataLayout();
     void SetPoolAndContName();
 
+    /// Phase-2 gating: when true, ES_Gate Allreduce and ES_SelAgg
+    /// BP5AggregateInformation are skipped, and each rank serializes
+    /// its own NewMetaMetaBlocks + AttributeEncodeBuffer into its
+    /// per-rank metadata blob.  Selected by DAOS_PER_RANK_METADATA env
+    /// var (default 0 = aggregated, today's Phase-1 behavior).
+    bool m_PerRankMetadata = false;
+    void SetPerRankMetadata();
+
     size_t m_step_offset = 0;
 
     // Declare WriteMetadata function
     void WriteMetadata(format::BP5Serializer::TimestepInfo &);
     void DaosArrayWriteMetadata(format::BP5Serializer::TimestepInfo &);
     void DaosKVWriteMetadata(format::BP5Serializer::TimestepInfo &);
+    /// Compose this rank's per-step metadata blob.  In aggregated mode
+    /// (Phase 1 default): [MetaEncodeBuffer][step_start u64], 8-byte
+    /// trailer.  In per-rank mode (Phase 2): [MetaEncode][MetaMetaBlocks
+    /// serialized][AttributeEncodeBuffer][footer], where footer is
+    /// (mmb_size, attr_size, step_start) = 24 bytes.  Returns a single
+    /// contiguous buffer; size determined by the caller from the result.
+    std::vector<char> BuildMetadataBlob(format::BP5Serializer::TimestepInfo &TSInfo);
     void CreateDaosArrayObject();
     void CreateDaosKVObject();
     void OpenDaosObjAndShare();
@@ -247,28 +262,20 @@ private:
     // updated during WriteMetaData
     uint64_t m_MetaDataPos = 0;
 
-    /** On every process, at the end of writing, this holds the offset
-     *  where they started writing (needed for global metadata)
+    /** Per-rank cursor into the data array at the start of this step.
+     *  Snapshotted in BeginStep so that, regardless of intermediate
+     *  PerformDataWrite calls, each rank knows where its step's data
+     *  begins.  Written as an 8-byte trailer on the per-rank metadata
+     *  blob; the reader uses it as the base offset for ReadData.
      */
-    uint64_t m_StartDataPos = 0;
-    /** End-of-step data offset (= cursor into m_DataArray after this step's
-     *  WriteData).  Mirrors what BP5 calls m_DataPos.
-     */
-    uint64_t m_DataPos = 0;
+    uint64_t m_StepStartDataPos = 0;
 
     /*
      *  Total data written this timestep
      */
     uint64_t m_ThisTimestepDataSize = 0;
 
-    /** rank 0 collects m_StartDataPos in this vector for writing it
-     *  to the index file
-     */
-    std::vector<uint64_t> m_WriterDataPos;
-
     bool m_MarshalAttributesNecessary = true;
-
-    std::vector<std::vector<size_t>> FlushPosSizeInfo;
 
     void MakeHeader(std::vector<char> &buffer, size_t &position, const std::string fileType,
                     const bool isActive);
@@ -276,6 +283,11 @@ private:
     // Latest metadata position/size for the metadata index file.
     uint64_t m_LatestMetaDataPos = 0;
     uint64_t m_LatestMetaDataSize = 0;
+    /// Tracks whether WriteMetadataFileIndex has been called yet.
+    /// In aggregated mode MetaDataPos==0 doubles as the first-call
+    /// sentinel; in per-rank mode every call has MetaDataPos==0 so
+    /// we need an explicit flag.
+    bool m_FirstIndexCall = true;
     TimePoint m_EngineStart;
     TimePoint m_BeginStepStart;
 

--- a/source/adios2/helper/adiosSystem.cpp
+++ b/source/adios2/helper/adiosSystem.cpp
@@ -182,6 +182,14 @@ char BPVersion(const std::string &name, helper::Comm &comm,
     return version;
 }
 
+bool IsDAOSDataset(const std::string &name) noexcept
+{
+    // The DAOS engine writes a data_oids.txt index alongside its
+    // metadata files; BP3/BP4/BP5 never produce this file, so it is the
+    // unambiguous marker for a DAOS-engine dataset directory.
+    return adios2sys::SystemTools::PathExists(name + PathSeparator + "data_oids.txt");
+}
+
 unsigned int NumHardwareThreadsPerNode() { return std::thread::hardware_concurrency(); }
 
 size_t RaiseLimitNoFile()

--- a/source/adios2/helper/adiosSystem.h
+++ b/source/adios2/helper/adiosSystem.h
@@ -76,6 +76,15 @@ bool IsHDF5File(const std::string &name, core::IO &io, helper::Comm &comm,
 char BPVersion(const std::string &name, helper::Comm &comm,
                const std::vector<Params> &transportsParameters) noexcept;
 
+/** Return true if 'name' is a dataset directory written by the DAOS
+ *  engine.  Identified by the data_oids.txt index file the DAOS engine
+ *  produces (mapping writer ranks to DAOS array object IDs); no
+ *  BP3/BP4/BP5 dataset contains this file.  Used by IO::Open to
+ *  auto-detect the DAOS engine -- a DAOS dataset directory also carries
+ *  an mmd.0 and would otherwise mis-detect as BP5.
+ */
+bool IsDAOSDataset(const std::string &name) noexcept;
+
 /** Return the number of available hardware threads on the node.
  * It might return 0 if the detection does not work
  */


### PR DESCRIPTION
Brings the DAOS engine to a working multi-node read/write state.

- IO::Open auto-detects the DAOS engine via a new helper::IsDAOSDataset() keyed on data_oids.txt, so bpls and other readers no longer mis-detect DAOS datasets as BP5.
- Always add data_position to each ranks metadata block rather than gathering it to rank 0.
- Per-rank metadata:  when the env variable DAOS_PER_RANK_METADATA is set - skip the ES_Gate Allreduce and ES_SelAgg, packing MetaMetaBlocks and the attribute buffer inline in each rank's blob.  ~3-4% faster at scale; the default aggregated path is unchanged.
- Fix a 32-bit overflow in DaosArrayWriteMetadata: the per-rank metadata-array offset was an int*int product that overflows at rank 2048 (2048 * 1 MiB == 2^31), stranding every metadata blob from rank 2048 on. 
- Allocate DAOS object IDs with daos_cont_alloc_oids instead of getpid()-derived OIDs.
- Per-rank mode: deduplicate MetaMetaBlocks.  Each writer rank ships its own copy of every format ID; install each unique ID once per reader.
- Add env-gated DAOS_MD_DEBUG reader diagnostics.