### PR TITLE
gh-actions: push apptainer SIF to its own GHCR package

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -505,6 +505,10 @@ jobs:
           apptainer-version: 1.3.6
       - name: Build image
         run: |
+            target_arch="$(echo '${{ runner.arch }}' | tr '[:upper:]' '[:lower:]')"
+            target_branch="${GITHUB_REF##refs/heads/}"
+            echo "image_name=ghcr.io/ornladios/adios2-apptainer-sif-${target_branch}-${target_arch}" >> "$GITHUB_ENV"
+            echo "timestamp=$(date -u +%Y%m%d%H%M%S)" >> "$GITHUB_ENV"
             apptainer build --fakeroot \
                 --build-arg baseos=${{ matrix.baseos }} \
                 adios2-ci.sif \
@@ -521,14 +525,16 @@ jobs:
       - name: Push image to GHCR
         if: github.event_name == 'push'
         run: |
-            target_tag="${GITHUB_REF##refs/heads/}-${{ matrix.baseos }}-apptainer"
             apptainer remote login \
                 --username="${{ github.actor }}" \
                 --password="${{ secrets.GITHUB_TOKEN }}" \
                 oras://ghcr.io
             apptainer push \
                 adios2-ci.sif \
-                "oras://ghcr.io/ornladios/adios2:${target_tag}"
+                "oras://${image_name}:${timestamp}"
+            apptainer push \
+                adios2-ci.sif \
+                "oras://${image_name}:latest"
 
 #######################################
 # Contract testing jobs

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -74,6 +74,11 @@ Once installed, refer to [Linking ADIOS2](https://adios2.readthedocs.io/en/lates
 | vcpkg               | [![Vcpkg package](https://repology.org/badge/version-for-repo/vcpkg/adios2.svg)](https://repology.org/project/adios2/versions)                             |
 | Dockerhub           | ![Docker Image Version](https://img.shields.io/docker/v/ornladios/adios2)                                                                                  |
 
+An Apptainer/Singularity SIF image is also published to GHCR on every `master` push:
+```bash
+apptainer pull adios2.sif oras://ghcr.io/ornladios/adios2-apptainer-sif-master-x64:latest
+```
+
 ## Notes for packagers other than HPC sysadmins
 
 ADIOS2 has a wide spectrum of optional features, from a small,


### PR DESCRIPTION
## Summary
- master's CI is currently broken: the `apptainer` job's "Push image to GHCR" step fails with `DENIED: permission_denied: write_package` when pushing to `ghcr.io/ornladios/adios2` (the pre-existing package used for the `ci-spack-*` base images), because that package predates this workflow and was never linked to grant this repo's `GITHUB_TOKEN` write access.
- Fix: push to a new, dedicated package instead — `ghcr.io/ornladios/adios2-apptainer-sif-<branch>-<baseos>-<arch>` (arch via `runner.arch`). A package name that doesn't exist yet gets auto-created and auto-linked to whichever repo's `GITHUB_TOKEN` first publishes it, which also makes it show up under this repo's own Packages list rather than only the org's.
- `image_name` and `timestamp` are computed once in the "Build image" step (properties of the built image) and passed via `GITHUB_ENV` to the push step. Each push is tagged with that timestamp for traceability, plus a rolling `latest` tag.
