### PR TITLE
Reader-defined derived variables (local BP5 path)

### DIFF
--- a/bindings/C/adios2/c/adios2_c_io.cpp
+++ b/bindings/C/adios2/c/adios2_c_io.cpp
@@ -181,6 +181,24 @@ adios2_derived_variable *adios2_define_derived_variable(adios2_io *io, const cha
     }
     return variable;
 }
+
+adios2_error adios2_define_reader_derived_variable(adios2_io *io, const char *name,
+                                                   const char *expression)
+{
+    try
+    {
+        adios2::helper::CheckForNullptr(
+            io, "for adios2_io, in call to adios2_define_reader_derived_variable");
+        adios2::core::IO &ioCpp = *reinterpret_cast<adios2::core::IO *>(io);
+        ioCpp.DefineReaderDerivedVariable(name, expression);
+        return adios2_error_none;
+    }
+    catch (...)
+    {
+        return static_cast<adios2_error>(
+            adios2::helper::ExceptionToError("adios2_define_reader_derived_variable"));
+    }
+}
 #endif
 
 adios2_variable *adios2_define_variable(adios2_io *io, const char *name, const adios2_type type,

--- a/bindings/C/adios2/c/adios2_c_io.h
+++ b/bindings/C/adios2/c/adios2_c_io.h
@@ -136,6 +136,21 @@ adios2_variable *adios2_define_variable(adios2_io *io, const char *name, const a
 adios2_derived_variable *adios2_define_derived_variable(adios2_io *io, const char *name,
                                                         const char *expression,
                                                         const adios2_derived_var_type type);
+
+/**
+ * @brief Define a reader-side derived variable within io: an expression the
+ * reader computes over variables in an opened file, without those variables
+ * having been marked derived at write time. It has no derived-variable type
+ * (the reader always computes, never stores) and no returned handle; it is
+ * resolved lazily against the file's variables, then found via adios2_inquire_
+ * variable. Use on a reading io.
+ * @param io handler that owns the variable
+ * @param name unique variable identifier
+ * @param expression derived expression over file variable names
+ * @return adios2_error 0: success, see enum adios2_error for errors
+ */
+adios2_error adios2_define_reader_derived_variable(adios2_io *io, const char *name,
+                                                   const char *expression);
 #endif
 
 /**

--- a/bindings/CXX/adios2/cxx/IO.cpp
+++ b/bindings/CXX/adios2/cxx/IO.cpp
@@ -191,6 +191,13 @@ VariableDerived IO::DefineDerivedVariable(const std::string &name, const std::st
 
     return VariableDerived(&m_IO->DefineDerivedVariable(name, expression, varType));
 }
+
+void IO::DefineReaderDerivedVariable(const std::string &name, const std::string &expression)
+{
+    helper::CheckForNullptr(m_IO, "for variable name " + name +
+                                      ", in call to IO::DefineReaderDerivedVariable");
+    m_IO->DefineReaderDerivedVariable(name, expression);
+}
 #endif
 StructDefinition IO::DefineStruct(const std::string &name, const size_t size)
 {

--- a/bindings/CXX/adios2/cxx/IO.h
+++ b/bindings/CXX/adios2/cxx/IO.h
@@ -159,6 +159,18 @@ public:
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
     VariableDerived DefineDerivedVariable(const std::string &name, const std::string &expression,
                                           const DerivedVarType varType = DerivedVarType::StatsOnly);
+
+    /**
+     * Define a reader-side derived variable: an expression the reader computes
+     * over variables in a file it opens, without those variables having been
+     * marked derived at write time. Has no DerivedVarType (the reader always
+     * computes). May be called before Open; it is resolved lazily against the
+     * file's variables, and InquireVariable finds it once an engine has resolved
+     * it. Use on a reading IO.
+     * @param name unique identifier, shares the IO namespace with all variables
+     * @param expression derived expression over file variable names
+     */
+    void DefineReaderDerivedVariable(const std::string &name, const std::string &expression);
 #endif
     VariableNT DefineVariable(const DataType type, const std::string &name,
                               const Dims &shape = Dims(), const Dims &start = Dims(),

--- a/bindings/Fortran/f2c/adios2_f2c_io.cpp
+++ b/bindings/Fortran/f2c/adios2_f2c_io.cpp
@@ -218,6 +218,21 @@ void FC_GLOBAL(adios2_define_derived_variable_f2c,
 #endif
 }
 
+void FC_GLOBAL(adios2_define_reader_derived_variable_f2c,
+               ADIOS2_DEFINE_READER_DERIVED_VARIABLE_F2C)(adios2_io **io, const char *name,
+                                                          const char *expression, int *ierr)
+{
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    *ierr = static_cast<int>(adios2_define_reader_derived_variable(*io, name, expression));
+#else
+    std::cout << "ADIOS2 Warning:  adios2_define_reader_derived_variable() is not supported in the "
+                 "current ADIOS2 build. The expression "
+              << expression << " will be ignored and the variable " << name
+              << " will not be produced." << std::endl;
+    *ierr = static_cast<int>(adios2_error_exception);
+#endif
+}
+
 struct cnamelist
 {
     char **names;

--- a/bindings/Fortran/modules/adios2_io_define_derived_variable_mod.f90
+++ b/bindings/Fortran/modules/adios2_io_define_derived_variable_mod.f90
@@ -8,6 +8,7 @@ module adios2_io_define_derived_variable_mod
    implicit none
 
    external adios2_define_derived_variable_f2c
+   external adios2_define_reader_derived_variable_f2c
 
 contains
 
@@ -28,6 +29,20 @@ contains
          variable%name = name
          variable%type = adios2_derived_var_type
       end if
+
+   end subroutine
+
+   ! Reader-side derived variable: the reader computes the expression over
+   ! variables in an opened file. No derived-var type and no returned handle
+   ! (resolved lazily; find it afterwards with adios2_inquire_variable).
+   subroutine adios2_define_reader_derived_variable(io, name, expression, ierr)
+      type(adios2_io), intent(in) :: io
+      character*(*), intent(in) :: name
+      character*(*), intent(in) :: expression
+      integer, intent(out) :: ierr
+
+      call adios2_define_reader_derived_variable_f2c(io%f2c, &
+         TRIM(ADJUSTL(name))//char(0), TRIM(ADJUSTL(expression))//char(0), ierr)
 
    end subroutine
 

--- a/bindings/Python/nbGlue.cpp
+++ b/bindings/Python/nbGlue.cpp
@@ -237,6 +237,9 @@ NB_MODULE(ADIOS2_PYTHON_MODULE_NAME, m)
              nb::arg("name"), nb::arg("expression"),
              nb::arg("vartype") = adios2::DerivedVarType::StatsOnly)
 
+        .def("DefineReaderDerivedVariable", &adios2::py11::IO::DefineReaderDerivedVariable,
+             nb::arg("name"), nb::arg("expression"))
+
         .def("InquireVariable", &adios2::py11::IO::InquireVariable)
 
         .def("InquireAttribute",

--- a/bindings/Python/nbIO.cpp
+++ b/bindings/Python/nbIO.cpp
@@ -161,6 +161,19 @@ VariableDerived IO::DefineDerivedVariable(const std::string &name, const std::st
     return vd;
 }
 
+void IO::DefineReaderDerivedVariable(const std::string &name, const std::string &expression)
+{
+    helper::CheckForNullptr(m_IO, "for variable " + name +
+                                      ", in call to IO::DefineReaderDerivedVariable");
+
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    m_IO->DefineReaderDerivedVariable(name, expression);
+#else
+    throw std::invalid_argument("ERROR: Derived Variables are not supported in this adios2 build "
+                                ", in call to DefineReaderDerivedVariable\n");
+#endif
+}
+
 Variable IO::InquireVariable(const std::string &name)
 {
     helper::CheckForNullptr(m_IO, "for variable " + name + ", in call to IO::InquireVariable");

--- a/bindings/Python/nbIO.h
+++ b/bindings/Python/nbIO.h
@@ -64,6 +64,8 @@ public:
     VariableDerived DefineDerivedVariable(const std::string &name, const std::string &expression,
                                           const DerivedVarType varType = DerivedVarType::StatsOnly);
 
+    void DefineReaderDerivedVariable(const std::string &name, const std::string &expression);
+
     Variable InquireVariable(const std::string &name);
 
     Attribute DefineAttribute(const std::string &name, const nb::ndarray<nb::numpy> &array,

--- a/docs/user_guide/source/ecosystem/utilities/bpls.rst
+++ b/docs/user_guide/source/ecosystem/utilities/bpls.rst
@@ -174,7 +174,19 @@ Here is the description of the most used options
 
 .. note::
 
-  HDF5 files can also be dumped with bpls if ADIOS was built with HDF5 support. Note that the HDF5 files do not contain min/max information for the arrays and therefore bpls always prints 0 for them:
+  The min/max column requires statistics stored in the file. A BP file written with statistics disabled has no min/max to report, and bpls prints ``N/A / N/A`` for those variables:
+
+
+  .. code-block:: bash
+
+    $ bpls -l nostats.bp
+      double   T     3*{15, 16} = N/A / N/A
+      double   dT    3*{15, 16} = N/A / N/A
+
+
+.. note::
+
+  HDF5 files can also be dumped with bpls if ADIOS was built with HDF5 support. HDF5 files do not carry array min/max information, so bpls prints 0 for them:
 
 
   .. code-block:: bash

--- a/docs/user_guide/source/introduction/whatsnew.rst
+++ b/docs/user_guide/source/introduction/whatsnew.rst
@@ -61,6 +61,22 @@ environment-variable fallback. On Slingshot, the required OFI auth key is
 supplied automatically from ``SLINGSHOT_VNIS``. See the SST engine
 documentation for details.
 
+Reader-defined derived variables
+--------------------------------
+
+A read IO can now define a derived expression over a file's variables that were
+never marked derived at write time: ``IO::DefineReaderDerivedVariable(name,
+expression)``, then ``InquireVariable``/``Get`` after Open. The reader computes
+it from the file data. BP5 only; inputs must be same-shaped global arrays.
+C++, C, Fortran, Python.
+
+Missing min/max reported as N/A
+-------------------------------
+
+Variables stored without statistics (``StatsLevel=0``) now report an unset
+range (``Min() > Max()``) instead of a misleading ``0/0``; ``bpls`` prints
+``N/A``.
+
 
 ======================
 What's new in v2.12?

--- a/source/adios2/common/ADIOSTypes.cpp
+++ b/source/adios2/common/ADIOSTypes.cpp
@@ -324,6 +324,41 @@ void MinMaxStruct::Init(DataType Type)
     }
 }
 
+bool MinMaxStruct::IsUnset(DataType Type) const
+{
+    // Unset == the inverted range Init() leaves (min > max). Test the typed
+    // field, not memcmp: the union's long double padding isn't reliably set.
+    switch (Type)
+    {
+    case DataType::Int8:
+        return MinUnion.field_int8 > MaxUnion.field_int8;
+    case DataType::Int16:
+        return MinUnion.field_int16 > MaxUnion.field_int16;
+    case DataType::Int32:
+        return MinUnion.field_int32 > MaxUnion.field_int32;
+    case DataType::Int64:
+        return MinUnion.field_int64 > MaxUnion.field_int64;
+    case DataType::Char:
+    case DataType::UInt8:
+        return MinUnion.field_uint8 > MaxUnion.field_uint8;
+    case DataType::UInt16:
+        return MinUnion.field_uint16 > MaxUnion.field_uint16;
+    case DataType::UInt32:
+        return MinUnion.field_uint32 > MaxUnion.field_uint32;
+    case DataType::UInt64:
+        return MinUnion.field_uint64 > MaxUnion.field_uint64;
+    case DataType::Float:
+        return MinUnion.field_float > MaxUnion.field_float;
+    case DataType::Double:
+        return MinUnion.field_double > MaxUnion.field_double;
+    case DataType::LongDouble:
+        return MinUnion.field_ldouble > MaxUnion.field_ldouble;
+    default:
+        // Types without a min/max (complex, string, struct, none).
+        return false;
+    }
+}
+
 void MinMaxStruct::Dump(DataType Type)
 {
     switch (Type)

--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -186,6 +186,9 @@ struct MinMaxStruct
     union PrimitiveStdtypeUnion MaxUnion;
     void Init(DataType Type);
     void Dump(DataType Type);
+    /** True if this holds the unset range Init() produces (min > max), meaning
+     *  the variable carried no statistics. Callers should render it as N/A. */
+    bool IsUnset(DataType Type) const;
 };
 struct MinBlockInfo
 {

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -1054,6 +1054,146 @@ VariableDerived &IO::DefineDerivedVariable(const std::string &name, const std::s
     }
     return variable;
 }
+
+void IO::DefineReaderDerivedVariable(const std::string &name, const std::string &expression)
+{
+    PERFSTUBS_SCOPED_TIMER("IO::DefineReaderDerivedVariable");
+
+    // Name shares the IO namespace with every variable. Reject the collisions we
+    // can see now; a clash with a file variable not yet installed is caught at
+    // resolve time, when creating the placeholder throws on the duplicate name.
+    if (m_ReaderDerivedVariables.find(name) != m_ReaderDerivedVariables.end() ||
+        m_VariablesDerived.find(name) != m_VariablesDerived.end() ||
+        m_Variables.find(name) != m_Variables.end())
+    {
+        helper::Throw<std::invalid_argument>("Core", "IO", "DefineReaderDerivedVariable",
+                                             "variable " + name + " already defined in IO " +
+                                                 m_Name);
+    }
+
+    // Parse now so syntax errors surface at define time. Input variables are not
+    // resolved here: on a read IO the file's variables need not exist until Open.
+    derived::ExprNode exprTree = detail::ParseToExprNode(expression);
+
+    ReaderDerivedVariable rec;
+    rec.Expression = expression;
+    rec.ExprTree = std::move(exprTree);
+    m_ReaderDerivedVariables.emplace(name, std::move(rec));
+}
+
+std::vector<std::string> IO::GetUnresolvedReaderDerivedVariables() const
+{
+    std::vector<std::string> names;
+    for (const auto &pair : m_ReaderDerivedVariables)
+    {
+        if (!pair.second.Variable)
+        {
+            names.push_back(pair.first);
+        }
+    }
+    return names;
+}
+
+VariableDerived *IO::ResolveReaderDerivedVariable(const std::string &name)
+{
+    PERFSTUBS_SCOPED_TIMER("IO::ResolveReaderDerivedVariable");
+
+    auto it = m_ReaderDerivedVariables.find(name);
+    if (it == m_ReaderDerivedVariables.end())
+    {
+        return nullptr;
+    }
+    ReaderDerivedVariable &rec = it->second;
+    if (rec.Variable)
+    {
+        return rec.Variable.get(); // already resolved
+    }
+
+    // The name shares the IO namespace. A clash with a file variable could not be
+    // seen at define time (before Open); reject it clearly here rather than let
+    // the placeholder creation fail deep in the engine. rec.Variable is null, so
+    // the placeholder does not yet exist and any match is a foreign variable.
+    if (m_Variables.find(name) != m_Variables.end())
+    {
+        helper::Throw<std::invalid_argument>(
+            "Core", "IO", "ResolveReaderDerivedVariable",
+            "reader derived variable " + name +
+                " collides with a variable of the same name in the opened file");
+    }
+
+    // Bind inputs against the file's variables. If any input is not yet
+    // installed (e.g. a step that has not written it), stay pending and let a
+    // later step resolve. Check before ResolveTreeTypes, which annotates the
+    // tree in place and needs every input type.
+    std::vector<std::string> var_list = derived::VariableNameList(rec.ExprTree);
+    if (var_list.empty())
+    {
+        // A reader-side derived variable must read something from the file; an
+        // expression over no variables (e.g. all constants) has nothing to
+        // resolve against and no block structure to inherit.
+        helper::Throw<std::invalid_argument>("Core", "IO", "ResolveReaderDerivedVariable",
+                                             "reader derived variable " + name +
+                                                 " must reference at least one file variable");
+    }
+    std::map<std::string, DataType> name_to_type;
+    std::map<std::string, std::tuple<Dims, Dims, Dims>> name_to_dims;
+    for (const auto &var_name : var_list)
+    {
+        auto itVariable = m_Variables.find(var_name);
+        if (itVariable == m_Variables.end())
+        {
+            return nullptr; // input not present yet
+        }
+        name_to_type.insert({var_name, InquireVariableType(var_name)});
+        name_to_dims.insert({var_name,
+                             {itVariable->second->m_Start, itVariable->second->m_Count,
+                              itVariable->second->m_Shape}});
+    }
+
+    // Require input congruence. The reader-side read path takes the derived
+    // variable's block structure from its first input, so every input must share
+    // the same global shape (differing per-rank start/count is fine). This is the
+    // reader-side contract; shape-changing or broadcasting expressions are not
+    // supported on read.
+    const Dims &refShape = std::get<2>(name_to_dims.at(var_list.front()));
+    for (const auto &var_name : var_list)
+    {
+        if (std::get<2>(name_to_dims.at(var_name)) != refShape)
+        {
+            helper::Throw<std::invalid_argument>(
+                "Core", "IO", "ResolveReaderDerivedVariable",
+                "reader derived variable " + name + " requires congruent inputs, but " + var_name +
+                    " and " + var_list.front() + " have different shapes");
+        }
+    }
+
+    // Work on a copy so the stored tree stays pristine: ResolveTreeTypes mutates
+    // it in place, and a re-Open on the same IO must be able to resolve again.
+    derived::ExprNode exprTree = rec.ExprTree;
+    derived::ResolveTreeTypes(exprTree, name_to_type);
+    derived::ExprCodeStream codeStream = derived::GenerateCode(exprTree);
+    codeStream.ExprString = rec.Expression;
+    derived::SemanticsPass(codeStream, name_to_type);
+    derived::PlanBuffers(codeStream);
+    DataType expressionType = codeStream.OutputType;
+    auto outDims = derived::GetDims(codeStream, name_to_dims);
+
+    // varType is inert on the read side (the reader always computes, never
+    // stores); StatsOnly is the neutral value.
+    rec.Variable = std::unique_ptr<VariableDerived>(
+        new VariableDerived(name, std::move(exprTree), std::move(codeStream), rec.Expression,
+                            expressionType, std::get<2>(outDims), std::get<0>(outDims),
+                            std::get<1>(outDims), false, DerivedVarType::StatsOnly, name_to_type));
+    return rec.Variable.get();
+}
+
+void IO::ResetReaderDerivedResolutions() noexcept
+{
+    for (auto &pair : m_ReaderDerivedVariables)
+    {
+        pair.second.Variable.reset();
+    }
+}
 #endif
 
 StructDefinition &IO::DefineStruct(const std::string &name, const size_t size)

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -992,6 +992,14 @@ VariableDerived &IO::DefineDerivedVariable(const std::string &name, const std::s
         }
     }
 
+    if (m_ReaderDerivedVariables.find(name) != m_ReaderDerivedVariables.end())
+    {
+        helper::Throw<std::invalid_argument>("Core", "IO", "DefineDerivedVariable",
+                                             "derived variable " + name +
+                                                 " collides with a reader-derived variable in IO " +
+                                                 m_Name);
+    }
+
     // Parse expression string into ExprNode tree
     derived::ExprNode exprTree = detail::ParseToExprNode(exp_string);
     std::vector<std::string> var_list = derived::VariableNameList(exprTree);
@@ -1143,6 +1151,13 @@ VariableDerived *IO::ResolveReaderDerivedVariable(const std::string &name)
         if (itVariable == m_Variables.end())
         {
             return nullptr; // input not present yet
+        }
+        if (itVariable->second->m_ShapeID == ShapeID::LocalArray)
+        {
+            helper::Throw<std::invalid_argument>(
+                "Core", "IO", "ResolveReaderDerivedVariable",
+                "reader derived variable " + name + " input " + var_name +
+                    " is a local array; reader-side derived variables require global arrays");
         }
         name_to_type.insert({var_name, InquireVariableType(var_name)});
         name_to_dims.insert({var_name,

--- a/source/adios2/core/IO.h
+++ b/source/adios2/core/IO.h
@@ -183,6 +183,49 @@ public:
     VariableDerived &
     DefineDerivedVariable(const std::string &name, const std::string &expression,
                           const DerivedVarType varType = DerivedVarType::StatsOnly);
+
+    /**
+     * @brief Define a reader-side derived variable: an expression the reader
+     * supplies over variables present in a file it opens, without those
+     * variables having been marked derived at write time. The reader's own
+     * process computes the result on Get.
+     *
+     * Unlike DefineDerivedVariable (a writer-side concept), this has no
+     * DerivedVarType: the reader always computes, never stores. The expression
+     * is parsed here (syntax errors throw now) but resolved lazily against the
+     * file's variables the first time an opened engine can satisfy it, so it may
+     * be defined before Open. Kept separate from the writer-side derived
+     * registry so a write engine sharing this IO never sees it.
+     * @param name unique identifier, shares the IO namespace with all variables
+     * @param expression derived expression over file variable names
+     * @exception std::invalid_argument if the name is already in use or the
+     * expression fails to parse
+     */
+    void DefineReaderDerivedVariable(const std::string &name, const std::string &expression);
+
+    /** @brief Whether any reader-side derived variable is defined on this IO.
+     * Cheap guard for the engine's per-step resolution pass. */
+    bool HasReaderDerivedVariables() const noexcept { return !m_ReaderDerivedVariables.empty(); }
+
+    /**
+     * @brief Names of reader-side derived variables not yet resolved. Used by the
+     * engine to drive lazy resolution once the file's variables are installed.
+     */
+    std::vector<std::string> GetUnresolvedReaderDerivedVariables() const;
+
+    /**
+     * @brief Resolve a reader-side derived variable against the currently
+     * installed file variables: bind input types and dims, run the derived
+     * pipeline, and build its VariableDerived. Idempotent. Returns the resolved
+     * object, or nullptr if it is unknown or an input is not yet installed (in
+     * which case it stays pending and can be resolved on a later step).
+     */
+    VariableDerived *ResolveReaderDerivedVariable(const std::string &name);
+
+    /** @brief Drop the resolved state of every reader-side derived variable,
+     * keeping the definitions. Called on engine close so a later Open on this IO
+     * re-resolves against the new file. */
+    void ResetReaderDerivedResolutions() noexcept;
 #endif
     VariableStruct &DefineStructVariable(const std::string &name, StructDefinition &def,
                                          const Dims &shape = Dims(), const Dims &start = Dims(),
@@ -552,6 +595,18 @@ private:
     VarMap m_Variables;
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
     VarMap m_VariablesDerived;
+
+    /** A reader-side derived variable, before and after lazy resolution.
+     *  Parsed at define time; Variable stays null until an opened engine
+     *  resolves the expression against the file's variables. Segregated from
+     *  m_VariablesDerived so a write engine sharing this IO never picks it up. */
+    struct ReaderDerivedVariable
+    {
+        std::string Expression;
+        adios2::derived::ExprNode ExprTree;
+        std::unique_ptr<VariableDerived> Variable; // null until resolved
+    };
+    std::unordered_map<std::string, ReaderDerivedVariable> m_ReaderDerivedVariables;
 #endif
 
     AttrMap m_Attributes;

--- a/source/adios2/core/Variable.h
+++ b/source/adios2/core/Variable.h
@@ -117,6 +117,11 @@ public:
      */
     size_t SelectionSize(const Selection &selection) const;
 
+    /**
+     * Min/max from statistics stored in the file. If the file has no statistics
+     * for this variable, the range is unset (min > max); test for that to
+     * distinguish it from real data.
+     */
     std::pair<T, T> MinMax(const size_t step = adios2::DefaultSizeT) const;
 
     T Min(const size_t step = adios2::DefaultSizeT) const;

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -272,13 +272,25 @@ void BP5Deserializer::BreakdownArrayName(const char *Name, char **base_name_p, D
 BP5Deserializer::BP5VarRec *BP5Deserializer::LookupVarByKey(void *Key) const
 {
     auto ret = VarByKey.find(Key);
-    if (ret == VarByKey.end())
+    if (ret != VarByKey.end())
     {
-        helper::Throw<std::runtime_error>(
-            "Toolkit", "format::BP5Deserializer", "LookupVarByKey",
-            "Attempt to lookup variable unknown to BP5 reader engine.  Possible logic error?");
+        return ret->second;
     }
-    return ret->second;
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    // A reader-derived placeholder is not in VarByKey. Its structural queries
+    // (shape, blocks, steps) mirror its congruent input, so answer from that
+    // input's VarRec, which carries the per-step bookkeeping. Get instead uses
+    // m_ReaderDerivedByVar directly to reach the derived VarRec.
+    auto rd = m_ReaderDerivedByVar.find(Key);
+    if (rd != m_ReaderDerivedByVar.end())
+    {
+        return rd->second->ReaderDerivedStructInput;
+    }
+#endif
+    helper::Throw<std::runtime_error>(
+        "Toolkit", "format::BP5Deserializer", "LookupVarByKey",
+        "Attempt to lookup variable unknown to BP5 reader engine.  Possible logic error?");
+    return nullptr;
 }
 
 BP5Deserializer::BP5VarRec *BP5Deserializer::LookupVarByName(const char *Name)
@@ -586,7 +598,7 @@ void *BP5Deserializer::VarSetup(core::Engine *engine, const char *variableName, 
 void *BP5Deserializer::ArrayVarSetup(core::Engine *engine, const char *variableName,
                                      const DataType type, int DimCount, size_t *Shape,
                                      size_t *Start, size_t *Count, core::StructDefinition *Def,
-                                     core::StructDefinition *ReaderDef)
+                                     core::StructDefinition *ReaderDef, bool registerCreated)
 {
     std::vector<size_t> VecShape;
     std::vector<size_t> VecStart;
@@ -619,7 +631,8 @@ void *BP5Deserializer::ArrayVarSetup(core::Engine *engine, const char *variableN
     {
         core::VariableStruct *variable =
             &(engine->m_IO.DefineStructVariable(variableName, *Def, VecShape, VecStart, VecCount));
-        engine->RegisterCreatedVariable(variable);
+        if (registerCreated)
+            engine->RegisterCreatedVariable(variable);
         variable->m_ReadStructDefinition = ReaderDef;
         return (void *)variable;
     }
@@ -627,7 +640,8 @@ void *BP5Deserializer::ArrayVarSetup(core::Engine *engine, const char *variableN
     else if (Type == helper::GetDataType<T>())                                                     \
     {                                                                                              \
         core::Variable<T> *variable = &(engine->m_IO.DefineVariable<T>(variableName));             \
-        engine->RegisterCreatedVariable(variable);                                                 \
+        if (registerCreated)                                                                       \
+            engine->RegisterCreatedVariable(variable);                                             \
         variable->m_Shape = VecShape;                                                              \
         variable->m_Start = VecStart;                                                              \
         variable->m_Count = VecCount;                                                              \
@@ -642,6 +656,69 @@ void *BP5Deserializer::ArrayVarSetup(core::Engine *engine, const char *variableN
 #undef declare_type
     return (void *)NULL;
 };
+
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+void BP5Deserializer::InstallReaderDerivedVariables(size_t Step)
+{
+    core::IO &io = m_Engine->m_IO;
+    if (!io.HasReaderDerivedVariables())
+    {
+        return; // common case: nothing to do, no allocation
+    }
+    for (const auto &name : io.GetUnresolvedReaderDerivedVariables())
+    {
+        core::VariableDerived *derived = io.ResolveReaderDerivedVariable(name);
+        if (!derived)
+        {
+            // An input variable is not yet installed; leave it pending and let a
+            // later writer rank or step resolve it.
+            continue;
+        }
+        // Build a persistent placeholder the user can InquireVariable and Get.
+        // registerCreated=false keeps it off the engine's created-variable list
+        // (so per-step teardown does not remove it), and it is deliberately not
+        // added to VarByKey (which SetupForStep sweeps). Get routing goes through
+        // m_ReaderDerivedByVar instead.
+        void *variable =
+            ArrayVarSetup(m_Engine, name.c_str(), derived->m_Type, (int)derived->m_Shape.size(),
+                          derived->m_Shape.data(), derived->m_Start.data(), derived->m_Count.data(),
+                          nullptr, nullptr, false /* registerCreated */);
+        static_cast<core::VariableBase *>(variable)->m_Engine = m_Engine;
+
+        // Synthesize a VarRec so Get can reuse the writer-derived read machinery.
+        // It carries no file metadata; its block structure comes from a congruent
+        // input variable (ReaderDerivedStructInput), and it is kept out of
+        // VarByName/VarByKey so no teardown touches it. Freed in the destructor.
+        BP5VarRec *vr = new BP5VarRec();
+        vr->VarName = strdup(name.c_str());
+        vr->Variable = variable;
+        vr->DerivedVariable = (void *)derived;
+        vr->Derived = true;
+        vr->ReaderDerived = true;
+        vr->Type = derived->m_Type;
+        vr->ElementSize = (int)helper::GetDataTypeSize(derived->m_Type);
+        vr->DimCount = derived->m_Shape.size();
+        vr->OrigShapeID = ShapeID::GlobalArray;
+        // Congruence is required, so any input's block layout works; use the first.
+        vr->ReaderDerivedStructInput = LookupVarByName(derived->VariableNameList()[0].c_str());
+        m_ReaderDerivedByVar[variable] = vr;
+    }
+
+    // A reader-derived placeholder is not in the VarByKey loop that grows the
+    // available-step count per step, so mirror its structure input's count here
+    // (the input was updated earlier in this same InstallMetadataBuffer pass).
+    for (auto &pair : m_ReaderDerivedByVar)
+    {
+        BP5VarRec *vr = pair.second;
+        auto *placeholder = static_cast<core::VariableBase *>(vr->Variable);
+        auto *inputVar = static_cast<core::VariableBase *>(vr->ReaderDerivedStructInput->Variable);
+        if (inputVar)
+        {
+            placeholder->m_AvailableStepsCount = inputVar->m_AvailableStepsCount;
+        }
+    }
+}
+#endif
 
 void BP5Deserializer::SetupForStep(size_t Step, size_t WriterCount)
 {
@@ -1054,6 +1131,12 @@ void BP5Deserializer::InstallMetadataBuffer(void *BaseData, size_t WriterRank, s
             }
         }
     }
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    // The file's variables for this rank are now installed; try to resolve any
+    // reader-side derived variables whose inputs have become available. Cheap and
+    // idempotent: the unresolved set is empty once none remain (the common case).
+    InstallReaderDerivedVariables(Step);
+#endif
 }
 
 void BP5Deserializer::InstallAttributeData(void *AttributeBlock, size_t BlockLen, size_t Step)
@@ -1385,7 +1468,23 @@ bool BP5Deserializer::QueueGetSingle(BP5GetContext &ctx, core::VariableBase &var
                                      void *DestData, size_t AbsStep, size_t RelStep,
                                      const core::Selection &selection)
 {
-    BP5VarRec *VarRec = VarByKey[&variable];
+    // Use find, not operator[]: a reader-derived placeholder is not in VarByKey,
+    // and inserting a NULL entry would crash the teardown loop that dereferences
+    // it. Fall back to the reader-derived routing map on a miss.
+    BP5VarRec *VarRec = nullptr;
+    {
+        auto vk = VarByKey.find(&variable);
+        if (vk != VarByKey.end())
+            VarRec = vk->second;
+    }
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    if (!VarRec)
+    {
+        auto it = m_ReaderDerivedByVar.find(&variable);
+        if (it != m_ReaderDerivedByVar.end())
+            VarRec = it->second;
+    }
+#endif
     if (variable.m_Type == adios2::DataType::Struct)
     {
         StructQueueReadChecks(dynamic_cast<core::VariableStruct *>(&variable), VarRec);
@@ -1496,7 +1595,7 @@ bool BP5Deserializer::QueueGetSingle(BP5GetContext &ctx, core::VariableBase &var
              (variable.m_ShapeID == ShapeID::LocalArray))
     {
         BP5ArrayRequest Req;
-        Req.VarRec = VarByKey[&variable];
+        Req.VarRec = VarRec;
         Req.VarName = (char *)variable.m_Name.c_str();
         Req.RequestType = Local;
         Req.BlockID = hasBlock ? blockID : 0;
@@ -1630,7 +1729,11 @@ bool BP5Deserializer::QueueGet(BP5GetContext &ctx, core::VariableBase &variable,
     }
     else
     {
-        BP5VarRec *VarRec = VarByKey[&variable];
+        // LookupVarByKey (not operator[]) so a reader-derived placeholder resolves
+        // to its structure-input VarRec for step iteration, and an unknown key
+        // throws instead of inserting a NULL. QueueGetSingle re-resolves the
+        // placeholder to its synthetic derived VarRec.
+        BP5VarRec *VarRec = LookupVarByKey((void *)&variable);
         bool ret = false;
         if (variable.m_Type == adios2::DataType::Struct)
         {
@@ -1802,9 +1905,13 @@ BP5Deserializer::GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTemp
             if (VarRec->Derived)
             {
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
-                auto &derivedMap = m_Engine->m_IO.GetDerivedVariables();
-                auto derivedVar =
-                    static_cast<VariableDerived *>(derivedMap.at(VarRec->VarName).get());
+                // Reader-side derived variables keep their VariableDerived on the
+                // synthetic VarRec; writer-defined ones live in the IO registry.
+                VariableDerived *derivedVar =
+                    VarRec->ReaderDerived
+                        ? static_cast<VariableDerived *>(VarRec->DerivedVariable)
+                        : static_cast<VariableDerived *>(
+                              m_Engine->m_IO.GetDerivedVariables().at(VarRec->VarName).get());
                 derivedVarInputNameList = derivedVar->VariableNameList();
                 nameToVarInfo = new std::map<std::string, std::unique_ptr<MinVarInfo>>();
                 Req->DerivedInputMap = nameToVarInfo;
@@ -2548,8 +2655,11 @@ void BP5Deserializer::FinalizeDerivedGets(BP5GetContext &ctx, std::vector<ReadRe
         auto VarRec = (struct BP5VarRec *)Req.VarRec;
         if (!VarRec->Derived)
             continue;
-        auto &derivedMap = m_Engine->m_IO.GetDerivedVariables();
-        auto derivedVar = static_cast<VariableDerived *>(derivedMap.at(VarRec->VarName).get());
+        VariableDerived *derivedVar =
+            VarRec->ReaderDerived
+                ? static_cast<VariableDerived *>(VarRec->DerivedVariable)
+                : static_cast<VariableDerived *>(
+                      m_Engine->m_IO.GetDerivedVariables().at(VarRec->VarName).get());
 
         auto nameToVarInfo = Req.DerivedInputMap;
         bool needsHalo = adios2::derived::HasHalo(derivedVar->m_CodeStream);
@@ -2763,6 +2873,21 @@ BP5Deserializer::~BP5Deserializer()
             delete VarRec.second->Def;
         delete VarRec.second;
     }
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    // Reader-side derived placeholders are IO-owned (not in VarByName), so free
+    // their synthetic VarRecs here and remove the placeholders from the IO. The
+    // expression definitions persist on the IO; reset their resolution so a later
+    // Open on the same IO re-resolves against the new file.
+    for (auto &pair : m_ReaderDerivedByVar)
+    {
+        BP5VarRec *vr = pair.second;
+        m_Engine->m_IO.RemoveVariable(vr->VarName);
+        free(vr->VarName);
+        delete vr;
+    }
+    m_ReaderDerivedByVar.clear();
+    m_Engine->m_IO.ResetReaderDerivedResolutions();
+#endif
     if (m_FreeableMBA)
     {
         delete m_FreeableMBA;
@@ -2785,6 +2910,14 @@ BP5Deserializer::~BP5Deserializer()
 
 void *BP5Deserializer::GetMetadataBase(BP5VarRec *VarRec, size_t Step, size_t WriterRank) const
 {
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    if (VarRec->ReaderDerived)
+    {
+        // A reader-side derived variable has no file metadata of its own; its
+        // block structure is that of its (congruent) input variables.
+        return GetMetadataBase(VarRec->ReaderDerivedStructInput, Step, WriterRank);
+    }
+#endif
     MetaArrayRec *writer_meta_base = NULL;
     if (m_RandomAccessMode)
     {
@@ -3270,6 +3403,22 @@ bool BP5Deserializer::VarShape(const VariableBase &Var, const size_t RelStep, Di
 bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
                                      MinMaxStruct &MinMax)
 {
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    // Reader-side derived variables carry no precomputed statistics: nothing was
+    // computed at write time, and the LookupVarByKey redirect would otherwise
+    // return an input variable's min/max. Report an explicitly invalid range
+    // (Init sets min = TYPE_MAX, max = TYPE_MIN, which no real data can produce;
+    // zeroed would be ambiguous with all-zero data). Return true so
+    // Variable::DoMinMax does not fall back to scanning the input's block stats.
+    {
+        auto rd = m_ReaderDerivedByVar.find(&Var);
+        if (rd != m_ReaderDerivedByVar.end())
+        {
+            MinMax.Init(rd->second->Type);
+            return true;
+        }
+    }
+#endif
     BP5VarRec *VarRec = LookupVarByKey((void *)&Var);
     if (!TypeHasMinMax(VarRec->Type))
     {
@@ -3284,7 +3433,10 @@ bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
     {
         if (VarRec->MinMaxOffset == SIZE_MAX)
         {
-            std::memset(&MinMax, 0, sizeof(struct MinMaxStruct));
+            // No min/max was stored for this variable. Report an explicitly
+            // invalid range (min > max) rather than zeroed, which would be
+            // ambiguous with genuinely all-zero data.
+            MinMax.Init(VarRec->Type);
             return true;
         }
     }

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -272,13 +272,25 @@ void BP5Deserializer::BreakdownArrayName(const char *Name, char **base_name_p, D
 BP5Deserializer::BP5VarRec *BP5Deserializer::LookupVarByKey(void *Key) const
 {
     auto ret = VarByKey.find(Key);
-    if (ret == VarByKey.end())
+    if (ret != VarByKey.end())
     {
-        helper::Throw<std::runtime_error>(
-            "Toolkit", "format::BP5Deserializer", "LookupVarByKey",
-            "Attempt to lookup variable unknown to BP5 reader engine.  Possible logic error?");
+        return ret->second;
     }
-    return ret->second;
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    // A reader-derived placeholder is not in VarByKey. Its structural queries
+    // (shape, blocks, steps) mirror its congruent input, so answer from that
+    // input's VarRec, which carries the per-step bookkeeping. Get instead uses
+    // m_ReaderDerivedByVar directly to reach the derived VarRec.
+    auto rd = m_ReaderDerivedByVar.find(Key);
+    if (rd != m_ReaderDerivedByVar.end())
+    {
+        return rd->second->ReaderDerivedStructInput;
+    }
+#endif
+    helper::Throw<std::runtime_error>(
+        "Toolkit", "format::BP5Deserializer", "LookupVarByKey",
+        "Attempt to lookup variable unknown to BP5 reader engine.  Possible logic error?");
+    return nullptr;
 }
 
 BP5Deserializer::BP5VarRec *BP5Deserializer::LookupVarByName(const char *Name)
@@ -586,7 +598,7 @@ void *BP5Deserializer::VarSetup(core::Engine *engine, const char *variableName, 
 void *BP5Deserializer::ArrayVarSetup(core::Engine *engine, const char *variableName,
                                      const DataType type, int DimCount, size_t *Shape,
                                      size_t *Start, size_t *Count, core::StructDefinition *Def,
-                                     core::StructDefinition *ReaderDef)
+                                     core::StructDefinition *ReaderDef, bool registerCreated)
 {
     std::vector<size_t> VecShape;
     std::vector<size_t> VecStart;
@@ -619,7 +631,8 @@ void *BP5Deserializer::ArrayVarSetup(core::Engine *engine, const char *variableN
     {
         core::VariableStruct *variable =
             &(engine->m_IO.DefineStructVariable(variableName, *Def, VecShape, VecStart, VecCount));
-        engine->RegisterCreatedVariable(variable);
+        if (registerCreated)
+            engine->RegisterCreatedVariable(variable);
         variable->m_ReadStructDefinition = ReaderDef;
         return (void *)variable;
     }
@@ -627,7 +640,8 @@ void *BP5Deserializer::ArrayVarSetup(core::Engine *engine, const char *variableN
     else if (Type == helper::GetDataType<T>())                                                     \
     {                                                                                              \
         core::Variable<T> *variable = &(engine->m_IO.DefineVariable<T>(variableName));             \
-        engine->RegisterCreatedVariable(variable);                                                 \
+        if (registerCreated)                                                                       \
+            engine->RegisterCreatedVariable(variable);                                             \
         variable->m_Shape = VecShape;                                                              \
         variable->m_Start = VecStart;                                                              \
         variable->m_Count = VecCount;                                                              \
@@ -642,6 +656,69 @@ void *BP5Deserializer::ArrayVarSetup(core::Engine *engine, const char *variableN
 #undef declare_type
     return (void *)NULL;
 };
+
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+void BP5Deserializer::InstallReaderDerivedVariables(size_t Step)
+{
+    core::IO &io = m_Engine->m_IO;
+    if (!io.HasReaderDerivedVariables())
+    {
+        return; // common case: nothing to do, no allocation
+    }
+    for (const auto &name : io.GetUnresolvedReaderDerivedVariables())
+    {
+        core::VariableDerived *derived = io.ResolveReaderDerivedVariable(name);
+        if (!derived)
+        {
+            // An input variable is not yet installed; leave it pending and let a
+            // later writer rank or step resolve it.
+            continue;
+        }
+        // Build a persistent placeholder the user can InquireVariable and Get.
+        // registerCreated=false keeps it off the engine's created-variable list
+        // (so per-step teardown does not remove it), and it is deliberately not
+        // added to VarByKey (which SetupForStep sweeps). Get routing goes through
+        // m_ReaderDerivedByVar instead.
+        void *variable =
+            ArrayVarSetup(m_Engine, name.c_str(), derived->m_Type, (int)derived->m_Shape.size(),
+                          derived->m_Shape.data(), derived->m_Start.data(), derived->m_Count.data(),
+                          nullptr, nullptr, false /* registerCreated */);
+        static_cast<core::VariableBase *>(variable)->m_Engine = m_Engine;
+
+        // Synthesize a VarRec so Get can reuse the writer-derived read machinery.
+        // It carries no file metadata; its block structure comes from a congruent
+        // input variable (ReaderDerivedStructInput), and it is kept out of
+        // VarByName/VarByKey so no teardown touches it. Freed in the destructor.
+        BP5VarRec *vr = new BP5VarRec();
+        vr->VarName = strdup(name.c_str());
+        vr->Variable = variable;
+        vr->DerivedVariable = (void *)derived;
+        vr->Derived = true;
+        vr->ReaderDerived = true;
+        vr->Type = derived->m_Type;
+        vr->ElementSize = (int)helper::GetDataTypeSize(derived->m_Type);
+        vr->DimCount = derived->m_Shape.size();
+        vr->OrigShapeID = ShapeID::GlobalArray;
+        // Congruence is required, so any input's block layout works; use the first.
+        vr->ReaderDerivedStructInput = LookupVarByName(derived->VariableNameList()[0].c_str());
+        m_ReaderDerivedByVar[variable] = vr;
+    }
+
+    // A reader-derived placeholder is not in the VarByKey loop that grows the
+    // available-step count per step, so mirror its structure input's count here
+    // (the input was updated earlier in this same InstallMetadataBuffer pass).
+    for (auto &pair : m_ReaderDerivedByVar)
+    {
+        BP5VarRec *vr = pair.second;
+        auto *placeholder = static_cast<core::VariableBase *>(vr->Variable);
+        auto *inputVar = static_cast<core::VariableBase *>(vr->ReaderDerivedStructInput->Variable);
+        if (inputVar)
+        {
+            placeholder->m_AvailableStepsCount = inputVar->m_AvailableStepsCount;
+        }
+    }
+}
+#endif
 
 void BP5Deserializer::SetupForStep(size_t Step, size_t WriterCount)
 {
@@ -1054,6 +1131,12 @@ void BP5Deserializer::InstallMetadataBuffer(void *BaseData, size_t WriterRank, s
             }
         }
     }
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    // The file's variables for this rank are now installed; try to resolve any
+    // reader-side derived variables whose inputs have become available. Cheap and
+    // idempotent: the unresolved set is empty once none remain (the common case).
+    InstallReaderDerivedVariables(Step);
+#endif
 }
 
 void BP5Deserializer::InstallAttributeData(void *AttributeBlock, size_t BlockLen, size_t Step)
@@ -1385,7 +1468,23 @@ bool BP5Deserializer::QueueGetSingle(BP5GetContext &ctx, core::VariableBase &var
                                      void *DestData, size_t AbsStep, size_t RelStep,
                                      const core::Selection &selection)
 {
-    BP5VarRec *VarRec = VarByKey[&variable];
+    // Use find, not operator[]: a reader-derived placeholder is not in VarByKey,
+    // and inserting a NULL entry would crash the teardown loop that dereferences
+    // it. Fall back to the reader-derived routing map on a miss.
+    BP5VarRec *VarRec = nullptr;
+    {
+        auto vk = VarByKey.find(&variable);
+        if (vk != VarByKey.end())
+            VarRec = vk->second;
+    }
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    if (!VarRec)
+    {
+        auto it = m_ReaderDerivedByVar.find(&variable);
+        if (it != m_ReaderDerivedByVar.end())
+            VarRec = it->second;
+    }
+#endif
     if (variable.m_Type == adios2::DataType::Struct)
     {
         StructQueueReadChecks(dynamic_cast<core::VariableStruct *>(&variable), VarRec);
@@ -1496,7 +1595,7 @@ bool BP5Deserializer::QueueGetSingle(BP5GetContext &ctx, core::VariableBase &var
              (variable.m_ShapeID == ShapeID::LocalArray))
     {
         BP5ArrayRequest Req;
-        Req.VarRec = VarByKey[&variable];
+        Req.VarRec = VarRec;
         Req.VarName = (char *)variable.m_Name.c_str();
         Req.RequestType = Local;
         Req.BlockID = hasBlock ? blockID : 0;
@@ -1630,7 +1729,11 @@ bool BP5Deserializer::QueueGet(BP5GetContext &ctx, core::VariableBase &variable,
     }
     else
     {
-        BP5VarRec *VarRec = VarByKey[&variable];
+        // LookupVarByKey (not operator[]) so a reader-derived placeholder resolves
+        // to its structure-input VarRec for step iteration, and an unknown key
+        // throws instead of inserting a NULL. QueueGetSingle re-resolves the
+        // placeholder to its synthetic derived VarRec.
+        BP5VarRec *VarRec = LookupVarByKey((void *)&variable);
         bool ret = false;
         if (variable.m_Type == adios2::DataType::Struct)
         {
@@ -1802,9 +1905,13 @@ BP5Deserializer::GenerateReadRequests(BP5GetContext &ctx, const bool doAllocTemp
             if (VarRec->Derived)
             {
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
-                auto &derivedMap = m_Engine->m_IO.GetDerivedVariables();
-                auto derivedVar =
-                    static_cast<VariableDerived *>(derivedMap.at(VarRec->VarName).get());
+                // Reader-side derived variables keep their VariableDerived on the
+                // synthetic VarRec; writer-defined ones live in the IO registry.
+                VariableDerived *derivedVar =
+                    VarRec->ReaderDerived
+                        ? static_cast<VariableDerived *>(VarRec->DerivedVariable)
+                        : static_cast<VariableDerived *>(
+                              m_Engine->m_IO.GetDerivedVariables().at(VarRec->VarName).get());
                 derivedVarInputNameList = derivedVar->VariableNameList();
                 nameToVarInfo = new std::map<std::string, std::unique_ptr<MinVarInfo>>();
                 Req->DerivedInputMap = nameToVarInfo;
@@ -2549,8 +2656,11 @@ void BP5Deserializer::FinalizeDerivedGets(BP5GetContext &ctx, std::vector<ReadRe
         auto VarRec = (struct BP5VarRec *)Req.VarRec;
         if (!VarRec->Derived)
             continue;
-        auto &derivedMap = m_Engine->m_IO.GetDerivedVariables();
-        auto derivedVar = static_cast<VariableDerived *>(derivedMap.at(VarRec->VarName).get());
+        VariableDerived *derivedVar =
+            VarRec->ReaderDerived
+                ? static_cast<VariableDerived *>(VarRec->DerivedVariable)
+                : static_cast<VariableDerived *>(
+                      m_Engine->m_IO.GetDerivedVariables().at(VarRec->VarName).get());
 
         auto nameToVarInfo = Req.DerivedInputMap;
         bool needsHalo = adios2::derived::HasHalo(derivedVar->m_CodeStream);
@@ -2764,6 +2874,21 @@ BP5Deserializer::~BP5Deserializer()
             delete VarRec.second->Def;
         delete VarRec.second;
     }
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    // Reader-side derived placeholders are IO-owned (not in VarByName), so free
+    // their synthetic VarRecs here and remove the placeholders from the IO. The
+    // expression definitions persist on the IO; reset their resolution so a later
+    // Open on the same IO re-resolves against the new file.
+    for (auto &pair : m_ReaderDerivedByVar)
+    {
+        BP5VarRec *vr = pair.second;
+        m_Engine->m_IO.RemoveVariable(vr->VarName);
+        free(vr->VarName);
+        delete vr;
+    }
+    m_ReaderDerivedByVar.clear();
+    m_Engine->m_IO.ResetReaderDerivedResolutions();
+#endif
     if (m_FreeableMBA)
     {
         delete m_FreeableMBA;
@@ -2786,6 +2911,14 @@ BP5Deserializer::~BP5Deserializer()
 
 void *BP5Deserializer::GetMetadataBase(BP5VarRec *VarRec, size_t Step, size_t WriterRank) const
 {
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    if (VarRec->ReaderDerived)
+    {
+        // A reader-side derived variable has no file metadata of its own; its
+        // block structure is that of its (congruent) input variables.
+        return GetMetadataBase(VarRec->ReaderDerivedStructInput, Step, WriterRank);
+    }
+#endif
     MetaArrayRec *writer_meta_base = NULL;
     if (m_RandomAccessMode)
     {
@@ -3271,6 +3404,22 @@ bool BP5Deserializer::VarShape(const VariableBase &Var, const size_t RelStep, Di
 bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
                                      MinMaxStruct &MinMax)
 {
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    // Reader-side derived variables carry no precomputed statistics: nothing was
+    // computed at write time, and the LookupVarByKey redirect would otherwise
+    // return an input variable's min/max. Report an explicitly invalid range
+    // (Init sets min = TYPE_MAX, max = TYPE_MIN, which no real data can produce;
+    // zeroed would be ambiguous with all-zero data). Return true so
+    // Variable::DoMinMax does not fall back to scanning the input's block stats.
+    {
+        auto rd = m_ReaderDerivedByVar.find(&Var);
+        if (rd != m_ReaderDerivedByVar.end())
+        {
+            MinMax.Init(rd->second->Type);
+            return true;
+        }
+    }
+#endif
     BP5VarRec *VarRec = LookupVarByKey((void *)&Var);
     if (!TypeHasMinMax(VarRec->Type))
     {
@@ -3285,7 +3434,10 @@ bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
     {
         if (VarRec->MinMaxOffset == SIZE_MAX)
         {
-            std::memset(&MinMax, 0, sizeof(struct MinMaxStruct));
+            // No min/max was stored for this variable. Report an explicitly
+            // invalid range (min > max) rather than zeroed, which would be
+            // ambiguous with genuinely all-zero data.
+            MinMax.Init(VarRec->Type);
             return true;
         }
     }

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -295,8 +295,10 @@ BP5Deserializer::BP5VarRec *BP5Deserializer::LookupVarByKey(void *Key) const
 
 BP5Deserializer::BP5VarRec *BP5Deserializer::LookupVarByName(const char *Name)
 {
-    auto ret = VarByName[Name];
-    return ret;
+    // find, not operator[]: a miss must not insert a null entry (the destructor
+    // and other iterators dereference VarByName values).
+    auto it = VarByName.find(Name);
+    return (it != VarByName.end()) ? it->second : nullptr;
 }
 
 BP5Deserializer::BP5VarRec *BP5Deserializer::CreateVarRec(const char *ArrayName)
@@ -658,7 +660,7 @@ void *BP5Deserializer::ArrayVarSetup(core::Engine *engine, const char *variableN
 };
 
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
-void BP5Deserializer::InstallReaderDerivedVariables(size_t Step)
+void BP5Deserializer::InstallReaderDerivedVariables()
 {
     core::IO &io = m_Engine->m_IO;
     if (!io.HasReaderDerivedVariables())
@@ -673,6 +675,18 @@ void BP5Deserializer::InstallReaderDerivedVariables(size_t Step)
             // An input variable is not yet installed; leave it pending and let a
             // later writer rank or step resolve it.
             continue;
+        }
+        // The read path takes block structure from the first (congruent) input's
+        // VarRec, so it must exist now that the derived var has resolved against
+        // the file. Look it up before building anything; a miss is a logic error,
+        // not a null to propagate into GetMetadataBase.
+        BP5VarRec *structInput = LookupVarByName(derived->VariableNameList()[0].c_str());
+        if (!structInput)
+        {
+            helper::Throw<std::logic_error>(
+                "Toolkit", "format::BP5Deserializer", "InstallReaderDerivedVariables",
+                "reader derived variable " + name + " resolved but its input " +
+                    derived->VariableNameList()[0] + " has no BP5 record");
         }
         // Build a persistent placeholder the user can InquireVariable and Get.
         // registerCreated=false keeps it off the engine's created-variable list
@@ -699,8 +713,7 @@ void BP5Deserializer::InstallReaderDerivedVariables(size_t Step)
         vr->ElementSize = (int)helper::GetDataTypeSize(derived->m_Type);
         vr->DimCount = derived->m_Shape.size();
         vr->OrigShapeID = ShapeID::GlobalArray;
-        // Congruence is required, so any input's block layout works; use the first.
-        vr->ReaderDerivedStructInput = LookupVarByName(derived->VariableNameList()[0].c_str());
+        vr->ReaderDerivedStructInput = structInput;
         m_ReaderDerivedByVar[variable] = vr;
     }
 
@@ -1135,7 +1148,7 @@ void BP5Deserializer::InstallMetadataBuffer(void *BaseData, size_t WriterRank, s
     // The file's variables for this rank are now installed; try to resolve any
     // reader-side derived variables whose inputs have become available. Cheap and
     // idempotent: the unresolved set is empty once none remain (the common case).
-    InstallReaderDerivedVariables(Step);
+    InstallReaderDerivedVariables();
 #endif
 }
 
@@ -3508,6 +3521,12 @@ bool BP5Deserializer::VariableMinMax(const VariableBase &Var, const size_t Step,
 
 char *BP5Deserializer::VariableExprStr(const VariableBase &Var)
 {
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    auto rd = m_ReaderDerivedByVar.find(&Var);
+    if (rd != m_ReaderDerivedByVar.end())
+        return const_cast<char *>(static_cast<core::VariableDerived *>(rd->second->DerivedVariable)
+                                      ->m_ExprString.c_str());
+#endif
     BP5VarRec *VarRec = LookupVarByKey((void *)&Var);
     return VarRec->ExprStr;
 }

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -166,6 +166,13 @@ private:
         size_t *LastJoinedOffset = NULL;
         size_t *LastJoinedShape = NULL;
         bool Derived = false;
+        // Reader-side derived variable: no file metadata of its own. Its block
+        // structure is taken from ReaderDerivedStructInput (a congruent input
+        // variable's VarRec), and DerivedVariable points at the reader-owned
+        // VariableDerived (which the writer path instead finds in the IO's
+        // derived-variable registry).
+        bool ReaderDerived = false;
+        BP5VarRec *ReaderDerivedStructInput = nullptr;
         char *ExprStr = NULL;
         ShapeID OrigShapeID;
         core::StructDefinition *Def = nullptr;
@@ -233,6 +240,17 @@ private:
     std::unordered_map<std::string, BP5VarRec *> VarByName;
     std::unordered_map<void *, BP5VarRec *> VarByKey;
 
+#ifdef ADIOS2_HAVE_DERIVED_VARIABLE
+    // Reader-side derived variables: placeholder Variable* -> its synthetic
+    // VarRec. Deliberately kept OUT of VarByKey so the per-step teardown
+    // (SetupForStep) never sweeps these IO-owned, reader-defined variables, and
+    // the placeholder is not RegisterCreatedVariable'd so it is not engine-owned.
+    // Populated lazily as the file's input variables appear; used to route Get
+    // when VarByKey has no entry for the placeholder.
+    std::unordered_map<const void *, BP5VarRec *> m_ReaderDerivedByVar;
+    void InstallReaderDerivedVariables(size_t Step);
+#endif
+
     std::vector<void *> *m_MetadataBaseAddrs =
         nullptr; // may be a pointer into MetadataBaseArray or m_FreeableMBA
     std::vector<void *> *m_FreeableMBA = nullptr;
@@ -267,7 +285,8 @@ private:
     void *VarSetup(core::Engine *engine, const char *variableName, const DataType type, void *data);
     void *ArrayVarSetup(core::Engine *engine, const char *variableName, const DataType type,
                         int DimCount, size_t *Shape, size_t *Start, size_t *Count,
-                        core::StructDefinition *Def, core::StructDefinition *ReaderDef);
+                        core::StructDefinition *Def, core::StructDefinition *ReaderDef,
+                        bool registerCreated = true);
     void MapGlobalToLocalIndex(size_t Dims, const size_t *GlobalIndex, const size_t *LocalOffsets,
                                size_t *LocalIndex);
     size_t RelativeToAbsoluteStep(const BP5VarRec *VarRec, size_t RelStep);

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -248,7 +248,7 @@ private:
     // Populated lazily as the file's input variables appear; used to route Get
     // when VarByKey has no entry for the placeholder.
     std::unordered_map<const void *, BP5VarRec *> m_ReaderDerivedByVar;
-    void InstallReaderDerivedVariables(size_t Step);
+    void InstallReaderDerivedVariables();
 #endif
 
     std::vector<void *> *m_MetadataBaseAddrs =

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -1242,9 +1242,16 @@ int printVariableInfo(core::Engine *fp, core::IO *io, core::Variable<T> *variabl
                     if (fp->VariableMinMax(*variable, DefaultSizeT, MinMax))
                     {
                         fprintf(outf, " = ");
-                        print_data(&MinMax.MinUnion, 0, adiosvartype, false);
-                        fprintf(outf, " / ");
-                        print_data(&MinMax.MaxUnion, 0, adiosvartype, false);
+                        if (MinMax.IsUnset(adiosvartype))
+                        {
+                            fprintf(outf, "N/A / N/A"); // no statistics in the file
+                        }
+                        else
+                        {
+                            print_data(&MinMax.MinUnion, 0, adiosvartype, false);
+                            fprintf(outf, " / ");
+                            print_data(&MinMax.MaxUnion, 0, adiosvartype, false);
+                        }
                     }
                     else
                     {
@@ -3639,7 +3646,7 @@ void print_decomp(core::Engine *fp, core::IO *io, core::Variable<T> *variable)
                     /* Print per-block statistics if available */
                     if (longopt)
                     {
-                        if (true /* TODO: variable->has_minmax */)
+                        if (!blocks[j].MinMax.IsUnset(adiosvartype))
                         {
                             fprintf(outf, " = ");
                             print_data(&blocks[j].MinMax.MinUnion, 0, adiosvartype, false);
@@ -3797,7 +3804,7 @@ void print_decomp(core::Engine *fp, core::IO *io, core::Variable<T> *variable)
                 /* Print per-block statistics if available */
                 if (longopt)
                 {
-                    if (true /* TODO: variable->has_minmax */)
+                    if (!helper::GreaterThan<T>(blocks[j].Min, blocks[j].Max))
                     {
                         fprintf(outf, " = ");
                         print_data(&blocks[j].Min, 0, adiosvartype, false);
@@ -3974,30 +3981,28 @@ void print_decomp_singlestep(core::Engine *fp, core::IO *io, core::Variable<T> *
             /* Print per-block statistics if available */
             if (longopt)
             {
-                if (true /* TODO: variable->has_minmax */)
+                const bool unset =
+                    minBlocks ? minBlocks->BlocksInfo[j].MinMax.IsUnset(adiosvartype)
+                              : helper::GreaterThan<T>(coreBlocks[j].Min, coreBlocks[j].Max);
+                if (unset)
                 {
-                    if (!minBlocks)
-                    {
-                        fprintf(outf, " = ");
-                        print_data(&coreBlocks[j].Min, 0, adiosvartype, false);
+                    fprintf(outf, "N/A / N/A");
+                }
+                else if (!minBlocks)
+                {
+                    fprintf(outf, " = ");
+                    print_data(&coreBlocks[j].Min, 0, adiosvartype, false);
 
-                        fprintf(outf, " / ");
-                        print_data(&coreBlocks[j].Max, 0, adiosvartype, false);
-                    }
-                    else
-                    {
-                        fprintf(outf, " = ");
-                        print_data(&minBlocks->BlocksInfo[j].MinMax.MinUnion, 0, adiosvartype,
-                                   false);
-
-                        fprintf(outf, " / ");
-                        print_data(&minBlocks->BlocksInfo[j].MinMax.MaxUnion, 0, adiosvartype,
-                                   false);
-                    }
+                    fprintf(outf, " / ");
+                    print_data(&coreBlocks[j].Max, 0, adiosvartype, false);
                 }
                 else
                 {
-                    fprintf(outf, "N/A / N/A");
+                    fprintf(outf, " = ");
+                    print_data(&minBlocks->BlocksInfo[j].MinMax.MinUnion, 0, adiosvartype, false);
+
+                    fprintf(outf, " / ");
+                    print_data(&minBlocks->BlocksInfo[j].MinMax.MaxUnion, 0, adiosvartype, false);
                 }
             }
             fprintf(outf, "\n");

--- a/testing/adios2/derived/CMakeLists.txt
+++ b/testing/adios2/derived/CMakeLists.txt
@@ -9,3 +9,4 @@
 
 gtest_add_tests_helper(DerivedCorrectness MPI_NONE BP Derived. "")
 gtest_add_tests_helper(DerivedCorrectnessMPI MPI_ALLOW BP Derived. "")
+gtest_add_tests_helper(ReaderDerived MPI_NONE BP Derived. "")

--- a/testing/adios2/derived/CMakeLists.txt
+++ b/testing/adios2/derived/CMakeLists.txt
@@ -10,3 +10,4 @@
 gtest_add_tests_helper(DerivedCorrectness MPI_NONE BP Derived. "")
 gtest_add_tests_helper(DerivedCorrectnessMPI MPI_ALLOW BP Derived. "")
 gtest_add_tests_helper(ReaderDerived MPI_NONE BP Derived. "")
+gtest_add_tests_helper(ReaderDerivedMPI MPI_ONLY BP Derived. "")

--- a/testing/adios2/derived/TestBPReaderDerived.cpp
+++ b/testing/adios2/derived/TestBPReaderDerived.cpp
@@ -1,0 +1,300 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+// Reader-side derived variables: an expression defined on a READ IO over
+// variables that were never marked derived at write time. The reader computes
+// the result on Get. See IO::DefineReaderDerivedVariable.
+
+namespace
+{
+const std::string expr = "x=vx \n y=vy \n z=vz \n magnitude(x,y,z)";
+
+double component(size_t step, size_t i, int c)
+{
+    return 1.0 + static_cast<double>(i) + 100.0 * static_cast<double>(step) + 10.0 * c;
+}
+
+double expectedSpeed(size_t step, size_t i)
+{
+    const double x = component(step, i, 0);
+    const double y = component(step, i, 1);
+    const double z = component(step, i, 2);
+    return std::sqrt(x * x + y * y + z * z);
+}
+
+// Write vx, vy, vz as ordinary (non-derived) global arrays.
+void WriteInputs(adios2::ADIOS &adios, const std::string &fname, size_t N, size_t steps)
+{
+    adios2::IO io = adios.DeclareIO("w_" + fname);
+    io.SetEngine("BP5");
+    auto vx = io.DefineVariable<double>("vx", {N}, {0}, {N});
+    auto vy = io.DefineVariable<double>("vy", {N}, {0}, {N});
+    auto vz = io.DefineVariable<double>("vz", {N}, {0}, {N});
+    auto w = io.Open(fname, adios2::Mode::Write);
+    for (size_t s = 0; s < steps; s++)
+    {
+        std::vector<double> dx(N), dy(N), dz(N);
+        for (size_t i = 0; i < N; i++)
+        {
+            dx[i] = component(s, i, 0);
+            dy[i] = component(s, i, 1);
+            dz[i] = component(s, i, 2);
+        }
+        w.BeginStep();
+        w.Put(vx, dx.data());
+        w.Put(vy, dy.data());
+        w.Put(vz, dz.data());
+        w.EndStep();
+    }
+    w.Close();
+}
+} // namespace
+
+TEST(ReaderDerived, StreamingBasic)
+{
+    const size_t N = 16;
+    adios2::ADIOS adios;
+    WriteInputs(adios, "ReaderDerivedStreaming.bp", N, 1);
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    // Defined BEFORE Open: resolved lazily against the file's variables.
+    io.DefineReaderDerivedVariable("speed", expr);
+    auto r = io.Open("ReaderDerivedStreaming.bp", adios2::Mode::Read);
+
+    ASSERT_EQ(r.BeginStep(), adios2::StepStatus::OK);
+    auto speed = io.InquireVariable<double>("speed");
+    ASSERT_TRUE(speed);
+    EXPECT_EQ(speed.Shape().size(), 1u);
+    EXPECT_EQ(speed.Shape()[0], N);
+
+    std::vector<double> out;
+    r.Get(speed, out);
+    r.EndStep();
+    r.Close();
+
+    ASSERT_EQ(out.size(), N);
+    for (size_t i = 0; i < N; i++)
+        EXPECT_NEAR(out[i], expectedSpeed(0, i), 1e-9);
+}
+
+TEST(ReaderDerived, RandomAccessMultiStep)
+{
+    const size_t N = 20;
+    const size_t steps = 3;
+    adios2::ADIOS adios;
+    WriteInputs(adios, "ReaderDerivedRA.bp", N, steps);
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    io.DefineReaderDerivedVariable("speed", expr);
+    auto r = io.Open("ReaderDerivedRA.bp", adios2::Mode::ReadRandomAccess);
+
+    auto speed = io.InquireVariable<double>("speed");
+    ASSERT_TRUE(speed);
+    EXPECT_EQ(speed.Steps(), steps);
+
+    // Read a single, non-zero step.
+    speed.SetStepSelection({2, 1});
+    std::vector<double> out;
+    r.Get(speed, out);
+    r.Close();
+
+    ASSERT_EQ(out.size(), N);
+    for (size_t i = 0; i < N; i++)
+        EXPECT_NEAR(out[i], expectedSpeed(2, i), 1e-9);
+}
+
+TEST(ReaderDerived, StreamingPartialSelection)
+{
+    const size_t N = 20;
+    const size_t steps = 3;
+    adios2::ADIOS adios;
+    WriteInputs(adios, "ReaderDerivedPartial.bp", N, steps);
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    io.DefineReaderDerivedVariable("speed", expr);
+    auto r = io.Open("ReaderDerivedPartial.bp", adios2::Mode::Read);
+
+    size_t s = 0;
+    while (r.BeginStep() == adios2::StepStatus::OK)
+    {
+        auto speed = io.InquireVariable<double>("speed");
+        ASSERT_TRUE(speed);
+        speed.SetSelection({{5}, {3}}); // start=5, count=3
+        std::vector<double> out;
+        r.Get(speed, out);
+        r.EndStep();
+
+        ASSERT_EQ(out.size(), 3u);
+        for (size_t k = 0; k < 3; k++)
+            EXPECT_NEAR(out[k], expectedSpeed(s, 5 + k), 1e-9);
+        s++;
+    }
+    r.Close();
+    EXPECT_EQ(s, steps);
+}
+
+TEST(ReaderDerived, ReopenSameIO)
+{
+    const size_t N = 8;
+    adios2::ADIOS adios;
+    WriteInputs(adios, "ReaderDerivedReopen.bp", N, 1);
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    io.DefineReaderDerivedVariable("speed", expr);
+
+    // Open, read, close, then re-open the SAME IO: the definition persists and
+    // must re-resolve against the freshly opened file.
+    for (int pass = 0; pass < 2; pass++)
+    {
+        auto r = io.Open("ReaderDerivedReopen.bp", adios2::Mode::Read);
+        ASSERT_EQ(r.BeginStep(), adios2::StepStatus::OK);
+        auto speed = io.InquireVariable<double>("speed");
+        ASSERT_TRUE(speed) << "pass " << pass;
+        std::vector<double> out;
+        r.Get(speed, out);
+        r.EndStep();
+        r.Close();
+        ASSERT_EQ(out.size(), N);
+        for (size_t i = 0; i < N; i++)
+            EXPECT_NEAR(out[i], expectedSpeed(0, i), 1e-9) << "pass " << pass;
+    }
+}
+
+TEST(ReaderDerived, SyntaxErrorAtDefine)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("r");
+    // Parse happens at define time, so a bad expression throws immediately,
+    // before any Open.
+    EXPECT_THROW(io.DefineReaderDerivedVariable("bad", "x=vx \n nofunction(x)"),
+                 std::invalid_argument);
+}
+
+TEST(ReaderDerived, DuplicateNameAtDefine)
+{
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("r");
+    io.DefineReaderDerivedVariable("speed", expr);
+    // Same name a second time is rejected at define.
+    EXPECT_THROW(io.DefineReaderDerivedVariable("speed", expr), std::invalid_argument);
+}
+
+TEST(ReaderDerived, NoPrecomputedMinMax)
+{
+    const size_t N = 16;
+    adios2::ADIOS adios;
+    WriteInputs(adios, "ReaderDerivedMinMax.bp", N, 1);
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    io.DefineReaderDerivedVariable("speed", expr);
+    auto r = io.Open("ReaderDerivedMinMax.bp", adios2::Mode::ReadRandomAccess);
+
+    auto speed = io.InquireVariable<double>("speed");
+    ASSERT_TRUE(speed);
+    // Reader-derived variables have no precomputed stats: min/max report an
+    // explicitly invalid range (min > max), which no real data can produce, not
+    // an input variable's min/max.
+    EXPECT_EQ(speed.Min(), std::numeric_limits<double>::max());
+    EXPECT_EQ(speed.Max(), std::numeric_limits<double>::lowest());
+    EXPECT_GT(speed.Min(), speed.Max());
+    r.Close();
+}
+
+TEST(ReaderDerived, NoInputVariablesThrow)
+{
+    const size_t N = 8;
+    adios2::ADIOS adios;
+    WriteInputs(adios, "ReaderDerivedNoInputs.bp", N, 1);
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    // An expression over no file variables has nothing to read; rejected at
+    // resolve (it parses fine, so the define itself succeeds).
+    io.DefineReaderDerivedVariable("constant", "3 + 4");
+    auto r = io.Open("ReaderDerivedNoInputs.bp", adios2::Mode::Read);
+    EXPECT_THROW(r.BeginStep(), std::exception);
+    r.Close();
+}
+
+TEST(ReaderDerived, IncongruentInputsThrow)
+{
+    const size_t N = 12, M = 8;
+    adios2::ADIOS adios;
+    {
+        adios2::IO io = adios.DeclareIO("w");
+        io.SetEngine("BP5");
+        auto vx = io.DefineVariable<double>("vx", {N}, {0}, {N});
+        auto vy = io.DefineVariable<double>("vy", {N}, {0}, {N});
+        auto vz = io.DefineVariable<double>("vz", {M}, {0}, {M}); // different shape
+        std::vector<double> dx(N, 1.0), dy(N, 2.0), dz(M, 3.0);
+        auto w = io.Open("ReaderDerivedIncongruent.bp", adios2::Mode::Write);
+        w.BeginStep();
+        w.Put(vx, dx.data());
+        w.Put(vy, dy.data());
+        w.Put(vz, dz.data());
+        w.EndStep();
+        w.Close();
+    }
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    io.DefineReaderDerivedVariable("speed", expr);
+    // Resolution happens on Open/BeginStep; mismatched input shapes must throw.
+    auto r = io.Open("ReaderDerivedIncongruent.bp", adios2::Mode::Read);
+    EXPECT_THROW(r.BeginStep(), std::exception);
+    r.Close();
+}
+
+TEST(ReaderDerived, NameCollidesWithFileVariable)
+{
+    const size_t N = 8;
+    adios2::ADIOS adios;
+    {
+        adios2::IO io = adios.DeclareIO("w");
+        io.SetEngine("BP5");
+        auto vx = io.DefineVariable<double>("vx", {N}, {0}, {N});
+        auto vy = io.DefineVariable<double>("vy", {N}, {0}, {N});
+        auto vz = io.DefineVariable<double>("vz", {N}, {0}, {N});
+        auto speed = io.DefineVariable<double>("speed", {N}, {0}, {N}); // occupies the name
+        std::vector<double> d(N, 1.0);
+        auto w = io.Open("ReaderDerivedCollision.bp", adios2::Mode::Write);
+        w.BeginStep();
+        w.Put(vx, d.data());
+        w.Put(vy, d.data());
+        w.Put(vz, d.data());
+        w.Put(speed, d.data());
+        w.EndStep();
+        w.Close();
+    }
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    // Cannot be seen at define time (file not open), so it surfaces at resolve.
+    io.DefineReaderDerivedVariable("speed", expr);
+    auto r = io.Open("ReaderDerivedCollision.bp", adios2::Mode::Read);
+    EXPECT_THROW(r.BeginStep(), std::exception);
+    r.Close();
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/testing/adios2/derived/TestBPReaderDerived.cpp
+++ b/testing/adios2/derived/TestBPReaderDerived.cpp
@@ -293,6 +293,34 @@ TEST(ReaderDerived, NameCollidesWithFileVariable)
     r.Close();
 }
 
+TEST(ReaderDerived, LocalArrayInputThrows)
+{
+    const size_t N = 8;
+    adios2::ADIOS adios;
+    {
+        adios2::IO io = adios.DeclareIO("w");
+        io.SetEngine("BP5");
+        auto vx = io.DefineVariable<double>("vx", {}, {}, {N}); // local arrays
+        auto vy = io.DefineVariable<double>("vy", {}, {}, {N});
+        auto vz = io.DefineVariable<double>("vz", {}, {}, {N});
+        std::vector<double> d(N, 1.0);
+        auto w = io.Open("ReaderDerivedLocalArray.bp", adios2::Mode::Write);
+        w.BeginStep();
+        w.Put(vx, d.data());
+        w.Put(vy, d.data());
+        w.Put(vz, d.data());
+        w.EndStep();
+        w.Close();
+    }
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    io.DefineReaderDerivedVariable("speed", expr);
+    auto r = io.Open("ReaderDerivedLocalArray.bp", adios2::Mode::Read);
+    EXPECT_THROW(r.BeginStep(), std::exception);
+    r.Close();
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/testing/adios2/derived/TestBPReaderDerivedMPI.cpp
+++ b/testing/adios2/derived/TestBPReaderDerivedMPI.cpp
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cmath>
+#include <vector>
+
+#include <adios2.h>
+
+#include <gtest/gtest.h>
+
+// Reader-side derived variable over a global array decomposed across ranks. The
+// derived var's per-block structure is taken from its (congruent) inputs, so a
+// multi-rank read exercises the block-structure redirect that serial cannot.
+
+namespace
+{
+const std::string expr = "x=vx \n y=vy \n z=vz \n magnitude(x,y,z)";
+
+double value(size_t global_i, int c) { return 1.0 + static_cast<double>(global_i) + 10.0 * c; }
+
+double expectedSpeed(size_t global_i)
+{
+    const double x = value(global_i, 0);
+    const double y = value(global_i, 1);
+    const double z = value(global_i, 2);
+    return std::sqrt(x * x + y * y + z * z);
+}
+} // namespace
+
+TEST(ReaderDerivedMPI, DecomposedGlobalArray)
+{
+    int mpiRank = 0, mpiSize = 1;
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
+
+    const size_t Nlocal = 10;
+    const size_t Nglobal = Nlocal * static_cast<size_t>(mpiSize);
+    const size_t start = Nlocal * static_cast<size_t>(mpiRank);
+    const std::string fname = "ReaderDerivedMPI.bp";
+
+    adios2::ADIOS adios(MPI_COMM_WORLD);
+    {
+        adios2::IO io = adios.DeclareIO("w");
+        io.SetEngine("BP5");
+        auto vx = io.DefineVariable<double>("vx", {Nglobal}, {start}, {Nlocal});
+        auto vy = io.DefineVariable<double>("vy", {Nglobal}, {start}, {Nlocal});
+        auto vz = io.DefineVariable<double>("vz", {Nglobal}, {start}, {Nlocal});
+        std::vector<double> dx(Nlocal), dy(Nlocal), dz(Nlocal);
+        for (size_t i = 0; i < Nlocal; i++)
+        {
+            dx[i] = value(start + i, 0);
+            dy[i] = value(start + i, 1);
+            dz[i] = value(start + i, 2);
+        }
+        auto w = io.Open(fname, adios2::Mode::Write);
+        w.BeginStep();
+        w.Put(vx, dx.data());
+        w.Put(vy, dy.data());
+        w.Put(vz, dz.data());
+        w.EndStep();
+        w.Close();
+    }
+
+    adios2::IO io = adios.DeclareIO("r");
+    io.SetEngine("BP5");
+    io.DefineReaderDerivedVariable("speed", expr);
+    auto r = io.Open(fname, adios2::Mode::Read);
+
+    ASSERT_EQ(r.BeginStep(), adios2::StepStatus::OK);
+    auto speed = io.InquireVariable<double>("speed");
+    ASSERT_TRUE(speed);
+    EXPECT_EQ(speed.Shape()[0], Nglobal);
+
+    // Read this rank's own block back and check it against the global indices.
+    speed.SetSelection({{start}, {Nlocal}});
+    std::vector<double> out;
+    r.Get(speed, out);
+    r.EndStep();
+    r.Close();
+
+    ASSERT_EQ(out.size(), Nlocal);
+    for (size_t i = 0; i < Nlocal; i++)
+        EXPECT_NEAR(out[i], expectedSpeed(start + i), 1e-9);
+}
+
+int main(int argc, char **argv)
+{
+    int provided;
+    MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
+    ::testing::InitGoogleTest(&argc, argv);
+    int result = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return result;
+}


### PR DESCRIPTION
IO::DefineReaderDerivedVariable defines an expression on a read IO over file variables; the reader computes it on Get. Parsed at define, resolved lazily against the file on Open, and kept out of the writer-side derived registry so a write engine sharing the IO never picks it up.

BP5Deserializer synthesizes a VarRec routed off the input variables' block structure (GetMetadataBase redirect), requiring congruent input shapes. Bindings for CXX, Python, C, and Fortran.

Also: reader-derived vars carry no precomputed min/max, and the existing "no stored min/max" path now reports an invalid range (min>max).