### PR TITLE
Remote: XrdCl HTTP backend

### DIFF
--- a/source/adios2/CMakeLists.txt
+++ b/source/adios2/CMakeLists.txt
@@ -267,15 +267,23 @@ if(ADIOS2_HAVE_OpenSSL)
 endif()
 
 if(ADIOS2_HAVE_XRootD)
-  target_sources(adios2_core PRIVATE toolkit/remote/XrootdRemote.cpp)
+  # Native XRootD (XrdSsi) remote, plus the XrdCl HTTP-lane backend (uses libXrdCl,
+  # the CLIENT component, to reach a Pelican federation or an HTTPS origin)
+  target_sources(adios2_core PRIVATE toolkit/remote/XrootdRemote.cpp toolkit/remote/XrdClBackend.cpp)
   target_include_directories(adios2_core PRIVATE ${XROOTD_INCLUDE_DIRS})
   target_link_libraries(adios2_core PRIVATE ${XROOTD_CLIENT_LIBRARIES} ${XROOTD_UTILS_LIBRARIES} ${XROOTD_SSI_LIBRARIES})
 endif()
 
 if(ADIOS2_HAVE_CURL)
-  # HTTP/HTTPS-based remote access to XRootD SSI services (alternative to native XRootD protocol)
-  target_sources(adios2_core PRIVATE toolkit/remote/XrootdHttpRemote.cpp)
+  # libcurl HTTP-lane backend
+  target_sources(adios2_core PRIVATE toolkit/remote/LibcurlBackend.cpp)
   target_link_libraries(adios2_core PRIVATE CURL::libcurl)
+endif()
+
+if(ADIOS2_HAVE_CURL OR ADIOS2_HAVE_XRootD)
+  # HTTP-lane remote: path-encoded request grammar + response framing, served by
+  # a libcurl or XrdCl backend (alternative to the native XRootD protocol)
+  target_sources(adios2_core PRIVATE toolkit/remote/XrootdHttpRemote.cpp)
 endif()
 
 if(ADIOS2_HAVE_SST)

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -400,7 +400,8 @@ enum class XRootDTransferProtocol
 {
     XRootD,
     HTTP,
-    HTTPS
+    HTTPS,
+    XrdCl
 };
 
 struct HostConfig

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -552,17 +552,23 @@ void BP5Reader::PerformGets()
         if (m_BP5Deserializer->DefaultGetContext().PendingGetRequests.size() == 0)
             return;
 
-#ifdef ADIOS2_HAVE_CURL
+#if defined(ADIOS2_HAVE_CURL) || defined(ADIOS2_HAVE_XROOTD)
         if (m_RemoteProtocol == HostAccessProtocol::XRootD &&
             (m_XrootdTransferProtocol == XRootDTransferProtocol::HTTP ||
-             m_XrootdTransferProtocol == XRootDTransferProtocol::HTTPS))
+             m_XrootdTransferProtocol == XRootDTransferProtocol::HTTPS ||
+             m_XrootdTransferProtocol == XRootDTransferProtocol::XrdCl))
         {
-            // Determine if using HTTPS or plain HTTP
-            const bool useHttps = (m_XrootdTransferProtocol == XRootDTransferProtocol::HTTPS);
+            // XrdCl reaches the origin/federation over HTTPS; the libcurl path
+            // additionally supports plain HTTP.
+            const bool useXrdCl = (m_XrootdTransferProtocol == XRootDTransferProtocol::XrdCl);
+            const bool useHttps =
+                useXrdCl || (m_XrootdTransferProtocol == XRootDTransferProtocol::HTTPS);
             auto tup = lf_getXRootDHostPort(useHttps ? 443 : 80);
             m_Remote = std::make_unique<XrootdHttpRemote>(ADIOS::GetHostOptions());
             Params params;
             params["UseHttps"] = useHttps ? "true" : "false";
+            if (useXrdCl)
+                params["Backend"] = "XrdCl";
             // For testing, disable SSL verification (only relevant for HTTPS)
             if (useHttps) // && getenv("XRootDHttpsNoVerify"))
             {
@@ -1216,7 +1222,7 @@ void BP5Reader::Init()
     if (!m_Parameters.RemoteDataPath.empty())
         m_dataIsRemote = true;
     if (getenv("DoRemote") || getenv("DoXRootD") || getenv("DoXRootDHttps") ||
-        getenv("DoXRootDHttp"))
+        getenv("DoXRootDHttp") || getenv("DoXRootDXrdCl"))
         m_dataIsRemote = true;
 
     if (m_dataIsRemote)
@@ -1226,7 +1232,7 @@ void BP5Reader::Init()
             m_RemoteName = m_Parameters.RemoteDataPath;
         }
         else if (getenv("DoRemote") || getenv("DoXRootD") || getenv("DoXRootDHttps") ||
-                 getenv("DoXRootDHttp"))
+                 getenv("DoXRootDHttp") || getenv("DoXRootDXrdCl"))
         {
             m_RemoteName = m_Name;
         }
