### PR TITLE
fix dumping a file with local arrays over time (-t -d option).

### DIFF
--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -4005,9 +4005,19 @@ void print_decomp_singlestep(core::Engine *fp, core::IO *io, core::Variable<T> *
             {
                 if (minBlocks)
                 {
-                    Dims s(minBlocks->BlocksInfo[j].Start, minBlocks->BlocksInfo[j].Start + ndim);
                     Dims c(minBlocks->BlocksInfo[j].Count, minBlocks->BlocksInfo[j].Count + ndim);
-                    readVarBlock(fp, io, variable, stepRelative, j, c, s);
+                    if (variable->m_ShapeID == ShapeID::GlobalArray)
+                    {
+                        Dims s(minBlocks->BlocksInfo[j].Start,
+                               minBlocks->BlocksInfo[j].Start + ndim);
+
+                        readVarBlock(fp, io, variable, stepRelative, j, c, s);
+                    }
+                    else
+                    {
+                        // blockStart is empty vector for LocalArrays
+                        readVarBlock(fp, io, variable, stepRelative, j, c, Dims());
+                    }
                 }
                 else
                 {

--- a/source/utils/bpls/bpls.h
+++ b/source/utils/bpls/bpls.h
@@ -71,7 +71,8 @@ template <class T>
 int readVar(core::Engine *fp, core::IO *io, core::Variable<T> *variable);
 
 template <class T>
-int readVarBlock(core::Engine *fp, core::IO *io, core::Variable<T> *variable, int blockid);
+int readVarBlock(core::Engine *fp, core::IO *io, core::Variable<T> *variable, size_t step,
+                 size_t blockid, Dims Count, Dims Start);
 
 template <class T>
 size_t relative_to_absolute_step(core::Engine *fp, core::Variable<T> *variable,


### PR DESCRIPTION
This branch of bpls was not checking global vs. local arrays and used the MinBlockInfo->Start nullptr as vector.