### PR TITLE
docs: show introduction content on ReadTheDocs home page

### DIFF
--- a/docs/user_guide/source/index.rst
+++ b/docs/user_guide/source/index.rst
@@ -8,6 +8,9 @@ ADIOS 2: The Adaptable Input/Output System version 2
 
 Funded by the `Exascale Computing Project (ECP) <https://www.exascaleproject.org/>`_, U.S. Department of Energy
 
+.. include:: introduction/nutshell.rst
+.. include:: introduction/adaptable_io.rst
+
 .. toctree::
    :caption: Introduction
 


### PR DESCRIPTION
Include the introduction content directly in `index.rst` so it appears on the ReadTheDocs home page rather than requiring a click through to a separate page.