### PR TITLE
Remote response size check

### DIFF
--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -818,7 +818,8 @@ void BP5Reader::PerformRemoteGetsWithKVCache()
                 size_t stepStart = box.Start[0];
                 size_t stepCount = box.Count[0];
                 auto handle = m_Remote->Get(Req.VarName, stepStart, stepCount, Req.BlockID, count,
-                                            start, VB->m_AccuracyRequested, ReqInfo.Data);
+                                            start, VB->m_AccuracyRequested, ReqInfo.Data,
+                                            ReqInfo.ReqSize * ReqInfo.TypeSize);
                 handles.push_back(handle);
                 remoteRequestsInfo.push_back(ReqInfo);
             }
@@ -904,8 +905,9 @@ void BP5Reader::PerformRemoteGets()
         for (auto &Req : GetRequests)
         {
             VariableBase *VB = m_BP5Deserializer->GetVariableBaseFromBP5VarRec(Req.VarRec);
+            size_t destSize = helper::GetTotalSize(Req.Count) * Req.StepCount * VB->m_ElementSize;
             batchReqs.push_back({Req.VarName, Req.RelStep, Req.StepCount, Req.BlockID, Req.Count,
-                                 Req.Start, VB->m_AccuracyRequested, Req.Data});
+                                 Req.Start, VB->m_AccuracyRequested, Req.Data, destSize});
         }
         if (m_Remote->BatchGet(batchReqs))
         {
@@ -918,8 +920,9 @@ void BP5Reader::PerformRemoteGets()
     for (auto &Req : GetRequests)
     {
         VariableBase *VB = m_BP5Deserializer->GetVariableBaseFromBP5VarRec(Req.VarRec);
+        size_t destSize = helper::GetTotalSize(Req.Count) * Req.StepCount * VB->m_ElementSize;
         auto handle = m_Remote->Get(Req.VarName, Req.RelStep, Req.StepCount, Req.BlockID, Req.Count,
-                                    Req.Start, VB->m_AccuracyRequested, Req.Data);
+                                    Req.Start, VB->m_AccuracyRequested, Req.Data, destSize);
         handles.push_back(handle);
     }
 

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -170,7 +170,7 @@ size_t HDF5ReaderP::ReadDataset(hid_t dataSetId, hid_t h5Type, Variable<T> &vari
             // read from remote
             auto handle = m_Remote->Get(variable.m_Name.c_str(), variable.m_StepsStart,
                                         variable.m_StepsCount, variable.m_BlockID, variable.m_Count,
-                                        variable.m_Start, variable.m_AccuracyRequested, values);
+                                        variable.m_Start, variable.m_AccuracyRequested, values, 0);
             remoteHandles.push_back(handle);
         }
         else

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -366,12 +366,12 @@ void EVPathRemote::ProcessReadResponse(GetHandle handle)
     }
 
     case adios2::core::Operator::OperatorType::COMPRESS_NULL:
