### PR TITLE
Python docs: read semantics and deferred reads

### DIFF
--- a/docs/user_guide/source/api_python/python_example.rst
+++ b/docs/user_guide/source/api_python/python_example.rst
@@ -198,12 +198,12 @@ Python Read Random Access example
 Python Deferred (batched) Read example
 --------------------------------------
 
-Each synchronous ``read()`` call is a separate request, and when the data is
-remote (campaign files, remote servers) a full network round trip. When
-reading more than one variable, defer every read and complete them all with one
-``read_complete()`` call: the engine pipelines or batches the requests, so N
-variables cost roughly one round trip instead of N. The returned arrays
-contain data only after ``read_complete()`` returns.
+When reading more than one variable, defer every read and complete them all
+with one ``read_complete()`` call. Local file engines serve the queued reads
+with multiple threads (often several times faster from fast storage), and
+when the data is remote (campaign files, remote servers) the batch costs
+roughly one network round trip instead of one per ``read()``. The returned
+arrays contain data only after ``read_complete()`` returns.
 
 .. code-block:: python
 

--- a/docs/user_guide/source/api_python/python_example.rst
+++ b/docs/user_guide/source/api_python/python_example.rst
@@ -194,3 +194,33 @@ Python Read Random Access example
     temperature array size is 200 of shape (200,)
     temperature unit is K of type <class 'str'>
 
+
+Python Deferred (batched) Read example
+--------------------------------------
+
+Each synchronous ``read()`` call is a separate request, and when the data is
+remote (campaign files, remote servers) a full network round trip. When
+reading more than one variable, defer every read and complete them all with one
+``read_complete()`` call: the engine pipelines or batches the requests, so N
+variables cost roughly one round trip instead of N. The returned arrays
+contain data only after ``read_complete()`` returns.
+
+.. code-block:: python
+
+    import numpy as np
+    from adios2 import FileReader
+
+    with FileReader("cfd.bp") as s:
+        # queue all reads; nothing is transferred yet
+        temperature = s.read("temperature", defer_read=True)
+        pressure = s.read("pressure", defer_read=True)
+        physical_time = s.read("physical_time", step_selection=[0, 5], defer_read=True)
+
+        # one call performs every queued read
+        s.read_complete()
+
+        # arrays are now filled
+        print(f"temperature array size is {temperature.size}")
+        print(f"pressure array size is {pressure.size}")
+        print(f"physical_time is {physical_time}")
+

--- a/python/adios2/file_reader.py
+++ b/python/adios2/file_reader.py
@@ -10,7 +10,14 @@ from adios2 import bindings, Adios, Stream, IO
 
 
 class FileReader(Stream):  # noqa: PLR0902
-    """High level implementation of the FileReader class for read Random access mode"""
+    """High level implementation of the FileReader class for read Random access mode.
+
+    Opens in ReadRandomAccess mode: metadata for all steps is loaded at open
+    (expensive for files with very large metadata; use Stream(path, "r") to
+    process step by step instead) and read() may select any steps directly.
+    When reading several variables, defer each read (defer_read=True) and
+    complete them together with read_complete(); see Stream.read_complete().
+    """
 
     def __repr__(self):
         return f"<adios.file named {self._io_name}>"

--- a/python/adios2/stream.py
+++ b/python/adios2/stream.py
@@ -418,10 +418,11 @@ class Stream:  # noqa: PLR0902
                         The returned numpy array will be filled with data
                         only after calling read_complete().
                         Prefer deferring when reading several variables or
-                        step ranges: each synchronous read is a separate
-                        request (a full network round trip on remote or
-                        campaign data), while deferred reads complete
-                        together in a single read_complete() call.
+                        step ranges: the queued reads complete together in
+                        a single read_complete() call, served by multiple
+                        threads from local files and without paying one
+                        network round trip per read on remote or campaign
+                        data.
         Returns
             array
                 resulting array from selection
@@ -556,10 +557,11 @@ class Stream:  # noqa: PLR0902
                       The returned numpy array will be filled with data
                       only after calling read_complete().
                       Prefer deferring when reading several variables or