@@ -1258,7 +1264,16 @@ void BP5Reader::Init()
         }
         else
         {
-            if (getenv("DoXRootDHttps"))
+            if (getenv("DoXRootDXrdCl"))
+            {
+                // XrdCl client against the same HTTPS server (reuses XRootDHttpsHost).
+                char *env = getenv("XRootDHttpsHost");
+                if (env)
+                    m_RemoteHost = std::string(env);
+                m_RemoteProtocol = HostAccessProtocol::XRootD;
+                m_XrootdTransferProtocol = XRootDTransferProtocol::XrdCl;
+            }
+            else if (getenv("DoXRootDHttps"))
             {
                 char *env = getenv("XRootDHttpsHost");
                 if (env)

--- a/source/adios2/helper/adiosYAML.cpp
+++ b/source/adios2/helper/adiosYAML.cpp
@@ -354,6 +354,10 @@ XRootDTransferProtocol GetXRootDTransferProtocol(std::string valueStr)
     {
         return XRootDTransferProtocol::HTTP;
     }
+    else if (valueStr == "xrdcl")
+    {
+        return XRootDTransferProtocol::XrdCl;
+    }
     return XRootDTransferProtocol::XRootD;
 }
 

--- a/source/adios2/toolkit/remote/LibcurlBackend.cpp
+++ b/source/adios2/toolkit/remote/LibcurlBackend.cpp
@@ -1,0 +1,330 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "LibcurlBackend.h"
+#include "adios2/helper/adiosLog.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <sstream>
+#include <thread>
+
+#include <curl/curl.h>
+
+namespace adios2
+{
+
+namespace
+{
+
+size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    size_t totalSize = size * nmemb;
+    std::vector<char> *buffer = static_cast<std::vector<char> *>(userp);
+    char *data = static_cast<char *>(contents);
+    buffer->insert(buffer->end(), data, data + totalSize);
+    return totalSize;
+}
+
+/** A fully-configured easy handle waiting to be added to the multi handle. */
+struct PendingSubmit
+{
+    CURL *easyHandle;
+    AsyncGet *asyncOp;
+};
+
+/**
+ * @brief Shared CURL multi pool singleton.
+ *
+ * All LibcurlBackend instances submit fully-configured easy handles to this
+ * pool.  A single worker thread drives all transfers via one curl_multi
+ * handle, bounding the total number of concurrent TCP connections.
+ */
+class CurlMultiPool
+{
+public:
+    static CurlMultiPool &getInstance()
+    {
+        static CurlMultiPool instance;
+        return instance;
+    }
+
+    /** Submit a fully-configured easy handle for async execution. Thread-safe. */
+    void Submit(CURL *easyHandle, AsyncGet *asyncOp)
+    {
+        {
+            std::lock_guard<std::mutex> lock(m_QueueMutex);
+            m_PendingQueue.push_back({easyHandle, asyncOp});
+        }
+        m_QueueCV.notify_one();
+    }
+
+    CurlMultiPool(const CurlMultiPool &) = delete;
+    CurlMultiPool &operator=(const CurlMultiPool &) = delete;
+
+private:
+    CurlMultiPool()
+    {
+        curl_global_init(CURL_GLOBAL_DEFAULT);
+
+        m_MultiHandle = curl_multi_init();
+        if (!m_MultiHandle)
+        {
+            helper::Log("Remote", "CurlMultiPool", "CurlMultiPool",
+                        "Failed to initialize CURL multi handle", helper::LogMode::FATALERROR);
+            return;
+        }
+
+        curl_multi_setopt(m_MultiHandle, CURLMOPT_MAXCONNECTS, 50L);
+        curl_multi_setopt(m_MultiHandle, CURLMOPT_MAX_TOTAL_CONNECTIONS, 50L);
+        curl_multi_setopt(m_MultiHandle, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
+
+        m_Running = true;
+        m_WorkerThread = std::thread(&CurlMultiPool::WorkerLoop, this);
+    }
+
+    ~CurlMultiPool()
+    {
+        {
+            std::lock_guard<std::mutex> lock(m_QueueMutex);
+            m_Running = false;
+        }
+        m_QueueCV.notify_all();
+
+        if (m_WorkerThread.joinable())
+        {
+            m_WorkerThread.join();
+        }
+
+        if (m_MultiHandle)
+        {
+            curl_multi_cleanup(m_MultiHandle);
+            m_MultiHandle = nullptr;
+        }
+    }
+
+    void ProcessCompletedTransfers()
+    {
+        CURLMsg *msg;
+        int msgsLeft;
+
+        while ((msg = curl_multi_info_read(m_MultiHandle, &msgsLeft)))
+        {
+            if (msg->msg == CURLMSG_DONE)
+            {
+                CURL *easy = msg->easy_handle;
+                CURLcode result = msg->data.result;
+
+                AsyncGet *asyncOp = nullptr;
+                curl_easy_getinfo(easy, CURLINFO_PRIVATE, &asyncOp);
+
+                if (asyncOp)
+                {
+                    bool success = false;
+
+                    if (result == CURLE_OK)
+                    {
+                        long httpCode = 0;
+                        curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &httpCode);
+
+                        if (httpCode == 200 || httpCode == 201)
+                        {
+                            // Reject a response that would overrun dest; 0 = caller
+                            // gave no expected size.
+                            if (asyncOp->expectedSize != 0 &&
+                                asyncOp->responseData.size() > asyncOp->expectedSize)
+                            {
+                                asyncOp->errorMsg = "response size " +
+                                                    std::to_string(asyncOp->responseData.size()) +
+                                                    " exceeds expected " +
+                                                    std::to_string(asyncOp->expectedSize) +
+                                                    " bytes";
+                            }
+                            else
+                            {
+                                if (asyncOp->destBuffer && !asyncOp->responseData.empty())
+                                {
+                                    memcpy(asyncOp->destBuffer, asyncOp->responseData.data(),
+                                           asyncOp->responseData.size());
+                                    asyncOp->destSize = asyncOp->responseData.size();
+                                }
+                                success = true;
+                            }
+                        }
+                        else
+                        {
+                            std::ostringstream ss;
+                            ss << "HTTP error " << httpCode;
+                            if (!asyncOp->responseData.empty())
+                            {
+                                ss << ": "
+                                   << std::string(asyncOp->responseData.begin(),
+                                                  asyncOp->responseData.end());
+                            }
+                            asyncOp->errorMsg = ss.str();
+                        }
+                    }
+                    else
+                    {
+                        asyncOp->errorMsg = curl_easy_strerror(result);
+                    }
+
+                    // Clean up the easy handle BEFORE signaling completion.  Once
+                    // set_value() is called, the waiting thread may immediately
+                    // delete asyncOp, causing use-after-free.
+                    curl_multi_remove_handle(m_MultiHandle, easy);
+                    curl_easy_cleanup(easy);
+                    easy = nullptr;
+
+                    asyncOp->promise.set_value(success);
+                }
+
+                if (easy)
+                {
+                    curl_multi_remove_handle(m_MultiHandle, easy);
+                    curl_easy_cleanup(easy);
+                }
+            }
+        }
+    }
+
+    void WorkerLoop()
+    {
+        while (true)
+        {
+            // Drain pending queue into curl multi handle
+            {
+                std::unique_lock<std::mutex> lock(m_QueueMutex);
+
+                while (!m_PendingQueue.empty())
+                {
+                    PendingSubmit req = m_PendingQueue.front();
+                    m_PendingQueue.pop_front();
+
+                    CURLMcode rc = curl_multi_add_handle(m_MultiHandle, req.easyHandle);
+                    if (rc != CURLM_OK)
+                    {
+                        req.asyncOp->errorMsg =
+                            std::string("curl_multi_add_handle failed: ") + curl_multi_strerror(rc);
+                        req.asyncOp->promise.set_value(false);
+                        curl_easy_cleanup(req.easyHandle);
+                    }
+                }
+            }
+
+            // Drive transfers and process completions
+            int runningHandles = 0;
+            curl_multi_perform(m_MultiHandle, &runningHandles);
+            ProcessCompletedTransfers();
+
+            // Check if we should block waiting for new work
+            if (runningHandles == 0)
+            {
+                std::unique_lock<std::mutex> lock(m_QueueMutex);
+                if (!m_Running && m_PendingQueue.empty())
+                {
+                    break;
+                }
+                if (m_PendingQueue.empty())
+                {
+                    m_QueueCV.wait(lock);
+                }
+                continue;
+            }
+
+            // Skip waiting if new requests are queued -- submit them immediately
+            {
+                std::lock_guard<std::mutex> lock(m_QueueMutex);
+                if (!m_PendingQueue.empty())
+                {
+                    continue;
+                }
+            }
+
+            // Wait for socket activity (up to 10ms)
+            int numfds;
+            CURLMcode mc = curl_multi_wait(m_MultiHandle, nullptr, 0, 10, &numfds);
+            if (mc != CURLM_OK)
+            {
+                helper::Log("Remote", "CurlMultiPool", "WorkerLoop",
+                            "curl_multi_wait failed: " + std::string(curl_multi_strerror(mc)),
+                            helper::LogMode::WARNING);
+            }
+        }
+
+        ProcessCompletedTransfers();
+    }
+
+    CURLM *m_MultiHandle = nullptr;
+    std::thread m_WorkerThread;
+    std::atomic<bool> m_Running{false};
+    std::mutex m_QueueMutex;
+    std::condition_variable m_QueueCV;
+    std::deque<PendingSubmit> m_PendingQueue;
+};
+
+CURL *CreateEasyHandle(const RemoteHttpBackend::Config &config, AsyncGet *asyncOp,
+                       const std::string &url)
+{
+    CURL *easy = curl_easy_init();
+    if (!easy)
+        return nullptr;
+
+    curl_easy_setopt(easy, CURLOPT_PRIVATE, asyncOp);
+
+    curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(easy, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(easy, CURLOPT_WRITEDATA, &asyncOp->responseData);
+    curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT, config.connectTimeout);
+    curl_easy_setopt(easy, CURLOPT_TIMEOUT, config.requestTimeout);
+
+    if (config.useHttps)
+    {
+        if (!config.verifySSL)
+        {
+            curl_easy_setopt(easy, CURLOPT_SSL_VERIFYPEER, 0L);
+            curl_easy_setopt(easy, CURLOPT_SSL_VERIFYHOST, 0L);
+        }
+        else
+        {
+            curl_easy_setopt(easy, CURLOPT_SSL_VERIFYPEER, 1L);
+            curl_easy_setopt(easy, CURLOPT_SSL_VERIFYHOST, 2L);
+            if (!config.caCertPath.empty())
+                curl_easy_setopt(easy, CURLOPT_CAINFO, config.caCertPath.c_str());
+        }
+    }
+
+    curl_easy_setopt(easy, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
+
+    return easy;
+}
+
+} // anonymous namespace
+
+void LibcurlBackend::SetConfig(const Config &config) { m_Config = config; }
+
+void LibcurlBackend::SubmitGet(const std::string &url, AsyncGet *op)
+{
+    // Get pool reference first to ensure curl_global_init() runs before any
+    // curl_easy_init() call in CreateEasyHandle().
+    CurlMultiPool &pool = CurlMultiPool::getInstance();
+
+    CURL *easy = CreateEasyHandle(m_Config, op, url);
+    if (!easy)
+    {
+        op->errorMsg = "failed to create curl handle";
+        op->promise.set_value(false);
+        return;
+    }
+
+    pool.Submit(easy, op);
+}
+
+} // end namespace adios2

--- a/source/adios2/toolkit/remote/LibcurlBackend.h
+++ b/source/adios2/toolkit/remote/LibcurlBackend.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ADIOS2_LIBCURLBACKEND_H
+#define ADIOS2_LIBCURLBACKEND_H
+
+#include "RemoteHttpBackend.h"
+
+namespace adios2
+{
+
+/**
+ * @brief libcurl implementation of RemoteHttpBackend.
+ *
+ * All instances share a single process-wide curl_multi worker (one thread,
+ * one multi handle) for connection pooling; see the CurlMultiPool singleton
+ * in the .cpp.
+ */
+class LibcurlBackend : public RemoteHttpBackend
+{
+public:
+    void SetConfig(const Config &config) override;
+    void SubmitGet(const std::string &url, AsyncGet *op) override;
+
+private:
+    Config m_Config;
+};
+
+} // end namespace adios2
+
+#endif // ADIOS2_LIBCURLBACKEND_H

--- a/source/adios2/toolkit/remote/RemoteHttpBackend.h
+++ b/source/adios2/toolkit/remote/RemoteHttpBackend.h
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ADIOS2_REMOTEHTTPBACKEND_H
+#define ADIOS2_REMOTEHTTPBACKEND_H
+
+#include <future>
+#include <string>
+#include <vector>
+
+namespace adios2
+{
+
+/**
+ * @brief Async state for one HTTP GET, shared across HTTP transport backends.
+ *
+ * A backend fetches the body of a path-encoded URL into @ref responseData and
+ * sets @ref promise: true on HTTP success, or false with @ref errorMsg set on
+ * a transport/HTTP failure.  For a single Get the backend also checks the
+ * response against @ref expectedSize and copies it into @ref destBuffer; batch
+ * requests leave @ref destBuffer null and are framed/parsed by the caller
+ * (XrootdHttpRemote), which owns the wire format.
+ */
+struct AsyncGet
+{
+    std::promise<bool> promise;
+    std::string errorMsg;
+    void *destBuffer = nullptr;     ///< single-get dest; null for batch
+    size_t destSize = 0;            ///< bytes delivered to destBuffer on success
+    size_t expectedSize = 0;        ///< expected response bytes; 0 = unchecked
+    std::vector<char> responseData; ///< full response body
+};
+
+/**
+ * @brief Transport seam for the HTTPS remote lane.
+ *
+ * Implementations move bytes for a path-encoded URL.  URL building, response
+ * framing/parsing, and overrun checks live in XrootdHttpRemote and are shared
+ * across backends; a backend is only responsible for the HTTP round trip.
+ */
+class RemoteHttpBackend
+{
+public:
+    struct Config
+    {
+        bool useHttps = true;
+        long connectTimeout = 30;
+        long requestTimeout = 300;
+        std::string caCertPath;
+        bool verifySSL = true;
+    };
+
+    virtual ~RemoteHttpBackend() = default;
+
+    /** Apply per-engine transport settings (called once at Open()). */
+    virtual void SetConfig(const Config &config) = 0;
+
+    /**
+     * Asynchronously GET @p url.  On completion the implementation has filled
+     * @c op->responseData with the body and set @c op->promise (true on HTTP
+     * success; false with @c op->errorMsg set otherwise).  When @c op->destBuffer
+     * is set, the body is checked against @c op->expectedSize and copied in.
+     * @p op is owned by the caller and must outlive the request.
+     */
+    virtual void SubmitGet(const std::string &url, AsyncGet *op) = 0;
+};
+
+} // end namespace adios2
+
+#endif // ADIOS2_REMOTEHTTPBACKEND_H

--- a/source/adios2/toolkit/remote/XrdClBackend.cpp
+++ b/source/adios2/toolkit/remote/XrdClBackend.cpp
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "XrdClBackend.h"
+
+#include <climits> // INT_MAX
+#include <cstdint>
+#include <string>
+#include <thread>
+
+#include <XrdCl/XrdClFile.hh>
+
+namespace adios2
+{
+
+namespace
+{
+
+// XrdCl declares Open/Close warn_unused_result, which GCC enforces even
+// through a (void) cast; deliberately-ignored statuses are routed here.
+void IgnoreStatus(const XrdCl::XRootDStatus &) {}
+
+// Fetch one URL synchronously: Open(url) then a single Read(0, expectedSize)
+// of the whole response into the destination buffer (single Get) or into
+// responseData (batch, which the caller then frames/parses).  Runs on its own
+// thread; the result is delivered through op->promise.
+void DoGet(const std::string &url, AsyncGet *op)
+{
+    XrdCl::File file;
+
+    // The xrdcl-curl plugin fetches the whole response in one GET (full_download
+    // mode; the origin returns a complete body per GET).  Properties only reach
+    // the plugin once its object exists, so a no-op Open (Compress/None) loads
+    // it, then SetProperty enables full_download, then the real Open runs.
+    IgnoreStatus(file.Open(url, XrdCl::OpenFlags::Compress, XrdCl::Access::None, nullptr, 0));
+    (void)file.SetProperty("XrdClCurlFullDownload", "true");
+
+    XrdCl::XRootDStatus status = file.Open(url, XrdCl::OpenFlags::Read);
+    if (!status.IsOK())
+    {
+        op->errorMsg = "XrdCl Open failed: " + status.ToString();
+        op->promise.set_value(false);
+        return;
+    }
+
+    // The read needs the exact byte count up front: single Get carries it as
+    // expectedSize, batch as the framed total.
+    if (op->expectedSize == 0)
+    {
+        op->errorMsg = "XrdCl backend requires a known response size";
+        IgnoreStatus(file.Close());
+        op->promise.set_value(false);
+        return;
+    }
+    // XrdCl::File::Read takes a uint32_t count (and the server caps a single
+    // response at INT_MAX), so reject anything the cast below would truncate.
+    if (op->expectedSize > static_cast<size_t>(INT_MAX))
+    {
+        op->errorMsg = "XrdCl backend response size " + std::to_string(op->expectedSize) +
+                       " exceeds the 2 GiB single-request limit";
+        IgnoreStatus(file.Close());
+        op->promise.set_value(false);
+        return;
+    }
+    const auto size = static_cast<uint32_t>(op->expectedSize);
+
+    char *target = nullptr;
+    if (op->destBuffer)
+    {
+        target = static_cast<char *>(op->destBuffer);
+    }
+    else
+    {
+        op->responseData.resize(size);
+        target = op->responseData.data();
+    }
+
+    uint32_t bytesRead = 0;
+    status = file.Read(0, size, target, bytesRead);
+    IgnoreStatus(file.Close());
+
+    if (!status.IsOK())
+    {
+        op->errorMsg = "XrdCl Read failed: " + status.ToString();
+        op->promise.set_value(false);
+        return;
+    }
+
+    if (op->destBuffer)
+    {
+        op->destSize = bytesRead;
+    }
+    else
+    {
+        op->responseData.resize(bytesRead);
+    }
+    op->promise.set_value(true);
+}
+
+} // anonymous namespace
+
+// Stored but not yet consumed: xrdcl-curl has no per-File equivalents for
+// these settings.  CA trust comes from the process-global XrdCl environment
+// (XRD_CURLCERTFILE, falling back to X509_CERT_FILE); there is no insecure
+// mode (verifySSL=false cannot be honored); timeouts ride on the plugin's
+// own defaults.  Revisit as the XrdCl/Pelican picture firms up.
+void XrdClBackend::SetConfig(const Config &config) { m_Config = config; }
+
+void XrdClBackend::SubmitGet(const std::string &url, AsyncGet *op)
+{
+    std::thread(DoGet, url, op).detach();
+}
+
+} // end namespace adios2

--- a/source/adios2/toolkit/remote/XrdClBackend.h
+++ b/source/adios2/toolkit/remote/XrdClBackend.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ADIOS2_XRDCLBACKEND_H
+#define ADIOS2_XRDCLBACKEND_H
+
+#include "RemoteHttpBackend.h"
+
+namespace adios2
+{
+
+/**
+ * @brief XrdCl implementation of RemoteHttpBackend.
+ *
+ * Fetches a path-encoded URL with XrdCl::File: Open(url) followed by a single
+ * Read(0, expectedSize) of the whole response.  The URL scheme selects the
+ * XrdCl plugin at runtime, so the same backend serves a Pelican federation
+ * (pelican://) or a direct HTTPS origin (https://, via xrdcl-curl).
+ *
+ * Each request runs on its own worker thread issuing synchronous XrdCl calls;
+ * XrdCl manages connection pooling internally.  (A bounded pool or XrdCl-native
+ * async submission is a future optimization.)
+ */
+class XrdClBackend : public RemoteHttpBackend
+{
+public:
+    void SetConfig(const Config &config) override;
+    void SubmitGet(const std::string &url, AsyncGet *op) override;
+
+private:
+    Config m_Config;
+};
+
+} // end namespace adios2
+
+#endif // ADIOS2_XRDCLBACKEND_H

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
@@ -26,250 +26,14 @@
 #endif
 
 #ifdef ADIOS2_HAVE_CURL
-#include <curl/curl.h>
+#include "LibcurlBackend.h"
+#endif
+#ifdef ADIOS2_HAVE_XROOTD
+#include "XrdClBackend.h"
 #endif
 
 namespace adios2
 {
-
-#ifdef ADIOS2_HAVE_CURL
-
-namespace
-{
-
-size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
-{
-    size_t totalSize = size * nmemb;
-    std::vector<char> *buffer = static_cast<std::vector<char> *>(userp);
-    char *data = static_cast<char *>(contents);
-    buffer->insert(buffer->end(), data, data + totalSize);
-    return totalSize;
-}
-
-} // anonymous namespace
-
-// ======================================================================
-// CurlMultiPool implementation
-// ======================================================================
-
-CurlMultiPool &CurlMultiPool::getInstance()
-{
-    static CurlMultiPool instance;
-    return instance;
-}
-
-CurlMultiPool::CurlMultiPool()
-{
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-
-    m_MultiHandle = curl_multi_init();
-    if (!m_MultiHandle)
-    {
-        helper::Log("Remote", "CurlMultiPool", "CurlMultiPool",
-                    "Failed to initialize CURL multi handle", helper::LogMode::FATALERROR);
-        return;
-    }
-
-    curl_multi_setopt(m_MultiHandle, CURLMOPT_MAXCONNECTS, 50L);
-    curl_multi_setopt(m_MultiHandle, CURLMOPT_MAX_TOTAL_CONNECTIONS, 50L);
-    curl_multi_setopt(m_MultiHandle, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
-
-    m_Running = true;
-    m_WorkerThread = std::thread(&CurlMultiPool::WorkerLoop, this);
-}
-
-CurlMultiPool::~CurlMultiPool()
-{
-    {
-        std::lock_guard<std::mutex> lock(m_QueueMutex);
-        m_Running = false;
-    }
-    m_QueueCV.notify_all();
-
-    if (m_WorkerThread.joinable())
-    {
-        m_WorkerThread.join();
-    }
-
-    if (m_MultiHandle)
-    {
-        curl_multi_cleanup(m_MultiHandle);
-        m_MultiHandle = nullptr;
-    }
-}
-
-void CurlMultiPool::Submit(CURL *easyHandle, AsyncGet *asyncOp)
-{
-    {
-        std::lock_guard<std::mutex> lock(m_QueueMutex);
-        m_PendingQueue.push_back({easyHandle, asyncOp});
-    }
-    m_QueueCV.notify_one();
-}
-
-void CurlMultiPool::ProcessCompletedTransfers()
-{
-    CURLMsg *msg;
-    int msgsLeft;
-
-    while ((msg = curl_multi_info_read(m_MultiHandle, &msgsLeft)))
-    {
-        if (msg->msg == CURLMSG_DONE)
-        {
-            CURL *easy = msg->easy_handle;
-            CURLcode result = msg->data.result;
-
-            AsyncGet *asyncOp = nullptr;
-            curl_easy_getinfo(easy, CURLINFO_PRIVATE, &asyncOp);
-
-            if (asyncOp)
-            {
-                bool success = false;
-
-                if (result == CURLE_OK)
-                {
-                    long httpCode = 0;
-                    curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &httpCode);
-
-                    if (httpCode == 200 || httpCode == 201)
-                    {
-                        // Reject a response that would overrun dest; 0 = caller
-                        // gave no expected size.
-                        if (asyncOp->expectedSize != 0 &&
-                            asyncOp->responseData.size() > asyncOp->expectedSize)
-                        {
-                            asyncOp->errorMsg = "response size " +
-                                                std::to_string(asyncOp->responseData.size()) +
-                                                " exceeds expected " +
-                                                std::to_string(asyncOp->expectedSize) + " bytes";
-                        }
-                        else
-                        {
-                            if (asyncOp->destBuffer && !asyncOp->responseData.empty())
-                            {
-                                memcpy(asyncOp->destBuffer, asyncOp->responseData.data(),
-                                       asyncOp->responseData.size());
-                                asyncOp->destSize = asyncOp->responseData.size();
-                            }
-                            success = true;
-                        }
-                    }
-                    else
-                    {
-                        std::ostringstream ss;
-                        ss << "HTTP error " << httpCode;
-                        if (!asyncOp->responseData.empty())
-                        {
-                            ss << ": "
-                               << std::string(asyncOp->responseData.begin(),
-                                              asyncOp->responseData.end());
-                        }
-                        asyncOp->errorMsg = ss.str();
-                    }
-                }
-                else
-                {
-                    asyncOp->errorMsg = curl_easy_strerror(result);
-                }
-
-                // Clean up headers and easy handle BEFORE signaling completion.
-                // Once set_value() is called, the waiting thread in WaitForGet()
-                // may immediately delete asyncOp, causing use-after-free.
-                if (asyncOp->headers)
-                {
-                    curl_slist_free_all(asyncOp->headers);
-                    asyncOp->headers = nullptr;
-                }
-
-                curl_multi_remove_handle(m_MultiHandle, easy);
-                curl_easy_cleanup(easy);
-                easy = nullptr;
-
-                asyncOp->promise.set_value(success);
-            }
-
-            if (easy)
-            {
-                curl_multi_remove_handle(m_MultiHandle, easy);
-                curl_easy_cleanup(easy);
-            }
-        }
-    }
-}
-
-void CurlMultiPool::WorkerLoop()
-{
-    while (true)
-    {
-        // Drain pending queue into curl multi handle
-        {
-            std::unique_lock<std::mutex> lock(m_QueueMutex);
-
-            while (!m_PendingQueue.empty())
-            {
-                PendingSubmit req = m_PendingQueue.front();
-                m_PendingQueue.pop_front();
-
-                CURLMcode rc = curl_multi_add_handle(m_MultiHandle, req.easyHandle);
-                if (rc != CURLM_OK)
-                {
-                    req.asyncOp->errorMsg =
-                        std::string("curl_multi_add_handle failed: ") + curl_multi_strerror(rc);
-                    req.asyncOp->promise.set_value(false);
-                    if (req.asyncOp->headers)
-                    {
-                        curl_slist_free_all(req.asyncOp->headers);
-                        req.asyncOp->headers = nullptr;
-                    }
-                    curl_easy_cleanup(req.easyHandle);
-                }
-            }
-        }
-
-        // Drive transfers and process completions
-        int runningHandles = 0;
-        curl_multi_perform(m_MultiHandle, &runningHandles);
-        ProcessCompletedTransfers();
-
-        // Check if we should block waiting for new work
-        if (runningHandles == 0)
-        {
-            std::unique_lock<std::mutex> lock(m_QueueMutex);
-            if (!m_Running && m_PendingQueue.empty())
-            {
-                break;
-            }
-            if (m_PendingQueue.empty())
-            {
-                m_QueueCV.wait(lock);
-            }
-            continue;
-        }
-
-        // Skip waiting if new requests are queued -- submit them immediately
-        {
-            std::lock_guard<std::mutex> lock(m_QueueMutex);
-            if (!m_PendingQueue.empty())
-            {
-                continue;
-            }
-        }
-
-        // Wait for socket activity (up to 10ms)
-        int numfds;
-        CURLMcode mc = curl_multi_wait(m_MultiHandle, nullptr, 0, 10, &numfds);
-        if (mc != CURLM_OK)
-        {
-            helper::Log("Remote", "CurlMultiPool", "WorkerLoop",
-                        "curl_multi_wait failed: " + std::string(curl_multi_strerror(mc)),
-                        helper::LogMode::WARNING);
-        }
-    }
-
-    ProcessCompletedTransfers();
-}
-
-#endif // ADIOS2_HAVE_CURL
 
 // ======================================================================
 // XrootdHttpRemote implementation
@@ -368,7 +132,8 @@ void XrootdHttpRemote::Open(const std::string hostname, const int32_t port,
     for (const auto &p : params)
     {
         if (p.first != "UseHttps" && p.first != "CAPath" && p.first != "VerifySSL" &&
-            p.first != "ConnectTimeout" && p.first != "RequestTimeout" && p.first != "FileUUID")
+            p.first != "ConnectTimeout" && p.first != "RequestTimeout" && p.first != "FileUUID" &&
+            p.first != "Backend")
         {
             engineParams[p.first] = p.second;
         }
@@ -387,51 +152,48 @@ void XrootdHttpRemote::Open(const std::string hostname, const int32_t port,
     // the file-config path segment and reused on every request.
     m_FileConfigSegment = BuildFileConfigSegment();
 
+    // Select the HTTP transport.  "Backend=XrdCl" routes through XrdCl::File
+    // (Pelican/xrdcl-curl); the default is libcurl.
+    std::string backend = "Libcurl";
+    it = params.find("Backend");
+    if (it != params.end())
+        backend = it->second;
+
+    if (backend == "XrdCl")
+    {
+#ifdef ADIOS2_HAVE_XROOTD
+        m_Backend.reset(new XrdClBackend());
+#else
+        helper::Throw<std::runtime_error>(
+            "Remote", "XrootdHttpRemote", "Open",
+            "XrdCl backend requested but ADIOS2 was not built with XRootD");
+        return;
+#endif
+    }
+    else
+    {
+#ifdef ADIOS2_HAVE_CURL
+        m_Backend.reset(new LibcurlBackend());
+#else
+        helper::Throw<std::runtime_error>(
+            "Remote", "XrootdHttpRemote", "Open",
+            "libcurl backend requested but ADIOS2 was not built with CURL");
+        return;
+#endif
+    }
+
+    RemoteHttpBackend::Config cfg;
+    cfg.useHttps = m_UseHttps;
+    cfg.connectTimeout = m_ConnectTimeout;
+    cfg.requestTimeout = m_RequestTimeout;
+    cfg.caCertPath = m_CACertPath;
+    cfg.verifySSL = m_VerifySSL;
+    m_Backend->SetConfig(cfg);
+
     m_OpenSuccess = true;
 }
 
 void XrootdHttpRemote::Close() { m_OpenSuccess = false; }
-
-CURL *XrootdHttpRemote::CreateEasyHandle(AsyncGet *asyncOp, const std::string &url)
-{
-#ifdef ADIOS2_HAVE_CURL
-    CURL *easy = curl_easy_init();
-    if (!easy)
-        return nullptr;
-
-    curl_easy_setopt(easy, CURLOPT_PRIVATE, asyncOp);
-    asyncOp->easyHandle = easy;
-
-    curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(easy, CURLOPT_HTTPGET, 1L);
-    curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, WriteCallback);
-    curl_easy_setopt(easy, CURLOPT_WRITEDATA, &asyncOp->responseData);
-    curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT, m_ConnectTimeout);
-    curl_easy_setopt(easy, CURLOPT_TIMEOUT, m_RequestTimeout);
-
-    if (m_UseHttps)
-    {
-        if (!m_VerifySSL)
-        {
-            curl_easy_setopt(easy, CURLOPT_SSL_VERIFYPEER, 0L);
-            curl_easy_setopt(easy, CURLOPT_SSL_VERIFYHOST, 0L);
-        }
-        else
-        {
-            curl_easy_setopt(easy, CURLOPT_SSL_VERIFYPEER, 1L);
-            curl_easy_setopt(easy, CURLOPT_SSL_VERIFYHOST, 2L);
-            if (!m_CACertPath.empty())
-                curl_easy_setopt(easy, CURLOPT_CAINFO, m_CACertPath.c_str());
-        }
-    }
-
-    curl_easy_setopt(easy, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
-
-    return easy;
-#else
-    return nullptr;
-#endif
-}
 
 // ---------------------------------------------------------------------
 // Path-encoded URL builders (Pelican/XCache-friendly form).
@@ -538,6 +300,23 @@ std::string XrootdHttpRemote::BuildBatchGetSegment(const std::vector<BatchGetReq
     return s.str();
 }
 
+// Expected size of a framed batch response:
+//   [uint64 NVars][uint64 size_0 … size_{N-1}][data_0 … data_{N-1}]
+// Returns 0 (unchecked) if any sub-request lacks a known destSize, since then
+// the total can't be predicted (the libcurl backend streams to EOF; the XrdCl
+// backend needs this size to issue its read).
+static size_t ExpectedBatchResponseSize(const std::vector<Remote::BatchGetRequest> &reqs)
+{
+    size_t total = sizeof(uint64_t) * (1 + reqs.size());
+    for (const auto &r : reqs)
+    {
+        if (r.destSize == 0)
+            return 0;
+        total += r.destSize;
+    }
+    return total;
+}
+
 bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
 {
     if (!m_OpenSuccess || requests.empty())
@@ -552,14 +331,11 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
         return false;
     }
 
-#ifdef ADIOS2_HAVE_CURL
     // Split requests into sub-batches for server-side parallelism.
-    // Each sub-batch becomes a separate HTTP POST handled by its own
+    // Each sub-batch becomes a separate HTTP request handled by its own
     // server thread, giving us parallelism without individual-Get overhead.
     const size_t subBatchSize = 10;
     size_t nBatches = (requests.size() + subBatchSize - 1) / subBatchSize;
-
-    CurlMultiPool &pool = CurlMultiPool::getInstance();
 
     // Track each sub-batch: its offset into requests[], count, and async state
     struct SubBatch
@@ -582,20 +358,8 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
             m_BaseUrl + "/" + m_FileConfigSegment + "/" + BuildBatchGetSegment(subRequests);
 
         AsyncGet *asyncOp = new AsyncGet();
-        CURL *easy = CreateEasyHandle(asyncOp, url);
-        if (!easy)
-        {
-            delete asyncOp;
-            // Wait for already-submitted sub-batches before returning
-            for (auto &sb : subBatches)
-            {
-                sb.asyncOp->promise.get_future().get();
-                delete sb.asyncOp;
-            }
-            return false;
-        }
-
-        pool.Submit(easy, asyncOp);
+        asyncOp->expectedSize = ExpectedBatchResponseSize(subRequests);
+        m_Backend->SubmitGet(url, asyncOp);
         subBatches.push_back({startIdx, count, asyncOp});
     }
 
@@ -629,13 +393,8 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
                     m_BaseUrl + "/" + m_FileConfigSegment + "/" + BuildBatchGetSegment(subRequests);
 
                 AsyncGet *retryOp = new AsyncGet();
-                CURL *easy = CreateEasyHandle(retryOp, url);
-                if (!easy)
-                {
-                    delete retryOp;
-                    continue;
-                }
-                pool.Submit(easy, retryOp);
+                retryOp->expectedSize = ExpectedBatchResponseSize(subRequests);
+                m_Backend->SubmitGet(url, retryOp);
                 success = retryOp->promise.get_future().get();
                 if (success)
                 {
@@ -717,11 +476,6 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
     }
 
     return allOk;
-#else
-    helper::Log("Remote", "XrootdHttpRemote", "BatchGet", "ADIOS2 was not built with CURL support",
-                helper::LogMode::WARNING);
-    return false;
-#endif
 }
 
 Remote::GetHandle XrootdHttpRemote::Get(const char *VarName, size_t Step, size_t StepCount,
@@ -733,11 +487,6 @@ Remote::GetHandle XrootdHttpRemote::Get(const char *VarName, size_t Step, size_t
         return nullptr;
     }
 
-#ifdef ADIOS2_HAVE_CURL
-    // Get pool reference first to ensure curl_global_init() runs
-    // before any curl_easy_init() calls in CreateEasyHandle()
-    CurlMultiPool &pool = CurlMultiPool::getInstance();
-
     AsyncGet *asyncOp = new AsyncGet();
     asyncOp->destBuffer = dest;
     asyncOp->expectedSize = destSize;
@@ -745,20 +494,8 @@ Remote::GetHandle XrootdHttpRemote::Get(const char *VarName, size_t Step, size_t
     std::string url =
         m_BaseUrl + "/" + m_FileConfigSegment + "/" +
         BuildSingleGetSegment(VarName, Step, StepCount, BlockID, Count, Start, accuracy);
-    CURL *easy = CreateEasyHandle(asyncOp, url);
-    if (!easy)
-    {
-        delete asyncOp;
-        return nullptr;
-    }
-
-    pool.Submit(easy, asyncOp);
+    m_Backend->SubmitGet(url, asyncOp);
     return static_cast<GetHandle>(asyncOp);
-#else
-    helper::Log("Remote", "XrootdHttpRemote", "Get", "ADIOS2 was not built with CURL support",
-                helper::LogMode::WARNING);
-    return nullptr;
-#endif
 }
 
 bool XrootdHttpRemote::WaitForGet(GetHandle handle)

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.h
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.h
@@ -8,91 +8,24 @@
 #define ADIOS2_XROOTDHTTPREMOTE_H
 
 #include "Remote.h"
+#include "RemoteHttpBackend.h"
 #include "adios2/common/ADIOSConfig.h"
 #include "adios2/common/ADIOSTypes.h"
 #include "adios2/toolkit/profiling/iochrono/IOChrono.h"
 
-#include <atomic>
-#include <condition_variable>
-#include <deque>
-#include <future>
 #include <memory>
-#include <mutex>
 #include <string>
-#include <thread>
-
-// Forward declarations for CURL handles
-typedef void CURL;
-typedef void CURLM;
-struct curl_slist;
 
 namespace adios2
 {
 
-class XrootdHttpRemote;
-
 /**
- * @brief Async operation state for a single HTTP GET/POST request.
- */
-struct AsyncGet
-{
-    std::promise<bool> promise;
-    std::string errorMsg;
-    void *destBuffer = nullptr;
-    size_t destSize = 0;
-    size_t expectedSize = 0; // expected response bytes; 0 = unchecked
-    std::vector<char> responseData;
-    CURL *easyHandle = nullptr;
-    ::curl_slist *headers = nullptr;
-};
-
-/**
- * @brief A fully-configured easy handle waiting to be added to the multi handle.
- */
-struct PendingSubmit
-{
-    CURL *easyHandle;
-    AsyncGet *asyncOp;
-};
-
-/**
- * @brief Shared CURL multi pool singleton.
+ * @brief HTTP/HTTPS-based remote access to ADIOS data via an XRootD HTTP-SSI
+ * bridge or a Pelican federation.
  *
- * All XrootdHttpRemote instances submit fully-configured easy handles to
- * this pool. A single worker thread drives all transfers via one curl_multi
- * handle, bounding the total number of concurrent TCP connections.
- */
-class CurlMultiPool
-{
-public:
-    static CurlMultiPool &getInstance();
-
-    /** Submit a fully-configured easy handle for async execution. Thread-safe. */
-    void Submit(CURL *easyHandle, AsyncGet *asyncOp);
-
-    // Non-copyable, non-movable
-    CurlMultiPool(const CurlMultiPool &) = delete;
-    CurlMultiPool &operator=(const CurlMultiPool &) = delete;
-
-private:
-    CurlMultiPool();
-    ~CurlMultiPool();
-
-    void WorkerLoop();
-    void ProcessCompletedTransfers();
-
-    CURLM *m_MultiHandle = nullptr;
-    std::thread m_WorkerThread;
-    std::atomic<bool> m_Running{false};
-    std::mutex m_QueueMutex;
-    std::condition_variable m_QueueCV;
-    std::deque<PendingSubmit> m_PendingQueue;
-};
-
-/**
- * @brief HTTP/HTTPS-based remote access to ADIOS data via XRootD HTTP-SSI bridge
- *
- * All instances share a single CurlMultiPool for efficient connection pooling.
+ * This class owns URL building (the path-encoded, cache-friendly request
+ * grammar) and response framing/parsing.  The HTTP round trip itself is
+ * delegated to a RemoteHttpBackend (libcurl by default).
  */
 class XrootdHttpRemote : public Remote
 {
@@ -143,7 +76,9 @@ private:
     std::string BuildBatchGetSegment(const std::vector<BatchGetRequest> &requests);
 
     static std::string Base64urlEncode(const std::string &str);
-    CURL *CreateEasyHandle(AsyncGet *asyncOp, const std::string &url);
+
+    /** HTTP transport (libcurl by default). */
+    std::unique_ptr<RemoteHttpBackend> m_Backend;
 
     std::string m_BaseUrl;
     std::string m_Filename;

--- a/source/utils/xrootd-plugin/README.md
+++ b/source/utils/xrootd-plugin/README.md
@@ -16,6 +16,14 @@ This document covers operator-facing configuration. Other operational knobs
 (file-pool FD/metadata limits, the admin HTTP interface) are described in the
 release notes and will be folded in here over time.
 
+## Limits
+
+A single response (one variable get, or one batch frame) is capped at 2 GiB, a
+bound imposed by the XRootD SSI response API. A request whose result would
+exceed it is rejected with an error telling the client to request a smaller
+selection or fewer variables per batch. Lifting the cap requires a streaming
+response path, which is not yet supported.
+
 ## Access log
 
 An optional per-request access log records every remote read as one JSON object

--- a/source/utils/xrootd-plugin/XrdHttpSsiHandler.cpp
+++ b/source/utils/xrootd-plugin/XrdHttpSsiHandler.cpp
@@ -744,10 +744,25 @@ int XrdHttpSsiHandler::ProcessReq(XrdHttpExtReq &req)
         return SendError(req, 400, "GET request missing xrd-http-fullresource");
     }
 
-    std::string ssiCommand;
-    if (it->second.find('?') == std::string::npos)
+    // Decide the wire form by the query's first token, not by the mere presence
+    // of a query: the legacy form puts a bare verb (get/batchget) there, while
+    // an XrdCl/Pelican client appends opaque params (e.g. xrdclcurl.timeout=…,
+    // authz=…) to an otherwise path-encoded request.
+    bool legacyQuery = false;
     {
-        // No query string → new path-encoded form.
+        size_t qpos = it->second.find('?');
+        if (qpos != std::string::npos)
+        {
+            std::string query = it->second.substr(qpos + 1);
+            std::string verb = query.substr(0, query.find_first_of("&="));
+            legacyQuery = (verb == "get" || verb == "batchget");
+        }
+    }
+
+    std::string ssiCommand;
+    if (!legacyQuery)
+    {
+        // Path-encoded form (DecodePathEncodedRequest ignores any trailing query).
         std::string err;
         std::string pathResource;
         if (!DecodePathEncodedRequest(it->second, m_pathPrefix, ssiCommand, pathResource, err))

--- a/source/utils/xrootd-plugin/XrdSsiSvService.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvService.cpp
@@ -34,6 +34,8 @@
 /******************************************************************************/
 
 #include <algorithm> // std::reverse
+#include <cerrno>
+#include <climits> // INT_MAX
 #include <complex>
 #include <fcntl.h>
 #include <iostream>
@@ -1202,7 +1204,18 @@ void XrdSsiSvService::AdiosRespond(const char *rData, const char *mData)
     // We copy the response into a buffer that must live even after we return to
     // the caller because the data in that buffer will be sent back to the client.
     //
-    rLen = m_responseBufferSize;
+    // XrdSsiResponder::SetResponse takes an int length, so a single response is
+    // capped at ~2 GiB.  Reject an over-large response with a clear error rather
+    // than silently truncating it into a corrupt reply.  (Lifting this needs the
+    // streaming/chunked response path, not yet supported.)
+    if (m_responseBufferSize > static_cast<size_t>(INT_MAX))
+    {
+        RespondErr("response exceeds the 2 GiB single-response limit; request a "
+                   "smaller selection or fewer variables per batch",
+                   EFBIG);
+        return;
+    }
+    rLen = static_cast<int>(m_responseBufferSize);
     // We use the inherited method XrdSsiResponder::SetResponse to post the response
     // Note we always send the null byte to make it easy on the client :-)
     //

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -253,6 +253,48 @@ if (ADIOS2_HAVE_XRootD AND ADIOS2_HAVE_CURL)
          WORKING_DIRECTORY ${XROOTD_HTTPS_DIR})
    endmacro()
 
+   # Opt-in XrdCl-client variant: reader fetches via the xrdcl-curl plugin.
+   # Needs the prebuilt plugin: -DXRDCL_CURL_PLUGIN=<path/to/libXrdClCurl.dylib>.
+   set(XRDCL_CURL_PLUGIN "" CACHE FILEPATH "xrdcl-curl plugin for the XrdCl remote test")
+   if (XRDCL_CURL_PLUGIN)
+      set(XRDCL_PLUGIN_CONFDIR ${XROOTD_HTTPS_DIR}/xrdcl-plugins)
+      file(MAKE_DIRECTORY ${XRDCL_PLUGIN_CONFDIR})
+      file(WRITE ${XRDCL_PLUGIN_CONFDIR}/curl-plugin.conf
+         "url = http://*;https://*\nlib = ${XRDCL_CURL_PLUGIN}\nenable = true\n")
+      # Own working dir so .bp filenames don't alias the libcurl GetXRHttps tests.
+      set(XRDCL_WORK_DIR ${XROOTD_HTTPS_DIR}/xrdcl)
+      file(MAKE_DIRECTORY ${XRDCL_WORK_DIR})
+      macro(add_get_xrhttps_xrdcl_tests_helper testname)
+         add_test(NAME "Remote.BP${testname}.GetXRHttpsXrdCl" COMMAND Test.Engine.BP.${testname}.Serial bp5)
+         set_tests_properties(Remote.BP${testname}.GetXRHttpsXrdCl PROPERTIES
+            FIXTURES_REQUIRED XRHttpsServer
+            ENVIRONMENT "DoXRootDXrdCl=1;XRootDHttpsHost=localhost:${XROOTD_HTTP_PORT};XRD_PLUGINCONFDIR=${XRDCL_PLUGIN_CONFDIR};X509_CERT_FILE=${XROOTD_HTTPS_DIR}/xroot-http/certs/server.crt"
+            WORKING_DIRECTORY ${XRDCL_WORK_DIR})
+      endmacro()
+   else()
+      macro(add_get_xrhttps_xrdcl_tests_helper testname)
+      endmacro()
+   endif()
+
+   # LEGACY WIRE-FORMAT REGRESSION TEST.  Released clients up through v2.12.x
+   # encode requests as a query string (?get&Varname=...); the current client
+   # speaks the path-encoded form.  This test hand-builds the legacy form and
+   # checks the server still answers it correctly.  Remove the test (and
+   # TestBPXRootDHttpLegacyWire.cpp) when legacy query-string support is
+   # retired from the server.
+   add_executable(Test.Engine.BP.XRootDHttpLegacyWire.Serial TestBPXRootDHttpLegacyWire.cpp)
+   target_link_libraries(Test.Engine.BP.XRootDHttpLegacyWire.Serial
+      adios2::cxx adios2_core adios2::thirdparty::gtest CURL::libcurl)
+   # Own working dir so .bp filenames don't alias other tests' server-side engines.
+   set(XROOTD_LEGACY_DIR ${XROOTD_HTTPS_DIR}/legacy-wire)
+   file(MAKE_DIRECTORY ${XROOTD_LEGACY_DIR})
+   add_test(NAME "Remote.BPXRootDHttpLegacyWire.GetXRHttps"
+      COMMAND Test.Engine.BP.XRootDHttpLegacyWire.Serial)
+   set_tests_properties(Remote.BPXRootDHttpLegacyWire.GetXRHttps PROPERTIES
+      FIXTURES_REQUIRED XRHttpsServer
+      ENVIRONMENT "XRootDHttpsHost=localhost:${XROOTD_HTTP_PORT}"
+      WORKING_DIRECTORY ${XROOTD_LEGACY_DIR})
+
    add_test(NAME generateXRootDHttpConfig COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/generateXRootDHttpConfig.sh $<TARGET_FILE:adios2_xrootd> $<TARGET_FILE:adios2_xrootd_http> ${XROOTD_XRD_PORT} ${XROOTD_HTTP_PORT})
    set_tests_properties(generateXRootDHttpConfig PROPERTIES WORKING_DIRECTORY ${XROOTD_HTTPS_DIR})
 
@@ -266,6 +308,8 @@ if (ADIOS2_HAVE_XRootD AND ADIOS2_HAVE_CURL)
    ##### add HTTPS remote tests below this line
    add_get_xrhttps_tests_helper(WriteReadADIOS2Transport)
    add_get_xrhttps_tests_helper(WriteMemorySelectionRead)
+   add_get_xrhttps_xrdcl_tests_helper(WriteReadADIOS2Transport)
+   add_get_xrhttps_xrdcl_tests_helper(WriteMemorySelectionRead)
 endif()
 
 if(ADIOS2_HAVE_MPI)

--- a/testing/adios2/engine/bp/TestBPXRootDHttpLegacyWire.cpp
+++ b/testing/adios2/engine/bp/TestBPXRootDHttpLegacyWire.cpp
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// REGRESSION TEST FOR THE LEGACY XROOTD-HTTP WIRE FORMAT.
+//
+// Released clients up through v2.12.x encode remote-read requests as a URL
+// query string:
+//     /adios/<filename>?get&Varname=<v>&Count=...&Start=...
+//     /adios/<filename>?batchget&NVars=<n>&Varname=...&Varname=...
+// The current client speaks the path-encoded form instead, but the server
+// must keep answering the legacy form until those clients age out.  This
+// test hand-builds requests exactly as the v2.12.0 client did and verifies
+// the bytes that come back.
+//
+// REMOVE this test (and its registration in CMakeLists.txt) when legacy
+// query-string support is retired from the server.
+
+#include <array>
+#include <climits>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <unistd.h> // getcwd; the server plugin is POSIX-only
+
+#include <adios2.h>
+#include <curl/curl.h>
+#include <gtest/gtest.h>
+
+namespace
+{
+
+size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    auto *buffer = static_cast<std::vector<char> *>(userp);
+    const char *data = static_cast<const char *>(contents);
+    buffer->insert(buffer->end(), data, data + size * nmemb);
+    return size * nmemb;
+}
+
+constexpr long kHttpOK = 200;
+constexpr size_t kNElems = 16; // elements in the test variable
+
+// Synchronous GET; returns true on HTTP 200 with the body in `out`.
+bool LegacyFetch(const std::string &url, std::vector<char> &out)
+{
+    CURL *curl = curl_easy_init();
+    if (!curl)
+    {
+        return false;
+    }
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &out);
+    // The test fixture's certificate is self-signed.
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    CURLcode rc = curl_easy_perform(curl);
+    long httpCode = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+    curl_easy_cleanup(curl);
+    return rc == CURLE_OK && httpCode == kHttpOK;
+}
+
+} // anonymous namespace
+
+class XRootDHttpLegacyWire : public ::testing::Test
+{
+protected:
+    // Write one BP5 file and compute the legacy base URL,
+    // https://<host>/adios<absolute-filename>, shared by both tests.
+    static void SetUpTestSuite()
+    {
+        const char *host = getenv("XRootDHttpsHost");
+        ASSERT_NE(host, nullptr) << "XRootDHttpsHost must be set (host:port of the test server)";
+
+        s_Expected.resize(kNElems);
+        std::iota(s_Expected.begin(), s_Expected.end(), 0.0);
+
+        adios2::ADIOS adios;
+        adios2::IO io = adios.DeclareIO("legacywire");
+        io.SetEngine("BP5");
+        auto var = io.DefineVariable<double>("t", {kNElems}, {0}, {kNElems});
+        adios2::Engine writer = io.Open("legacywire.bp", adios2::Mode::Write);
+        writer.BeginStep();
+        writer.Put(var, s_Expected.data());
+        writer.EndStep();
+        writer.Close();
+
+        std::array<char, PATH_MAX> cwd{};
+        ASSERT_NE(getcwd(cwd.data(), cwd.size()), nullptr);
+        s_BaseUrl = "https://" + std::string(host) + "/adios" + cwd.data() + "/legacywire.bp";
+    }
+
+    static std::vector<double> s_Expected;
+    static std::string s_BaseUrl;
+};
+
+std::vector<double> XRootDHttpLegacyWire::s_Expected;
+std::string XRootDHttpLegacyWire::s_BaseUrl;
+
+// Single get: raw variable bytes come back, nothing else.
+TEST_F(XRootDHttpLegacyWire, SingleGet)
+{
+    std::vector<char> body;
+    ASSERT_TRUE(LegacyFetch(s_BaseUrl + "?get&Varname=t&RMOrder=1&Count=16&Start=0", body));
+    ASSERT_EQ(body.size(), s_Expected.size() * sizeof(double));
+    EXPECT_EQ(memcmp(body.data(), s_Expected.data(), body.size()), 0);
+}
+
+// Batch get: [uint64 NVars][uint64 size_i ...][data_i ...] framing.
+TEST_F(XRootDHttpLegacyWire, BatchGet)
+{
+    std::vector<char> body;
+    ASSERT_TRUE(LegacyFetch(s_BaseUrl + "?batchget&NVars=2&RMOrder=1"
+                                        "&Varname=t&Count=4&Start=0"
+                                        "&Varname=t&Count=4&Start=12",
+                            body));
+
+    const size_t chunkBytes = 4 * sizeof(double);
+    ASSERT_EQ(body.size(), 3 * sizeof(uint64_t) + 2 * chunkBytes);
+
+    std::array<uint64_t, 3> frame{};
+    memcpy(frame.data(), body.data(), sizeof(frame));
+    EXPECT_EQ(frame[0], 2u); // NVars
+    EXPECT_EQ(frame[1], chunkBytes);
+    EXPECT_EQ(frame[2], chunkBytes);
+
+    const char *chunk0 = body.data() + sizeof(frame);
+    const char *chunk1 = chunk0 + chunkBytes;
+    EXPECT_EQ(memcmp(chunk0, &s_Expected[0], chunkBytes), 0);
+    EXPECT_EQ(memcmp(chunk1, &s_Expected[12], chunkBytes), 0);
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/testing/adios2/engine/bp/generateXRootDHttpConfig.sh
+++ b/testing/adios2/engine/bp/generateXRootDHttpConfig.sh
@@ -37,6 +37,7 @@ if [ ! -f xroot-http/certs/server.crt ]; then
         -keyout xroot-http/certs/server.key \
         -out xroot-http/certs/server.crt \
         -subj "/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
         -batch; then
         echo "Certificate generated successfully"
         # Key permissions will be adjusted by start script if needed for user switching


### PR DESCRIPTION
The goal here is to restructure the HTTP remote-read path so that the previous libcurl interaction with our XRootD server is just one possibility, and to add an XrdCl-based approach alongside it. Most of the changes are in service of that goal, moving code rather than changing it: the curl-multi machinery comes out of XrootdHttpRemote verbatim into a LibcurlBackend behind a small RemoteHttpBackend interface, while URL building and response parsing stay in XrootdHttpRemote where both backends share them. The libcurl path is largely unchanged.

The XrdCl backend is new, and it's deliberately less capable and complete than the libcurl one. It fetches whole responses through XrdCl::File with the xrdcl-curl plugin in full_download mode (our origin computes a complete body per GET, with no HEAD or range support, so that's the mode that fits).  Honestly I'm not sure this is more than a starting point for Pelican collab, but hopefully it is at least that.

Selecting it: transfer_protocol "xrdcl" on an XRootD entry in ~/.config/hpc-campaign/hosts.yaml, alongside the existing xrootd/http/https values, reached as usual through the reader's RemoteHost parameter. For testing and development there's also a DoXRootDXrdCl environment variable (with XRootDHttpsHost giving host:port), following the existing DoXRootDHttps pattern. libcurl remains the default for the http and https lanes. XrootdHttpRemote now builds when either CURL or XRootD is available, and asking for a backend whose library wasn't built produces an error at Open.

There are server-side changes to accommodate XrdCl-style clients, which append opaque query parameters to request URLs (xrdclcurl.timeout=..., authz=...). The handler now distinguishes the legacy query form from the path-encoded form by the query's first token rather than by the mere presence of a '?'. While in there, the server also now rejects responses over 2 GiB with a clear error instead of silently truncating them (the SSI response API takes an int length; lifting that limit needs the streaming path we don't have yet).

There is a standard set of tests routing through XrdCl.  I've also added a new regression test that issues v2.12.0-style query-string requests directly and verifies the returned bytes.  This can be removed when we think 2.12 clients are sufficiently far in the past
