### PR TITLE
gh-actions: add apptainer image job

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -490,6 +490,59 @@ jobs:
                 ornladios/adios2:${target_tag}
 
 #######################################
+# Apptainer container jobs
+#######################################
+
+  apptainer:
+    needs: [format, git_checks]
+    if: needs.git_checks.outputs.num_code_changes > 0
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write  # for upload-artifact
+      packages: write  # for pushing to GHCR
+    strategy:
+      fail-fast: false
+      matrix:
+        baseos: [ubuntu-bionic]
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ci-source
+      - uses: eWaterCycle/setup-apptainer@4bb22c52d4f63406c49e94c804632975787312b3 # v2.0.0
+        with:
+          apptainer-version: 1.3.6
+      - name: Build image
+        run: |
+            apptainer build --fakeroot \
+                --build-arg baseos=${{ matrix.baseos }} \
+                adios2-ci.sif \
+                ci-source/scripts/ci/images/spack/Apptainer.def
+            ls -lah adios2-ci.sif
+      - name: Smoke test
+        run: apptainer exec adios2-ci.sif bpls --help
+      - name: Upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          retention-days: 1
+          name: ci-apptainer ${{ matrix.baseos }} ${{ github.sha }}
+          path: adios2-ci.sif
+      - name: Push image to GHCR
+        if: github.event_name == 'push'
+        run: |
+            target_tag="${GITHUB_REF##refs/heads/}-${{ matrix.baseos }}-apptainer"
+            apptainer remote login \
+                --username="${{ github.actor }}" \
+                --password="${{ secrets.GITHUB_TOKEN }}" \
+                oras://ghcr.io
+            apptainer push \
+                adios2-ci.sif \
+                "oras://ghcr.io/ornladios/adios2:${target_tag}"
+
+#######################################
 # Contract testing jobs
 #######################################
 
@@ -646,7 +699,7 @@ jobs:
 #######################################
 
   build_and_test:
-    needs: [el8, ubuntu, macos, windows, docker, contract]
+    needs: [el8, ubuntu, macos, windows, docker, apptainer, contract]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All required jobs complete"

--- a/scripts/ci/images/spack/Apptainer.def
+++ b/scripts/ci/images/spack/Apptainer.def
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+Bootstrap: docker
+From: docker.io/ornladios/adios2:spack-dependencies-{{ baseos }}
+
+%files
+    ci-source /opt/adios2/source
+
+%post
+    set -e
+    . /opt/spack/share/spack/setup-env.sh
+    spack dev-build \
+        -j$(grep -c '^processor' /proc/cpuinfo) \
+        -d /opt/adios2/source \
+        --skip-patch \
+        adios2@develop ~python
+    spack clean -a
+
+    spack env create --without-view adios2
+    spack -e adios2 add $(spack find --format "/{hash}")
+    spack -e adios2 install -v
+    adios2_prefix="$(spack -e adios2 location -i adios2)"
+    echo "export PATH=\"${adios2_prefix}/bin:\$PATH\"" > /opt/adios2/spack-env.sh
+    echo "export LD_LIBRARY_PATH=\"${adios2_prefix}/lib:${adios2_prefix}/lib64:\$LD_LIBRARY_PATH\"" >> /opt/adios2/spack-env.sh
+    rm -rf /root/.spack
+
+%environment
+    . /opt/adios2/spack-env.sh
+
+%runscript
+    exec bash --login "$@"


### PR DESCRIPTION
## Summary
- Adds a new `apptainer` job to `.github/workflows/everything.yml` that builds an Apptainer SIF image from the same `scripts/ci/images/spack/Dockerfile` used by the existing `docker` job.
- The docker image is built with the same command/args as the `docker` job, then converted to a SIF via `apptainer build --fakeroot adios2-ci.sif docker-daemon://ornladios/adios2:ci-tmp`, so the SIF contains the same spack-built binaries.
- Uploads the SIF as a CI artifact (1 day retention), mirroring the docker job's tar upload.
- On `push` events, pushes the SIF to GHCR as an OCI artifact (`oras://ghcr.io/ornladios/adios2:<branch>-<baseos>-apptainer`), mirroring the docker job's Docker Hub push, using the built-in `GITHUB_TOKEN`.
- `apptainer` added to `build_and_test`'s `needs` list alongside `docker`, so it's part of the required-checks gate.