-                      step ranges: each synchronous read is a separate
-                      request (a full network round trip on remote or
-                      campaign data), while deferred reads complete
-                      together in a single read_complete() call.
+                      step ranges: the queued reads complete together in
+                      a single read_complete() call, served by multiple
+                      threads from local files and without paying one
+                      network round trip per read on remote or campaign
+                      data.
         """
         variable = self._set_variable_settings(variable, start, count, block_id, step_selection)
         # make sure the buffer is a mutable array
@@ -643,10 +645,11 @@ class Stream:  # noqa: PLR0902
                       The returned numpy array will be filled with data
                       only after calling read_complete().
                       Prefer deferring when reading several variables or
-                      step ranges: each synchronous read is a separate
-                      request (a full network round trip on remote or
-                      campaign data), while deferred reads complete
-                      together in a single read_complete() call.
+                      step ranges: the queued reads complete together in
+                      a single read_complete() call, served by multiple
+                      threads from local files and without paying one
+                      network round trip per read on remote or campaign
+                      data.
         """
         variable = self._io.inquire_variable(name)
         if not variable:
@@ -698,10 +701,11 @@ class Stream:  # noqa: PLR0902
                         The returned numpy array will be filled with data
                         only after calling read_complete().
                         Prefer deferring when reading several variables or
-                        step ranges: each synchronous read is a separate
-                        request (a full network round trip on remote or
-                        campaign data), while deferred reads complete
-                        together in a single read_complete() call.
+                        step ranges: the queued reads complete together in
+                        a single read_complete() call, served by multiple
+                        threads from local files and without paying one
+                        network round trip per read on remote or campaign
+                        data.
         Returns
             array
                 resulting array from selection
@@ -752,10 +756,11 @@ class Stream:  # noqa: PLR0902
                         The returned numpy array will be filled with data
                         only after calling read_complete().
                         Prefer deferring when reading several variables or
-                        step ranges: each synchronous read is a separate
-                        request (a full network round trip on remote or
-                        campaign data), while deferred reads complete
-                        together in a single read_complete() call.
+                        step ranges: the queued reads complete together in
+                        a single read_complete() call, served by multiple
+                        threads from local files and without paying one
+                        network round trip per read on remote or campaign
+                        data.
         Returns
             array
                 resulting array from selection
@@ -772,9 +777,10 @@ class Stream:  # noqa: PLR0902
         The returned numpy arrays of each read(..., defer_read=True) will be
         filled with data after this call.
 
-        This is the efficient way to read several variables, especially from
-        remote or campaign data where every synchronous read() is a full
-        network round trip::
+        This is the efficient way to read several variables. Local file
+        engines serve the queued reads with multiple threads, and on
+        remote or campaign data the batch avoids one network round trip
+        per read()::
 
             temp = s.read("temperature", defer_read=True)
             pres = s.read("pressure", defer_read=True)

--- a/python/adios2/stream.py
+++ b/python/adios2/stream.py
@@ -63,13 +63,45 @@ def string_to_mode(mode: str) -> [bindings.Mode, bool]:
 
 
 class Stream:  # noqa: PLR0902
-    """High level implementation of the Stream class from the core API"""
+    """High level implementation of the Stream class from the core API.
+
+    The open mode determines the access semantics:
+
+        "r"   Step-by-step reading. Iterate with steps() (or
+              begin_step()/end_step()); read() applies to the current
+              step only, and step_selection is not available. Only the
+              current step's metadata is held in memory.
+        "rra" Random access reading, not streaming at all: no step
+              loop, metadata for all steps is loaded at open (expensive
+              for very large metadata), and read() may address any
+              steps with step_selection. Prefer the FileReader
+              subclass, which is exactly this mode under a clearer
+              name.
+        "w"   Write a new dataset step by step.
+        "a"   Append steps to an existing dataset.
+    """
 
     # Default timeout for stream.begin_step()
     DEFAULT_TIMEOUT_SEC = -1.0
 
     @singledispatchmethod
     def __init__(self, path, mode, comm=None):  # noqa: PLR0912
+        """
+        Open a stream on a file or dataset.
+
+        Parameters
+            path
+                dataset path (e.g. a .bp directory or .aca campaign file)
+
+            mode
+                "r" (step-by-step read), "rra" (random access read),
+                "w" (write), or "a" (append). See the Stream class
+                documentation for the read-mode semantics.
+
+            comm
+                optional mpi4py communicator (requires an MPI-enabled
+                ADIOS2 build)
+        """
         if comm and not bindings.is_built_with_mpi:
             raise RuntimeError("Cannot use MPI since ADIOS2 was built without MPI support")
 
@@ -385,6 +417,11 @@ class Stream:  # noqa: PLR0902
                 True: defer reading all requests until read_complete().
                         The returned numpy array will be filled with data
                         only after calling read_complete().
+                        Prefer deferring when reading several variables or
+                        step ranges: each synchronous read is a separate
+                        request (a full network round trip on remote or
+                        campaign data), while deferred reads complete
+                        together in a single read_complete() call.
         Returns
             array
                 resulting array from selection
