### PR TITLE
One EVPathRemote per remote file open

### DIFF
--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -28,8 +28,9 @@ EVPathRemote::EVPathRemote(const adios2::HostOptions &hostOptions) : Remote(host
 #ifdef ADIOS2_HAVE_SST
 EVPathRemote::~EVPathRemote()
 {
+    // dereference, not close: the connection is shared via CMget_conn()
     if (m_conn)
-        CMConnection_close(m_conn);
+        CMConnection_dereference(m_conn);
     m_conn = NULL;
 }
 
@@ -134,12 +135,12 @@ void EVPathRemote::Open(const std::string hostname, const int32_t port, const st
         CM_IP_PORT = attr_atom_from_string("IP_PORT");
         add_attr(contact_list, CM_IP_HOSTNAME, Attr_String, (attr_value)strdup(hostname.c_str()));
         add_attr(contact_list, CM_IP_PORT, Attr_Int4, (attr_value)port);
-        m_conn = CMinitiate_conn(ev_state.cm, contact_list);
+        m_conn = CMget_conn(ev_state.cm, contact_list);
         if ((m_conn == NULL) && (getenv("DoRemote") || getenv("DoFileRemote")))
         {
             // if we didn't find a server, but we're in testing, wait briefly and once more
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-            m_conn = CMinitiate_conn(ev_state.cm, contact_list);
+            m_conn = CMget_conn(ev_state.cm, contact_list);
         }
         free_attr_list(contact_list);
         if (!m_conn)
@@ -199,7 +200,7 @@ void EVPathRemote::OpenSimpleFile(const std::string hostname, const int32_t port
         CM_IP_PORT = attr_atom_from_string("IP_PORT");
         add_attr(contact_list, CM_IP_HOSTNAME, Attr_String, (attr_value)strdup(hostname.c_str()));
         add_attr(contact_list, CM_IP_PORT, Attr_Int4, (attr_value)port);
-        m_conn = CMinitiate_conn(ev_state.cm, contact_list);
+        m_conn = CMget_conn(ev_state.cm, contact_list);
         free_attr_list(contact_list);
         if (!m_conn)
         {
@@ -245,7 +246,7 @@ void EVPathRemote::OpenReadSimpleFile(const std::string hostname, const int32_t 
         CM_IP_PORT = attr_atom_from_string("IP_PORT");
         add_attr(contact_list, CM_IP_HOSTNAME, Attr_String, (attr_value)strdup(hostname.c_str()));
         add_attr(contact_list, CM_IP_PORT, Attr_Int4, (attr_value)port);
-        m_conn = CMinitiate_conn(ev_state.cm, contact_list);
+        m_conn = CMget_conn(ev_state.cm, contact_list);
         free_attr_list(contact_list);
         if (!m_conn)
         {
@@ -413,27 +414,27 @@ EVPathRemote::GetHandle EVPathRemote::Read(size_t Start, size_t Size, void *Dest
     return (Remote::GetHandle)(intptr_t)ReadMsg.ReadResponseCondition;
 }
 
-std::map<std::string, std::pair<std::shared_ptr<EVPathRemote>, int>>
-    CManagerSingleton::m_EVPathRemotes;
-
 std::pair<std::shared_ptr<EVPathRemote>, int>
 CManagerSingleton::MakeEVPathConnection(const std::string &hostName)
 {
-    auto it = m_EVPathRemotes.find(hostName);
-    if (it != m_EVPathRemotes.end())
+    // Each caller gets its own EVPathRemote (it carries the per-file server
+    // handle).  Per-host costs stay shared: the tunnel port is cached here
+    // and Open() reuses the CM connection via CMget_conn().
+    static std::mutex portMapMutex;
+    static std::map<std::string, int> hostPorts;
+    auto remote = std::make_shared<EVPathRemote>(core::ADIOS::StaticGetHostOptions());
     {
-        if (it->second.first && *(it->second.first))
-        {
-            return it->second;
-        }
+        const std::lock_guard<std::mutex> lock(portMapMutex);
+        auto it = hostPorts.find(hostName);
+        if (it != hostPorts.end())
+            return std::pair<std::shared_ptr<EVPathRemote>, int>(remote, it->second);
     }
-    auto m_Remote = std::make_shared<EVPathRemote>(core::ADIOS::StaticGetHostOptions());
     try
     {
-        int localPort = m_Remote->LaunchRemoteServerViaConnectionManager(hostName);
-        std::pair<std::shared_ptr<EVPathRemote>, int> pair(m_Remote, localPort);
-        m_EVPathRemotes.emplace(hostName, pair);
-        return pair;
+        int localPort = remote->LaunchRemoteServerViaConnectionManager(hostName);
+        const std::lock_guard<std::mutex> lock(portMapMutex);
+        hostPorts[hostName] = localPort;
+        return std::pair<std::shared_ptr<EVPathRemote>, int>(remote, localPort);
     }
     catch (const std::invalid_argument &e)
     {

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -108,9 +108,8 @@ class CManagerSingleton
 public:
     static CManagerSingleton &Instance(EVPathRemoteCommon::Remote_evpath_state &ev_state);
 
-    /* Map of hostname : connection/port */
-    static std::map<std::string, std::pair<std::shared_ptr<EVPathRemote>, int>> m_EVPathRemotes;
-    /* Helper function to manage connections, one per host */
+    /* Returns a new EVPathRemote (never shared: it carries the per-file
+     * server handle) plus the local port of the tunnel to hostName. */
     static std::pair<std::shared_ptr<EVPathRemote>, int>
     MakeEVPathConnection(const std::string &hostName);
 
@@ -125,11 +124,7 @@ private:
         CMfork_comm_thread(internalEvState.cm);
     }
 
-    ~CManagerSingleton()
-    {
-        m_EVPathRemotes.clear();
-        CManager_close(m_cm);
-    }
+    ~CManagerSingleton() { CManager_close(m_cm); }
 };
 #endif
 

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -137,6 +137,9 @@ if(UNIX)
   target_link_libraries(Test.Engine.BP.LargeBlocks.Serial adios2sys)
 endif()
 
+# Interleaved reads from two files open at once (also run remotely below)
+bp5_gtest_add_tests_helper(RemoteMultiFileRead MPI_NONE)
+
 # Transport tests (parameterized for stdio and fstream)
 bp_gtest_add_tests_helper(WriteReadADIOS2Transport MPI_ALLOW)
 bp_gtest_add_tests_helper(WriteReadAsStreamADIOS2 MPI_ALLOW)
@@ -211,6 +214,7 @@ if ((NOT WIN32) AND ADIOS2_HAVE_SST)
    add_get_remote_tests_helper(WriteReadADIOS2Transport)
    add_get_remote_tests_helper(WriteMemorySelectionRead)
    add_file_remote_tests_helper(WriteMemorySelectionRead)
+   add_get_remote_tests_helper(RemoteMultiFileRead)
 endif()
 
 if (ADIOS2_HAVE_XRootD)

--- a/testing/adios2/engine/bp/TestBPRemoteMultiFileRead.cpp
+++ b/testing/adios2/engine/bp/TestBPRemoteMultiFileRead.cpp
@@ -1,0 +1,131 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Interleaved reads from two files open at once.  Run remotely
+ * (DoRemote=1), both readers share one server connection; each read must
+ * address the reader's own file regardless of open/read ordering.
+ */
+
+#include <cstdint>
+
+#include <numeric>
+#include <vector>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+#include "../TestHelpers.h"
+
+std::string engineName; // comes from command line
+
+TEST(BPRemoteMultiFileRead, InterleavedReads)
+{
+    const std::string fnameA = "RemoteMultiFileA.bp";
+    const std::string fnameB = "RemoteMultiFileB.bp";
+    const size_t Nx = 100;
+
+    std::vector<double> uniqueA(Nx), uniqueB(Nx), sharedA(Nx), sharedB(Nx);
+    std::iota(uniqueA.begin(), uniqueA.end(), 0.0);
+    std::iota(uniqueB.begin(), uniqueB.end(), 1000.0);
+    std::iota(sharedA.begin(), sharedA.end(), 2000.0);
+    std::iota(sharedB.begin(), sharedB.end(), 3000.0);
+
+    adios2::ADIOS adios;
+
+    // Write the two files, each with one uniquely named variable and one
+    // variable whose name exists in both files but with different content
+    {
+        adios2::IO io = adios.DeclareIO("WriteA");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        auto varUnique = io.DefineVariable<double>("uniqueA", {Nx}, {0}, {Nx});
+        auto varShared = io.DefineVariable<double>("shared", {Nx}, {0}, {Nx});
+        adios2::Engine writer = io.Open(fnameA, adios2::Mode::Write);
+        writer.BeginStep();
+        writer.Put(varUnique, uniqueA.data());
+        writer.Put(varShared, sharedA.data());
+        writer.EndStep();
+        writer.Close();
+    }
+    {
+        adios2::IO io = adios.DeclareIO("WriteB");
+        if (!engineName.empty())
+        {
+            io.SetEngine(engineName);
+        }
+        auto varUnique = io.DefineVariable<double>("uniqueB", {Nx}, {0}, {Nx});
+        auto varShared = io.DefineVariable<double>("shared", {Nx}, {0}, {Nx});
+        adios2::Engine writer = io.Open(fnameB, adios2::Mode::Write);
+        writer.BeginStep();
+        writer.Put(varUnique, uniqueB.data());
+        writer.Put(varShared, sharedB.data());
+        writer.EndStep();
+        writer.Close();
+    }
+
+    // Read with both files open at once, switching between them
+    {
+        adios2::IO ioA = adios.DeclareIO("ReadA");
+        adios2::IO ioB = adios.DeclareIO("ReadB");
+        if (!engineName.empty())
+        {
+            ioA.SetEngine(engineName);
+            ioB.SetEngine(engineName);
+        }
+        adios2::Engine readerA = ioA.Open(fnameA, adios2::Mode::ReadRandomAccess);
+        adios2::Engine readerB = ioB.Open(fnameB, adios2::Mode::ReadRandomAccess);
+
+        auto varUniqueA = ioA.InquireVariable<double>("uniqueA");
+        auto varSharedA = ioA.InquireVariable<double>("shared");
+        auto varUniqueB = ioB.InquireVariable<double>("uniqueB");
+        auto varSharedB = ioB.InquireVariable<double>("shared");
+        ASSERT_TRUE(varUniqueA);
+        ASSERT_TRUE(varSharedA);
+        ASSERT_TRUE(varUniqueB);
+        ASSERT_TRUE(varSharedB);
+
+        std::vector<double> in(Nx);
+
+        readerA.Get(varUniqueA, in.data(), adios2::Mode::Sync);
+        ASSERT_EQ(in, uniqueA);
+
+        readerB.Get(varUniqueB, in.data(), adios2::Mode::Sync);
+        ASSERT_EQ(in, uniqueB);
+
+        // back to reader A: same-named variable must come from file A
+        readerA.Get(varSharedA, in.data(), adios2::Mode::Sync);
+        ASSERT_EQ(in, sharedA);
+
+        // and a variable that exists only in file A must still resolve
+        readerA.Get(varUniqueA, in.data(), adios2::Mode::Sync);
+        ASSERT_EQ(in, uniqueA);
+
+        readerB.Get(varSharedB, in.data(), adios2::Mode::Sync);
+        ASSERT_EQ(in, sharedB);
+
+        readerA.Close();
+        readerB.Close();
+    }
+
+    CleanupTestFiles(fnameA);
+    CleanupTestFiles(fnameB);
+}
+
+int main(int argc, char **argv)
+{
+    int result;
+    ::testing::InitGoogleTest(&argc, argv);
+    if (argc > 1)
+    {
+        engineName = std::string(argv[1]);
+    }
+    result = RUN_ALL_TESTS();
+    return result;
+}


### PR DESCRIPTION
The per-host cached EVPathRemote held the file handle of the last Open(), redirecting earlier engines' reads to the wrong file (hang or wrong data when switching between files). Give each open its own EVPathRemote; per-host costs stay shared (tunnel port cache, CM connection reuse via CMget_conn, dereference on destruction). Add interleaved two-file remote read test.