### PR TITLE
ci: tighten GITHUB_TOKEN permissions (Scorecard Token-Permissions)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -12,13 +12,15 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ornladios/ADIOS2'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -114,9 +114,6 @@ jobs:
     if: needs.git_checks.outputs.num_code_changes > 0
 
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
-    permissions:
-      contents: read
-      actions: write  # for cache save
     env:
       GH_YML_JOBNAME: ${{ matrix.os }}-${{ matrix.compiler }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}${{ matrix.shared == 'static' && '-static' || '' }}${{ matrix.deps == 'external' && '-external' || '' }}-${{ matrix.parallel }}
       GH_YML_BASE_OS: Linux
@@ -230,9 +227,6 @@ jobs:
     if: needs.git_checks.outputs.num_code_changes > 0
 
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write  # for cache save
     container:
       image: ghcr.io/ornladios/adios2:ci-el8-${{ matrix.compiler }}
       options: --shm-size=1g
@@ -297,9 +291,6 @@ jobs:
     if: needs.git_checks.outputs.num_code_changes > 0
 
     runs-on: ${{ matrix.image }}
-    permissions:
-      contents: read
-      actions: write  # for cache save
     env:
       # Only way to source a file in a non interactive/non login shell.
       BASH_ENV: "/Users/runner/.bash_profile"
@@ -435,9 +426,6 @@ jobs:
     if: needs.git_checks.outputs.num_code_changes > 0
 
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write  # for upload-artifact
     strategy:
       fail-fast: false
       matrix:
@@ -570,7 +558,6 @@ jobs:
         GH_YML_MATRIX_COMPILER: gcc9
         GH_YML_MATRIX_PARALLEL: serial
     permissions:
-      actions: write  # for cache save and upload-artifact
       contents: read
       security-events: write
 

--- a/.github/workflows/pypackaging.yml
+++ b/.github/workflows/pypackaging.yml
@@ -43,9 +43,6 @@ jobs:
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write  # for upload-artifact
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
@@ -65,9 +62,6 @@ jobs:
   build_wheels_legacy:
     name: Wheels cp39–cp311
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write  # for upload-artifact
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
@@ -89,9 +83,6 @@ jobs:
   build_wheels_stable:
     name: Wheels cp312-abi3
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write  # for upload-artifact
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
@@ -111,9 +102,6 @@ jobs:
   build_wheels_freethreaded:
     name: Wheels cp314t
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write  # for upload-artifact
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -9,11 +9,13 @@ on:
     types: [published]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sbom:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
## Summary
- Remove `actions: write` grants added for upload-artifact/cache steps; those authenticate via `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`, so the permission was unused (pypackaging.yml, everything.yml).
- Move `contents: write` from workflow-level to job-level in sbom.yml and dependabot-automerge.yml.

Fixes Scorecard Token-Permissions alerts #216, #217, #218, #220, #242, #244, #258, #259, #260, #261, #262.

## Test plan
- [x] `yaml.safe_load` on all edited files
- [x] `actionlint` on all edited files (no new findings)