-        // Reject a response that would overrun dest (stale metadata, wrong-size
-        // reply). Compressed cases bound their output in the operator, not here.
+        // Reject a response that would overrun dest. Compressed cases bound
+        // their output in the operator, not here.
         if (expectedSize != 0 && read_response_msg->Size > expectedSize)
             helper::Throw<std::runtime_error>("Remote", "EVPathRemote", "ProcessReadResponse",
-                                              "remote response larger than expected buffer; "
-                                              "remote metadata may be stale");
+                                              "remote response larger than the expected buffer "
+                                              "size");
         memcpy(read_response_msg->Dest, read_response_msg->ReadData, read_response_msg->Size);
         break;
     default:

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -291,7 +291,7 @@ void EVPathRemote::Close()
 
 EVPathRemote::GetHandle EVPathRemote::Get(const char *VarName, size_t Step, size_t StepCount,
                                           size_t BlockID, Dims &Count, Dims &Start,
-                                          Accuracy &accuracy, void *dest)
+                                          Accuracy &accuracy, void *dest, size_t /*destSize*/)
 {
     EVPathRemoteCommon::_GetRequestMsg GetMsg;
     if (!m_Active)

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -291,7 +291,7 @@ void EVPathRemote::Close()
 
 EVPathRemote::GetHandle EVPathRemote::Get(const char *VarName, size_t Step, size_t StepCount,
                                           size_t BlockID, Dims &Count, Dims &Start,
-                                          Accuracy &accuracy, void *dest, size_t /*destSize*/)
+                                          Accuracy &accuracy, void *dest, size_t destSize)
 {
     EVPathRemoteCommon::_GetRequestMsg GetMsg;
     if (!m_Active)
@@ -300,6 +300,10 @@ EVPathRemote::GetHandle EVPathRemote::Get(const char *VarName, size_t Step, size
 
     memset(&GetMsg, 0, sizeof(GetMsg));
     GetMsg.GetResponseCondition = CMCondition_get(ev_state.cm, m_conn);
+    {
+        const std::lock_guard<std::mutex> lock(m_ResponsesMutex);
+        m_ExpectedSizes[GetMsg.GetResponseCondition] = destSize;
+    }
     GetMsg.FileHandle = m_ID;
     GetMsg.VarName = VarName;
     GetMsg.Step = Step;
@@ -332,6 +336,18 @@ void EVPathRemote::ProcessReadResponse(GetHandle handle)
     }
 
     EVPathRemoteCommon::ReadResponseMsg read_response_msg = it->second;
+
+    size_t expectedSize = 0;
+    {
+        const std::lock_guard<std::mutex> lock(m_ResponsesMutex);
+        auto eit = m_ExpectedSizes.find((int)(intptr_t)handle);
+        if (eit != m_ExpectedSizes.end())
+        {
+            expectedSize = eit->second;
+            m_ExpectedSizes.erase(eit);
+        }
+    }
+
     switch (read_response_msg->OperatorType)
     {
 
@@ -350,6 +366,12 @@ void EVPathRemote::ProcessReadResponse(GetHandle handle)
     }
 
     case adios2::core::Operator::OperatorType::COMPRESS_NULL:
+        // Reject a response that would overrun dest (stale metadata, wrong-size
+        // reply). Compressed cases bound their output in the operator, not here.
+        if (expectedSize != 0 && read_response_msg->Size > expectedSize)
+            helper::Throw<std::runtime_error>("Remote", "EVPathRemote", "ProcessReadResponse",
+                                              "remote response larger than expected buffer; "
+                                              "remote metadata may be stale");
         memcpy(read_response_msg->Dest, read_response_msg->ReadData, read_response_msg->Size);
         break;
     default:

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -88,7 +88,8 @@ public:
 #ifdef ADIOS2_HAVE_SST
     std::mutex m_ResponsesMutex;
     std::map<int, EVPathRemoteCommon::ReadResponseMsg>
-        m_Responses; // read/get responses to be processed
+        m_Responses;                       // read/get responses to be processed
+    std::map<int, size_t> m_ExpectedSizes; // per-request expected dest bytes (0 = unchecked)
 #endif
 
 private:

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -64,7 +64,7 @@ public:
                             const std::string filename, std::vector<char> &contents);
 
     GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
-                  Dims &Start, Accuracy &accuracy, void *dest);
+                  Dims &Start, Accuracy &accuracy, void *dest, size_t destSize);
 
     bool WaitForGet(GetHandle handle);
 

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -43,7 +43,8 @@ void Remote::OpenReadSimpleFile(const std::string hostname, const int32_t port,
 };
 
 Remote::GetHandle Remote::Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID,
-                              Dims &Count, Dims &Start, Accuracy &accuracy, void *dest)
+                              Dims &Count, Dims &Start, Accuracy &accuracy, void *dest,
+                              size_t /*destSize*/)
 {
     ThrowUp("RemoteGet");
     return (Remote::GetHandle)(intptr_t)0;

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -48,8 +48,11 @@ public:
 
     typedef void *GetHandle;
 
+    // destSize = expected byte size of dest (0 = unknown/unchecked); lets the
+    // backend reject a response that would overrun the buffer.
     virtual GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID,
-                          Dims &Count, Dims &Start, Accuracy &accuracy, void *dest);
+                          Dims &Count, Dims &Start, Accuracy &accuracy, void *dest,
+                          size_t destSize);
 
     virtual bool WaitForGet(GetHandle handle);
 
