### PR TITLE
BP5: thread-safe context-bearing Get/PerformGets pipeline

### DIFF
--- a/bindings/CXX/adios2/cxx/Engine.cpp
+++ b/bindings/CXX/adios2/cxx/Engine.cpp
@@ -89,6 +89,18 @@ void Engine::PerformGets()
     m_Engine->PerformGets();
 }
 
+std::unique_ptr<core::GetContext> Engine::NewGetContext()
+{
+    helper::CheckForNullptr(m_Engine, "in call to Engine::NewGetContext");
+    return m_Engine->NewGetContext();
+}
+
+void Engine::PerformGets(core::GetContext &ctx)
+{
+    helper::CheckForNullptr(m_Engine, "in call to Engine::PerformGets(GetContext&)");
+    m_Engine->PerformGets(ctx);
+}
+
 void Engine::LockWriterDefinitions()
 {
     helper::CheckForNullptr(m_Engine, "in call to Engine::LockWriterDefinitions");
@@ -334,6 +346,7 @@ Engine::AllStepsBlocksInfo(const VariableNT &variable) const
     template void Engine::Get<T>(const std::string &, std::vector<T> &, const Mode);               \
                                                                                                    \
     template void Engine::Get<T>(Variable<T>, T *, const Selection &, const Mode);                 \
+    template void Engine::Get<T>(core::GetContext &, Variable<T>, T *, const Selection &);         \
     template void Engine::Get<T>(Variable<T>, std::vector<T> &, const Selection &, const Mode);    \
                                                                                                    \
     template void Engine::Get<T>(Variable<T>, typename Variable<T>::Info & info, const Mode);      \

--- a/bindings/CXX/adios2/cxx/Engine.h
+++ b/bindings/CXX/adios2/cxx/Engine.h
@@ -26,6 +26,7 @@ class Selection; // for selection-based Get()
 namespace core
 {
 class Engine; // private implementation
+class GetContext;
 
 }
 /// \endcond
@@ -447,6 +448,15 @@ public:
 
     /** Perform all Get calls in Deferred mode up to this point */
     void PerformGets();
+
+    // Context-bearing Get / PerformGets — thread-safe pipeline (BP5 reader only).
+    // Returns nullptr if the engine doesn't support concurrent contexts.
+    std::unique_ptr<core::GetContext> NewGetContext();
+
+    template <class T>
+    void Get(core::GetContext &ctx, Variable<T> variable, T *data, const Selection &selection);
+
+    void PerformGets(core::GetContext &ctx);
 
     /**
      * Ends current step, by default calls PerformsPut/Get internally

--- a/bindings/CXX/adios2/cxx/Engine.tcc
+++ b/bindings/CXX/adios2/cxx/Engine.tcc
@@ -305,6 +305,17 @@ void Engine::Get(Variable<T> variable, std::vector<T> &dataV, const Selection &s
                   selection.GetCoreSelection(), launch);
 }
 
+template <class T>
+void Engine::Get(core::GetContext &ctx, Variable<T> variable, T *data, const Selection &selection)
+{
+    using IOType = typename TypeInfo<T>::IOType;
+    adios2::helper::CheckForNullptr(m_Engine, "in call to Engine::Get(GetContext &, ...)");
+    adios2::helper::CheckForNullptr(variable.m_Variable,
+                                    "for variable in call to Engine::Get(GetContext &, ...)");
+    m_Engine->Get(ctx, *variable.m_Variable, reinterpret_cast<IOType *>(data),
+                  selection.GetCoreSelection());
+}
+
 } // end namespace adios2
 
 #endif /* ADIOS2_BINDINGS_CXX_CXX_ENGINE_TCC_ */

--- a/docs/user_guide/source/components/engine.rst
+++ b/docs/user_guide/source/components/engine.rst
@@ -472,6 +472,11 @@ PerformGets
 
    Executes all pending ``Get`` calls in deferred mode.
 
+   A second overload, ``PerformGets(GetContext&)``, drains only the requests
+   queued on the supplied context, supporting concurrent ``Get`` pipelines on
+   a single engine. See `Thread-Safe Concurrent Reads with GetContext`_ in
+   the Selection chapter.
+
 
 Engine usage example
 --------------------

--- a/docs/user_guide/source/components/selection.rst
+++ b/docs/user_guide/source/components/selection.rst
@@ -183,6 +183,46 @@ Selection-based ``Get()`` is currently supported by the **BP5** and **SST**
 (with BP5 marshalling) engines. Other engines will throw a runtime error if a
 ``Selection`` is passed to ``Get()``.
 
+Thread-Safe Concurrent Reads with GetContext
+--------------------------------------------
+
+The Selection-based ``Get()`` shown above shares per-engine queue state with
+every other ``Get()`` call on the same engine, so concurrent calls from
+multiple threads are not safe. A second overload takes an explicit
+``GetContext`` so each thread (or each independent reader) can queue and drain
+``Get()`` requests on its own:
+
+.. code-block:: c++
+
+   auto ctx = engine.NewGetContext();
+   if (!ctx) {
+       // Engine does not support concurrent contexts; fall back to the
+       // single-threaded Selection-based Get above.
+   }
+
+   auto sel = adios2::Selection::BoundingBox({0, 0}, {10, 20}).WithSteps(0, 1);
+   engine.Get(*ctx, var, data, sel);
+   engine.PerformGets(*ctx);
+
+Each ``GetContext`` owns its own queue of pending requests, so
+``PerformGets(ctxA)`` drains only ``ctxA`` and leaves any requests queued on
+``ctxB`` untouched. A context is reusable after ``PerformGets``; the queue is
+cleared on the success path. Calls in ctx-form are always deferred — there is
+no ``Mode::Sync`` variant.
+
+``NewGetContext()`` is a feature probe: it returns ``nullptr`` if the engine
+does not support concurrent contexts. Currently only the **BP5** reader
+supports them, and only when:
+
+- the engine was opened in ``Mode::ReadRandomAccess`` (no step lifecycle to
+  race on), and
+- the underlying file transport is reentrant for ``Read`` (the POSIX
+  transport is; ``fstream`` and others are not).
+
+The legacy ``Selection``-less ``Get()``/``PerformGets()`` API and the
+single-threaded Selection-based ``Get()`` are unchanged; the ctx-form is an
+additional API for callers that need concurrency.
+
 Compatibility
 -------------
 

--- a/docs/user_guide/source/introduction/whatsnew.rst
+++ b/docs/user_guide/source/introduction/whatsnew.rst
@@ -2,6 +2,30 @@
 What's new in Development
 ==============================
 
+Thread-Safe Get with GetContext
+-------------------------------
+
+A new ``GetContext`` API extends the Selection-based ``Get()`` to support
+concurrent read pipelines on a single engine. Each caller allocates its own
+``GetContext`` via ``Engine::NewGetContext()`` and uses it as the first
+argument to ``Get()`` and ``PerformGets()``; per-context queues mean two
+threads can drive independent ``Get`` batches against the same open engine
+without racing.
+
+.. code-block:: c++
+
+   auto ctx = engine.NewGetContext();
+   if (ctx) {
+       engine.Get(*ctx, var, data, adios2::Selection::BoundingBox(start, count));
+       engine.PerformGets(*ctx);
+   }
+
+``NewGetContext()`` returns ``nullptr`` when the engine does not support
+concurrent contexts; callers feature-probe with the null check. Currently
+only the **BP5** reader supports them, and only when opened in
+``Mode::ReadRandomAccess`` with a reentrant file transport (POSIX). See the
+Selection chapter for full details.
+
 SST Mercury Data Plane
 -----------------------
 

--- a/source/adios2/core/Engine.cpp
+++ b/source/adios2/core/Engine.cpp
@@ -83,6 +83,14 @@ void Engine::PerformPuts() { ThrowUp("PerformPuts"); }
 void Engine::PerformGets() { ThrowUp("PerformGets"); }
 void Engine::PerformDataWrite() { return; }
 
+// Feature probe: null => engine doesn't support the ctx-form pipeline.
+std::unique_ptr<GetContext> Engine::NewGetContext() { return nullptr; }
+void Engine::PerformGets(GetContext &) { ThrowUp("PerformGets(GetContext&)"); }
+void Engine::DoGetContextDeferred(GetContext &, VariableBase &, void *, const Selection &)
+{
+    ThrowUp("DoGetContextDeferred");
+}
+
 void Engine::Close(const int transportIndex)
 {
     if (m_IsOpen)
@@ -374,6 +382,8 @@ std::vector<VariableStruct::BPInfo> Engine::BlocksInfoStruct(const VariableStruc
                                                                                                    \
     template void Engine::Get<T>(Variable<T> &, T *, const Selection &, const Mode);               \
     template void Engine::Get<T>(Variable<T> &, std::vector<T> &, const Selection &, const Mode);  \
+                                                                                                   \
+    template void Engine::Get<T>(GetContext &, Variable<T> &, T *, const Selection &);             \
                                                                                                    \
     template typename Variable<T>::BPInfo *Engine::Get<T>(Variable<T> &, const Mode);              \
     template typename Variable<T>::BPInfo *Engine::Get<T>(const std::string &, const Mode);        \

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -23,6 +23,7 @@
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/common/Selection.h"
+#include "adios2/core/GetContext.h"
 #include "adios2/core/IO.h"
 #include "adios2/core/Variable.h"
 #include "adios2/core/VariableStruct.h"
@@ -387,6 +388,15 @@ public:
     void Get(Variable<T> &variable, std::vector<T> &dataV, const Selection &selection,
              const Mode launch = Mode::Deferred);
 
+    // Context-bearing thread-safe Get pipeline (BP5 only).
+    // NewGetContext returns nullptr if the engine doesn't support it.
+    virtual std::unique_ptr<GetContext> NewGetContext();
+
+    template <class T>
+    void Get(GetContext &ctx, Variable<T> &variable, T *data, const Selection &selection);
+
+    virtual void PerformGets(GetContext &ctx);
+
     /**
      * Reader application indicates that no more data will be read from the
      * current stream before advancing.
@@ -609,6 +619,8 @@ protected:
     virtual void DoGetDeferred(Variable<T> &, T *, const Selection &);
     ADIOS2_FOREACH_STDTYPE_1ARG(declare_type)
 #undef declare_type
+
+    virtual void DoGetContextDeferred(GetContext &, VariableBase &, void *, const Selection &);
 
     virtual void DoGetStructSync(VariableStruct &, void *);
     virtual void DoGetStructDeferred(VariableStruct &, void *);

--- a/source/adios2/core/Engine.tcc
+++ b/source/adios2/core/Engine.tcc
@@ -180,6 +180,14 @@ void Engine::Get(Variable<T> &variable, T *data, const Selection &selection, con
 }
 
 template <class T>
+void Engine::Get(GetContext &ctx, Variable<T> &variable, T *data, const Selection &selection)
+{
+    CommonChecks(variable, data, {Mode::Read, Mode::ReadRandomAccess},
+                 "in call to Get(GetContext &, Variable, T*, Selection)");
+    DoGetContextDeferred(ctx, variable, data, selection);
+}
+
+template <class T>
 void Engine::Get(Variable<T> &variable, std::vector<T> &dataV, const Selection &selection,
                  const Mode launch)
 {

--- a/source/adios2/core/GetContext.h
+++ b/source/adios2/core/GetContext.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ADIOS2_CORE_GETCONTEXT_H_
+#define ADIOS2_CORE_GETCONTEXT_H_
+
+namespace adios2
+{
+namespace core
+{
+
+// Opaque per-caller state for thread-safe Get/PerformGets.
+class GetContext
+{
+public:
+    virtual ~GetContext() = default;
+};
+
+} // end namespace core
+} // end namespace adios2
+
+#endif /* ADIOS2_CORE_GETCONTEXT_H_ */

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -549,7 +549,7 @@ void BP5Reader::PerformGets()
         bool RowMajorOrdering = (m_IO.m_ArrayOrder == ArrayOrdering::RowMajor);
 
         // If nothing is pending, don't open
-        if (m_BP5Deserializer->PendingGetRequests.size() == 0)
+        if (m_BP5Deserializer->DefaultGetContext().PendingGetRequests.size() == 0)
             return;
 
 #ifdef ADIOS2_HAVE_CURL
@@ -656,16 +656,49 @@ void BP5Reader::PerformGets()
     }
     else
     {
-        PerformLocalGets();
+        PerformLocalGets(m_BP5Deserializer->DefaultGetContext());
     }
 
     // clear pending requests inside deserializer
     m_BP5Deserializer->ClearGetState();
 }
 
+std::unique_ptr<core::GetContext> BP5Reader::NewGetContext()
+{
+    // Needs ReadRandomAccess (no step lifecycle) + reentrant Read (POSIX only).
+    if (m_OpenMode != Mode::ReadRandomAccess)
+    {
+        return nullptr;
+    }
+    if (!m_HasReentrantReadTransport)
+    {
+        return nullptr;
+    }
+    return std::make_unique<format::BP5Deserializer::BP5GetContext>();
+}
+
+void BP5Reader::DoGetContextDeferred(core::GetContext &abstract_ctx, VariableBase &variable,
+                                     void *data, const Selection &selection)
+{
+    auto &ctx = static_cast<format::BP5Deserializer::BP5GetContext &>(abstract_ctx);
+    m_BP5Deserializer->QueueGet(ctx, variable, data, selection);
+}
+
+void BP5Reader::PerformGets(core::GetContext &abstract_ctx)
+{
+    if (m_dataIsRemote)
+    {
+        helper::Throw<std::logic_error>("Engine", "BP5Reader", "PerformGets(GetContext&)",
+                                        "Context-bearing PerformGets is supported only for "
+                                        "local (non-remote) BP5 reads");
+    }
+    auto &ctx = static_cast<format::BP5Deserializer::BP5GetContext &>(abstract_ctx);
+    PerformLocalGets(ctx);
+}
+
 void BP5Reader::PerformRemoteGetsWithKVCache()
 {
-    auto GetRequests = m_BP5Deserializer->PendingGetRequests;
+    auto GetRequests = m_BP5Deserializer->DefaultGetContext().PendingGetRequests;
     std::vector<Remote::GetHandle> handles;
 
     struct RequestInfo
@@ -859,7 +892,7 @@ void BP5Reader::PerformRemoteGetsWithKVCache()
 
 void BP5Reader::PerformRemoteGets()
 {
-    auto GetRequests = m_BP5Deserializer->PendingGetRequests;
+    auto GetRequests = m_BP5Deserializer->DefaultGetContext().PendingGetRequests;
 
     // Try batch get first — single HTTP round-trip for all variables
     {
@@ -942,7 +975,7 @@ void BP5Reader::PerformRemoteGets()
     }
 }
 
-void BP5Reader::PerformLocalGets()
+void BP5Reader::PerformLocalGets(format::BP5Deserializer::BP5GetContext &ctx)
 {
     auto lf_CompareReqSubfile =
         [&](const adios2::format::BP5Deserializer::ReadRequest &r1,
@@ -951,10 +984,8 @@ void BP5Reader::PerformLocalGets()
                 m_WriterMap[m_WriterMapIndex[r2.Timestep]].RankToSubfile[r2.WriterRank]);
     };
 
-    if (!m_InitialWriterActiveCheckDone)
-    {
+    std::call_once(m_InitialWriterActiveCheckFlag, [this]() {
         CheckWriterActive();
-        m_InitialWriterActiveCheckDone = true;
         if (!m_WriterIsActive)
         {
             Params transportParameters;
@@ -967,14 +998,17 @@ void BP5Reader::PerformLocalGets()
             if (m_MetaMetadataFile)
                 m_MetaMetadataFile->SetParameters(transportParameters);
         }
-    }
+    });
     // TP start = NOW();
     PERFSTUBS_SCOPED_TIMER("BP5Reader::PerformGets");
-    m_JSONProfiler.Start("DataRead");
+    {
+        std::lock_guard<std::mutex> lock(m_ProfilerMutex);
+        m_JSONProfiler.Start("DataRead");
+    }
     size_t maxReadSize;
 
     // TP startGenerate = NOW();
-    auto ReadRequests = m_BP5Deserializer->GenerateReadRequests(false, &maxReadSize);
+    auto ReadRequests = m_BP5Deserializer->GenerateReadRequests(ctx, false, &maxReadSize);
     size_t nRequest = ReadRequests.size();
     // TP endGenerate = NOW();
     // double generateTime = DURATION(startGenerate, endGenerate);
@@ -992,6 +1026,7 @@ void BP5Reader::PerformLocalGets()
         }
         if (reqidx <= nRequest)
         {
+            std::lock_guard<std::mutex> profLock(m_ProfilerMutex);
             m_JSONProfiler.AddBytes("dataread", ReadRequests[reqidx].ReadLength);
         }
         return reqidx;
@@ -1040,7 +1075,7 @@ void BP5Reader::PerformLocalGets()
                                        Req.StartOffset, Req.ReadLength, Req.DestinationAddr);
 
             TP startCopy = NOW();
