### PR TITLE
BP5: add per-file id to index header

### DIFF
--- a/bindings/CXX/adios2/cxx/Engine.cpp
+++ b/bindings/CXX/adios2/cxx/Engine.cpp
@@ -143,6 +143,12 @@ size_t Engine::Steps() const
     return m_Engine->Steps();
 }
 
+uint32_t Engine::FileUUID() const
+{
+    helper::CheckForNullptr(m_Engine, "in call to Engine::FileUUID");
+    return m_Engine->FileUUID();
+}
+
 Engine::Engine(core::Engine *engine) : m_Engine(engine) {}
 
 void Engine::Put(VariableNT &variable, const void *data, const Mode launch)

--- a/bindings/CXX/adios2/cxx/Engine.h
+++ b/bindings/CXX/adios2/cxx/Engine.h
@@ -533,6 +533,12 @@ public:
     size_t Steps() const;
 
     /**
+     * Per-file id, for engines that carry one (currently BP5).
+     * @return the file id, or 0 if the engine/file has none
+     */
+    uint32_t FileUUID() const;
+
+    /**
      * @brief Promise that no more definitions or changes to defined variables
      * will occur. Useful information if called before the first EndStep() of an
      * output Engine, as it will know that the definitions are complete and

--- a/source/adios2/core/Engine.h
+++ b/source/adios2/core/Engine.h
@@ -539,6 +539,9 @@ public:
 
     virtual std::string VariableExprStr(const VariableBase &) { return ""; }
 
+    /** Per-file id, for engines that carry one (currently BP5); 0 means none. */
+    virtual uint32_t FileUUID() const { return 0; }
+
     /** Notify the engine when a new attribute is defined. Called from IO.tcc
      */
     virtual void NotifyEngineAttribute(std::string name, DataType type) noexcept;

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -62,7 +62,8 @@ public:
         uint8_t activeFlag;
         char columnMajor;     // y or n
         uint8_t flattenSteps; // writer requests all steps flattened to one on read
-        char unused2[22];     // init to zero
+        char fileUUID[4];     // random per-file id; 0 = none (legacy/neutralized output)
+        char unused2[18];     // init to zero
     };
     static constexpr size_t m_IndexHeaderSize = sizeof(BP5IndexTableHeader);
     static constexpr size_t m_EndianFlagPosition = offsetof(BP5IndexTableHeader, isLittleEndian);
@@ -74,6 +75,10 @@ public:
     static constexpr size_t m_FlattenStepsPosition = offsetof(BP5IndexTableHeader, flattenSteps);
     static constexpr size_t m_VersionTagPosition = offsetof(BP5IndexTableHeader, VersionTag);
     static constexpr size_t m_VersionTagLength = sizeof(BP5IndexTableHeader().VersionTag);
+    static constexpr size_t m_FileUUIDPosition = offsetof(BP5IndexTableHeader, fileUUID);
+    static constexpr size_t m_FileUUIDLength = sizeof(BP5IndexTableHeader().fileUUID);
+    static_assert(m_FileUUIDLength == sizeof(uint32_t),
+                  "fileUUID is read and written as a uint32_t");
     static constexpr size_t m_HeaderTailPadding = sizeof(BP5IndexTableHeader().unused2);
 
     static constexpr uint8_t m_BP5MinorVersion = 2;

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -2042,6 +2042,10 @@ size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t 
         if (m_Parameters.IgnoreFlattenSteps)
             m_FlattenSteps = false;
 
+        // byte 42-45: per-file id (0 = none)
+        position = m_FileUUIDPosition;
+        m_FileUUID = helper::ReadValue<uint32_t>(buffer, position, m_Minifooter.IsLittleEndian);
+
         // move position to first row
         position = m_IndexHeaderSize;
     }

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -74,6 +74,9 @@ public:
     std::string VariableExprStr(const VariableBase &Var);
     void SetFlattenMode(bool flatten) { m_FlattenSteps = flatten; };
 
+    /** Per-file id from the index header; 0 if the file carries none. */
+    uint32_t FileUUID() const { return m_FileUUID; }
+
 private:
     format::BP5Deserializer *m_BP5Deserializer = nullptr;
     /* How many bytes of metadata have we already read in? */
@@ -263,6 +266,8 @@ private:
     bool m_ReaderIsRowMajor = true;
     bool m_WriterIsRowMajor = true;
     bool m_FlattenSteps = false; // set to true of writer requested all steps be flattened into 1