@@ -63,6 +66,7 @@ public:
         Dims Start;
         Accuracy accuracy;
         void *dest;
+        size_t destSize = 0; // expected byte size of dest; 0 = unchecked
     };
 
     // Batch multiple Get requests into a single round-trip.

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
@@ -133,13 +133,26 @@ void CurlMultiPool::ProcessCompletedTransfers()
 
                     if (httpCode == 200 || httpCode == 201)
                     {
-                        if (asyncOp->destBuffer && !asyncOp->responseData.empty())
+                        // Reject a response that would overrun dest (stale metadata,
+                        // wrong-size reply); 0 = caller gave no expected size.
+                        if (asyncOp->expectedSize != 0 &&
+                            asyncOp->responseData.size() > asyncOp->expectedSize)
                         {
-                            memcpy(asyncOp->destBuffer, asyncOp->responseData.data(),
-                                   asyncOp->responseData.size());
-                            asyncOp->destSize = asyncOp->responseData.size();
+                            asyncOp->errorMsg =
+                                "response size " + std::to_string(asyncOp->responseData.size()) +
+                                " exceeds expected " + std::to_string(asyncOp->expectedSize) +
+                                " bytes; remote metadata may be stale";
                         }
-                        success = true;
+                        else
+                        {
+                            if (asyncOp->destBuffer && !asyncOp->responseData.empty())
+                            {
+                                memcpy(asyncOp->destBuffer, asyncOp->responseData.data(),
+                                       asyncOp->responseData.size());
+                                asyncOp->destSize = asyncOp->responseData.size();
+                            }
+                            success = true;
+                        }
                     }
                     else
                     {
@@ -685,9 +698,17 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
 
         for (size_t i = 0; i < nVars; i++)
         {
-            if (requests[sb.startIdx + i].dest && sizes[i] > 0)
+            auto &req = requests[sb.startIdx + i];
+            // Reject a chunk that would overrun dest (stale metadata, wrong-size
+            // reply); destSize 0 = caller gave no expected size.
+            if (req.destSize != 0 && sizes[i] > req.destSize)
             {
-                memcpy(requests[sb.startIdx + i].dest, ptr, sizes[i]);
+                allOk = false;
+                break;
+            }
+            if (req.dest && sizes[i] > 0)
+            {
+                memcpy(req.dest, ptr, sizes[i]);
             }
             ptr += sizes[i];
         }
@@ -705,7 +726,7 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
 
 Remote::GetHandle XrootdHttpRemote::Get(const char *VarName, size_t Step, size_t StepCount,
                                         size_t BlockID, Dims &Count, Dims &Start,
-                                        Accuracy &accuracy, void *dest)
+                                        Accuracy &accuracy, void *dest, size_t destSize)
 {
     if (!m_OpenSuccess)
     {
@@ -719,6 +740,7 @@ Remote::GetHandle XrootdHttpRemote::Get(const char *VarName, size_t Step, size_t
 
     AsyncGet *asyncOp = new AsyncGet();
     asyncOp->destBuffer = dest;
+    asyncOp->expectedSize = destSize;
 
     std::string url =
         m_BaseUrl + "/" + m_FileConfigSegment + "/" +

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
@@ -133,15 +133,15 @@ void CurlMultiPool::ProcessCompletedTransfers()
 
                     if (httpCode == 200 || httpCode == 201)
                     {
-                        // Reject a response that would overrun dest (stale metadata,
-                        // wrong-size reply); 0 = caller gave no expected size.
+                        // Reject a response that would overrun dest; 0 = caller
+                        // gave no expected size.
                         if (asyncOp->expectedSize != 0 &&
                             asyncOp->responseData.size() > asyncOp->expectedSize)
                         {
-                            asyncOp->errorMsg =
-                                "response size " + std::to_string(asyncOp->responseData.size()) +
-                                " exceeds expected " + std::to_string(asyncOp->expectedSize) +
-                                " bytes; remote metadata may be stale";
+                            asyncOp->errorMsg = "response size " +
+                                                std::to_string(asyncOp->responseData.size()) +
+                                                " exceeds expected " +
+                                                std::to_string(asyncOp->expectedSize) + " bytes";
                         }
                         else
                         {

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.h
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.h
@@ -40,6 +40,7 @@ struct AsyncGet
     std::string errorMsg;
     void *destBuffer = nullptr;
     size_t destSize = 0;
+    size_t expectedSize = 0; // expected response bytes; 0 = unchecked
     std::vector<char> responseData;
     CURL *easyHandle = nullptr;
     ::curl_slist *headers = nullptr;
@@ -107,7 +108,7 @@ public:
               const Mode mode, bool RowMajorOrdering, const Params &params = Params()) override;
 
     GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
-                  Dims &Start, Accuracy &accuracy, void *dest) override;
+                  Dims &Start, Accuracy &accuracy, void *dest, size_t destSize) override;
 
     bool WaitForGet(GetHandle handle) override;
     GetHandle Read(size_t Start, size_t Size, void *Dest) override;

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -339,7 +339,7 @@ bool XrootdRemote::WaitForGet(GetHandle handle)
 
 Remote::GetHandle XrootdRemote::Get(const char *VarName, size_t Step, size_t StepCount,
                                     size_t BlockID, Dims &Count, Dims &Start, Accuracy &accuracy,
-                                    void *dest)
+                                    void *dest, size_t /*destSize*/)
 {
 // FIXME: StepCount is not implemented here yet
 #ifdef ADIOS2_HAVE_XROOTD

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -104,6 +104,7 @@ public:
     char *responseBuffer;
     int responseBufferLen;
     char *dest;
+    size_t expectedSize = 0; // expected response bytes; 0 = unchecked
     std::promise<bool> *promise;
 
 private:
@@ -251,8 +252,19 @@ void myRequest::ProcessResponseData(const XrdSsiErrInfo &eInfo, char *buff, int 
         return;
     }
 
-    // fill in destination buffer
+    // fill in destination buffer; reject a response that would overrun dest
+    // (stale metadata, wrong-size reply). 0 = caller gave no expected size.
     //
+    if (expectedSize != 0 &&
+        static_cast<size_t>(totbytes) + static_cast<size_t>(dlen) > expectedSize)
+    {
+        fprintf(XrdSsiCl::outFile, "Response exceeds expected %zu bytes for %s\n", expectedSize,
+                rName);
+        promise->set_value(false);
+        Finished();
+        delete this;
+        return;
+    }
     totbytes += dlen;
     memcpy(dest, buff, dlen);
 
@@ -339,7 +351,7 @@ bool XrootdRemote::WaitForGet(GetHandle handle)
 
 Remote::GetHandle XrootdRemote::Get(const char *VarName, size_t Step, size_t StepCount,
                                     size_t BlockID, Dims &Count, Dims &Start, Accuracy &accuracy,
-                                    void *dest, size_t /*destSize*/)
+                                    void *dest, size_t destSize)
 {
 // FIXME: StepCount is not implemented here yet
 #ifdef ADIOS2_HAVE_XROOTD
@@ -385,6 +397,7 @@ Remote::GetHandle XrootdRemote::Get(const char *VarName, size_t Step, size_t Ste
     reqP = new myRequest(clUI, rName, GetReqID(), reqDataStr, reqLen);
     reqP->SetResource(rSpec);
     reqP->dest = (char *)dest;
+    reqP->expectedSize = destSize;
     reqP->promise = new std::promise<bool>();
     // We simply hand off the request to the service to deal with it. When a
     // response is ready or an error occured our callback is invoked.

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -104,7 +104,7 @@ public:
               const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
     GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
-                  Dims &Start, Accuracy &accuracy, void *dest);
+                  Dims &Start, Accuracy &accuracy, void *dest, size_t destSize);
 
     GetHandle Read(size_t Start, size_t Size, void *Dest);
     bool WaitForGet(GetHandle handle);


### PR DESCRIPTION
This PR adds a bit of a defense to our remote Get() paths.  Previously we had an implicit assumption that the server would respond with only as much data as we had calculated (from the Get() and available metadata) to expect.  However we had no protection from a malicious or miscalculating server and a larger returned value than we expected might write beyond the buffer that was allocated for it.  This PR adds a size check to the HTTPS, XRootD and EVPath remote data paths to plug this hole.