### PR TITLE
Release MGARD-X cache to free retained GPU memory in the MGARD operator

### DIFF
--- a/source/adios2/operator/compress/CompressMGARD.cpp
+++ b/source/adios2/operator/compress/CompressMGARD.cpp
@@ -180,6 +180,10 @@ size_t CompressMGARD::Operate(const char *dataIn, const Dims &blockStart, const 
     void *compressedData = bufferOut + bufferOutOffset;
     mgard_x::compress(mgardDim, mgardType, mgardCount, tolerance, s, errorBoundType, dataIn,
                       compressedData, sizeOut, config, true);
+    // Release MGARD-X's persistent compressor cache so the GPU device buffers it
+    // retains (compression workspace + staging buffers, sized to the largest block)
+    // are returned rather than held for the lifetime of the process.
+    mgard_x::release_cache(config);
     bufferOutOffset += sizeOut;
     return bufferOutOffset;
 }
@@ -230,6 +234,11 @@ size_t CompressMGARD::DecompressV1(const char *bufferIn, const size_t sizeIn, ch
             helper::Throw<std::runtime_error>("Operator", "CompressMGARD", "DecompressV1",
                                               m_VersionInfo);
         }
+        // Release MGARD-X's persistent cache so the GPU device buffers holding the
+        // decompressed data + workspace are returned. The decompressed data has
+        // already been copied to dataOut (host) before mgard_x::decompress returns,
+        // so freeing the device cache here cannot race the copy.
+        mgard_x::release_cache(mgard_x::Config());
         return sizeOut;
     }
 


### PR DESCRIPTION
The MGARD operator leaves MGARD-X's persistent thread-local CompressorCache allocated after Operate() and DecompressV1() return. That cache pins GPU device memory (compression/decompression workspace plus staging buffers, sized to the largest block processed) for the lifetime of the process. A long-running writer or reader that (de)compresses many blocks therefore holds a large, peak-sized GPU allocation that is never returned, even while idle.

Call mgard_x::release_cache() after each compress and decompress so the device buffers are returned. On decompress the reconstructed data has already been copied to the host output buffer before mgard_x::decompress() returns, so releasing the cache cannot race the copy-back. Verified on an AMD MI250X (HIP backend): peak GPU usage returns to baseline after each call, with no change in reconstruction accuracy and no measurable throughput regression.