+
+    uint32_t m_FileUUID = 0; // per-file id from the index header; 0 means none
 
     format::BufferSTL m_MetadataIndex;
     format::BufferSTL m_MetaMetadata;

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -26,6 +26,7 @@
 #include <iomanip> // setw
 #include <iostream>
 #include <memory> // make_shared
+#include <random>
 #include <sstream>
 
 namespace adios2
@@ -2154,6 +2155,22 @@ void BP5Writer::MakeHeader(std::vector<char> &buffer, size_t &position, const st
     helper::CopyToBuffer(buffer, position, &columnMajor);
 
     helper::CopyToBuffer(buffer, position, &m_Parameters.FlattenSteps);
+
+    // byte 42-45: random per-file id (written once here, preserved across append)
+    if (position != m_FileUUIDPosition)
+    {
+        helper::Throw<std::runtime_error>("Engine", "BP5Writer", "MakeHeader",
+                                          "ADIOS Coding ERROR in BP5Writer::MakeHeader. File UUID "
+                                          "position mismatch");
+    }
+    std::random_device rd;
+    uint32_t fileUUID = static_cast<uint32_t>(rd());
+    while (fileUUID == 0) // 0 is the "none" sentinel
+    {
+        fileUUID = static_cast<uint32_t>(rd());
+    }
+    helper::CopyToBuffer(buffer, position, &fileUUID);
+
     // remainder  unused
     position = m_IndexHeaderSize;
     // absolutePosition = position;

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -448,9 +448,11 @@ bool introspectAsBPDir(const std::string &name) noexcept
         return false;
     }
 
-    char major = buffer[32];
-    char minor = buffer[33];
-    char patch = buffer[34];
+    // Version bytes are ASCII-offset ('0' + value); convert back so a component
+    // > 9 (e.g. minor 12) prints as a number, not a stray char.
+    uint8_t major = static_cast<uint8_t>(buffer[32] - '0');
+    uint8_t minor = static_cast<uint8_t>(buffer[33] - '0');
+    uint8_t patch = static_cast<uint8_t>(buffer[34] - '0');
     bool isBigEndian = static_cast<bool>(buffer[36]);
     uint8_t BPVersion = static_cast<uint8_t>(buffer[37]);
     uint8_t flatten = static_cast<uint8_t>(buffer[41]);
