### PR TITLE
BP5: 32 Bit Crashes Fixed, 32bit-32bit Round-Trips

### DIFF
--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -263,7 +263,7 @@ constexpr bool end_step = true;
 constexpr bool LocalValue = true;
 constexpr bool GlobalValue = false;
 
-constexpr size_t UnknownStep = MaxU64;
+constexpr size_t UnknownStep = std::numeric_limits<size_t>::max();
 constexpr double UnknownTime = std::numeric_limits<double>::infinity();
 
 // Dims, Params, vParams are defined in ADIOSBaseTypes.h

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -263,7 +263,7 @@ constexpr bool end_step = true;
 constexpr bool LocalValue = true;
 constexpr bool GlobalValue = false;
 
-constexpr size_t UnknownStep = std::numeric_limits<size_t>::max();
+constexpr size_t UnknownStep = MaxSizeT;
 constexpr double UnknownTime = std::numeric_limits<double>::infinity();
 
 // Dims, Params, vParams are defined in ADIOSBaseTypes.h

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -351,7 +351,8 @@ std::pair<T, T> Variable<T>::DoMinMax(const size_t step) const
         }
 
         const bool isValue = ((blocksInfo.front().Shape.size() == 1 &&
-                               blocksInfo.front().Shape.front() == LocalValueDim) ||
+                               blocksInfo.front().Shape.front() ==
+                                   static_cast<size_t>(LocalValueDim)) ||
                               m_ShapeID == ShapeID::GlobalValue)
                                  ? true
                                  : false;

--- a/source/adios2/core/Variable.tcc
+++ b/source/adios2/core/Variable.tcc
@@ -350,12 +350,12 @@ std::pair<T, T> Variable<T>::DoMinMax(const size_t step) const
             return minMax;
         }
 
-        const bool isValue = ((blocksInfo.front().Shape.size() == 1 &&
-                               blocksInfo.front().Shape.front() ==
-                                   static_cast<size_t>(LocalValueDim)) ||
-                              m_ShapeID == ShapeID::GlobalValue)
-                                 ? true
-                                 : false;
+        const bool isValue =
+            ((blocksInfo.front().Shape.size() == 1 &&
+              blocksInfo.front().Shape.front() == static_cast<size_t>(LocalValueDim)) ||
+             m_ShapeID == ShapeID::GlobalValue)
+                ? true
+                : false;
 
         minMax.first = isValue ? blocksInfo.front().Value : blocksInfo.front().Min;
         minMax.second = isValue ? blocksInfo.front().Value : blocksInfo.front().Max;

