### PR TITLE
ci: bump cibuildwheel to v4.0.0, drop cp313t free-threaded wheels

### DIFF
--- a/.github/workflows/pypackaging.yml
+++ b/.github/workflows/pypackaging.yml
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 0
       - name: Generate common version file
         run: cmake -P scripts/ci/gh-actions/config/adios-version.cmake && echo VERSION.TXT
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+      - uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         env:
           CIBW_BEFORE_ALL: yum install -y libcurl-devel openssl-devel
           CIBW_BUILD: >-
@@ -98,7 +98,7 @@ jobs:
           fetch-depth: 0
       - name: Generate common version file
         run: cmake -P scripts/ci/gh-actions/config/adios-version.cmake && echo VERSION.TXT
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+      - uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         env:
           CIBW_BEFORE_ALL: yum install -y libcurl-devel openssl-devel
           # abi3 wheel valid for all CPython >= 3.12 (enabled via pyproject.toml override)
@@ -109,7 +109,7 @@ jobs:
           path: wheelhouse/*.whl
 
   build_wheels_freethreaded:
-    name: Wheels cp313t + cp314t
+    name: Wheels cp314t
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -120,16 +120,12 @@ jobs:
           fetch-depth: 0
       - name: Generate common version file
         run: cmake -P scripts/ci/gh-actions/config/adios-version.cmake && echo VERSION.TXT
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+      - uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         env:
           CIBW_BEFORE_ALL: yum install -y libcurl-devel openssl-devel
-          # free-threaded and prerelease are both opt-in groups in cibuildwheel;
-          # cp314t requires both since 3.14 is still prerelease
-          CIBW_ENABLE: cpython-freethreading cpython-prerelease
-          # free-threaded (no-GIL) wheels (enabled via pyproject.toml override)
-          CIBW_BUILD: >-
-            cp313t-manylinux_x86_64
-            cp314t-manylinux_x86_64
+          # cp314t free-threaded (no-GIL) wheel, enabled via pyproject.toml override.
+          # cibuildwheel v4 dropped cp313t support; cp314t builds by default.
+          CIBW_BUILD: cp314t-manylinux_x86_64
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact_wheels_freethreaded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,12 @@ select = "cp312-*"
 config-settings."wheel.py-api" = "cp312"
 config-settings."cmake.define.ADIOS2_USE_PythonStableABI" = "ON"
 
-# For free-threaded Python 3.13t enable the free-threaded (no-GIL) extension.
+# For free-threaded Python 3.14t enable the free-threaded (no-GIL) extension.
 # Note: Py_LIMITED_API (abi3) is incompatible with free-threaded builds, so a
 # separate wheel must be built for each future free-threaded Python version.
+# cibuildwheel v4 dropped support for the experimental cp313t builds.
 [[tool.cibuildwheel.overrides]]
-select = "cp313t-*"
+select = "cp314t-*"
 config-settings."cmake.define.ADIOS2_USE_PythonFreeThreaded" = "ON"
 
 [tool.scikit-build]


### PR DESCRIPTION
## Summary
- cibuildwheel v4.0.0 removed the experimental cp313t free-threaded build support and the \`cpython-freethreading\` enable flag; cp314t is supported by default without any enable flag.
- Bump all three wheel-building jobs from v3.4.1 back to v4.0.0.
- Drop \`cp313t-manylinux_x86_64\` from \`CIBW_BUILD\` and the pyproject.toml free-threaded override (now \`cp314t-*\` only). Rename the job to "Wheels cp314t".

This follows up on #5071 (which temporarily pinned cibuildwheel to v3.4.1 to unblock CI). Replaces #5069.

Background: manylinux dropped the cp313t build images (pypa/manylinux#1882), and cibuildwheel followed (pypa/cibuildwheel#2683, #2684) since cp313t was always an experimental bootstrap for the free-threading ecosystem and 3.14t is now the stable, non-experimental free-threaded build.

cc @eisenhauer