### PR TITLE
FileStream: detect BP version from md.idx header, race-free

### DIFF
--- a/docs/user_guide/source/engines/virtual_engines.rst
+++ b/docs/user_guide/source/engines/virtual_engines.rst
@@ -16,7 +16,10 @@ The following I/O uses cases are supported by virtual engine names:
 
    This allows a Consumer to concurrently read the data while the Producer is writing new output steps into it. The Consumer will
    wait for the appearance of the file itself in Open() (for up to one hour) and wait for the appearance of new steps in the file
-   (in BeginStep() up to the specificed timeout in that function). 
+   (in BeginStep() up to the specificed timeout in that function).
+
+   When writing, ``FileStream`` produces the ``BP5`` format. When reading, it uses the format of the existing dataset (``BP4`` or
+   ``BP5``); a stream that does not exist yet is assumed to be ``BP5``.
 
 3. ``InSituAnalysis``: Streaming data to another application. 
 

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -604,15 +604,9 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm, co
     {
         if (engineTypeLC == "filestream")
         {
-            // FileStream streams BP4/BP5 file output only (not DAOS, timeseries,
-            // etc.). The choice is mode-dependent: when writing a new file we
-            // produce the latest streamable format (BP5) and do not query the
-            // filesystem for a version (there is nothing to conform to). When
-            // reading, or appending to, an existing stream we conform to the
-            // file's version. A not-yet-created stream is normal (a reader may
-            // open before the writer creates the file): BPVersionLocal reports
-            // '0' (unknown), and we default to BP5, the format FileStream
-            // writers produce, so the reader matches rather than guessing BP4.
+            // FileStream writes BP5. When reading, nothing-on-disk resolves to
+            // BP5 (and waits); an existing dataset is read at its own version,
+            // so old BP4 files still open.
             if (mode_to_use == Mode::Write)
             {
                 engineTypeLC = "bp5";
@@ -620,13 +614,9 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm, co
             else
             {
                 char version = '5';
-                if (comm.Rank() == 0)
+                if (comm.Rank() == 0 && adios2sys::SystemTools::PathExists(name))
                 {
-                    char detected = helper::BPVersionLocal(name);
-                    if (detected != '0')
-                    {
-                        version = detected;
-                    }
+                    version = helper::BPVersionLocal(name);
                 }
                 engineTypeLC = std::string("bp") + comm.BroadcastValue(version);
             }

--- a/source/adios2/helper/adiosSystem.cpp
+++ b/source/adios2/helper/adiosSystem.cpp
@@ -7,6 +7,7 @@
 #include "adiosSystem.h"
 #include <chrono> //system_clock, now
 #include <ctime>
+#include <fstream>
 #include <stdexcept> // std::runtime_error, std::exception
 #include <system_error>
 #include <thread>
@@ -171,17 +172,18 @@ bool IsHDF5File(const std::string &name, core::IO &io, helper::Comm &comm,
 
 char BPVersionLocal(const std::string &name) noexcept
 {
-    if (!adios2sys::SystemTools::PathExists(name))
+    // Read the BP version byte at a fixed offset in md.idx (same for BP4/BP5);
+    // an absent or short index reads as the current format, BP5. Content-based,
+    // so it does not race a concurrent writer's file creation.
+    constexpr std::streamoff versionOffset = 37; // BP4Base/BP5Engine m_BPVersionPosition
+    char version = '5';
+    std::ifstream idx(name + PathSeparator + "md.idx", std::ios::binary);
+    char v = 0;
+    if (idx && idx.seekg(versionOffset).read(&v, 1) && v >= 3 && v <= 5)
     {
-        // The dataset directory does not exist (yet). We cannot know which
-        // version a future writer will produce, so report unknown ('0')
-        // rather than guessing BP4. Callers decide how to handle a
-        // not-yet-created stream. Only an existing directory that lacks the
-        // mmd.0 metadata index is genuinely BP4.
-        return '0';
+        version = static_cast<char>('0' + v);
     }
-    const std::string mmdFileName = name + PathSeparator + "mmd.0";
-    return adios2sys::SystemTools::PathExists(mmdFileName) ? '5' : '4';
+    return version;
 }
 
 bool IsDAOSDataset(const std::string &name) noexcept

--- a/source/adios2/helper/adiosSystem.h
+++ b/source/adios2/helper/adiosSystem.h
@@ -76,9 +76,8 @@ bool IsHDF5File(const std::string &name, core::IO &io, helper::Comm &comm,
 /** Rank-local IsHDF5File: no internal broadcast; call from a single rank. */
 bool IsHDF5FileLocal(const std::string &name, core::IO &io, helper::Comm &comm,
                      const std::vector<Params> &transportsParameters) noexcept;
-/** Rank-local BP version sniff (no broadcast): '5' if an mmd.0 is present in an
- *  existing directory, '4' for an existing directory without one, and '0'
- *  (unknown) when the dataset directory does not exist yet. */
+/** Rank-local BP version sniff: reads the version byte from the dataset's
+ *  md.idx; returns '3'/'4'/'5', or '5' when the index is absent/unreadable. */
 char BPVersionLocal(const std::string &name) noexcept;
 
 /** Return true if 'name' is a dataset directory written by the DAOS


### PR DESCRIPTION
Fixes possible race in current approach by reading a byte out of md.idx