### PR TITLE
Drop unused configure-time copy of iotest-config into the build tree

### DIFF
--- a/source/utils/adios_iotest/CMakeLists.txt
+++ b/source/utils/adios_iotest/CMakeLists.txt
@@ -7,10 +7,6 @@
 # accompanying file Copyright.txt for details.
 #------------------------------------------------------------------------------#
 
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/iotest-config
-  DESTINATION ${PROJECT_BINARY_DIR}
-)
-
 add_executable(adios_iotest settings.cpp decomp.cpp processConfig.cpp ioGroup.cpp stream.cpp adiosStream.cpp adios_iotest.cpp)
 target_link_libraries(adios_iotest adios2::cxx_mpi MPI::MPI_CXX adios2_core_mpi)
 if(WIN32)


### PR DESCRIPTION
Nothing consumes the copy (tests reference their own configs in the source tree) and file(COPY)'s permission preservation fails on filesystems that forbid chmod.  The installed copy via install(DIRECTORY) is unaffected.

Fixes #5075