### PR TITLE
DAOS: chunk bulk transfers, fix Close handle race, tune array chunk_size

### DIFF
--- a/source/adios2/engine/daos/DaosReader.cpp
+++ b/source/adios2/engine/daos/DaosReader.cpp
@@ -11,6 +11,7 @@
 #include "adios2/toolkit/transport/OpenFile.h"
 #include <adios2-perfstubs-interface.h>
 
+#include <algorithm> // std::min
 #include <chrono>
 #include <cstdio>  // fprintf (DAOS_MD_DEBUG)
 #include <cstdlib> // getenv
@@ -738,28 +739,46 @@ std::pair<double, double> DaosReader::ReadData(const size_t WriterRank, const si
     TP startRead = NOW();
     size_t arrayOffset = it->second[WriterRank] + StartOffset;
 
-    daos_range_t rgr;
-    rgr.rg_idx = arrayOffset;
-    rgr.rg_len = Length;
-    daos_array_iod_t iodr;
-    iodr.arr_nr = 1;
-    iodr.arr_rgs = &rgr;
-    d_iov_t iovr;
-    iovr.iov_buf = Destination;
-    iovr.iov_buf_len = Length;
-    iovr.iov_len = Length;
-    d_sg_list_t sglr;
-    sglr.sg_nr = 1;
-    sglr.sg_nr_out = 0;
-    sglr.sg_iovs = &iovr;
-    int rc = daos_array_read(aoh, DAOS_TX_NONE, &iodr, &sglr, NULL);
-    if (rc)
+    // Chunk large reads to bound Mercury bulk registration.  A single
+    // daos_array_read of the full per-rank blob (hundreds of MiB), issued
+    // concurrently by many reader threads (this function runs multi-threaded),
+    // exhausts Mercury's NA memory descriptors -> DER_NOMEM in hg_bulk_create.
+    // Reading in bounded pieces keeps each bulk transfer small.  IOR-DFS avoids
+    // the problem the same way (--dfs.chunk_size).  DAOS_READ_CHUNK_BYTES=0
+    // restores the single-read behavior (for A/B).
+    static const size_t readChunk = []() -> size_t {
+        if (const char *e = std::getenv("DAOS_READ_CHUNK_BYTES"))
+            return static_cast<size_t>(std::strtoull(e, nullptr, 10));
+        return size_t{16} * 1024 * 1024; // 16 MiB default
+    }();
+    const size_t step = (readChunk == 0) ? Length : readChunk;
+
+    for (size_t done = 0; done < Length; done += step)
     {
-        helper::Throw<std::runtime_error>("Engine", "DaosReader", "ReadData",
-                                          "daos_array_read failed rc=" + std::to_string(rc) +
-                                              " WriterRank=" + std::to_string(WriterRank) +
-                                              " offset=" + std::to_string(arrayOffset) +
-                                              " len=" + std::to_string(Length));
+        const size_t thisLen = std::min(step, Length - done);
+        daos_range_t rgr;
+        rgr.rg_idx = arrayOffset + done;
+        rgr.rg_len = thisLen;
+        daos_array_iod_t iodr;
+        iodr.arr_nr = 1;
+        iodr.arr_rgs = &rgr;
+        d_iov_t iovr;
+        iovr.iov_buf = Destination + done;
+        iovr.iov_buf_len = thisLen;
+        iovr.iov_len = thisLen;
+        d_sg_list_t sglr;
+        sglr.sg_nr = 1;
+        sglr.sg_nr_out = 0;
+        sglr.sg_iovs = &iovr;
+        int rc = daos_array_read(aoh, DAOS_TX_NONE, &iodr, &sglr, NULL);
+        if (rc)
+        {
+            helper::Throw<std::runtime_error>("Engine", "DaosReader", "ReadData",
+                                              "daos_array_read failed rc=" + std::to_string(rc) +
+                                                  " WriterRank=" + std::to_string(WriterRank) +
+                                                  " offset=" + std::to_string(arrayOffset + done) +
+                                                  " len=" + std::to_string(thisLen));
+        }
     }
     TP endRead = NOW();
     double timeRead = DURATION(startRead, endRead);
@@ -1957,6 +1976,17 @@ void DaosReader::DoClose(const int transportIndex)
     {
         EndStep();
     }
+
+    // Collaborative teardown.  The pool/container handles are shared across
+    // ranks via daos_{pool,cont}_global2local: rank 0 owns the real pool
+    // connection and container open; the other ranks hold lightweight local
+    // copies.  All data/metadata reads use those handles.  If any rank reaches
+    // Close first and tears them down (daos_cont_close / rank-0
+    // daos_pool_disconnect below), a straggler still reading the last step
+    // loses the shared handle mid-read -> DER_NO_HDL(-1002).  Barrier here so
+    // no handle is released until every rank has finished all its reads.
+    m_Comm.Barrier();
+
     if (m_Comm.Rank() == 0)
     {
         m_MetadataFile->Close();
@@ -1985,6 +2015,10 @@ void DaosReader::DoClose(const int transportIndex)
         daos_cont_close(coh, NULL);
         coh = {};
     }
+    // Ensure every rank has released its container handle before rank 0 drops
+    // the shared pool connection (rank-0 disconnect invalidates the pool for
+    // all global2local holders).
+    m_Comm.Barrier();
     if (m_Comm.Rank() == 0 && poh.cookie != 0)
     {
         daos_pool_disconnect(poh, NULL);

--- a/source/adios2/engine/daos/DaosWriter.cpp
+++ b/source/adios2/engine/daos/DaosWriter.cpp
@@ -22,8 +22,9 @@
 #include <adios2sys/SystemTools.hxx>
 #include <daos_array.h>
 
+#include <algorithm> // std::min
 #include <chrono>
-#include <cstdlib> // getenv
+#include <cstdlib> // getenv, strtoull
 #include <cstring> // memcpy
 #include <ctime>
 #include <fstream>
@@ -39,6 +40,44 @@ namespace engine
 {
 
 using namespace adios2::format;
+
+namespace
+{
+// Diagnostic Open-phase timing, gated on DAOS_TIME_OPEN so normal runs are
+// untouched.  A scoped timer appends (name, seconds) to a TU-local ordered
+// list; DaosWriter::Init prints and clears it on rank 0.  Init runs once per
+// engine open, single-threaded, so the shared list needs no locking.
+bool OpenTimingEnabled()
+{
+    static const bool on = std::getenv("DAOS_TIME_OPEN") != nullptr;
+    return on;
+}
+std::vector<std::pair<std::string, double>> &OpenPhaseLog()
+{
+    static std::vector<std::pair<std::string, double>> log;
+    return log;
+}
+struct OpenPhaseTimer
+{
+    const char *m_Name;
+    std::chrono::steady_clock::time_point m_Start;
+    explicit OpenPhaseTimer(const char *name)
+    : m_Name(name), m_Start(std::chrono::steady_clock::now())
+    {
+    }
+    ~OpenPhaseTimer()
+    {
+        if (!OpenTimingEnabled())
+            return;
+        std::chrono::duration<double> d = std::chrono::steady_clock::now() - m_Start;
+        OpenPhaseLog().emplace_back(m_Name, d.count());
+    }
+};
+} // namespace
+#define DAOS_OPEN_PHASE_CONCAT_(a, b) a##b
+#define DAOS_OPEN_PHASE_CONCAT(a, b) DAOS_OPEN_PHASE_CONCAT_(a, b)
+#define DAOS_OPEN_PHASE(name)                                                                      \
+    OpenPhaseTimer DAOS_OPEN_PHASE_CONCAT(_daos_open_phase_, __LINE__)(name)
 
 DaosWriter::DaosWriter(IO &io, const std::string &name, const Mode mode, helper::Comm comm)
 : Engine("DaosWriter", io, name, mode, std::move(comm)), m_BP5Serializer(), m_Profiler(m_Comm)
@@ -200,11 +239,14 @@ void DaosWriter::WriteData(format::BufferV *Data)
     if (!tail.empty())
     {
         profiling::ProfilerGuard g(m_Profiler, "WD_Tail");
-        // One synchronous daos_array_write covering the unflushed tail
-        // with one iov per VecEntry in the SGL.  Same shape as
-        // DaosChunkV's async submits, just synchronous and last.
-        daos_size_t total = 0;
+        // Synchronous daos_array_write(s) covering the unflushed tail, one
+        // iov per VecEntry in the SGL.  Same shape as DaosChunkV's async
+        // submits, just synchronous and last.  Chunked into bounded
+        // sub-writes to keep each Mercury bulk transfer small (mirrors
+        // DaosChunkV::SubmitRange); DAOS_WRITE_CHUNK_BYTES=0 (default)
+        // restores the single-write behavior for A/B testing.
         std::vector<d_iov_t> sgiovs;
+        daos_size_t total = 0;
         sgiovs.reserve(tail.size());
         for (const auto &e : tail)
         {
@@ -219,22 +261,56 @@ void DaosWriter::WriteData(format::BufferV *Data)
         }
         if (total > 0)
         {
-            daos_range_t rg;
-            rg.rg_idx = m_DataArrayCursor + daosBuf->SubmittedHigh();
-            rg.rg_len = total;
-            daos_array_iod_t iod;
-            iod.arr_nr = 1;
-            iod.arr_rgs = &rg;
-            d_sg_list_t sgl;
-            sgl.sg_nr = static_cast<uint32_t>(sgiovs.size());
-            sgl.sg_nr_out = 0;
-            sgl.sg_iovs = sgiovs.data();
-            int rc = daos_array_write(m_DataArrayOH, DAOS_TX_NONE, &iod, &sgl, NULL);
-            if (rc)
+            static const size_t writeChunk = []() -> size_t {
+                if (const char *e = std::getenv("DAOS_WRITE_CHUNK_BYTES"))
+                    return static_cast<size_t>(std::strtoull(e, nullptr, 10));
+                return size_t{16} * 1024 * 1024; // 16 MiB default (see DaosChunkV)
+            }();
+            const size_t step = (writeChunk == 0) ? static_cast<size_t>(total) : writeChunk;
+
+            const daos_size_t startOff = m_DataArrayCursor + daosBuf->SubmittedHigh();
+            daos_size_t rel = 0;
+            size_t i = 0;
+            size_t inIovOff = 0;
+            while (i < sgiovs.size())
             {
-                helper::Throw<std::runtime_error>("Engine", "DaosWriter", "WriteData",
-                                                  "tail daos_array_write failed rc=" +
-                                                      std::to_string(rc));
+                std::vector<d_iov_t> batch;
+                daos_size_t batchBytes = 0;
+                while (i < sgiovs.size() && batchBytes < step)
+                {
+                    const size_t avail = sgiovs[i].iov_len - inIovOff;
+                    const size_t take = std::min(avail, step - static_cast<size_t>(batchBytes));
+                    d_iov_t v;
+                    v.iov_buf = static_cast<char *>(sgiovs[i].iov_buf) + inIovOff;
+                    v.iov_buf_len = take;
+                    v.iov_len = take;
+                    batch.push_back(v);
+                    batchBytes += take;
+                    inIovOff += take;
+                    if (inIovOff == sgiovs[i].iov_len)
+                    {
+                        ++i;
+                        inIovOff = 0;
+                    }
+                }
+                daos_range_t rg;
+                rg.rg_idx = startOff + rel;
+                rg.rg_len = batchBytes;
+                daos_array_iod_t iod;
+                iod.arr_nr = 1;
+                iod.arr_rgs = &rg;
+                d_sg_list_t sgl;
+                sgl.sg_nr = static_cast<uint32_t>(batch.size());
+                sgl.sg_nr_out = 0;
+                sgl.sg_iovs = batch.data();
+                int rc = daos_array_write(m_DataArrayOH, DAOS_TX_NONE, &iod, &sgl, NULL);
+                if (rc)
+                {
+                    helper::Throw<std::runtime_error>("Engine", "DaosWriter", "WriteData",
+                                                      "tail daos_array_write failed rc=" +
+                                                          std::to_string(rc));
+                }
+                rel += batchBytes;
             }
         }
     }
@@ -723,16 +799,48 @@ void DaosWriter::Init()
 
     m_BP5Serializer.m_Engine = this;
     m_RankMPI = m_Comm.Rank();
-    InitParameters();
-    InitTransports();
+    {
+        DAOS_OPEN_PHASE("InitParameters");
+        InitParameters();
+    }
+    {
+        DAOS_OPEN_PHASE("InitTransports(dfuse md.0/mmd.0/md.idx)");
+        InitTransports();
+    }
     CALI_MARK_BEGIN("DaosWriter::InitDAOS");
-    InitDAOS();
+    {
+        DAOS_OPEN_PHASE("InitDAOS(total)");
+        InitDAOS();
+    }
     CALI_MARK_END("DaosWriter::InitDAOS");
 
     RegisterProfilerTimers();
-    OpenDataArray();
+    {
+        DAOS_OPEN_PHASE("OpenDataArray(data array_create)");
+        OpenDataArray();
+    }
 
-    InitBPBuffer();
+    {
+        DAOS_OPEN_PHASE("InitBPBuffer");
+        InitBPBuffer();
+    }
+
+    if (OpenTimingEnabled() && m_Comm.Rank() == 0)
+    {
+        double sum = 0.0;
+        for (const auto &p : OpenPhaseLog())
+            sum += p.second;
+        std::cout << "DAOS_OPEN_BREAKDOWN (rank 0, seconds):\n";
+        for (const auto &p : OpenPhaseLog())
+        {
+            std::cout << "  " << std::left << std::setw(40) << p.first << std::right << std::setw(9)
+                      << std::fixed << std::setprecision(4) << p.second << "  (" << std::setw(5)
+                      << std::setprecision(1) << (sum > 0 ? 100.0 * p.second / sum : 0.0) << "%)\n";
+        }
+        std::cout << "  " << std::left << std::setw(40) << "TOTAL(measured)" << std::right
+                  << std::setw(9) << std::fixed << std::setprecision(4) << sum << std::endl;
+    }
+    OpenPhaseLog().clear();
 }
 
 void DaosWriter::RegisterProfilerTimers()
@@ -934,7 +1042,10 @@ void DaosWriter::InitDAOS()
     // Rank 0 - Connect to DAOS pool, and open container
     int rc;
     CALI_MARK_BEGIN("DaosWriter::daos_init");
-    rc = daos_init();
+    {
+        DAOS_OPEN_PHASE("  daos_init");
+        rc = daos_init();
+    }
     if (rc)
     {
         helper::Throw<std::runtime_error>("Engine", "DaosWriter", "InitDAOS",
@@ -954,61 +1065,80 @@ void DaosWriter::InitDAOS()
     SetPoolAndContName();
 
     CALI_MARK_BEGIN("DaosWriter::daos_pool_connect");
-    if (m_Comm.Rank() == 0)
     {
-        /** connect to the just created DAOS pool */
-        rc = daos_pool_connect(m_pool_label, DSS_PSETID, DAOS_PC_RW /* read write access */,
-                               &poh /* returned pool handle */, NULL /* returned pool info */,
-                               NULL /* event */);
-        if (rc)
+        DAOS_OPEN_PHASE("  daos_pool_connect(rank0)");
+        if (m_Comm.Rank() == 0)
         {
-            helper::Throw<std::runtime_error>("Engine", "DaosWriter", "InitDAOS",
-                                              "daos_pool_connect failed rc=" + std::to_string(rc));
+            /** connect to the just created DAOS pool */
+            rc = daos_pool_connect(m_pool_label, DSS_PSETID, DAOS_PC_RW /* read write access */,
+                                   &poh /* returned pool handle */, NULL /* returned pool info */,
+                                   NULL /* event */);
+            if (rc)
+            {
+                helper::Throw<std::runtime_error>("Engine", "DaosWriter", "InitDAOS",
+                                                  "daos_pool_connect failed rc=" +
+                                                      std::to_string(rc));
+            }
         }
     }
     CALI_MARK_END("DaosWriter::daos_pool_connect");
 
     /** share pool handle with peer tasks */
     CALI_MARK_BEGIN("DaosWriter::daos_handle_share_pool");
-    daos_handle_share(&poh, DaosWriter::HANDLE_POOL);
+    {
+        DAOS_OPEN_PHASE("  pool_handle_share(l2g+bcast+g2l+barrier)");
+        daos_handle_share(&poh, DaosWriter::HANDLE_POOL);
+    }
     CALI_MARK_END("DaosWriter::daos_handle_share_pool");
 
     CALI_MARK_BEGIN("DaosWriter::daos_cont_open");
-    if (m_Comm.Rank() == 0)
     {
-        /** open container */
-        rc = daos_cont_open(poh, m_cont_label, DAOS_COO_RW, &coh, NULL, NULL);
-        if (rc)
+        DAOS_OPEN_PHASE("  daos_cont_open(rank0)");
+        if (m_Comm.Rank() == 0)
         {
-            helper::Throw<std::runtime_error>("Engine", "DaosWriter", "InitDAOS",
-                                              "daos_cont_open failed rc=" + std::to_string(rc));
+            /** open container */
+            rc = daos_cont_open(poh, m_cont_label, DAOS_COO_RW, &coh, NULL, NULL);
+            if (rc)
+            {
+                helper::Throw<std::runtime_error>("Engine", "DaosWriter", "InitDAOS",
+                                                  "daos_cont_open failed rc=" + std::to_string(rc));
+            }
         }
     }
     CALI_MARK_END("DaosWriter::daos_cont_open");
 
     /** share container handle with peer tasks */
     CALI_MARK_BEGIN("DaosWriter::daos_handle_share_cont");
-    daos_handle_share(&coh, HANDLE_CO);
+    {
+        DAOS_OPEN_PHASE("  cont_handle_share(l2g+bcast+g2l+barrier)");
+        daos_handle_share(&coh, HANDLE_CO);
+    }
     CALI_MARK_END("DaosWriter::daos_handle_share_cont");
 
-    if (m_Comm.Rank() == 0)
     {
-        switch (metadataLayout)
+        DAOS_OPEN_PHASE("  create+open md object + share");
+        if (m_Comm.Rank() == 0)
         {
-        case MetadataLayout::ARRAY:
-        case MetadataLayout::ARRAY_1MB_ALIGNED:
-            CreateDaosArrayObject();
-            break;
-        case MetadataLayout::KV:
-            CreateDaosKVObject();
-            break;
+            switch (metadataLayout)
+            {
+            case MetadataLayout::ARRAY:
+            case MetadataLayout::ARRAY_1MB_ALIGNED:
+                CreateDaosArrayObject();
+                break;
+            case MetadataLayout::KV:
+                CreateDaosKVObject();
+                break;
+            }
         }
+
+        OpenDaosObjAndShare();
     }
 
-    OpenDaosObjAndShare();
-
-    if (m_Comm.Rank() == 0)
-        WriteObjectIDsToFile();
+    {
+        DAOS_OPEN_PHASE("  WriteObjectIDsToFile(dfuse)");
+        if (m_Comm.Rank() == 0)
+            WriteObjectIDsToFile();
+    }
 }
 
 void DaosWriter::WriteObjectIDsToFile()
@@ -1343,6 +1473,15 @@ void DaosWriter::DoClose(const int transportIndex)
 
     SyncExternalCountersToProfiler();
 
+    // Collaborative teardown.  poh/coh are shared across ranks via
+    // daos_{pool,cont}_global2local (rank 0 owns the real connection/open; the
+    // others hold local copies).  Barrier so no rank releases the shared
+    // handles (daos_cont_close / rank-0 daos_pool_disconnect below) while
+    // another rank is still finishing writes/drains -> DER_NO_HDL(-1002).
+    // The writer's collective EndStep already keeps ranks largely in step, so
+    // this is defensive, matching DaosReader::DoClose.
+    m_Comm.Barrier();
+
     CloseDataArray();
 
     if (m_Comm.Rank() == 0)
@@ -1380,6 +1519,10 @@ void DaosWriter::DoClose(const int transportIndex)
         daos_cont_close(coh, NULL);
         coh = {};
     }
+    // Ensure every rank has released its container handle before rank 0 drops
+    // the shared pool connection (rank-0 disconnect invalidates the pool for
+    // all global2local holders).
+    m_Comm.Barrier();
     if (m_Comm.Rank() == 0 && poh.cookie != 0)
     {
         daos_pool_disconnect(poh, NULL);
@@ -1833,8 +1976,26 @@ void DaosWriter::OpenDataArray()
         }
 
         daos_size_t cell_size = 1;
-        daos_size_t chunk_size =
-            m_Parameters.BufferChunkSize ? m_Parameters.BufferChunkSize : (1ULL << 20);
+        // The DAOS array chunk_size sets the server-side record->dkey
+        // granularity: how this 1-D per-rank array distributes across
+        // targets (the analogue of IOR-DFS --dfs.chunk_size, which uses
+        // 1 MiB).  It is deliberately NOT tied to BufferChunkSize (the much
+        // larger client buffer-allocation granularity): a large array chunk
+        // maps each rank's per-step blob onto only a couple of
+        // dkeys/targets, capping aggregate write bandwidth well below the
+        // fabric/pool ceiling.  Data-phase bandwidth improves monotonically
+        // as this shrinks toward a 1 MiB sweet spot (matching IOR-DFS);
+        // below ~1 MiB it regresses as per-record overhead dominates.
+        // DAOS_ARRAY_CHUNK_BYTES overrides it independently of the
+        // client-side transfer chunking (DAOS_WRITE_CHUNK_BYTES); the
+        // value is stored on the OID (add_attr) so the reader picks it up.
+        daos_size_t chunk_size = 1ULL << 20; // 1 MiB
+        if (const char *e = std::getenv("DAOS_ARRAY_CHUNK_BYTES"))
+        {
+            unsigned long long v = std::strtoull(e, nullptr, 10);
+            if (v > 0)
+                chunk_size = static_cast<daos_size_t>(v);
+        }
         rc = daos_array_create(coh, m_DataArrayOid, DAOS_TX_NONE, cell_size, chunk_size,
                                &m_DataArrayOH, NULL);
         if (rc)

--- a/source/adios2/toolkit/format/buffer/chunk/DaosChunkV.cpp
+++ b/source/adios2/toolkit/format/buffer/chunk/DaosChunkV.cpp
@@ -9,6 +9,7 @@
 #include "adios2/helper/adiosLog.h"
 
 #include <algorithm>
+#include <cstdlib> // getenv, strtoull
 
 namespace adios2
 {
@@ -116,13 +117,12 @@ void DaosChunkV::SubmitRange(size_t firstIdx, size_t lastIdx)
     if (firstIdx > lastIdx || lastIdx >= DataV.size())
         return;
 
-    std::unique_ptr<PendingSubmit> p;
+    // Assemble the contiguous iov set for this range.
+    std::vector<d_iov_t> allIovs;
     daos_size_t total = 0;
     {
         profiling::ProfilerGuard g(m_Profiler, "subSetup");
-        p = std::make_unique<PendingSubmit>();
-        p->iovs.reserve(lastIdx - firstIdx + 1);
-
+        allIovs.reserve(lastIdx - firstIdx + 1);
         for (size_t i = firstIdx; i <= lastIdx; ++i)
         {
             const VecEntry &v = DataV[i];
@@ -133,47 +133,101 @@ void DaosChunkV::SubmitRange(size_t firstIdx, size_t lastIdx)
             iov.iov_buf = const_cast<void *>(base);
             iov.iov_buf_len = v.Size;
             iov.iov_len = v.Size;
-            p->iovs.push_back(iov);
+            allIovs.push_back(iov);
             total += v.Size;
         }
-
-        if (total == 0)
-            return;
-
-        p->range.rg_idx = m_BaseArrayOffset + m_SubmittedHigh;
-        p->range.rg_len = total;
-        p->iod.arr_nr = 1;
-        p->iod.arr_rgs = &p->range;
-        p->sgl.sg_nr = static_cast<uint32_t>(p->iovs.size());
-        p->sgl.sg_nr_out = 0;
-        p->sgl.sg_iovs = p->iovs.data();
     }
+    if (total == 0)
+        return;
 
-    int rc;
+    // Chunk large writes to bound Mercury bulk registration.  A single
+    // daos_array_write of the full pending range (up to BufferChunkSize,
+    // 128 MiB) creates one large bulk transfer; issued concurrently across
+    // ranks against a loaded/degraded pool this stresses Mercury's NA
+    // memory descriptors -- the write-side mirror of the read DER_NOMEM
+    // crash (see DaosReader::ReadData).  Splitting into bounded sub-writes,
+    // each its own async event, keeps every bulk transfer small (the same
+    // strategy IOR-DFS uses via --dfs.chunk_size) and lets earlier events
+    // reap/free before later ones register.  DAOS_WRITE_CHUNK_BYTES=0
+    // restores the single-write mode-B behavior for A/B testing.
+    //
+    // Default 16 MiB: a same-pool A/B sweep (job 8659453, 32r x 256 MiB x 4)
+    // showed the unchunked path at 5.31 GiB/s with 128 DER_HG mercury errors,
+    // vs 10.7-10.8 GiB/s and ZERO errors at 4-16 MiB (2x, and the retries the
+    // errors forced are gone).  1 MiB was past the sweet spot -- ~8K in-flight
+    // events/step reintroduced pressure and it did not complete.  16 MiB sits
+    // at the top of the plateau and matches the read path's default.
+    static const size_t writeChunk = []() -> size_t {
+        if (const char *e = std::getenv("DAOS_WRITE_CHUNK_BYTES"))
+            return static_cast<size_t>(std::strtoull(e, nullptr, 10));
+        return size_t{16} * 1024 * 1024; // 16 MiB default
+    }();
+    const size_t step = (writeChunk == 0) ? static_cast<size_t>(total) : writeChunk;
+
+    const daos_size_t startOff = m_BaseArrayOffset + m_SubmittedHigh;
+    daos_size_t rel = 0; // bytes of this range already assigned to a sub-write
+    size_t i = 0;        // index into allIovs
+    size_t inIovOff = 0; // bytes of allIovs[i] already consumed
+    while (i < allIovs.size())
     {
-        profiling::ProfilerGuard g(m_Profiler, "subEventInit");
-        rc = daos_event_init(&p->event, m_EventQueue, /*parent=*/nullptr);
-    }
-    if (rc)
-    {
-        helper::Throw<std::runtime_error>("Toolkit", "format::DaosChunkV", "SubmitRange",
-                                          "daos_event_init failed rc=" + std::to_string(rc));
-    }
+        std::unique_ptr<PendingSubmit> p;
+        {
+            profiling::ProfilerGuard g(m_Profiler, "subSetup");
+            p = std::make_unique<PendingSubmit>();
+            daos_size_t batchBytes = 0;
+            while (i < allIovs.size() && batchBytes < step)
+            {
+                const size_t avail = allIovs[i].iov_len - inIovOff;
+                const size_t take = std::min(avail, step - static_cast<size_t>(batchBytes));
+                d_iov_t v;
+                v.iov_buf = static_cast<char *>(allIovs[i].iov_buf) + inIovOff;
+                v.iov_buf_len = take;
+                v.iov_len = take;
+                p->iovs.push_back(v);
+                batchBytes += take;
+                inIovOff += take;
+                if (inIovOff == allIovs[i].iov_len)
+                {
+                    ++i;
+                    inIovOff = 0;
+                }
+            }
+            p->range.rg_idx = startOff + rel;
+            p->range.rg_len = batchBytes;
+            p->iod.arr_nr = 1;
+            p->iod.arr_rgs = &p->range;
+            p->sgl.sg_nr = static_cast<uint32_t>(p->iovs.size());
+            p->sgl.sg_nr_out = 0;
+            p->sgl.sg_iovs = p->iovs.data();
+            rel += batchBytes;
+        }
 
-    {
-        profiling::ProfilerGuard g(m_Profiler, "subWriteCall");
-        rc = daos_array_write(m_ArrayHandle, DAOS_TX_NONE, &p->iod, &p->sgl, &p->event);
-    }
-    if (rc)
-    {
-        // The event was initialized but the call failed before queuing;
-        // tear down the event so we don't leak.
-        daos_event_fini(&p->event);
-        helper::Throw<std::runtime_error>("Toolkit", "format::DaosChunkV", "SubmitRange",
-                                          "daos_array_write failed rc=" + std::to_string(rc));
-    }
+        int rc;
+        {
+            profiling::ProfilerGuard g(m_Profiler, "subEventInit");
+            rc = daos_event_init(&p->event, m_EventQueue, /*parent=*/nullptr);
+        }
+        if (rc)
+        {
+            helper::Throw<std::runtime_error>("Toolkit", "format::DaosChunkV", "SubmitRange",
+                                              "daos_event_init failed rc=" + std::to_string(rc));
+        }
 
-    m_Pending.push_back(std::move(p));
+        {
+            profiling::ProfilerGuard g(m_Profiler, "subWriteCall");
+            rc = daos_array_write(m_ArrayHandle, DAOS_TX_NONE, &p->iod, &p->sgl, &p->event);
+        }
+        if (rc)
+        {
+            // The event was initialized but the call failed before queuing;
+            // tear down the event so we don't leak.
+            daos_event_fini(&p->event);
+            helper::Throw<std::runtime_error>("Toolkit", "format::DaosChunkV", "SubmitRange",
+                                              "daos_array_write failed rc=" + std::to_string(rc));
+        }
+
+        m_Pending.push_back(std::move(p));
+    }
     m_SubmittedHigh += total;
 }
 


### PR DESCRIPTION
The DAOS engine's per-rank array data path issued each daos_array_read/daos_array_write as one bulk transfer covering the whole blob. Under real multi-rank concurrency those large transfers overran Mercury's NA memory descriptors — the reader crashed with DER_NOMEM, the writer hit DER_HG and silent RPC retries that halved bandwidth. Both paths now split into bounded sub-transfers at the SGL byte level, each the async path's own event, so earlier registrations reap before later ones register. Reads: 56 → 0 crashes. Writes (DAOS_WRITE_CHUNK_BYTES, default 16 MiB, 0 disables): same-pool A/B at 32 ranks went 5.31 GiB/s / 128 DER_HG → 10.69 GiB/s / 0 errors; 4–16 MiB is a flat error-free plateau.

Separately, Close could race to DER_NO_HDL: ranks share pool/container handles via global2local, and a rank tearing its handles down while a peer still issued I/O against the shared handle lost. A collaborative barrier (reader and writer) before teardown orders the shutdown.

The server-side array chunk_size — daos_array_create's record→dkey granularity, the analogue of IOR-DFS --dfs.chunk_size — had tracked BufferChunkSize (128 MiB), mapping each rank's blob onto only a couple of targets and capping aggregate bandwidth. A same-pool sweep found data-phase bandwidth monotonic as it shrinks to a 1 MiB sweet spot (7.3 → 29.5 GiB/s, past the IOR-DFS reference) and regressing below that as per-record overhead dominates. Default is now a fixed 1 MiB, decoupled from BufferChunkSize and overridable via DAOS_ARRAY_CHUNK_BYTES; it's stored on the OID so the reader follows automatically.

Also adds an env-gated DAOS_TIME_OPEN breakdown of DaosWriter::Init (zero cost when unset).