### PR TITLE
Remove unnecessary includes in FileAWSSDK

### DIFF
--- a/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
+++ b/source/adios2/toolkit/transport/file/FileAWSSDK.cpp
@@ -10,20 +10,6 @@
 #include "adios2/helper/adiosString.h"
 #include "adios2/helper/adiosSystem.h"
 
-#include <algorithm> // sort
-#include <cstdio>    // remove
-#include <cstring>   // strerror
-#include <errno.h>   // errno
-#include <fcntl.h>   // open
-#include <regex>
-#include <sys/stat.h>  // open, fstat
-#include <sys/types.h> // open
-#include <unistd.h>    // write, close, ftruncate
-
-/// \cond EXCLUDE_FROM_DOXYGEN
-#include <ios> //std::ios_base::failure
-/// \endcond
-
 namespace adios2
 {
 namespace transport


### PR DESCRIPTION
Removing <unistd.h> solves a MSVC compile issue (unknown include)

Removing also other includes to see, which are really necessary, as there is no `strerror`, `ftruncate`, ...