-            m_BP5Deserializer->FinalizeGet(Req, false);
+            m_BP5Deserializer->FinalizeGet(ctx, Req, false);
             TP endCopy = NOW();
             subfileTotal += timeSubfile;
             readTotal += timeRead;
@@ -1101,7 +1136,10 @@ void BP5Reader::PerformLocalGets()
             {
                 Req.DestinationAddr = buf.data();
             }
-            m_JSONProfiler.AddBytes("dataread", Req.ReadLength);
+            {
+                std::lock_guard<std::mutex> profLock(m_ProfilerMutex);
+                m_JSONProfiler.AddBytes("dataread", Req.ReadLength);
+            }
             size_t SubfileNum = static_cast<size_t>(
                 m_WriterMap[m_WriterMapIndex[Req.Timestep]].RankToSubfile[Req.WriterRank]);
 
@@ -1121,12 +1159,15 @@ void BP5Reader::PerformLocalGets()
             }
             ReadData(DataFile.get(), Req.WriterRank, Req.Timestep, Req.StartOffset, Req.ReadLength,
                      Req.DestinationAddr);
-            m_BP5Deserializer->FinalizeGet(Req, false);
+            m_BP5Deserializer->FinalizeGet(ctx, Req, false);
         }
     }
-    m_BP5Deserializer->FinalizeDerivedGets(ReadRequests);
-    m_BP5Deserializer->ClearGetState();
-    m_JSONProfiler.Stop("DataRead");
+    m_BP5Deserializer->FinalizeDerivedGets(ctx, ReadRequests);
+    ctx.Clear();
+    {
+        std::lock_guard<std::mutex> profLock(m_ProfilerMutex);
+        m_JSONProfiler.Stop("DataRead");
+    }
     /*TP end = NOW();
     double t1 = DURATION(start, end);
     double t2 = DURATION(startRead, end);
@@ -1370,6 +1411,10 @@ size_t BP5Reader::OpenWithTimeout(std::unique_ptr<PoolableFile> &file, const std
             // if dataIsRemote, our filename is real and not in a tar file
             bool skipTarInfoParameter = m_dataIsRemote;
             file = filePool->Acquire(fileName, skipTarInfoParameter);
+            if (file && file->file)
+            {
+                m_HasReentrantReadTransport = file->file->m_ReentrantRead;
+            }
             flag = 0; // found file
             break;
         }

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -23,6 +23,7 @@
 
 #include <chrono>
 #include <map>
+#include <mutex>
 #include <vector>
 
 namespace adios2
@@ -59,6 +60,12 @@ public:
 
     void PerformGets() final;
 
+    // Context-bearing thread-safe Get pipeline; local data path only.
+    std::unique_ptr<core::GetContext> NewGetContext() final;
+    void PerformGets(core::GetContext &ctx) final;
+    void DoGetContextDeferred(core::GetContext &ctx, VariableBase &variable, void *data,
+                              const Selection &selection) final;
+
     MinVarInfo *MinBlocksInfo(const VariableBase &, const size_t Step) const;
     MinVarInfo *MinBlocksInfo(const VariableBase &, const size_t Step, const size_t WriterID,
                               const size_t BlockID) const;
@@ -90,6 +97,9 @@ private:
     std::unique_ptr<PoolableFile> m_MDIndexFile;
     std::unique_ptr<PoolableFile> m_MDFile;
     std::unique_ptr<PoolableFile> m_MetaMetadataFile;
+
+    // Cached at first transport open; gates NewGetContext.
+    bool m_HasReentrantReadTransport = false;
 
     /* How many bytes of metadata index have we already read in? */
     size_t m_MDIndexFileAlreadyReadSize = 0;