@@ -448,7 +485,10 @@ class Stream:  # noqa: PLR0902
                 value.
 
             step_selection
-                (list): On the form of [start, count].
+                (list): On the form of [start, count]. Requires "rra"
+                (ReadRandomAccess) mode. In "r" mode there is no step
+                addressing: reads apply to the current step of the
+                steps() loop.
         Returns
             variable
                 the variable with the selection set
@@ -505,13 +545,21 @@ class Stream:  # noqa: PLR0902
                 value.
 
             step_selection
-                (list): On the form of [start, count].
+                (list): On the form of [start, count]. Requires "rra"
+                (ReadRandomAccess) mode. In "r" mode there is no step
+                addressing: reads apply to the current step of the
+                steps() loop.
 
             defer_read
                 False: read now and blocking wait for completion (Sync mode)
                 True: defer reading all requests until read_complete().
                       The returned numpy array will be filled with data
                       only after calling read_complete().
+                      Prefer deferring when reading several variables or
+                      step ranges: each synchronous read is a separate
+                      request (a full network round trip on remote or
+                      campaign data), while deferred reads complete
+                      together in a single read_complete() call.
         """
         variable = self._set_variable_settings(variable, start, count, block_id, step_selection)
         # make sure the buffer is a mutable array
@@ -584,13 +632,21 @@ class Stream:  # noqa: PLR0902
                 value.
 
             step_selection
-                (list): On the form of [start, count].
+                (list): On the form of [start, count]. Requires "rra"
+                (ReadRandomAccess) mode. In "r" mode there is no step
+                addressing: reads apply to the current step of the
+                steps() loop.
 
             defer_read
                 False: read now and blocking wait for completion (Sync mode)
                 True: defer reading all requests until read_complete().
                       The returned numpy array will be filled with data
                       only after calling read_complete().
+                      Prefer deferring when reading several variables or
+                      step ranges: each synchronous read is a separate
+                      request (a full network round trip on remote or
+                      campaign data), while deferred reads complete
+                      together in a single read_complete() call.
         """
         variable = self._io.inquire_variable(name)
         if not variable:
@@ -631,13 +687,21 @@ class Stream:  # noqa: PLR0902
                 value.
 
             step_selection
-                (list): On the form of [start, count].
+                (list): On the form of [start, count]. Requires "rra"
+                (ReadRandomAccess) mode. In "r" mode there is no step
+                addressing: reads apply to the current step of the
+                steps() loop.
 
             defer_read
                 False: read now and blocking wait for completion (Sync mode)
                 True: defer reading all requests until read_complete().
                         The returned numpy array will be filled with data
                         only after calling read_complete().
+                        Prefer deferring when reading several variables or
+                        step ranges: each synchronous read is a separate
+                        request (a full network round trip on remote or
+                        campaign data), while deferred reads complete
+                        together in a single read_complete() call.
         Returns
             array
                 resulting array from selection
@@ -677,13 +741,21 @@ class Stream:  # noqa: PLR0902
                 value.
 
             step_selection
-                (list): On the form of [start, count].
+                (list): On the form of [start, count]. Requires "rra"
+                (ReadRandomAccess) mode. In "r" mode there is no step
+                addressing: reads apply to the current step of the
+                steps() loop.
 
             defer_read
                 False: read now and blocking wait for completion (Sync mode)
                 True: defer reading all requests until read_complete().
                         The returned numpy array will be filled with data
                         only after calling read_complete().
+                        Prefer deferring when reading several variables or
+                        step ranges: each synchronous read is a separate
+                        request (a full network round trip on remote or
+                        campaign data), while deferred reads complete
+                        together in a single read_complete() call.
         Returns
             array
                 resulting array from selection
@@ -699,6 +771,14 @@ class Stream:  # noqa: PLR0902
         Complete reading all deferred read requests.
         The returned numpy arrays of each read(..., defer_read=True) will be
         filled with data after this call.
+
+        This is the efficient way to read several variables, especially from
+        remote or campaign data where every synchronous read() is a full
+        network round trip::
+
+            temp = s.read("temperature", defer_read=True)
+            pres = s.read("pressure", defer_read=True)
+            s.read_complete()  # temp and pres now contain data
         """
         self._engine.perform_gets()
 


### PR DESCRIPTION
Document some things that IMHO were unclear in the python API and give deferred reading more prominence in examples and in the interface (partly with the idea that coding agents will pick up these notes and be more likely to use the calls properly).

Read vs ReadRandomAccess semantics (Stream mode table, first __init__ docstring, step_selection is rra-only, FileReader loads all metadata at open) and when to use defer_read/read_complete, with a deferred-read example in the user guide.