--- a/source/adios2/core/VariableBase.cpp
+++ b/source/adios2/core/VariableBase.cpp
@@ -527,7 +527,7 @@ void VariableBase::InitShapeType()
 
     if (!m_Shape.empty())
     {
-        if (std::count(m_Shape.begin(), m_Shape.end(), JoinedDim) == 1)
+        if (std::count(m_Shape.begin(), m_Shape.end(), static_cast<size_t>(JoinedDim)) == 1)
         {
             if (!m_Start.empty() && static_cast<size_t>(std::count(m_Start.begin(), m_Start.end(),
                                                                    0)) != m_Start.size())
@@ -543,7 +543,7 @@ void VariableBase::InitShapeType()
         }
         else if (m_Start.empty() && m_Count.empty())
         {
-            if (m_Shape.size() == 1 && m_Shape.front() == LocalValueDim)
+            if (m_Shape.size() == 1 && m_Shape.front() == static_cast<size_t>(LocalValueDim))
             {
                 m_ShapeID = ShapeID::LocalValue;
                 m_Start.resize(1, 0); // start[0] == 0
@@ -638,9 +638,12 @@ void VariableBase::CheckDimensionsCommon(const std::string hint) const
 {
     if (m_ShapeID != ShapeID::LocalValue)
     {
-        if ((!m_Shape.empty() && std::count(m_Shape.begin(), m_Shape.end(), LocalValueDim) > 0) ||
-            (!m_Start.empty() && std::count(m_Start.begin(), m_Start.end(), LocalValueDim) > 0) ||
-            (!m_Count.empty() && std::count(m_Count.begin(), m_Count.end(), LocalValueDim) > 0))
+        if ((!m_Shape.empty() &&
+             std::count(m_Shape.begin(), m_Shape.end(), static_cast<size_t>(LocalValueDim)) > 0) ||
+            (!m_Start.empty() &&
+             std::count(m_Start.begin(), m_Start.end(), static_cast<size_t>(LocalValueDim)) > 0) ||
+            (!m_Count.empty() &&
+             std::count(m_Count.begin(), m_Count.end(), static_cast<size_t>(LocalValueDim)) > 0))
         {
             helper::Throw<std::invalid_argument>("Core", "VariableBase", "CheckDimensionsCommon",
                                                  "LocalValueDim parameter is only "
@@ -649,9 +652,12 @@ void VariableBase::CheckDimensionsCommon(const std::string hint) const
         }
     }
 
-    if ((!m_Shape.empty() && std::count(m_Shape.begin(), m_Shape.end(), JoinedDim) > 1) ||
-        (!m_Start.empty() && std::count(m_Start.begin(), m_Start.end(), JoinedDim) > 0) ||
-        (!m_Count.empty() && std::count(m_Count.begin(), m_Count.end(), JoinedDim) > 0))
+    if ((!m_Shape.empty() &&
+         std::count(m_Shape.begin(), m_Shape.end(), static_cast<size_t>(JoinedDim)) > 1) ||
+        (!m_Start.empty() &&
+         std::count(m_Start.begin(), m_Start.end(), static_cast<size_t>(JoinedDim)) > 0) ||
+        (!m_Count.empty() &&
+         std::count(m_Count.begin(), m_Count.end(), static_cast<size_t>(JoinedDim)) > 0))
     {
         helper::Throw<std::invalid_argument>("Core", "VariableBase", "CheckDimensionsCommon",
                                              "JoinedDim is only allowed once in "

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -10,8 +10,8 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
-#include <stdexcept>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <tuple>
 
@@ -479,9 +479,8 @@ double BP5Reader::ReadData(PoolableFile *DataFile, const size_t WriterRank, cons
         const uint64_t maxOffset = static_cast<uint64_t>(std::numeric_limits<size_t>::max());
         if (offset > maxOffset || base > maxOffset - offset)
         {
-            helper::Throw<std::overflow_error>(
-                "Engine", "BP5Reader", "ReadData",
-                "file offset exceeds size_t on this platform");
+            helper::Throw<std::overflow_error>("Engine", "BP5Reader", "ReadData",
+                                               "file offset exceeds size_t on this platform");
         }
         DataFile->Read(Destination, Length, static_cast<size_t>(base + offset));
     };
@@ -490,9 +489,9 @@ double BP5Reader::ReadData(PoolableFile *DataFile, const size_t WriterRank, cons
     for (size_t flush = 0; flush < FlushCount; flush++)
     {
         uint64_t ThisDataPos = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
-                                                         m_Minifooter.IsLittleEndian);
+                                                           m_Minifooter.IsLittleEndian);
         uint64_t ThisDataSize = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
-                                                          m_Minifooter.IsLittleEndian);
+                                                            m_Minifooter.IsLittleEndian);
 
         if (StartOffset < SumDataSize + ThisDataSize)
         {
@@ -507,7 +506,7 @@ double BP5Reader::ReadData(PoolableFile *DataFile, const size_t WriterRank, cons
     }
 
     uint64_t ThisDataPos = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
-                                                     m_Minifooter.IsLittleEndian);
+                                                       m_Minifooter.IsLittleEndian);
     uint64_t Offset = StartOffset - SumDataSize;
     lf_ReadAt(ThisDataPos, Offset);
 

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -9,6 +9,8 @@
 #include <errno.h>
 #include <fstream>
 #include <iostream>
+#include <limits>
+#include <stdexcept>
 #include <mutex>
 #include <thread>
 #include <tuple>
@@ -461,7 +463,7 @@ std::string BP5Reader::UpdateWithTarInfo(const std::string &path, Params &params
 }
 
 double BP5Reader::ReadData(PoolableFile *DataFile, const size_t WriterRank, const size_t Timestep,
-                           const size_t StartOffset, const size_t Length, char *Destination)
+                           const uint64_t StartOffset, const size_t Length, char *Destination)
 {
     /*
      * Warning: this function is called by multiple threads
@@ -473,20 +475,30 @@ double BP5Reader::ReadData(PoolableFile *DataFile, const size_t WriterRank, cons
        as if all the flushes were in a single contiguous block in file.
     */
     TP startRead = NOW();
+    auto lf_ReadAt = [&](const uint64_t base, const uint64_t offset) {
+        const uint64_t maxOffset = static_cast<uint64_t>(std::numeric_limits<size_t>::max());
+        if (offset > maxOffset || base > maxOffset - offset)
+        {
+            helper::Throw<std::overflow_error>(
+                "Engine", "BP5Reader", "ReadData",
+                "file offset exceeds size_t on this platform");
+        }
+        DataFile->Read(Destination, Length, static_cast<size_t>(base + offset));
+    };
     size_t InfoStartPos = DataPosPos + (WriterRank * (2 * FlushCount + 1) * sizeof(uint64_t));
-    size_t SumDataSize = 0; // count in contiguous space
+    uint64_t SumDataSize = 0; // count in contiguous space
     for (size_t flush = 0; flush < FlushCount; flush++)
     {
-        size_t ThisDataPos = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
+        uint64_t ThisDataPos = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
                                                          m_Minifooter.IsLittleEndian);
-        size_t ThisDataSize = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
+        uint64_t ThisDataSize = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
                                                           m_Minifooter.IsLittleEndian);
 
         if (StartOffset < SumDataSize + ThisDataSize)
         {
             // discount offsets of skipped flushes
-            size_t Offset = StartOffset - SumDataSize;
-            DataFile->Read(Destination, Length, ThisDataPos + Offset);
+            uint64_t Offset = StartOffset - SumDataSize;
+            lf_ReadAt(ThisDataPos, Offset);
             TP endRead = NOW();
             double timeRead = DURATION(startRead, endRead);
             return timeRead;
@@ -494,10 +506,10 @@ double BP5Reader::ReadData(PoolableFile *DataFile, const size_t WriterRank, cons
         SumDataSize += ThisDataSize;
     }
 
-    size_t ThisDataPos = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
+    uint64_t ThisDataPos = helper::ReadValue<uint64_t>(m_MetadataIndex.m_Buffer, InfoStartPos,
                                                      m_Minifooter.IsLittleEndian);
-    size_t Offset = StartOffset - SumDataSize;
-    DataFile->Read(Destination, Length, ThisDataPos + Offset);
+    uint64_t Offset = StartOffset - SumDataSize;
+    lf_ReadAt(ThisDataPos, Offset);
 
     TP endRead = NOW();
     double timeRead = DURATION(startRead, endRead);

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -277,7 +277,7 @@ private:
     void InstallMetadataForTimestep(size_t Step);
     void ParallelInstallMetadataForTimestep(size_t Step);
     double ReadData(PoolableFile *DataFile, const size_t WriterRank, const size_t Timestep,
-                    const size_t StartOffset, const size_t Length, char *Destination);
+                    const uint64_t StartOffset, const size_t Length, char *Destination);
 
     struct WriterMapStruct
     {

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -313,7 +313,7 @@ uint64_t BP5Writer::WriteMetadata(const std::vector<char> &ContigMetaData,
     uint64_t MetaDataSize = 0;
     std::vector<uint64_t> AttrSizeVector;
 
-    MDataTotalSize += SizeVector.size() * sizeof(size_t);
+    MDataTotalSize += SizeVector.size() * sizeof(uint64_t);
     for (size_t a = 0; a < SizeVector.size(); a++)
     {
         if (a < AttributeBlocks.size())
@@ -2362,12 +2362,12 @@ void BP5Writer::FlushData(const bool isFinal)
 
     if (!isFinal)
     {
-        size_t tmp[2];
+        uint64_t tmp[2];
         // aggregate start pos and data size to rank 0
         tmp[0] = m_StartDataPos;
         tmp[1] = databufsize;
 
-        std::vector<size_t> RecvBuffer;
+        std::vector<uint64_t> RecvBuffer;
         if (m_Comm.Rank() == 0)
         {
             RecvBuffer.resize(m_Comm.Size() * 2);

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -243,8 +243,8 @@ void BP5Writer::WriteMetaMetadata(
 
     for (auto &b : MetaMetaBlocks)
     {
-        m_MetaMetadataFile->Write((char *)&b.MetaMetaIDLen, sizeof(size_t));
-        m_MetaMetadataFile->Write((char *)&b.MetaMetaInfoLen, sizeof(size_t));
+        m_MetaMetadataFile->Write((char *)&b.MetaMetaIDLen, sizeof(uint64_t));
+        m_MetaMetadataFile->Write((char *)&b.MetaMetaInfoLen, sizeof(uint64_t));
         m_MetaMetadataFile->Write((char *)b.MetaMetaID, b.MetaMetaIDLen);
         m_MetaMetadataFile->Write((char *)b.MetaMetaInfo, b.MetaMetaInfoLen);
     }

--- a/source/adios2/engine/bp5/BP5Writer.h
+++ b/source/adios2/engine/bp5/BP5Writer.h
@@ -287,7 +287,7 @@ private:
 
     bool m_MarshalAttributesNecessary = true;
 
-    std::vector<std::vector<size_t>> FlushPosSizeInfo;
+    std::vector<std::vector<uint64_t>> FlushPosSizeInfo;
 
     void MakeHeader(std::vector<char> &buffer, size_t &position, const std::string fileType,
                     const bool isActive);

--- a/source/adios2/engine/campaign/CampaignData.cpp
+++ b/source/adios2/engine/campaign/CampaignData.cpp
@@ -185,7 +185,7 @@ static int sqlcb_dataset(void *p, int argc, char **argv, char **azColName)
     size_t keyid = helper::StringToSizeT(std::string(argv[15]), hint_text_to_int);
     cdr.hasKey = (keyid); // keyid == 0 means there is no key used
     cdr.keyIdx = size_t(keyid - 1);
-    cdr.size = helper::StringToSizeT(std::string(argv[16]), hint_text_to_int);
+    cdr.size = helper::StringTo<uint64_t>(std::string(argv[16]), hint_text_to_int);
 
     // file
     if (argv[17])
@@ -213,8 +213,8 @@ static int sqlcb_file(void *p, int argc, char **argv, char **azColName)
     cf.name = std::string(argv[1]);
     int comp = helper::StringTo<int>(std::string(argv[2]), hint_text_to_int);
     cf.compressed = (bool)comp;
-    cf.lengthOriginal = helper::StringToSizeT(std::string(argv[3]), hint_text_to_int);
-    cf.lengthCompressed = helper::StringToSizeT(std::string(argv[4]), hint_text_to_int);
+    cf.lengthOriginal = helper::StringTo<uint64_t>(std::string(argv[3]), hint_text_to_int);
+    cf.lengthCompressed = helper::StringTo<uint64_t>(std::string(argv[4]), hint_text_to_int);
     cf.modtime =
         helper::StringTo<int64_t>(std::string(argv[5]), "SQL callback convert modtime to int");
     cf.checksum = argv[6];
@@ -703,7 +703,8 @@ void CampaignData::DumpToFileOrMemory(const size_t fileIdx, std::string &keyHex,
         // Verify file size matches expected size to detect truncated cache files
         // (e.g. from a process killed mid-write)
         struct stat st;
-        if (stat(path.c_str(), &st) == 0 && static_cast<size_t>(st.st_size) == file.lengthOriginal)
+        if (stat(path.c_str(), &st) == 0 &&
+            static_cast<uint64_t>(st.st_size) == file.lengthOriginal)
         {
             return;
         }
@@ -751,7 +752,7 @@ void CampaignData::DumpToFileOrMemory(const size_t fileIdx, std::string &keyHex,
 #ifdef ADIOS2_HAVE_SODIUM
     if (!keyHex.empty())
     {
-        size_t decryptedSize = (file.compressed ? file.lengthCompressed : file.lengthOriginal);
+        uint64_t decryptedSize = (file.compressed ? file.lengthCompressed : file.lengthOriginal);
         q = malloc(decryptedSize);
         free_q = true;
         DecryptData(static_cast<const unsigned char *>(blob), blobsize, decryptedSize, file, keyHex,

--- a/source/adios2/engine/campaign/CampaignData.h
+++ b/source/adios2/engine/campaign/CampaignData.h
@@ -52,8 +52,8 @@ struct CampaignFile
     // size_t datasetIdx; // index of grandparent CampaignDataset in the map
     //  std::vector<size_t> replicaIdxs; // CampaignReplicas using this file in CampaignDataset
     bool compressed;
-    size_t lengthOriginal;
-    size_t lengthCompressed;
+    uint64_t lengthOriginal;
+    uint64_t lengthCompressed;
     int64_t modtime;
     std::string checksum; // SHA1 checksum of file
 };
@@ -101,7 +101,7 @@ struct CampaignReplica
     bool deleted;
     bool hasKey;
     size_t keyIdx;
-    size_t size;               // replica size on remote location
+    uint64_t size;             // replica size on remote location (may exceed 4 GB on 32-bit)
     std::vector<size_t> files; // file indices in CampaignDataset, ordered by fileid
     // image replicas have resolution information (ds.format == FileFormat::IMAGE)
     size_t x;

--- a/source/adios2/engine/campaign/CampaignReader.tcc
+++ b/source/adios2/engine/campaign/CampaignReader.tcc
@@ -262,7 +262,8 @@ CampaignReader::BlocksInfoCommon(const core::Variable<std::string> &variable,
             blockInfo.MinMaxs = blockCharacteristics.Statistics.MinMaxs;
             blockInfo.SubBlockInfo = blockCharacteristics.Statistics.SubBlockInfo;
         }
-        if (blockInfo.Shape.size() == 1 && blockInfo.Shape.front() == LocalValueDim)
+        if (blockInfo.Shape.size() == 1 &&
+            blockInfo.Shape.front() == static_cast<size_t>(LocalValueDim))
         {
             blockInfo.Shape = Dims{blocksIndexOffsets.size()};
             blockInfo.Count = Dims{1};

--- a/source/adios2/engine/daos/DaosWriter.cpp
+++ b/source/adios2/engine/daos/DaosWriter.cpp
@@ -178,8 +178,8 @@ void DaosWriter::WriteMetaMetadata(
     profiling::ProfilerGuard g(m_Profiler, "MD_Posix");
     for (auto &b : MetaMetaBlocks)
     {
-        m_MetaMetadataFile->Write((char *)&b.MetaMetaIDLen, sizeof(size_t));
-        m_MetaMetadataFile->Write((char *)&b.MetaMetaInfoLen, sizeof(size_t));
+        m_MetaMetadataFile->Write((char *)&b.MetaMetaIDLen, sizeof(uint64_t));
+        m_MetaMetadataFile->Write((char *)&b.MetaMetaInfoLen, sizeof(uint64_t));
         m_MetaMetadataFile->Write((char *)b.MetaMetaID, b.MetaMetaIDLen);
         m_MetaMetadataFile->Write((char *)b.MetaMetaInfo, b.MetaMetaInfoLen);
     }

--- a/source/adios2/toolkit/format/bp/BPBase.h
+++ b/source/adios2/toolkit/format/bp/BPBase.h
@@ -165,10 +165,12 @@ public:
 
         /**
          * sub-block size for min/max calculation of large arrays in number of
-         * elements (not bytes). The default big number per Put() default will
-         * result in the original single min/max value-pair per block
+         * elements (not bytes). The default is effectively unlimited so no block
+         * is sub-divided (one min/max value-pair per block). SIZE_MAX expresses
+         * that on every platform; a fixed 2^50 truncated to 0 in a 32-bit size_t,
+         * causing a divide-by-zero.
          */
-        size_t StatsBlockSize = 1125899906842624ULL;
+        size_t StatsBlockSize = SIZE_MAX;
 
         /** buffer memory growth factor */
         float GrowthFactor = DefaultBufferGrowthFactor;

--- a/source/adios2/toolkit/format/bp5/BP5Base.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Base.cpp
@@ -53,7 +53,7 @@ int BP5Base::BP5BitfieldTest(struct BP5MetadataInfoStruct *MBase, int Bit) const
         {"Count", "integer[DBCount]", sizeof(size_t), FMOffset(BP5Base::MetaArrayRec *, Count)},   \
         {"Offset", "integer[DBCount]", sizeof(size_t),                                             \
          FMOffset(BP5Base::MetaArrayRec *, Offsets)},                                              \
-        {"DataBlockLocation", "integer[BlockCount]", sizeof(uint64_t),                               \
+        {"DataBlockLocation", "integer[BlockCount]", sizeof(uint64_t),                             \
          FMOffset(BP5Base::MetaArrayRec *, DataBlockLocation)},
 
 static FMField MetaArrayRecList[] = {BASE_FIELD_ENTRIES{NULL, NULL, 0, 0}};

--- a/source/adios2/toolkit/format/bp5/BP5Base.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Base.cpp
@@ -53,7 +53,7 @@ int BP5Base::BP5BitfieldTest(struct BP5MetadataInfoStruct *MBase, int Bit) const
         {"Count", "integer[DBCount]", sizeof(size_t), FMOffset(BP5Base::MetaArrayRec *, Count)},   \
         {"Offset", "integer[DBCount]", sizeof(size_t),                                             \
          FMOffset(BP5Base::MetaArrayRec *, Offsets)},                                              \
-        {"DataBlockLocation", "integer[BlockCount]", sizeof(size_t),                               \
+        {"DataBlockLocation", "integer[BlockCount]", sizeof(uint64_t),                               \
          FMOffset(BP5Base::MetaArrayRec *, DataBlockLocation)},
 
 static FMField MetaArrayRecList[] = {BASE_FIELD_ENTRIES{NULL, NULL, 0, 0}};

--- a/source/adios2/toolkit/format/bp5/BP5Base.h
+++ b/source/adios2/toolkit/format/bp5/BP5Base.h
@@ -39,12 +39,12 @@ public:
     };
 
 #define BASE_FIELDS                                                                                \
-    size_t Dims;               /* How many dimensions does this array have */                      \
-    size_t BlockCount;         /* How many blocks are written   */                                 \
-    size_t DBCount;            /* Dimens * BlockCount   */                                         \
-    size_t *Shape;             /* Global dimensionality  [Dims] NULL for local */                  \
-    size_t *Count;             /* Per-block Counts    [DBCount] */                                 \
-    size_t *Offsets;           /* Per-block Offsets   [DBCount] NULL for local */                  \
+    size_t Dims;                 /* How many dimensions does this array have */                    \
+    size_t BlockCount;           /* How many blocks are written   */                               \
+    size_t DBCount;              /* Dimens * BlockCount   */                                       \
+    size_t *Shape;               /* Global dimensionality  [Dims] NULL for local */                \
+    size_t *Count;               /* Per-block Counts    [DBCount] */                               \
+    size_t *Offsets;             /* Per-block Offsets   [DBCount] NULL for local */                \
     uint64_t *DataBlockLocation; /* Per-block Offset in PG [BlockCount] */
 
     typedef struct _MetaArrayRec

--- a/source/adios2/toolkit/format/bp5/BP5Base.h
+++ b/source/adios2/toolkit/format/bp5/BP5Base.h
@@ -7,6 +7,8 @@
 #ifndef ADIOS2_TOOLKIT_FORMAT_BP5_BP5BASE_H_
 #define ADIOS2_TOOLKIT_FORMAT_BP5_BP5BASE_H_
 
+#include <stdint.h>
+
 #include "adios2/core/Attribute.h"
 #include "adios2/core/IO.h"
 #include "adios2/toolkit/format/buffer/BufferV.h"
@@ -31,9 +33,9 @@ public:
     struct MetaMetaInfoBlock
     {
         char *MetaMetaInfo;
-        size_t MetaMetaInfoLen;
+        uint64_t MetaMetaInfoLen;
         char *MetaMetaID;
-        size_t MetaMetaIDLen;
+        uint64_t MetaMetaIDLen;
     };
 
 #define BASE_FIELDS                                                                                \
@@ -43,7 +45,7 @@ public:
     size_t *Shape;             /* Global dimensionality  [Dims] NULL for local */                  \
     size_t *Count;             /* Per-block Counts    [DBCount] */                                 \
     size_t *Offsets;           /* Per-block Offsets   [DBCount] NULL for local */                  \
-    size_t *DataBlockLocation; /* Per-block Offset in PG [BlockCount] */
+    uint64_t *DataBlockLocation; /* Per-block Offset in PG [BlockCount] */
 
     typedef struct _MetaArrayRec
     {

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -828,7 +828,7 @@ void BP5Deserializer::InstallMetadataBuffer(void *BaseData, size_t WriterRank, s
             {
                 for (size_t i = 0; i < meta_base->Dims; i++)
                 {
-                    if (meta_base->Shape[i] == JoinedDim)
+                    if (meta_base->Shape[i] == static_cast<size_t>(JoinedDim))
                     {
                         VarRec->JoinedDimen = i;
                     }
@@ -1856,7 +1856,7 @@ BP5Deserializer::GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTemp
                             RR.Timestep = Req->Step;
                             RR.WriterRank = WriterRank;
                             RR.StartOffset = writer_meta_base->DataBlockLocation[NeededBlock];
-                            if (RR.StartOffset == (size_t)-1)
+                            if (RR.StartOffset == static_cast<uint64_t>(-1))
                                 throw std::runtime_error("No data exists for this variable");
                             if (Req->MemSpace != MemorySpace::Host)
                                 RR.DirectToAppMemory = false;
@@ -2037,7 +2037,7 @@ BP5Deserializer::GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTemp
                                                  1);
 
                                             if (writer_meta_base_input->DataBlockLocation[Block] ==
-                                                (size_t)-1)
+                                                static_cast<uint64_t>(-1))
                                                 helper::Throw<std::runtime_error>(
                                                     "Toolkit", "BP5Deserializer",
                                                     "GenerateReadRequests",
@@ -2149,7 +2149,7 @@ BP5Deserializer::GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTemp
                                                  1);
 
                                             if (writer_meta_base_input->DataBlockLocation[Block] ==
-                                                (size_t)-1)
+                                                static_cast<uint64_t>(-1))
                                                 helper::Throw<std::runtime_error>(
                                                     "Toolkit", "BP5Deserializer",
                                                     "GenerateReadRequests",
@@ -2195,7 +2195,7 @@ BP5Deserializer::GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTemp
                                     RR.StartOffset = writer_meta_base->DataBlockLocation[Block];
                                     RR.ReadLength = writer_meta_base->DataBlockSize[Block];
                                     RR.DestinationAddr = nullptr;
-                                    if (RR.StartOffset == (size_t)-1)
+                                    if (RR.StartOffset == static_cast<uint64_t>(-1))
                                         throw std::runtime_error(
                                             "No data exists for this variable");
                                     if (doAllocTempBuffers)
@@ -2238,7 +2238,7 @@ BP5Deserializer::GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTemp
                                     RR.WriterRank = WriterRank;
                                     RR.StartOffset = writer_meta_base->DataBlockLocation[Block] +
                                                      StartOffsetInBlock;
-                                    if (writer_meta_base->DataBlockLocation[Block] == (size_t)-1)
+                                    if (writer_meta_base->DataBlockLocation[Block] == static_cast<uint64_t>(-1))
                                         throw std::runtime_error(
                                             "No data exists for this variable");
                                     RR.ReadLength = EndOffsetInBlock - StartOffsetInBlock;

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -2238,7 +2238,8 @@ BP5Deserializer::GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTemp
                                     RR.WriterRank = WriterRank;
                                     RR.StartOffset = writer_meta_base->DataBlockLocation[Block] +
                                                      StartOffsetInBlock;
-                                    if (writer_meta_base->DataBlockLocation[Block] == static_cast<uint64_t>(-1))
+                                    if (writer_meta_base->DataBlockLocation[Block] ==
+                                        static_cast<uint64_t>(-1))
                                         throw std::runtime_error(
                                             "No data exists for this variable");
                                     RR.ReadLength = EndOffsetInBlock - StartOffsetInBlock;

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -44,7 +44,7 @@ public:
     {
         size_t Timestep;
         size_t WriterRank;
-        size_t StartOffset;
+        uint64_t StartOffset;
         size_t ReadLength;
         char *DestinationAddr;
         bool DirectToAppMemory;

--- a/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Serializer.cpp
@@ -692,7 +692,7 @@ void BP5Serializer::DumpDeferredBlocks(bool forceCopyDeferred)
     for (auto &Def : DeferredExterns)
     {
         MetaArrayRec *MetaEntry = (MetaArrayRec *)((char *)(MetadataBuf) + Def.MetaOffset);
-        size_t DataOffset =
+        uint64_t DataOffset =
             m_PriorDataBufferSizeTotal +
             CurDataBuffer->AddToVec(Def.DataSize, Def.Data, Def.AlignReq, forceCopyDeferred);
         MetaEntry->DataBlockLocation[Def.BlockID] = DataOffset;
@@ -812,7 +812,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
         MemorySpace spanMemSpace = MemSpace;
         MetaArrayRec *MetaEntry = (MetaArrayRec *)((char *)(MetadataBuf) + Rec->MetaOffset);
         size_t ElemCount = CalcSize(DimCount, Count);
-        size_t DataOffset = 0;
+        uint64_t DataOffset = 0;
         size_t CompressedSize = 0;
         /* handle metadata */
         MetaEntry->Dims = DimCount;
@@ -868,7 +868,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
         }
         else if (!WriteData)
         {
-            DataOffset = (size_t)-1;
+            DataOffset = static_cast<uint64_t>(-1);
             DeferAddToVec = false;
         }
         else if (Span == nullptr)
@@ -902,7 +902,7 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
             MetaEntry->DBCount = DimCount;
             MetaEntry->Count = CopyDims(DimCount, Count);
             MetaEntry->BlockCount = 1;
-            MetaEntry->DataBlockLocation = (size_t *)malloc(sizeof(size_t));
+            MetaEntry->DataBlockLocation = (uint64_t *)malloc(sizeof(uint64_t));
             MetaEntry->DataBlockLocation[0] = DataOffset;
             if (Rec->OperatorType)
             {
@@ -946,8 +946,8 @@ void BP5Serializer::Marshal(void *Variable, const char *Name, const DataType Typ
             MetaEntry->DBCount += DimCount;
             MetaEntry->BlockCount++;
             MetaEntry->Count = AppendDims(MetaEntry->Count, PreviousDBCount, DimCount, Count);
-            MetaEntry->DataBlockLocation = (size_t *)realloc(
-                MetaEntry->DataBlockLocation, MetaEntry->BlockCount * sizeof(size_t));
+            MetaEntry->DataBlockLocation = (uint64_t *)realloc(
+                MetaEntry->DataBlockLocation, MetaEntry->BlockCount * sizeof(uint64_t));
             MetaEntry->DataBlockLocation[MetaEntry->BlockCount - 1] = DataOffset;
             if (Rec->OperatorType)
             {

--- a/testing/adios2/derived/TestBPDerivedCorrectnessMPI.cpp
+++ b/testing/adios2/derived/TestBPDerivedCorrectnessMPI.cpp
@@ -53,7 +53,7 @@ TEST_P(DerivedCorrectnessMPIP, JoinedArrayTest)
         simArray[i] = distribution(generator);
 
     adios2::IO bpOut = adios.DeclareIO("BPJoinedWrite");
-    auto U = bpOut.DefineVariable<double>("var", {adios2::JoinedDim}, {}, {N});
+    auto U = bpOut.DefineVariable<double>("var", {static_cast<size_t>(adios2::JoinedDim)}, {}, {N});
     bpOut.DefineDerivedVariable("derived", "x= var \n sqrt(sum(pow(x), x, 2))", mode);
     adios2::Engine bpFileWriter = bpOut.Open(filename, adios2::Mode::Write);
 

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -131,7 +131,9 @@ async_gtest_add_tests_helper(WriteReadADIOS2 MPI_ALLOW)
 
 gtest_add_tests_helper(WriteReadFlatten MPI_ONLY BP Engine.BP. .BP5 WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5" )
 
-if(UNIX)
+# LargeBlocks exercises ~4GB blocks, which cannot exist in a 32-bit address space
+# (and its RequiredDiskSpace constexpr overflows a 32-bit size_t), so build it 64-bit only.
+if(UNIX AND CMAKE_SIZEOF_VOID_P GREATER_EQUAL 8)
   gtest_add_tests_helper(LargeBlocks MPI_NONE BP Engine.BP. .BP5 WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5" )
   set_tests_properties(Engine.BP.LargeBlocks.MultiBlock.BP5.Serial PROPERTIES SKIP_REGULAR_EXPRESSION "SKIP:" RUN_SERIAL TRUE)
   target_link_libraries(Test.Engine.BP.LargeBlocks.Serial adios2sys)

--- a/testing/adios2/engine/bp/TestBPJoinedArray.cpp
+++ b/testing/adios2/engine/bp/TestBPJoinedArray.cpp
@@ -65,8 +65,8 @@ TEST_F(BPJoinedArray, MultiBlock)
         }
 
         adios2::Engine writer = outIO.Open(fname, adios2::Mode::Write);
-        auto var =
-            outIO.DefineVariable<double>("table", {adios2::JoinedDim, Ncols}, {}, {1, Ncols});
+        auto var = outIO.DefineVariable<double>(
+            "table", {static_cast<size_t>(adios2::JoinedDim), Ncols}, {}, {1, Ncols});
 
         if (!rank)
         {

--- a/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadBlockInfo.cpp
@@ -163,8 +163,10 @@ TEST_F(BPWriteReadBlockInfo, BPWriteReadBlockInfo1D8)
         const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
         const adios2::Dims count{Nx};
 
-        auto var_local = io.DefineVariable<int32_t>("local", {adios2::LocalValueDim});
-        auto var_localStr = io.DefineVariable<std::string>("localStr", {adios2::LocalValueDim});
+        auto var_local =
+            io.DefineVariable<int32_t>("local", {static_cast<size_t>(adios2::LocalValueDim)});
+        auto var_localStr = io.DefineVariable<std::string>(
+            "localStr", {static_cast<size_t>(adios2::LocalValueDim)});
 
         auto var_iString = io.DefineVariable<std::string>("iString");
         auto var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);
@@ -760,8 +762,10 @@ TEST_F(BPWriteReadBlockInfo, BPWriteReadBlockInfo1D8_C)
         const adios2::Dims start{static_cast<size_t>(Nx * mpiRank)};
         const adios2::Dims count{Nx};
 
-        auto var_local = io.DefineVariable<int32_t>("local", {adios2::LocalValueDim});
-        auto var_localStr = io.DefineVariable<std::string>("localStr", {adios2::LocalValueDim});
+        auto var_local =
+            io.DefineVariable<int32_t>("local", {static_cast<size_t>(adios2::LocalValueDim)});
+        auto var_localStr = io.DefineVariable<std::string>(
+            "localStr", {static_cast<size_t>(adios2::LocalValueDim)});
 
         auto var_iString = io.DefineVariable<std::string>("iString");
         auto var_i8 = io.DefineVariable<int8_t>("i8", shape, start, count);

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariables.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariables.cpp
@@ -72,8 +72,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1D)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -469,8 +471,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D2x4)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -852,8 +856,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D4x2)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -1237,8 +1243,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DAllSteps)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -1518,8 +1526,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DBlockInfo)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);

--- a/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSel.cpp
+++ b/testing/adios2/engine/bp/TestBPWriteReadLocalVariablesSel.cpp
@@ -71,8 +71,10 @@ TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal1DSel)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -491,8 +493,10 @@ TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal2D2x4Sel)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -958,8 +962,10 @@ TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal2D4x2Sel)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -1424,8 +1430,10 @@ TEST_F(BPWriteReadLocalVariablesSel, BPWriteReadLocal1DAllStepsSel)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);

--- a/testing/adios2/engine/bp/operations/TestBPWriteReadLocalVariables.cpp
+++ b/testing/adios2/engine/bp/operations/TestBPWriteReadLocalVariables.cpp
@@ -65,8 +65,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1D)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -422,8 +424,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D2x4)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -785,8 +789,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal2D4x2)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -1149,8 +1155,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DAllSteps)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);
@@ -1395,8 +1403,10 @@ TEST_F(BPWriteReadLocalVariables, ADIOS2BPWriteReadLocal1DBlockInfo)
             io.DefineVariable<int32_t>("stepsGlobalValue");
             io.DefineVariable<std::string>("stepsGlobalValueString");
 
-            io.DefineVariable<int32_t>("ranksLocalValue", {adios2::LocalValueDim});
-            io.DefineVariable<std::string>("ranksLocalValueString", {adios2::LocalValueDim});
+            io.DefineVariable<int32_t>("ranksLocalValue",
+                                       {static_cast<size_t>(adios2::LocalValueDim)});
+            io.DefineVariable<std::string>("ranksLocalValueString",
+                                           {static_cast<size_t>(adios2::LocalValueDim)});
 
             io.DefineVariable<int8_t>("i8", shape, start, count, adios2::ConstantDims);
             io.DefineVariable<int16_t>("i16", shape, start, count, adios2::ConstantDims);

--- a/testing/adios2/engine/staging-common/TestWriteJoined.cpp
+++ b/testing/adios2/engine/staging-common/TestWriteJoined.cpp
@@ -71,7 +71,8 @@ TEST_F(CommonWriteTest, ADIOS2CommonWrite)
 
     auto rows_var = outIO.DefineVariable<int>("totalrows");
 
-    auto var = outIO.DefineVariable<double>("table", {adios2::JoinedDim, Ncols}, {}, {1, Ncols});
+    auto var = outIO.DefineVariable<double>(
+        "table", {static_cast<size_t>(adios2::JoinedDim), Ncols}, {}, {1, Ncols});
 
     if (!mpiRank)
     {

--- a/testing/adios2/interface/TestADIOSDefineVariable.cpp
+++ b/testing/adios2/interface/TestADIOSDefineVariable.cpp
@@ -51,14 +51,15 @@ TEST_F(ADIOSDefineVariableTest, DefineGlobalValue)
 TEST_F(ADIOSDefineVariableTest, DefineLocalValue)
 {
     // Define ADIOS local value (a value changing across processes)
-    auto localvalue = io.DefineVariable<int>("localvalue", {adios2::LocalValueDim});
+    auto localvalue =
+        io.DefineVariable<int>("localvalue", {static_cast<size_t>(adios2::LocalValueDim)});
 
     // Verify the return type is as expected
     ::testing::StaticAssertTypeEq<decltype(localvalue), adios2::Variable<int>>();
 
     // Verify the dimensions, name, and type are correct
     ASSERT_EQ(localvalue.Shape().size(), 1);
-    EXPECT_EQ(localvalue.Shape()[0], adios2::LocalValueDim);
+    EXPECT_EQ(localvalue.Shape()[0], static_cast<size_t>(adios2::LocalValueDim));
     EXPECT_EQ(localvalue.Start().size(), 1);
     EXPECT_EQ(localvalue.Count().size(), 1);
     EXPECT_EQ(localvalue.Name(), "localvalue");
@@ -193,7 +194,8 @@ TEST_F(ADIOSDefineVariableTest, DefineGlobalArrayInvalidLocalValueDim)
 {
     // Define ADIOS global array
     std::size_t n = 50;
-    EXPECT_THROW(io.DefineVariable<int>("globalarray", {100, adios2::LocalValueDim, 30},
+    EXPECT_THROW(io.DefineVariable<int>("globalarray",
+                                        {100, static_cast<size_t>(adios2::LocalValueDim), 30},
                                         {50, n / 2, 0}, {10, n / 2, 30}),
                  std::invalid_argument);
 }
@@ -314,15 +316,15 @@ TEST_F(ADIOSDefineVariableTest, DefineJoinedArrayFirstDim)
 {
     // Define ADIOS joined array
     std::size_t n = 50;
-    auto joinedarray =
-        io.DefineVariable<int>("joinedarray", {adios2::JoinedDim, n, 30}, {}, {10, n, 30});
+    auto joinedarray = io.DefineVariable<int>(
+        "joinedarray", {static_cast<size_t>(adios2::JoinedDim), n, 30}, {}, {10, n, 30});
 
     // Verify the return type is as expected
     ::testing::StaticAssertTypeEq<decltype(joinedarray), adios2::Variable<int>>();
 
     // Verify the dimensions, name, and type are correct
     ASSERT_EQ(joinedarray.Shape().size(), 3);
-    EXPECT_EQ(joinedarray.Shape()[0], adios2::JoinedDim);
+    EXPECT_EQ(joinedarray.Shape()[0], static_cast<size_t>(adios2::JoinedDim));
     EXPECT_EQ(joinedarray.Shape()[1], n);
     EXPECT_EQ(joinedarray.Shape()[2], 30);
     EXPECT_EQ(joinedarray.Start().size(), 0);
@@ -338,8 +340,8 @@ TEST_F(ADIOSDefineVariableTest, DefineJoinedArraySecondDim)
 {
     // Define ADIOS joined array
     std::size_t n = 50;
-    auto joinedarray =
-        io.DefineVariable<int>("joinedarray", {n, adios2::JoinedDim, 30}, {0, 0, 0}, {n, 10, 30});
+    auto joinedarray = io.DefineVariable<int>(
+        "joinedarray", {n, static_cast<size_t>(adios2::JoinedDim), 30}, {0, 0, 0}, {n, 10, 30});
 
     // Verify the return type is as expected
     ::testing::StaticAssertTypeEq<decltype(joinedarray), adios2::Variable<int>>();
@@ -347,7 +349,7 @@ TEST_F(ADIOSDefineVariableTest, DefineJoinedArraySecondDim)
     // Verify the dimensions, name, and type are correct
     ASSERT_EQ(joinedarray.Shape().size(), 3);
     EXPECT_EQ(joinedarray.Shape()[0], n);
-    EXPECT_EQ(joinedarray.Shape()[1], adios2::JoinedDim);
+    EXPECT_EQ(joinedarray.Shape()[1], static_cast<size_t>(adios2::JoinedDim));
     EXPECT_EQ(joinedarray.Shape()[2], 30);
     EXPECT_EQ(joinedarray.Start().size(), 3);
     EXPECT_EQ(joinedarray.Start()[0], 0);
@@ -366,7 +368,9 @@ TEST_F(ADIOSDefineVariableTest, DefineJoinedArrayTooManyJoinedDims)
     // Define ADIOS joined array
     std::size_t n = 50;
 
-    EXPECT_THROW(io.DefineVariable<int>("joinedarray", {n, adios2::JoinedDim, adios2::JoinedDim},
+    EXPECT_THROW(io.DefineVariable<int>("joinedarray",
+                                        {n, static_cast<size_t>(adios2::JoinedDim),
+                                         static_cast<size_t>(adios2::JoinedDim)},
                                         {}, {n, 50, 30}),
                  std::invalid_argument);
 }
@@ -377,9 +381,9 @@ TEST_F(ADIOSDefineVariableTest, DefineJoinedArrayInvalidStart)
     std::size_t n = 10;
     std::size_t WrongValue = 1;
     // Start must be empty or full zero array
-    EXPECT_THROW(
-        io.DefineVariable<int>("joinedarray", {adios2::JoinedDim, 50}, {0, WrongValue}, {n, 50}),
-        std::invalid_argument);
+    EXPECT_THROW(io.DefineVariable<int>("joinedarray", {static_cast<size_t>(adios2::JoinedDim), 50},
+                                        {0, WrongValue}, {n, 50}),
+                 std::invalid_argument);
 }
 
 TEST_F(ADIOSDefineVariableTest, DefineString)


### PR DESCRIPTION
Ensures BP5 can round-trip writes & reads on 32bit. So far, ADIOS2 BP5 simply segfaulted when used on 32bit systems (tested on Linux, Windows).
Does not yet support cross-bitness portability to 64bit written hosts and back.

Credits to Codex + Claude for the typing.

cc @eisenhauer @pnorbert 