@@ -458,7 +460,7 @@ bool introspectAsBPDir(const std::string &name) noexcept
     if (BPVersion == 4)
     {
         isActive = static_cast<bool>(buffer[38]);
-        printf("ADIOS-BP Version %d %s - ADIOS v%c.%c.%c %s\n", BPVersion,
+        printf("ADIOS-BP Version %d %s - ADIOS v%d.%d.%d %s\n", BPVersion,
                (isBigEndian ? "Big Endian" : "Little Endian"), major, minor, patch,
                (isActive ? "- active" : ""));
     }
@@ -466,13 +468,21 @@ bool introspectAsBPDir(const std::string &name) noexcept
     {
         uint8_t minversion = static_cast<uint8_t>(buffer[38]);
         isActive = static_cast<bool>(buffer[39]);
-        printf("ADIOS-BP Version %d.%d %s - ADIOS v%c.%c.%c %s%s\n", BPVersion, minversion,
+        // per-file id at bytes 42-45; 0 = none
+        size_t uuidPos = 42;
+        uint32_t fileUUID = helper::ReadValue<uint32_t>(buffer, uuidPos, !isBigEndian);
+        char idStr[32] = "";
+        if (fileUUID != 0)
+        {
+            snprintf(idStr, sizeof(idStr), " - id 0x%08x", static_cast<unsigned int>(fileUUID));
+        }
+        printf("ADIOS-BP Version %d.%d %s - ADIOS v%d.%d.%d %s%s%s\n", BPVersion, minversion,
                (isBigEndian ? "Big Endian" : "Little Endian"), major, minor, patch,
-               (isActive ? "- active" : ""), (flatten ? "- flatten_steps " : ""));
+               (isActive ? "- active" : ""), (flatten ? "- flatten_steps " : ""), idStr);
     }
     else
     {
-        printf("ADIOS-BP Version %d %s - ADIOS v%c.%c.%c %s\n", BPVersion,
+        printf("ADIOS-BP Version %d %s - ADIOS v%d.%d.%d %s\n", BPVersion,
                (isBigEndian ? "Big Endian" : "Little Endian"), major, minor, patch,
                (isActive ? "- active" : ""));
     }

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -152,6 +152,7 @@ bp_gtest_add_tests_helper(LargeMetadata MPI_ALLOW)
 bp5_gtest_add_tests_helper(WriteStatsOnly MPI_ALLOW)
 bp5_gtest_add_tests_helper(SelectionGet MPI_NONE)
 bp5_gtest_add_tests_helper(GetContextIsolation MPI_NONE)
+bp5_gtest_add_tests_helper(FileUUID MPI_NONE)
 
 if (ADIOS2_HAVE_MPI)
   # Extra arguments: engine parameters, number of timesteps

--- a/testing/adios2/engine/bp/TestBPFileUUID.cpp
+++ b/testing/adios2/engine/bp/TestBPFileUUID.cpp
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+std::string engineName;       // comes from command line
+std::string engineParameters; // comes from command line
+
+namespace
+{
+
+// Write `steps` timesteps of a small 1D variable to `fname`.
+void WriteFile(const std::string &fname, size_t steps, adios2::Mode openMode)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("WriteIO");
+    if (!engineName.empty())
+    {
+        io.SetEngine(engineName);
+    }
+
+    const std::size_t Nx = 10;
+    auto var = io.InquireVariable<int32_t>("data");
+    if (!var)
+    {
+        var = io.DefineVariable<int32_t>("data", {Nx}, {0}, {Nx});
+    }
+
+    adios2::Engine writer = io.Open(fname, openMode);
+    for (size_t s = 0; s < steps; ++s)
+    {
+        std::vector<int32_t> data(Nx, static_cast<int32_t>(s));
+        writer.BeginStep();
+        writer.Put(var, data.data());
+        writer.EndStep();
+    }
+    writer.Close();
+}
+
+uint32_t ReadFileUUID(const std::string &fname)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("ReadIO");
+    if (!engineName.empty())
+    {
+        io.SetEngine(engineName);
+    }
+    adios2::Engine reader = io.Open(fname, adios2::Mode::ReadRandomAccess);
+    const uint32_t id = reader.FileUUID();
+    reader.Close();
+    return id;
+}
+
+} // namespace
+
+// The writer stamps a non-zero per-file id, and appending preserves it (the
+// header is written once at creation, never on append).
+TEST(BPFileUUID, StampedAndPreservedAcrossAppend)
+{
+    const std::string fname = "BPFileUUID.bp";
+    WriteFile(fname, 3, adios2::Mode::Write);
+
+    const uint32_t created = ReadFileUUID(fname);
+    EXPECT_NE(created, 0u) << "writer should stamp a non-zero per-file id";
+
+    WriteFile(fname, 2, adios2::Mode::Append);
+    EXPECT_EQ(ReadFileUUID(fname), created) << "append must preserve the per-file id";
+}
+
+int main(int argc, char **argv)
+{
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+    if (argc > 2)
+    {
+        engineParameters = std::string(argv[2]);
+    }
+    result = RUN_ALL_TESTS();
+    return result;
+}

--- a/testing/adios2/output_archive/archive_utility.c
+++ b/testing/adios2/output_archive/archive_utility.c
@@ -159,6 +159,20 @@ int main(int argc, char **argv)
             fprintf(stderr, "Write failed\n");
             exit(1);
         }
+        /* Zero the random per-file id (bytes 42-45) so -test_unique stays stable. */
+        ret = lseek(fd, 42, SEEK_SET);
+        if (ret == -1)
+        {
+            fprintf(stderr, "Lseek failed\n");
+            exit(1);
+        }
+        memset(buf, 0, sizeof(buf));
+        ret = write(fd, buf, 4);
+        if (ret == -1)
+        {
+            fprintf(stderr, "Write failed\n");
+            exit(1);
+        }
         close(fd);
     }
     return 0;


### PR DESCRIPTION
Stamp a random 32-bit id into a reserved index-header field at file creation, preserved across append. Read it back and expose it via BP5Reader::FileUUID(). Lets a remote reader detect that a file was overwritten out from under its cached metadata.

@pnorbert This is infrastructure to support a defensive tactic against local metadata and remote metadata being inconsistent.