@@ -134,7 +144,8 @@ private:
 
     Minifooter m_Minifooter;
 
-    bool m_InitialWriterActiveCheckDone = false;
+    std::once_flag m_InitialWriterActiveCheckFlag;
+    std::mutex m_ProfilerMutex;
     bool m_ReadMetadataFromFile = true;
 
     void Init();
@@ -276,7 +287,7 @@ private:
     // step -> writermap index (for all steps)
     std::vector<uint64_t> m_WriterMapIndex;
 
-    void PerformLocalGets();
+    void PerformLocalGets(format::BP5Deserializer::BP5GetContext &ctx);
 
     void PerformRemoteGets();
 

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -656,7 +656,7 @@ void BP5Deserializer::SetupForStep(size_t Step, size_t WriterCount)
     }
     else
     {
-        PendingGetRequests.clear();
+        m_DefaultGetContext.Clear();
 
         for (auto RecPair : VarByKey)
         {
@@ -1381,8 +1381,9 @@ bool BP5Deserializer::GetSingleValueFromMetadata(core::VariableBase &variable, B
     return true;
 }
 
-bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestData, size_t AbsStep,
-                                     size_t RelStep, const core::Selection &selection)
+bool BP5Deserializer::QueueGetSingle(BP5GetContext &ctx, core::VariableBase &variable,
+                                     void *DestData, size_t AbsStep, size_t RelStep,
+                                     const core::Selection &selection)
 {
     BP5VarRec *VarRec = VarByKey[&variable];
     if (variable.m_Type == adios2::DataType::Struct)
@@ -1489,7 +1490,7 @@ bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestDat
         Req.StepCount = 1;
         Req.MemSpace = MemSpace;
         Req.Data = DestData;
-        PendingGetRequests.push_back(Req);
+        ctx.PendingGetRequests.push_back(Req);
     }
     else if ((effectiveSelType == adios2::SelectionType::WriteBlock) ||
              (variable.m_ShapeID == ShapeID::LocalArray))
@@ -1512,7 +1513,7 @@ bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestDat
         Req.Step = AbsStep;
         Req.RelStep = RelStep;
         Req.StepCount = 1;
-        PendingGetRequests.push_back(Req);
+        ctx.PendingGetRequests.push_back(Req);
     }
     else
     {
@@ -1522,8 +1523,8 @@ bool BP5Deserializer::QueueGetSingle(core::VariableBase &variable, void *DestDat
     return true;
 }
 
-bool BP5Deserializer::QueueGetSingleRemote(core::VariableBase &variable, void *DestData,
-                                           size_t RelStep, size_t StepCount,
+bool BP5Deserializer::QueueGetSingleRemote(BP5GetContext &ctx, core::VariableBase &variable,
+                                           void *DestData, size_t RelStep, size_t StepCount,
                                            const core::Selection &selection)
 {
     BP5VarRec *VarRec = VarByKey[&variable];
@@ -1584,7 +1585,7 @@ bool BP5Deserializer::QueueGetSingleRemote(core::VariableBase &variable, void *D
         Req.StepCount = StepCount;
         Req.MemSpace = MemSpace;
         Req.Data = DestData;
-        PendingGetRequests.push_back(Req);
+        ctx.PendingGetRequests.push_back(Req);
     }
     else if ((effectiveSelType == adios2::SelectionType::WriteBlock) ||
              (variable.m_ShapeID == ShapeID::LocalArray))
@@ -1607,7 +1608,7 @@ bool BP5Deserializer::QueueGetSingleRemote(core::VariableBase &variable, void *D
         Req.Step = RelStep;
         Req.RelStep = RelStep;
         Req.StepCount = StepCount;
-        PendingGetRequests.push_back(Req);
+        ctx.PendingGetRequests.push_back(Req);
     }
     else
     {
@@ -1617,7 +1618,7 @@ bool BP5Deserializer::QueueGetSingleRemote(core::VariableBase &variable, void *D
     return true;
 }
 
-bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData,
+bool BP5Deserializer::QueueGet(BP5GetContext &ctx, core::VariableBase &variable, void *DestData,
                                const core::Selection &selection, bool dataIsRemote)
 {
     const size_t stepsStart = selection.GetStepStart();
@@ -1625,7 +1626,7 @@ bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData,
 
     if (!m_RandomAccessMode)
     {
-        return QueueGetSingle(variable, DestData, CurTimestep, CurTimestep, selection);
+        return QueueGetSingle(ctx, variable, DestData, CurTimestep, CurTimestep, selection);
     }
     else
     {
@@ -1651,7 +1652,7 @@ bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData,
         if (dataIsRemote && VarRec->OrigShapeID != ShapeID::LocalValue &&
             VarRec->OrigShapeID != ShapeID::GlobalValue)
         {
-            ret = QueueGetSingleRemote(variable, DestData, stepsStart, stepsCount, selection);
+            ret = QueueGetSingleRemote(ctx, variable, DestData, stepsStart, stepsCount, selection);
         }
         else
         {
@@ -1664,7 +1665,7 @@ bool BP5Deserializer::QueueGet(core::VariableBase &variable, void *DestData,
                     if (GetMetadataBase(VarRec, AbsStep, WriterRank))
                     {
                         // This writer wrote on this timestep
-                        ret = QueueGetSingle(variable, DestData, AbsStep, RelStep, selection);
+                        ret = QueueGetSingle(ctx, variable, DestData, AbsStep, RelStep, selection);
                         size_t increment = variable.TotalSize() * variable.m_ElementSize;
                         DestData = (void *)((char *)DestData + increment);
                         break;
@@ -1764,7 +1765,8 @@ bool BP5Deserializer::IsContiguousTransfer(BP5ArrayRequest *Req, size_t *offsets
 }
 
 std::vector<BP5Deserializer::ReadRequest>
-BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *maxReadSize)
+BP5Deserializer::GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTempBuffers,
+                                      size_t *maxReadSize)
 {
     std::vector<BP5Deserializer::ReadRequest> Ret;
     *maxReadSize = 0;
@@ -1773,9 +1775,9 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
 
     try
     {
-        for (size_t ReqIndex = 0; ReqIndex < PendingGetRequests.size(); ReqIndex++)
+        for (size_t ReqIndex = 0; ReqIndex < ctx.PendingGetRequests.size(); ReqIndex++)
         {
-            auto Req = &PendingGetRequests[ReqIndex];
+            auto Req = &ctx.PendingGetRequests[ReqIndex];
             auto VarRec = (struct BP5VarRec *)Req->VarRec;
             VariableBase *VB = static_cast<VariableBase *>(VarRec->Variable);
             std::vector<std::string> derivedVarInputNameList;
@@ -2307,18 +2309,18 @@ BP5Deserializer::GenerateReadRequests(const bool doAllocTempBuffers, size_t *max
     catch (...)
     {
         std::exception_ptr ex = std::current_exception();
-        // if something in GenerateReadRequests threw an exception, clear the PendingGetRequests so
-        // it doesn't happen again (I.E. if this happened in PerformGets(), then EndStep() should
+        // if something in GenerateReadRequests threw an exception, clear the ctx.PendingGetRequests
+        // so it doesn't happen again (I.E. if this happened in PerformGets(), then EndStep() should
         // then happen cleanly.)
-        PendingGetRequests.clear();
+        ctx.PendingGetRequests.clear();
         std::rethrow_exception(ex);
     }
     return Ret;
 }
 
-void BP5Deserializer::FinalizeGet(const ReadRequest &Read, const bool freeAddr)
+void BP5Deserializer::FinalizeGet(BP5GetContext &ctx, const ReadRequest &Read, const bool freeAddr)
 {
-    auto &Req = PendingGetRequests[Read.ReqIndex];
+    auto &Req = ctx.PendingGetRequests[Read.ReqIndex];
     auto VarRec = (struct BP5VarRec *)Req.VarRec;
 
     // if we could do this, nothing else to do
@@ -2411,9 +2413,9 @@ void BP5Deserializer::FinalizeGet(const ReadRequest &Read, const bool freeAddr)
         {
             std::exception_ptr ex = std::current_exception();
             // if MakeOperator or Decompress throws an exception, we can't complete this request. To
-            // make it isn't tried again, we have to clear PendingGetRequests.  Also cleanup
+            // make it isn't tried again, we have to clear ctx.PendingGetRequests.  Also cleanup
             // Read.DestinationAddr.
-            PendingGetRequests.clear();
+            ctx.PendingGetRequests.clear();
             if (freeAddr)
             {
                 free((char *)Read.DestinationAddr);
@@ -2537,12 +2539,12 @@ void BP5Deserializer::FinalizeGet(const ReadRequest &Read, const bool freeAddr)
     }
 }
 
-void BP5Deserializer::FinalizeDerivedGets(std::vector<ReadRequest> &Reads)
+void BP5Deserializer::FinalizeDerivedGets(BP5GetContext &ctx, std::vector<ReadRequest> &Reads)
 {
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
-    for (size_t ReqIndex = 0; ReqIndex < PendingGetRequests.size(); ReqIndex++)
+    for (size_t ReqIndex = 0; ReqIndex < ctx.PendingGetRequests.size(); ReqIndex++)
     {
-        auto &Req = PendingGetRequests[ReqIndex];
+        auto &Req = ctx.PendingGetRequests[ReqIndex];
         auto VarRec = (struct BP5VarRec *)Req.VarRec;
         if (!VarRec->Derived)
             continue;
@@ -2658,13 +2660,11 @@ void BP5Deserializer::FinalizeDerivedGets(std::vector<ReadRequest> &Reads)
 #endif
 }
 
-void BP5Deserializer::ClearGetState() { PendingGetRequests.clear(); }
-
-void BP5Deserializer::FinalizeGets(std::vector<ReadRequest> &Reads)
+void BP5Deserializer::FinalizeGets(BP5GetContext &ctx, std::vector<ReadRequest> &Reads)
 {
     for (const auto &Read : Reads)
     {
-        FinalizeGet(Read, true);
+        FinalizeGet(ctx, Read, true);
     }
 }
 

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -9,6 +9,7 @@
 
 #include "adios2/common/Selection.h"
 #include "adios2/core/Attribute.h"
+#include "adios2/core/GetContext.h"
 #include "adios2/core/IO.h"
 #include "adios2/core/Variable.h"
 
@@ -64,38 +65,6 @@ public:
                                FFSTypeHandle FFSFormat);
 
     void SetupForStep(size_t Step, size_t WriterCount);
-    // return from QueueGet is true if a sync is needed to fill the data
-    bool QueueGet(core::VariableBase &variable, void *DestData, const core::Selection &selection,
-                  bool dataIsRemote = false);
-
-    /* generate read requests. return vector of requests AND the size of
-     * the largest allocation block necessary for reading.
-     * input flag: true allocates a temporary buffer for each read request
-     * unless the request can go directly to user memory.
-     * False will not allocate a temporary buffer
-     * (RR.DestinationAddress==nullptr) but may also assign the user memory
-     * pointer for direct read in
-     */
-    std::vector<ReadRequest> GenerateReadRequests(const bool doAllocTempBuffers,
-                                                  size_t *maxReadSize);
-    void FinalizeGet(const ReadRequest &, const bool freeAddr);
-    void FinalizeGets(std::vector<ReadRequest> &);
-    void FinalizeDerivedGets(std::vector<ReadRequest> &);
-    void ClearGetState();
-
-    MinVarInfo *AllRelativeStepsMinBlocksInfo(const VariableBase &var);
-    MinVarInfo *AllStepsMinBlocksInfo(const VariableBase &var);
-    MinVarInfo *MinBlocksInfo(const VariableBase &Var, const size_t Step);
-    MinVarInfo *MinBlocksInfo(const VariableBase &Var, const size_t Step, const size_t WriterID,
-                              const size_t BlockID);
-    bool VarShape(const VariableBase &, const size_t Step, Dims &Shape) const;
-    bool VariableMinMax(const VariableBase &var, const size_t Step, MinMaxStruct &MinMax);
-    char *VariableExprStr(const VariableBase &var);
-    void GetAbsoluteSteps(const VariableBase &variable, std::vector<size_t> &keys) const;
-
-    const bool m_WriterIsRowMajor;
-    const bool m_ReaderIsRowMajor;
-    core::Engine *m_Engine = NULL;
 
     enum RequestTypeEnum
     {
@@ -121,7 +90,68 @@ public:
         std::map<std::string, std::unique_ptr<MinVarInfo>> *DerivedInputMap;
         void *Data;
     };
-    std::vector<BP5ArrayRequest> PendingGetRequests;
+
+    // Per-caller queue. Concurrent contexts may be in flight on one engine.
+    class BP5GetContext : public core::GetContext
+    {
+    public:
+        std::vector<BP5ArrayRequest> PendingGetRequests;
+        void Clear() { PendingGetRequests.clear(); }
+    };
+
+    BP5GetContext &DefaultGetContext() { return m_DefaultGetContext; }
+
+    // QueueGet returns true if a sync is needed.
+    bool QueueGet(BP5GetContext &ctx, core::VariableBase &variable, void *DestData,
+                  const core::Selection &selection, bool dataIsRemote = false);
+
+    /* maxReadSize: largest allocation needed for reading.
+     * doAllocTempBuffers true: allocate a temp buffer per request unless it
+     * can read directly into user memory. false: leave DestinationAddress
+     * null but still wire up user memory for direct reads when possible.
+     */
+    std::vector<ReadRequest> GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTempBuffers,
+                                                  size_t *maxReadSize);
+    void FinalizeGet(BP5GetContext &ctx, const ReadRequest &, const bool freeAddr);
+    void FinalizeGets(BP5GetContext &ctx, std::vector<ReadRequest> &);
+    void FinalizeDerivedGets(BP5GetContext &ctx, std::vector<ReadRequest> &);
+    void ClearGetState(BP5GetContext &ctx) { ctx.Clear(); }
+
+    // Legacy non-context overloads forward via DefaultGetContext.
+    bool QueueGet(core::VariableBase &variable, void *DestData, const core::Selection &selection,
+                  bool dataIsRemote = false)
+    {
+        return QueueGet(m_DefaultGetContext, variable, DestData, selection, dataIsRemote);
+    }
+    std::vector<ReadRequest> GenerateReadRequests(const bool doAllocTempBuffers,
+                                                  size_t *maxReadSize)
+    {
+        return GenerateReadRequests(m_DefaultGetContext, doAllocTempBuffers, maxReadSize);
+    }
+    void FinalizeGet(const ReadRequest &r, const bool freeAddr)
+    {
+        FinalizeGet(m_DefaultGetContext, r, freeAddr);
+    }
+    void FinalizeGets(std::vector<ReadRequest> &r) { FinalizeGets(m_DefaultGetContext, r); }
+    void FinalizeDerivedGets(std::vector<ReadRequest> &r)
+    {
+        FinalizeDerivedGets(m_DefaultGetContext, r);
+    }
+    void ClearGetState() { m_DefaultGetContext.Clear(); }
+
+    MinVarInfo *AllRelativeStepsMinBlocksInfo(const VariableBase &var);
+    MinVarInfo *AllStepsMinBlocksInfo(const VariableBase &var);
+    MinVarInfo *MinBlocksInfo(const VariableBase &Var, const size_t Step);
+    MinVarInfo *MinBlocksInfo(const VariableBase &Var, const size_t Step, const size_t WriterID,
+                              const size_t BlockID);
+    bool VarShape(const VariableBase &, const size_t Step, Dims &Shape) const;
+    bool VariableMinMax(const VariableBase &var, const size_t Step, MinMaxStruct &MinMax);
+    char *VariableExprStr(const VariableBase &var);
+    void GetAbsoluteSteps(const VariableBase &variable, std::vector<size_t> &keys) const;
+
+    const bool m_WriterIsRowMajor;
+    const bool m_ReaderIsRowMajor;
+    core::Engine *m_Engine = NULL;
 
 private:
     size_t m_VarCount = 0;
@@ -244,10 +274,10 @@ private:
     int FindOffset(size_t Dims, const size_t *Size, const size_t *Index);
     bool GetSingleValueFromMetadata(core::VariableBase &variable, BP5VarRec *VarRec, void *DestData,
                                     size_t Step, size_t WriterRank, bool hasBlock, size_t blockID);
-    bool QueueGetSingle(core::VariableBase &variable, void *DestData, size_t AbsStep,
-                        size_t RelStep, const core::Selection &selection);
-    bool QueueGetSingleRemote(core::VariableBase &variable, void *DestData, size_t RelStep,
-                              size_t StepCount, const core::Selection &selection);
+    bool QueueGetSingle(BP5GetContext &ctx, core::VariableBase &variable, void *DestData,
+                        size_t AbsStep, size_t RelStep, const core::Selection &selection);
+    bool QueueGetSingleRemote(BP5GetContext &ctx, core::VariableBase &variable, void *DestData,
+                              size_t RelStep, size_t StepCount, const core::Selection &selection);
     void StructQueueReadChecks(core::VariableStruct *variable, BP5VarRec *VarRec);
 
     void *GetMetadataBase(BP5VarRec *VarRec, size_t Step, size_t WriterRank) const;
@@ -259,6 +289,9 @@ private:
     /* We assume operators are not thread-safe, call Decompress() one at a time
      */
     std::mutex mutexDecompress;
+
+    // Backs the legacy non-context Get/Perform API.
+    BP5GetContext m_DefaultGetContext;
 
 public:
     VariableBase *GetVariableBaseFromBP5VarRec(void *VarRec)

--- a/source/utils/xrootd-plugin/AdiosFilePool.cpp
+++ b/source/utils/xrootd-plugin/AdiosFilePool.cpp
@@ -5,6 +5,9 @@
  */
 
 #include "AdiosFilePool.h"
+
+#include "adios2/core/GetContext.h"
+
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
@@ -267,29 +270,62 @@ AnonADIOSFile *ADIOSFilePool::SubPool::GetFree(std::string Filename, bool RowMaj
                                                const std::string &EngineParams)
 {
     std::lock_guard<std::mutex> guard(subpool_mutex);
-    for (size_t i = 0; i < m_busy.size(); i++)
+
+    if (m_modeDetermined && m_shareable)
     {
-        if (!m_busy[i])
-        {
-            m_busy[i] = true;
-            in_use_count++;
-            return m_list[i].get();
-        }
+        in_use_count++;
+        return m_list[0].get();
     }
-    // no free files — open new one (only blocks requests for this same file)
+
+    if (m_modeDetermined && !m_shareable)
+    {
+        for (size_t i = 0; i < m_busy.size(); i++)
+        {
+            if (!m_busy[i])
+            {
+                m_busy[i] = true;
+                in_use_count++;
+                return m_list[i].get();
+            }
+        }
+        auto t0 = std::chrono::steady_clock::now();
+        m_list.push_back(std::make_unique<AnonADIOSFile>(Filename, RowMajorArrays, EngineParams));
+        auto t1 = std::chrono::steady_clock::now();
+        open_micros += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+        m_busy.push_back(true);
+        in_use_count++;
+        return m_list[m_list.size() - 1].get();
+    }
+
+    // First open: pick mode based on engine's NewGetContext support.
     auto t0 = std::chrono::steady_clock::now();
     m_list.push_back(std::make_unique<AnonADIOSFile>(Filename, RowMajorArrays, EngineParams));
     auto t1 = std::chrono::steady_clock::now();
     open_micros += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
-    m_busy.push_back(true);
+
+    auto probe = m_list[0]->m_engine.NewGetContext();
+    m_shareable = (probe != nullptr);
+    m_modeDetermined = true;
+
+    if (!m_shareable)
+    {
+        m_busy.push_back(true);
+    }
     in_use_count++;
-    return m_list[m_list.size() - 1].get();
+    return m_list[0].get();
 }
 
 void ADIOSFilePool::SubPool::Return(adios2::AnonADIOSFile *to_free)
 {
     std::lock_guard<std::mutex> guard(subpool_mutex);
     last_used = std::chrono::steady_clock::now();
+
+    if (m_shareable)
+    {
+        in_use_count--;
+        return;
+    }
+
     for (size_t i = 0; i < m_busy.size(); i++)
     {
         if (to_free == m_list[i].get())

--- a/source/utils/xrootd-plugin/AdiosFilePool.h
+++ b/source/utils/xrootd-plugin/AdiosFilePool.h
@@ -119,6 +119,12 @@ public:
         std::mutex subpool_mutex;
         std::chrono::steady_clock::time_point last_used;
         size_t in_use_count = 0;
+        // Decided at first Open (see SubPool::GetFree).
+        // Shareable: one engine for all concurrent users; in_use_count = refcount.
+        // Exclusive: legacy m_list+m_busy, one engine per concurrent user.
+        // Requires BP5 + reentrant transport; probed via NewGetContext().
+        bool m_shareable = false;
+        bool m_modeDetermined = false;
         std::vector<std::unique_ptr<AnonADIOSFile>> m_list;
         std::vector<bool> m_busy;
 

--- a/source/utils/xrootd-plugin/XrdSsiSvService.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvService.cpp
@@ -53,6 +53,7 @@
 
 #include "adios2/common/ADIOSMacros.h"
 #include "adios2/common/ADIOSTypes.h"
+#include "adios2/core/GetContext.h"
 #include "adios2/core/IO.h"
 #include "adios2/helper/adiosFunctions.h"
 
@@ -650,16 +651,18 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
                     return;
                 }
 
+                // Inline Selection — no Variable mutation; safe under shared engine.
+                auto sel = vr.Start.size() ? adios2::Selection::BoundingBox(vr.Start, vr.Count)
+                                           : adios2::Selection::All();
+                sel.SetSteps(vr.StepStart, vr.StepCount);
+                if (vr.BlockID != (size_t)-1)
+                    sel.SetBlock(vr.BlockID);
+
 #define BATCHGET_SIZE(T)                                                                           \
     else if (TypeOfVar == adios2::helper::GetDataType<T>())                                        \
     {                                                                                              \
         adios2::Variable<T> var = io.InquireVariable<T>(vr.VarName);                               \
-        if (vr.BlockID != (size_t)-1)                                                              \
-            var.SetBlockSelection(vr.BlockID);                                                     \
-        var.SetStepSelection({vr.StepStart, vr.StepCount});                                        \
-        if (vr.Start.size())                                                                       \
-            var.SetSelection({vr.Start, vr.Count});                                                \
-        dataSizes[v] = var.SelectionSize() * sizeof(T);                                            \
+        dataSizes[v] = var.SelectionSize(sel) * sizeof(T);                                         \
     }
                 if (false)
                 {
@@ -690,24 +693,41 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
                 writePtr += sizeof(uint64_t);
             }
 
-            // Read all variables into the response buffer
+            // ctx != null: queue-and-perform (shareable engine).
+            // ctx == null: legacy SetSelection+Sync (exclusive engine).
+            auto ctx = engine.NewGetContext();
             for (size_t v = 0; v < NVars; v++)
             {
                 auto &vr = varRequests[v];
                 adios2::DataType TypeOfVar = io.InquireVariableType(vr.VarName);
 
+                auto sel = vr.Start.size() ? adios2::Selection::BoundingBox(vr.Start, vr.Count)
+                                           : adios2::Selection::All();
+                sel.SetSteps(vr.StepStart, vr.StepCount);
+                if (vr.BlockID != (size_t)-1)
+                    sel.SetBlock(vr.BlockID);
+                if (vr.AccuracyError != 0.0 || vr.AccuracyNorm != 0.0)
+                    sel.SetAccuracy(vr.AccuracyError, vr.AccuracyNorm, vr.AccuracyRelative);
+
 #define BATCHGET_READ(T)                                                                           \
     else if (TypeOfVar == adios2::helper::GetDataType<T>())                                        \
     {                                                                                              \
         adios2::Variable<T> var = io.InquireVariable<T>(vr.VarName);                               \
-        if (vr.BlockID != (size_t)-1)                                                              \
-            var.SetBlockSelection(vr.BlockID);                                                     \
-        var.SetStepSelection({vr.StepStart, vr.StepCount});                                        \
-        if (vr.Start.size())                                                                       \
-            var.SetSelection({vr.Start, vr.Count});                                                \
-        if (vr.AccuracyError != 0.0 || vr.AccuracyNorm != 0.0)                                     \
-            var.SetAccuracy({vr.AccuracyError, vr.AccuracyNorm, vr.AccuracyRelative});             \
-        engine.Get(var, (T *)writePtr, adios2::Mode::Sync);                                        \
+        if (ctx)                                                                                   \
+        {                                                                                          \
+            engine.Get(*ctx, var, (T *)writePtr, sel);                                             \
+        }                                                                                          \
+        else                                                                                       \
+        {                                                                                          \
+            if (vr.BlockID != (size_t)-1)                                                          \
+                var.SetBlockSelection(vr.BlockID);                                                 \
+            var.SetStepSelection({vr.StepStart, vr.StepCount});                                    \
+            if (vr.Start.size())                                                                   \
+                var.SetSelection({vr.Start, vr.Count});                                            \
+            if (vr.AccuracyError != 0.0 || vr.AccuracyNorm != 0.0)                                 \
+                var.SetAccuracy({vr.AccuracyError, vr.AccuracyNorm, vr.AccuracyRelative});         \
+            engine.Get(var, (T *)writePtr, adios2::Mode::Sync);                                    \
+        }                                                                                          \
     }
                 if (false)
                 {
@@ -715,6 +735,10 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
                 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(BATCHGET_READ)
 #undef BATCHGET_READ
                 writePtr += dataSizes[v];
+            }
+            if (ctx)
+            {
+                engine.PerformGets(*ctx);
             }
 
             // Track bytes served and operation count
@@ -863,24 +887,46 @@ void XrdSsiSvService::ProcessRequest4Me(XrdSsiRequest *rqstP)
                     RespondErr("get: unknown variable", EINVAL);
                     return;
                 }
+                auto sel = Start.size() ? adios2::Selection::BoundingBox(Start, Count)
+                                        : adios2::Selection::All();
+                sel.SetSteps(StepStart, StepCount);
+                if (BlockID != (size_t)-1)
+                    sel.SetBlock(BlockID);
+                if (AccuracyError != 0.0 || AccuracyNorm != 0.0)
+                    sel.SetAccuracy(AccuracyError, AccuracyNorm, AccuracyRelative);
+
+                // ctx != null: ctx-form; ctx == null: legacy SetSelection+Sync.
+                auto ctx = engine.NewGetContext();
+
 #define GET(T)                                                                                     \
     else if (TypeOfVar == adios2::helper::GetDataType<T>())                                        \
     {                                                                                              \
         adios2::Variable<T> var = io.InquireVariable<T>(VarName);                                  \
-        if (BlockID != (size_t)-1)                                                                 \
-            var.SetBlockSelection(BlockID);                                                        \
-        var.SetStepSelection({StepStart, StepCount});                                              \
-        if (Start.size())                                                                          \
-            var.SetSelection(varSel);                                                              \
-        if (AccuracyError != 0.0 || AccuracyNorm != 0.0)                                           \
-            var.SetAccuracy({AccuracyError, AccuracyNorm, AccuracyRelative});                      \
-        m_responseBufferSize = var.SelectionSize() * sizeof(T);                                    \
+        m_responseBufferSize = var.SelectionSize(sel) * sizeof(T);                                 \
         if (m_responseBufferSize > sizeof(m_respData))                                             \
             m_responseBuffer = (char *)malloc(m_responseBufferSize);                               \
         else                                                                                       \
             m_responseBuffer = &m_respData[0];                                                     \
-        engine.Get(var, (T *)m_responseBuffer, adios2::Mode::Sync);                                \
+        if (ctx)                                                                                   \
+        {                                                                                          \
+            engine.Get(*ctx, var, (T *)m_responseBuffer, sel);                                     \
+            engine.PerformGets(*ctx);                                                              \
+        }                                                                                          \
+        else                                                                                       \
+        {                                                                                          \
+            if (BlockID != (size_t)-1)                                                             \
+                var.SetBlockSelection(BlockID);                                                    \
+            var.SetStepSelection({StepStart, StepCount});                                          \
+            if (Start.size())                                                                      \
+                var.SetSelection(varSel);                                                          \
+            if (AccuracyError != 0.0 || AccuracyNorm != 0.0)                                       \
+                var.SetAccuracy({AccuracyError, AccuracyNorm, AccuracyRelative});                  \
+            engine.Get(var, (T *)m_responseBuffer, adios2::Mode::Sync);                            \
+        }                                                                                          \
     }
+                if (false)
+                {
+                }
                 ADIOS2_FOREACH_PRIMITIVE_STDTYPE_1ARG(GET)
 #undef GET
                 // Track bytes served and operation count

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -151,6 +151,7 @@ bp_gtest_add_tests_helper(WriteReadAttributesMultirank MPI_ALLOW)
 bp_gtest_add_tests_helper(LargeMetadata MPI_ALLOW)
 bp5_gtest_add_tests_helper(WriteStatsOnly MPI_ALLOW)
 bp5_gtest_add_tests_helper(SelectionGet MPI_NONE)
+bp5_gtest_add_tests_helper(GetContextIsolation MPI_NONE)
 
 if (ADIOS2_HAVE_MPI)
   # Extra arguments: engine parameters, number of timesteps

--- a/testing/adios2/engine/bp/TestBPGetContextIsolation.cpp
+++ b/testing/adios2/engine/bp/TestBPGetContextIsolation.cpp
@@ -1,0 +1,327 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// BP5 GetContext isolation and concurrent-use tests.  Local BP5 only.
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <adios2.h>
+#include <adios2/core/GetContext.h>
+
+#include <gtest/gtest.h>
+
+#include "../TestHelpers.h"
+
+std::string engineName;       // from command line
+std::string engineParameters; // from command line
+
+class BPGetContextIsolation : public ::testing::Test
+{
+public:
+    BPGetContextIsolation() = default;
+};
+
+TEST_F(BPGetContextIsolation, TwoIndependentContexts)
+{
+    const size_t Nx = 8;
+    const std::string fname("BPGetContextIsolation.bp");
+
+    adios2::ADIOS adios;
+
+    {
+        adios2::IO io = adios.DeclareIO("WriteIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        if (!engineParameters.empty())
+        {
+            io.SetParameters(engineParameters);
+        }
+
+        auto v0 = io.DefineVariable<std::int32_t>("v0", {Nx}, {0}, {Nx});
+        auto v1 = io.DefineVariable<double>("v1", {Nx}, {0}, {Nx});
+
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+        std::vector<std::int32_t> v0_data(Nx);
+        std::vector<double> v1_data(Nx);
+        for (size_t i = 0; i < Nx; ++i)
+        {
+            v0_data[i] = static_cast<std::int32_t>(100 + i);
+            v1_data[i] = 0.5 + static_cast<double>(i);
+        }
+        writer.BeginStep();
+        writer.Put(v0, v0_data.data());
+        writer.Put(v1, v1_data.data());
+        writer.EndStep();
+        writer.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        auto v0 = io.InquireVariable<std::int32_t>("v0");
+        auto v1 = io.InquireVariable<double>("v1");
+        ASSERT_TRUE(v0);
+        ASSERT_TRUE(v1);
+
+        auto ctxA = reader.NewGetContext();
+        auto ctxB = reader.NewGetContext();
+        ASSERT_NE(ctxA, nullptr);
+        ASSERT_NE(ctxB, nullptr);
+        ASSERT_NE(ctxA.get(), ctxB.get());
+
+        constexpr std::int32_t I_SENTINEL = -1;
+        constexpr double D_SENTINEL = -1.0;
+        std::vector<std::int32_t> bufA(Nx, I_SENTINEL);
+        std::vector<double> bufB(Nx, D_SENTINEL);
+
+        const auto sel = adios2::Selection::All().WithSteps(0, 1);
+
+        reader.Get(*ctxA, v0, bufA.data(), sel);
+        reader.Get(*ctxB, v1, bufB.data(), sel);
+
+        // PerformGets(ctxA) must fill bufA only, leave bufB untouched.
+        reader.PerformGets(*ctxA);
+        for (size_t i = 0; i < Nx; ++i)
+        {
+            EXPECT_EQ(bufA[i], static_cast<std::int32_t>(100 + i))
+                << "bufA[" << i << "] not filled by PerformGets(ctxA)";
+            EXPECT_DOUBLE_EQ(bufB[i], D_SENTINEL)
+                << "bufB[" << i << "] = " << bufB[i]
+                << " was modified by PerformGets(ctxA) — context isolation violated";
+        }
+
+        reader.PerformGets(*ctxB);
+        for (size_t i = 0; i < Nx; ++i)
+        {
+            EXPECT_DOUBLE_EQ(bufB[i], 0.5 + static_cast<double>(i))
+                << "bufB[" << i << "] not filled by PerformGets(ctxB)";
+        }
+
+        // Reuse ctxA after PerformGets — queue must have been cleared.
+        std::vector<std::int32_t> bufA2(Nx, I_SENTINEL);
+        reader.Get(*ctxA, v0, bufA2.data(), sel);
+        reader.PerformGets(*ctxA);
+        for (size_t i = 0; i < Nx; ++i)
+        {
+            EXPECT_EQ(bufA2[i], static_cast<std::int32_t>(100 + i))
+                << "bufA2[" << i << "] — ctxA reuse after PerformGets failed";
+        }
+
+        // Empty-queue PerformGets must be a benign no-op.
+        EXPECT_NO_THROW(reader.PerformGets(*ctxA));
+
+        reader.Close();
+    }
+
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
+}
+
+TEST_F(BPGetContextIsolation, ConcurrentGetsOnSameEngine)
+{
+    constexpr size_t Nx = 1024;
+    constexpr size_t NumVars = 4;
+    constexpr size_t NumThreads = NumVars;
+    const std::string fname("BPGetContextConcurrent.bp");
+
+    adios2::ADIOS adios;
+
+    {
+        adios2::IO io = adios.DeclareIO("ConcWriteIO");
+        if (!engineName.empty())
+            io.SetEngine(engineName);
+        if (!engineParameters.empty())
+            io.SetParameters(engineParameters);
+
+        std::array<adios2::Variable<double>, NumVars> vars;
+        for (size_t v = 0; v < NumVars; ++v)
+        {
+            vars[v] = io.DefineVariable<double>("var" + std::to_string(v), {Nx}, {0}, {Nx});
+        }
+
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+        for (int step = 0; step < 3; ++step)
+        {
+            writer.BeginStep();
+            for (size_t v = 0; v < NumVars; ++v)
+            {
+                std::vector<double> data(Nx);
+                for (size_t i = 0; i < Nx; ++i)
+                    data[i] = static_cast<double>(step * 1000 + v * 100 + i);
+                writer.Put(vars[v], data.data());
+            }
+            writer.EndStep();
+        }
+        writer.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ConcReadIO");
+        if (!engineName.empty())
+            io.SetEngine(engineName);
+        adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        std::vector<std::string> errors(NumThreads);
+        std::vector<std::thread> threads;
+
+        for (size_t t = 0; t < NumThreads; ++t)
+        {
+            threads.emplace_back(
+                [&](size_t tid) {
+                    try
+                    {
+                        auto var = io.InquireVariable<double>("var" + std::to_string(tid));
+                        if (!var)
+                        {
+                            errors[tid] = "InquireVariable failed for var" + std::to_string(tid);
+                            return;
+                        }
+
+                        auto ctx = reader.NewGetContext();
+
+                        const auto sel = adios2::Selection::All().WithSteps(0, 1);
+                        std::vector<double> buf(Nx, -1.0);
+                        reader.Get(*ctx, var, buf.data(), sel);
+                        reader.PerformGets(*ctx);
+
+                        for (size_t i = 0; i < Nx; ++i)
+                        {
+                            double expected = static_cast<double>(0 * 1000 + tid * 100 + i);
+                            if (buf[i] != expected)
+                            {
+                                errors[tid] = "var" + std::to_string(tid) + "[" +
+                                              std::to_string(i) + "] = " + std::to_string(buf[i]) +
+                                              ", expected " + std::to_string(expected);
+                                return;
+                            }
+                        }
+
+                        const auto sel2 = adios2::Selection::All().WithSteps(2, 1);
+                        std::fill(buf.begin(), buf.end(), -1.0);
+                        reader.Get(*ctx, var, buf.data(), sel2);
+                        reader.PerformGets(*ctx);
+
+                        for (size_t i = 0; i < Nx; ++i)
+                        {
+                            double expected = static_cast<double>(2 * 1000 + tid * 100 + i);
+                            if (buf[i] != expected)
+                            {
+                                errors[tid] = "var" + std::to_string(tid) + " step2[" +
+                                              std::to_string(i) + "] = " + std::to_string(buf[i]) +
+                                              ", expected " + std::to_string(expected);
+                                return;
+                            }
+                        }
+                    }
+                    catch (const std::exception &e)
+                    {
+                        errors[tid] = std::string("exception: ") + e.what();
+                    }
+                },
+                t);
+        }
+
+        for (auto &th : threads)
+            th.join();
+
+        for (size_t t = 0; t < NumThreads; ++t)
+        {
+            EXPECT_TRUE(errors[t].empty()) << "Thread " << t << ": " << errors[t];
+        }
+
+        reader.Close();
+    }
+
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
+}
+
+// Non-reentrant transport (fstream) — NewGetContext must return null.
+TEST_F(BPGetContextIsolation, NonReentrantTransportRejected)
+{
+    const size_t Nx = 8;
+    const std::string fname("BPGetContextNonReentrant.bp");
+
+    adios2::ADIOS adios;
+    {
+        adios2::IO io = adios.DeclareIO("WriteIO");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        auto v0 = io.DefineVariable<std::int32_t>("v0", {Nx}, {0}, {Nx});
+        adios2::Engine writer = io.Open(fname, adios2::Mode::Write);
+        std::vector<std::int32_t> data(Nx, 42);
+        writer.BeginStep();
+        writer.Put(v0, data.data());
+        writer.EndStep();
+        writer.Close();
+    }
+
+    {
+        adios2::IO io = adios.DeclareIO("ReadIO_fstream");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        io.AddTransport("File", {{"Library", "fstream"}});
+        adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+
+        auto ctx = reader.NewGetContext();
+        EXPECT_EQ(ctx, nullptr) << "fstream transport is not reentrant; "
+                                   "NewGetContext must return nullptr";
+
+        reader.Close();
+    }
+
+#if ADIOS2_USE_MPI
+    CleanupTestFilesMPI(fname, MPI_COMM_WORLD);
+#else
+    CleanupTestFiles(fname);
+#endif
+}
+
+int main(int argc, char **argv)
+{
+#if ADIOS2_USE_MPI
+    int provided;
+    MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
+#endif
+
+    ::testing::InitGoogleTest(&argc, argv);
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+    if (argc > 2)
+    {
+        engineParameters = std::string(argv[2]);
+    }
+    int result = RUN_ALL_TESTS();
+
+#if ADIOS2_USE_MPI
+    MPI_Finalize();
+#endif
+
+    return result;
+}


### PR DESCRIPTION
This is the final bit of a long arc towards thread-safe Get() operations, mostly to benefit the XRootD ADIOS server.  This takes advantage of the special case where we're using a POSIX transport (with using pread(), so no kernel-level state in the sockets, currently the default), and ReadRandomAccess where the metadata is pulled in at Open() and remains unchanging thereafter.  This opened up the possibility for thread-safe Get() operations, as long as you could specify the selection without modifying Variable state (enabled by the previous SelectionStruct additions), and as long as the PendingGetRequests queue was abstracted into something that could be specified separately from the engine (these changes).

This PR includes these changes as well as the mods to the XRootD file pool that take advantage of them (allow multiple threads to reuse an open file, as opposed to only reusing open files when there is no current operation on it).

While this feature is long-planned, the introduction of batch Get() operations and other optimizations at the curl https layer have significantly reduced the need for it.  For example, in the KSTAR data used in campaign testing, all the fetches for a particular file land in a single Get() batch, so there are never concurrent requests for the same file (and so no benefit to this change).  But other scenarios, particularly near-simultaneous fetches from multi-rank executables (ML training?) should show benefits from this.

This does make sure that batch Gets() are done deferred, so that multiple data reading threads can fetch the data. This was an oversight in prior work that we're fixing while we're modifying that particular code to use the new ReadContext.
