### PR TITLE
Fix deallocation of internal buffers in InlineWriter 

### DIFF
--- a/source/adios2/engine/inline/InlineWriter.cpp
+++ b/source/adios2/engine/inline/InlineWriter.cpp
@@ -94,6 +94,15 @@ StepStatus InlineWriter::BeginStep(StepMode mode, const float timeoutSeconds)
         return StepStatus::NotReady;
     }
     m_InsideStep = true;
+
+    // Free buffers from the previous step now that the reader has had a
+    // chance to consume them and before their BlocksInfo is cleared.
+    for (auto *buf : m_InternalBuffers)
+    {
+        free(buf);
+    }
+    m_InternalBuffers.clear();
+
     if (m_CurrentStep == static_cast<size_t>(-1))
     {
         m_CurrentStep = 0; // 0 is the first step
@@ -183,11 +192,8 @@ void InlineWriter::EndStep()
         std::cout << "Inline Writer " << m_WriterRank << " EndStep() Step " << m_CurrentStep
                   << std::endl;
     }
-    for (auto *buf : m_InternalBuffers)
-    {
-        free(buf);
-    }
-    m_InternalBuffers.clear();
+    // Buffers are kept alive until the next BeginStep() so the reader can
+    // still consume the step after the writer has left it.
     m_InsideStep = false;
 }
 


### PR DESCRIPTION
The work in https://github.com/ornladios/ADIOS2/pull/4922 has fixed public-facing API contracts, but the commit https://github.com/ornladios/ADIOS2/pull/4922/changes/098f82dbe4738de4775b77fda1ecdaef318128b0 has broken an internal expectation: it frees the buffers before `ParaViewFidesEngine` has used all data.

~The fix: swap `CatalystExecute` and `EndStep`, call `PerformPuts` first to ensure all data makes it into the buffers before use.~

_Edit:_ I've realized that changing `ParaViewFidesEngine` is wrong/not enough, because the `InlineReader` also checks if the writer is *inside step* and returns `StepStatus::NotReady` in that case. So we need to ensure the buffers live even after `EndStep` to ensure the reader can use them.

cc @eisenhauer 