### PR TITLE
DAOS: zero-copy data-path counters + cold-buffer warmth guard

### DIFF
--- a/source/adios2/engine/daos/DaosWriter.cpp
+++ b/source/adios2/engine/daos/DaosWriter.cpp
@@ -767,6 +767,10 @@ void DaosWriter::RegisterProfilerTimers()
     m_Profiler.AddTimerWatch("BP5_BufferAppend");
     m_Profiler.AddTimerWatch("BP5_GetMinMax");
     m_Profiler.AddTimerWatch("FreshChunkAllocs");
+    m_Profiler.AddTimerWatch("DAOS_ZeroCopyPuts");
+    m_Profiler.AddTimerWatch("DAOS_ZeroCopyMiB");
+    m_Profiler.AddTimerWatch("DAOS_CopyPuts");
+    m_Profiler.AddTimerWatch("DAOS_CopyMiB");
 }
 
 void DaosWriter::SyncExternalCountersToProfiler()
@@ -788,12 +792,21 @@ void DaosWriter::SyncExternalCountersToProfiler()
              m_BP5Serializer.m_GetMinMaxSecs > 0 ? 1 : 0);
     setTimer("FreshChunkAllocs", 0.0,
              m_DataBuf ? static_cast<uint64_t>(m_DataBuf->FreshAllocCount()) : 0);
+    setTimer("DAOS_ZeroCopyPuts", 0.0, m_ZeroCopyPuts);
+    setTimer("DAOS_ZeroCopyMiB", 0.0, m_ZeroCopyBytes >> 20);
+    setTimer("DAOS_CopyPuts", 0.0, m_CopyPuts);
+    setTimer("DAOS_CopyMiB", 0.0, m_CopyBytes >> 20);
 }
 
 void DaosWriter::InitParameters()
 {
     ParseParams(m_IO, m_Parameters);
     m_BP5Serializer.m_StatsLevel = m_Parameters.StatsLevel;
+
+    if (const char *ww = std::getenv("DAOS_WARMTH_WINDOW"))
+    {
+        m_WarmthWindow = static_cast<size_t>(std::strtoul(ww, nullptr, 10));
+    }
 }
 
 void DaosWriter::InitTransports()
@@ -1329,6 +1342,7 @@ void DaosWriter::DoClose(const int transportIndex)
     }
 
     SyncExternalCountersToProfiler();
+
     CloseDataArray();
 
     if (m_Comm.Rank() == 0)
@@ -1439,6 +1453,35 @@ size_t DaosWriter::DebugGetDataBufferSize() const
     return m_BP5Serializer.DebugGetDataBufferSize();
 }
 
+// True if addr was seen within the last m_WarmthWindow steps; records it.
+bool DaosWriter::AddrIsWarm(const void *addr)
+{
+    AddrWindow &w = m_AddrWindow;
+    if (w.slots.size() != m_WarmthWindow)
+    {
+        w.slots.assign(m_WarmthWindow, {});
+        w.cur = -1;
+        w.lastStep = -1;
+    }
+    if (w.lastStep != m_WriterStep)
+    {
+        w.cur = (w.cur + 1) % static_cast<int>(m_WarmthWindow);
+        w.slots[w.cur].clear();
+        w.lastStep = m_WriterStep;
+    }
+    bool warm = false;
+    for (const auto &slot : w.slots)
+    {
+        if (slot.count(addr))
+        {
+            warm = true;
+            break;
+        }
+    }
+    w.slots[w.cur].insert(addr);
+    return warm;
+}
+
 void DaosWriter::PutCommon(VariableBase &variable, const void *values, bool sync)
 {
     profiling::ProfilerGuard pc(m_Profiler, "PutCommon");
@@ -1482,15 +1525,38 @@ void DaosWriter::PutCommon(VariableBase &variable, const void *values, bool sync
         ObjSize = helper::GetDataTypeSize(variable.m_Type);
     }
 
+    size_t n = helper::GetTotalSize(variable.m_Count) * ObjSize;
     if (!sync)
     {
         /* If arrays is small, force copying to internal buffer to aggregate
          * small writes */
-        size_t n = helper::GetTotalSize(variable.m_Count) * ObjSize;
         if (n < m_Parameters.MinDeferredSize)
         {
             sync = true;
         }
+    }
+
+    // Warmth guard: skip zero-copy for a never-reused buffer (cold loses).
+    if (!sync && m_WarmthWindow > 0 && variable.m_Operations.empty() &&
+        variable.m_MemoryCount.empty() && variable.m_Type != DataType::String)
+    {
+        if (!AddrIsWarm(values))
+        {
+            sync = true;
+        }
+    }
+
+    // Tally the zero-copy (External) vs copy outcome.
+    if (!sync && variable.m_Operations.empty() && variable.m_MemoryCount.empty() &&
+        variable.m_Type != DataType::String)
+    {
+        ++m_ZeroCopyPuts;
+        m_ZeroCopyBytes += n;
+    }
+    else
+    {
+        ++m_CopyPuts;
+        m_CopyBytes += n;
     }
 
     if (!variable.m_MemoryCount.empty())

--- a/source/adios2/engine/daos/DaosWriter.h
+++ b/source/adios2/engine/daos/DaosWriter.h
@@ -28,6 +28,10 @@
 #include <daos.h>
 #include <daos_obj.h>
 
+#include <cstdint>
+#include <unordered_set>
+#include <vector>
+
 #define MAX_AGGREGATE_METADATA_SIZE (5'368'709'120ULL)
 #define chunk_size_1mb 1'048'576
 
@@ -270,6 +274,26 @@ private:
      *  Total data written this timestep
      */
     uint64_t m_ThisTimestepDataSize = 0;
+
+    // Zero-copy vs copy Put split, emitted as DAOS_* timers in profiling.json.
+    uint64_t m_ZeroCopyPuts = 0;
+    uint64_t m_ZeroCopyBytes = 0;
+    uint64_t m_CopyPuts = 0;
+    uint64_t m_CopyBytes = 0;
+
+    // Warmth guard: a large buffer zero-copied cold (never-reused, so its MR
+    // is unregistered) loses to a copy, so only zero-copy buffers that have
+    // recurred. Tracked global-by-address to match the VA-keyed MR cache;
+    // window depth covers multi-buffering. Env DAOS_WARMTH_WINDOW; 0 = off.
+    size_t m_WarmthWindow = 8;
+    struct AddrWindow
+    {
+        int64_t lastStep = -1;
+        int cur = -1;
+        std::vector<std::unordered_set<const void *>> slots;
+    };
+    AddrWindow m_AddrWindow;
+    bool AddrIsWarm(const void *addr);
 
     bool m_MarshalAttributesNecessary = true;
 


### PR DESCRIPTION
  Two small additions to DaosWriter, both around the existing MinDeferredSize zero-copy test:

  - Counters — per-rank zero-copy vs copy Put split, emitted as DAOS_ZeroCopy*/DAOS_Copy* timers in profiling.json. Visibility into how much of a workload actually zero-copies.
  - Warmth guard — forces a large buffer that has never recurred to copy rather than zero-copy, since a cold (unregistered) zero-copy loses to a memcpy into the already-registered chunk. Reuse is tracked by address over a short step window. On by default (DAOS_WARMTH_WINDOW=8, 0 disables).   Copy to a warm buffer is better than a cold zero-copy put(), so we only try zero-copy Put() if we've seen that user address before.