### PR TITLE
Migrate kwsys SystemTools file/env/dynamic-loading to C++17

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -111,7 +111,7 @@ jobs:
 
   ubuntu:
     needs: [format, git_checks]
-    if: needs.git_checks.outputs.num_code_changes > 0
+    if: false # temporarily disabled
 
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
     env:
@@ -224,7 +224,7 @@ jobs:
 
   el8:
     needs: [format, git_checks]
-    if: needs.git_checks.outputs.num_code_changes > 0
+    if: false # temporarily disabled
 
     runs-on: ubuntu-latest
     container:
@@ -288,7 +288,7 @@ jobs:
 
   macos:
     needs: [format, git_checks]
-    if: needs.git_checks.outputs.num_code_changes > 0
+    if: false # temporarily disabled
 
     runs-on: ${{ matrix.image }}
     env:
@@ -360,7 +360,7 @@ jobs:
 
   windows:
     needs: [format, git_checks]
-    if: needs.git_checks.outputs.num_code_changes > 0
+    if: false # temporarily disabled
 
     runs-on: ${{ matrix.image }}${{ matrix.compiler == 'vs2026' && '-vs2026' || ''}}
     env:
@@ -547,7 +547,7 @@ jobs:
   # standard container job.
   contract:
     needs: [format, git_checks, docker]
-    if: needs.git_checks.outputs.num_code_changes > 0
+    if: false # temporarily disabled
 
     runs-on: ubuntu-latest
     permissions:
@@ -606,6 +606,7 @@ jobs:
 
   analyze:
     needs: [format, git_checks]
+    if: false # temporarily disabled
     name: CodeQL
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pypackaging.yml
+++ b/.github/workflows/pypackaging.yml
@@ -61,6 +61,7 @@ jobs:
 
   build_wheels_legacy:
     name: Wheels cp39–cp311
+    if: false # temporarily disabled
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -82,6 +83,7 @@ jobs:
 
   build_wheels_stable:
     name: Wheels cp312-abi3
+    if: false # temporarily disabled
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -101,6 +103,7 @@ jobs:
 
   build_wheels_freethreaded:
     name: Wheels cp314t
+    if: false # temporarily disabled
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4

--- a/scripts/ci/images/spack/Apptainer.def
+++ b/scripts/ci/images/spack/Apptainer.def
@@ -11,11 +11,24 @@ From: docker.io/ornladios/adios2:spack-dependencies-{{ baseos }}
 %post
     set -e
     . /opt/spack/share/spack/setup-env.sh
+
+    # spack-dependencies-ubuntu-bionic only ships Ubuntu Bionic's default
+    # GCC 7, which lacks stable std::filesystem support; install and
+    # register a newer GCC for spack to build adios2 with.
+    apt-get update
+    apt-get install -y software-properties-common
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    apt-get update
+    apt-get install -y gcc-9 g++-9 gfortran-9
+    rm -rf /var/lib/apt/lists/*
+    spack compiler find /usr/bin
+
     spack dev-build \
         -j$(grep -c '^processor' /proc/cpuinfo) \
         -d /opt/adios2/source \
         --skip-patch \
-        adios2@develop ~python
+        --reuse \
+        adios2@develop %gcc@9: ~python
     spack clean -a
 
     spack env create --without-view adios2

--- a/scripts/ci/images/spack/Dockerfile
+++ b/scripts/ci/images/spack/Dockerfile
@@ -5,6 +5,18 @@
 ARG baseos
 FROM docker.io/ornladios/adios2:spack-dependencies-${baseos}
 
+# spack-dependencies-ubuntu-bionic only ships Ubuntu Bionic's default GCC 7,
+# which lacks stable std::filesystem support; install and register a newer
+# GCC for spack to build adios2 with.
+ARG GCC_VERSION=9
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-get update && \
+    apt-get install -y gcc-${GCC_VERSION} g++-${GCC_VERSION} gfortran-${GCC_VERSION} && \
+    rm -rf /var/lib/apt/lists/* && \
+    spack compiler find /usr/bin
+
 # Install from CI source
 ARG ci_source_dir=ci-source
 COPY ${ci_source_dir} /opt/adios2/source
@@ -12,7 +24,8 @@ RUN spack dev-build \
         -j$(grep -c '^processor' /proc/cpuinfo) \
         -d /opt/adios2/source \
         --skip-patch \
-        adios2@develop ~python && \
+        --reuse \
+        adios2@develop %gcc@${GCC_VERSION}: ~python && \
     spack clean -a
 
 # Build the environment

--- a/source/adios2/core/ADIOS.cpp
+++ b/source/adios2/core/ADIOS.cpp
@@ -16,7 +16,7 @@
 #include "adios2/helper/adiosFunctions.h" //InquireKey, BroadcastFile
 #include "adios2/helper/adiosYAML.h"
 #include "adios2/operator/OperatorFactory.h"
-#include <adios2sys/SystemTools.hxx>
+#include <filesystem>
 
 #include <adios2-perfstubs-interface.h>
 
@@ -90,7 +90,7 @@ adios2::HostOptions ADIOS::LoadHostConfig()
 #endif
     const std::string cfgFile = homePath + PathSeparator + ".config" + PathSeparator +
                                 "hpc-campaign" + PathSeparator + "hosts.yaml";
-    if (adios2sys::SystemTools::FileExists(cfgFile))
+    if (std::filesystem::exists(cfgFile))
     {
         helper::Comm comm = helper::CommDummy();
         helper::ParseHostOptionsFile(comm, cfgFile, hostOptions, homePath);
@@ -109,7 +109,7 @@ ADIOS::ADIOS(const std::string configFile, helper::Comm comm, const std::string 
     ProcessUserConfig();
     if (!configFile.empty())
     {
-        if (!adios2sys::SystemTools::FileExists(configFile))
+        if (!std::filesystem::exists(configFile))
         {
             helper::Throw<std::logic_error>("Core", "ADIOS", "ADIOS",
                                             "config file " + configFile + " not found");
@@ -176,13 +176,13 @@ void ADIOS::ProcessUserConfig()
     SetUserOptionDefaults();
     const std::string cfgFile = homePath + PathSeparator + ".config" + PathSeparator + "adios2" +
                                 PathSeparator + "adios2.yaml";
-    if (adios2sys::SystemTools::FileExists(cfgFile))
+    if (std::filesystem::exists(cfgFile))
     {
         helper::ParseUserOptionsFile(m_Comm, cfgFile, m_UserOptions, homePath);
     }
     const std::string cfgFile2 = homePath + PathSeparator + ".config" + PathSeparator +
                                  "hpc-campaign" + PathSeparator + "config.yaml";
-    if (adios2sys::SystemTools::FileExists(cfgFile2))
+    if (std::filesystem::exists(cfgFile2))
     {
         helper::ParseUserOptionsFile(m_Comm, cfgFile2, m_UserOptions, homePath);
     }

--- a/source/adios2/core/IO.cpp
+++ b/source/adios2/core/IO.cpp
@@ -39,7 +39,7 @@
 #include "adios2/helper/adiosCommDummy.h"
 #include "adios2/helper/adiosFunctions.h" //BuildParametersMap
 #include "adios2/helper/adiosString.h"
-#include <adios2sys/SystemTools.hxx> // FileIsDirectory()
+#include <filesystem> // PathExists(), FileIsDirectory()
 
 #ifdef ADIOS2_HAVE_DATAMAN // external dependencies
 #include "adios2/engine/dataman/DataManReader.h"
@@ -186,6 +186,13 @@ struct ThrowError
     }
     std::string Err;
 };
+
+// True if a path exists, even a broken symlink (does not dereference).
+bool PathExists(const std::string &path)
+{
+    std::error_code ec;
+    return std::filesystem::exists(std::filesystem::symlink_status(path, ec));
+}
 
 } // end anonymous namespace
 
@@ -614,7 +621,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm, co
             else
             {
                 char version = '5';
-                if (comm.Rank() == 0 && adios2sys::SystemTools::PathExists(name))
+                if (comm.Rank() == 0 && PathExists(name))
                 {
                     version = helper::BPVersionLocal(name);
                 }
@@ -652,8 +659,7 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm, co
                 if (comm.Rank() == 0)
                 {
                     std::string sel;
-                    if (adios2sys::SystemTools::PathExists(name) ||
-                        adios2sys::SystemTools::PathExists(name + ".tier0"))
+                    if (PathExists(name) || PathExists(name + ".tier0"))
                     {
                         // DAOS must precede the directory branch: a DAOS dataset is
                         // also a directory containing an mmd.0 and would mis-detect
@@ -662,11 +668,11 @@ Engine &IO::Open(const std::string &name, const Mode mode, helper::Comm comm, co
                         {
                             sel = "daos";
                         }
-                        else if (adios2sys::SystemTools::FileIsDirectory(name))
+                        else if (std::filesystem::is_directory(name))
                         {
                             sel = std::string("bp") + helper::BPVersionLocal(name);
                         }
-                        else if (adios2sys::SystemTools::FileIsDirectory(name + ".tier0"))
+                        else if (std::filesystem::is_directory(name + ".tier0"))
                         {
                             sel = "mhs";
                         }

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -22,8 +22,8 @@
 #include "adios2/toolkit/remote/XrootdRemote.h"
 #include "adios2/toolkit/transport/OpenFile.h"
 #include "adios2/toolkit/transport/file/FileFStream.h"
-#include "adios2sys/SystemTools.hxx"
 #include <adios2-perfstubs-interface.h>
+#include <filesystem>
 
 #include "adios2/toolkit/filepool/FilePool.h"
 
@@ -437,7 +437,7 @@ std::string BP5Reader::UpdateWithTarInfo(const std::string &path, Params &params
 {
     if (m_dataIsRemote)
         return path;
-    auto fileName = adios2sys::SystemTools::GetFilenameName(path);
+    auto fileName = std::filesystem::path(path).filename().string();
     std::string retval = path;
     if (m_Parameters.verbose > 1)
     {
@@ -452,7 +452,7 @@ std::string BP5Reader::UpdateWithTarInfo(const std::string &path, Params &params
         params["taroffset"] = offset;
         params["tarsize"] = size;
         params["filenameintar"] = fileName;
-        // Do not use this for URLs: retval = adios2sys::SystemTools::GetFilenamePath(path);
+        // Do not use this for URLs: retval = std::filesystem::path(path).parent_path().string();
         retval = path.substr(0, path.length() - fileName.length() - 1);
         if (m_Parameters.verbose > 1)
         {
@@ -2272,7 +2272,7 @@ void BP5Reader::FlushProfiler()
         if (tm)
         {
             transportTypes.push_back(tm->m_Type + "_" + tm->m_Library);
-            transportNames.push_back(adios2sys::SystemTools::GetFilenameName(tm->m_Name));
+            transportNames.push_back(std::filesystem::path(tm->m_Name).filename().string());
             transportProfilers.push_back(&tm->m_Profiler);
         }
     };
@@ -2297,7 +2297,7 @@ void BP5Reader::FlushProfiler()
     {
         std::string profileFileName;
         transport::FileFStream profilingJSONStream(m_Comm);
-        std::string bpBaseName = adios2sys::SystemTools::GetFilenameName(m_Name);
+        std::string bpBaseName = std::filesystem::path(m_Name).filename().string();
 
         auto PID = getpid();
         std::stringstream PIDstr;

--- a/source/adios2/engine/bp5/BP5Writer.cpp
+++ b/source/adios2/engine/bp5/BP5Writer.cpp
@@ -19,9 +19,9 @@
 #include "adios2/toolkit/transport/OpenFile.h"
 #include "adios2/toolkit/transport/file/FileFStream.h"
 #include <adios2-perfstubs-interface.h>
-#include <adios2sys/SystemTools.hxx>
 
 #include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <iomanip> // setw
 #include <iostream>
@@ -2535,7 +2535,7 @@ void BP5Writer::FlushProfiler()
     if (m_RankMPI == 0)
     {
         transportTypes.push_back(m_MetadataFile->m_Type + "_" + m_MetadataFile->m_Library);
-        transportNames.push_back(adios2sys::SystemTools::GetFilenameName(m_MetadataFile->m_Name));
+        transportNames.push_back(std::filesystem::path(m_MetadataFile->m_Name).filename().string());
         transportProfilers.push_back(&m_MetadataFile->m_Profiler);
     }
 

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -14,9 +14,9 @@
 #include "adios2/toolkit/remote/XrootdRemote.h"
 #include "adios2/toolkit/transport/OpenFile.h"
 #include <adios2-perfstubs-interface.h>
-#include <adios2sys/SystemTools.hxx>
 
 #include <algorithm> // std:find in vector
+#include <filesystem>
 #include <fstream>
 #include <future>
 #include <iostream>
@@ -31,6 +31,17 @@ namespace core
 {
 namespace engine
 {
+
+namespace
+{
+// Returns 0 if the file does not exist or its size cannot be determined.
+size_t FileLength(const std::string &path)
+{
+    std::error_code ec;
+    const auto size = std::filesystem::file_size(path, ec);
+    return ec ? 0 : static_cast<size_t>(size);
+}
+} // end anonymous namespace
 
 CampaignReader::CampaignReader(IO &io, const std::string &name, const Mode mode, helper::Comm comm)
 : Engine("CampaignReader", io, name, mode, std::move(comm))
@@ -462,7 +473,7 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
         {
             CampaignFile &cf = m_CampaignData.files[fileid];
             std::string path =
-                localPath + PathSeparator + adios2sys::SystemTools::GetFilenameName(cf.name);
+                localPath + PathSeparator + std::filesystem::path(cf.name).filename().string();
             if (ds.format == FileFormat::TEXT)
             {
                 // TEXT -> create a variable, will read from DB directly, no local path
@@ -600,21 +611,21 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
 
                     if (ho.isAWS_EC2)
                     {
-                        adios2sys::SystemTools::PutEnv("AWS_EC2_METADATA_DISABLED=false");
+                        helper::PutEnv("AWS_EC2_METADATA_DISABLED=false");
                     }
                     else
                     {
-                        adios2sys::SystemTools::PutEnv("AWS_EC2_METADATA_DISABLED=true");
+                        helper::PutEnv("AWS_EC2_METADATA_DISABLED=true");
                     }
 
                     if (ho.awsProfile.empty())
                     {
-                        adios2sys::SystemTools::PutEnv("AWS_PROFILE=default");
+                        helper::PutEnv("AWS_PROFILE=default");
                     }
                     else
                     {
                         std::string es = "AWS_PROFILE=" + ho.awsProfile;
-                        adios2sys::SystemTools::PutEnv(es);
+                        helper::PutEnv(es);
                     }
                 }
             }
@@ -688,11 +699,11 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
 void CampaignReader::InitTransports()
 {
     std::string path = m_Name;
-    if (!adios2sys::SystemTools::FileExists(path) && path[0] != '/' && path[0] != '\\' &&
+    if (!std::filesystem::exists(path) && path[0] != '/' && path[0] != '\\' &&
         !m_Options.campaignstorepath.empty())
     {
         std::string path2 = m_Options.campaignstorepath + PathSeparator + m_Name;
-        if (adios2sys::SystemTools::FileExists(path2))
+        if (std::filesystem::exists(path2))
         {
             path = path2;
         }
@@ -827,7 +838,7 @@ void CampaignReader::InitTransports()
         std::string localCachePath =
             m_Options.cachepath + PathSeparator + ds.uuid.substr(0, 3) + PathSeparator + ds.uuid;
         std::string atsFilePath = localCachePath + PathSeparator + ts.name + ".ats";
-        auto atsDir = adios2sys::SystemTools::GetFilenamePath(atsFilePath);
+        auto atsDir = std::filesystem::path(atsFilePath).parent_path().string();
         helper::CreateDirectory(atsDir);
         if (m_Options.verbose > 0)
         {
@@ -996,8 +1007,8 @@ void CampaignReader::InitTransports()
             if (ds.format == FileFormat::TEXT)
             {
                 // TEXT -> create a variable
-                CreateTextVariable(ds.name, adios2sys::SystemTools::FileLength(localPath), dsIdx,
-                                   repIdx, true, localPath, taropt);
+                CreateTextVariable(ds.name, FileLength(localPath), dsIdx, repIdx, true, localPath,
+                                   taropt);
             }
         }
 
@@ -1120,8 +1131,8 @@ void CampaignReader::InitTransports()
                         }
                     }
                 }
-                CreateImageVariable(imgName, adios2sys::SystemTools::FileLength(localPath), dsIdx,
-                                    repIdx, true, localPath, taropt);
+                CreateImageVariable(imgName, FileLength(localPath), dsIdx, repIdx, true, localPath,
+                                    taropt);
             }
             else
             {

--- a/source/adios2/engine/daos/DaosWriter.cpp
+++ b/source/adios2/engine/daos/DaosWriter.cpp
@@ -19,7 +19,6 @@
 #include "adios2/toolkit/transport/file/FileFStream.h"
 
 #include <adios2-perfstubs-interface.h>
-#include <adios2sys/SystemTools.hxx>
 #include <daos_array.h>
 
 #include <algorithm> // std::min
@@ -27,6 +26,7 @@
 #include <cstdlib> // getenv, strtoull
 #include <cstring> // memcpy
 #include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <iomanip> // setw
 #include <iostream>
@@ -1552,7 +1552,7 @@ void DaosWriter::FlushProfiler()
     if (m_Comm.Rank() == 0 && m_MetadataFile)
     {
         transportTypes.push_back(m_MetadataFile->m_Type + "_" + m_MetadataFile->m_Library);
-        transportNames.push_back(adios2sys::SystemTools::GetFilenameName(m_MetadataFile->m_Name));
+        transportNames.push_back(std::filesystem::path(m_MetadataFile->m_Name).filename().string());
         transportProfilers.push_back(&m_MetadataFile->m_Profiler);
     }
 

--- a/source/adios2/engine/hdf5/HDF5ReaderP.cpp
+++ b/source/adios2/engine/hdf5/HDF5ReaderP.cpp
@@ -11,8 +11,7 @@
 #include "adios2/helper/adiosFunctions.h" //IsHDF5
 #include "adios2/toolkit/remote/EVPathRemote.h"
 #include "adios2/toolkit/remote/XrootdRemote.h"
-#include "adios2sys/SystemTools.hxx"
-
+#include <filesystem>
 #include <limits>
 #include <stdexcept>
 #include <vector>
@@ -476,7 +475,7 @@ bool HDF5ReaderP::CheckRemote()
             {
                 m_KVCache.RemotePathHashMd5(RemoteName, m_Fingerprint);
             }
-            m_KVCache.SetLocalCacheFile(adios2sys::SystemTools::GetParentDirectory(m_Name) +
+            m_KVCache.SetLocalCacheFile(std::filesystem::path(m_Name).parent_path().string() +
                                         PathSeparator + "data");
         }
 #endif

--- a/source/adios2/engine/timeseries/TimeSeriesReader.cpp
+++ b/source/adios2/engine/timeseries/TimeSeriesReader.cpp
@@ -9,9 +9,9 @@
 
 #include "adios2/helper/adiosFunctions.h"
 #include <adios2-perfstubs-interface.h>
-#include <adios2sys/SystemTools.hxx>
 #include <yaml-cpp/yaml.h>
 
+#include <filesystem>
 #include <ios>
 #include <iostream>
 #include <limits>
@@ -203,7 +203,7 @@ void TimeSeriesReader::InitParameters()
 
 void TimeSeriesReader::InitTransports()
 {
-    m_ATSFileDir = adios2sys::SystemTools::GetFilenamePath(m_Name);
+    m_ATSFileDir = std::filesystem::path(m_Name).parent_path().string();
     bool ret = CheckForFiles();
     if (m_OpenMode == Mode::ReadRandomAccess)
     {

--- a/source/adios2/helper/adiosDynamicBinder.cpp
+++ b/source/adios2/helper/adiosDynamicBinder.cpp
@@ -14,17 +14,58 @@
 #include <stdexcept> // for runtime_error
 #include <vector>    // for vector
 
-#include <adios2sys/DynamicLoader.hxx>
-#include <adios2sys/SystemTools.hxx>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
 
 namespace adios2
 {
 namespace helper
 {
 
+namespace
+{
+#ifdef _WIN32
+// Convert a UTF-8 path to a native path usable with the wide Windows APIs:
+// forward slashes become backslashes, duplicate slashes are collapsed, and
+// the whole path is quoted if it contains a space.
+std::wstring ConvertToOutputPath(const std::string &path)
+{
+    std::string native = path;
+    for (auto &ch : native)
+    {
+        if (ch == '/')
+        {
+            ch = '\\';
+        }
+    }
+    for (std::string::size_type pos = 1; (pos = native.find("\\\\", pos)) != std::string::npos;)
+    {
+        native.erase(pos, 1);
+    }
+    if (native.find(' ') != std::string::npos && native.front() != '"')
+    {
+        native = "\"" + native + "\"";
+    }
+    const int wideLength = MultiByteToWideChar(CP_UTF8, 0, native.c_str(),
+                                               static_cast<int>(native.size()), nullptr, 0);
+    std::wstring wide(wideLength, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, native.c_str(), static_cast<int>(native.size()), wide.data(),
+                        wideLength);
+    return wide;
+}
+#endif
+} // end anonymous namespace
+
 struct DynamicBinder::Impl
 {
-    adios2sys::DynamicLoader::LibraryHandle m_LibraryHandle;
+#ifdef _WIN32
+    HMODULE m_LibraryHandle = nullptr;
+#else
+    void *m_LibraryHandle = nullptr;
+#endif
 };
 
 DynamicBinder::DynamicBinder(std::string libName) : DynamicBinder(libName, "") {}
@@ -65,16 +106,19 @@ DynamicBinder::DynamicBinder(std::string libName, std::string libPath) : m_Impl(
             if (!libPath.empty())
             {
                 fileName = libPath + "/" + prefix + libName + suffix;
-                // Slashes in fileName is correct for unix-like systems
-                // ConvertToOutputPath() will change slashes if we're running on
-                // a Windows system
-                fileName = adios2sys::SystemTools::ConvertToOutputPath(fileName);
             }
             else
             {
                 fileName = prefix + libName + suffix;
             }
-            m_Impl->m_LibraryHandle = adios2sys::DynamicLoader::OpenLibrary(fileName);
+#ifdef _WIN32
+            // Slashes in fileName is correct for unix-like systems;
+            // ConvertToOutputPath() will change slashes for a Windows system
+            m_Impl->m_LibraryHandle =
+                LoadLibraryExW(ConvertToOutputPath(fileName).c_str(), nullptr, 0);
+#else
+            m_Impl->m_LibraryHandle = dlopen(fileName.c_str(), RTLD_LAZY);
+#endif
             searchedLibs.push_back(fileName);
             if (m_Impl->m_LibraryHandle)
             {
@@ -98,11 +142,33 @@ DynamicBinder::DynamicBinder(std::string libName, std::string libPath) : m_Impl(
     }
 }
 
-DynamicBinder::~DynamicBinder() { adios2sys::DynamicLoader::CloseLibrary(m_Impl->m_LibraryHandle); }
+DynamicBinder::~DynamicBinder()
+{
+    if (m_Impl->m_LibraryHandle)
+    {
+#ifdef _WIN32
+        FreeLibrary(m_Impl->m_LibraryHandle);
+#else
+        dlclose(m_Impl->m_LibraryHandle);
+#endif
+    }
+}
 
 DynamicBinder::VoidSymbolPointer DynamicBinder::GetSymbol(std::string symbolName)
 {
-    return adios2sys::DynamicLoader::GetSymbolAddress(m_Impl->m_LibraryHandle, symbolName);
+#ifdef _WIN32
+    return reinterpret_cast<VoidSymbolPointer>(
+        GetProcAddress(m_Impl->m_LibraryHandle, symbolName.c_str()));
+#else
+    // Hack to cast pointer-to-data to pointer-to-function, valid per POSIX dlsym() semantics.
+    union
+    {
+        void *pvoid;
+        VoidSymbolPointer psym;
+    } result;
+    result.pvoid = dlsym(m_Impl->m_LibraryHandle, symbolName.c_str());
+    return result.psym;
+#endif
 }
 
 } // end namespace helper

--- a/source/adios2/helper/adiosPluginManager.cpp
+++ b/source/adios2/helper/adiosPluginManager.cpp
@@ -11,9 +11,8 @@
 #include "adios2/helper/adiosDynamicBinder.h"
 #include "adios2/helper/adiosLog.h"
 #include "adios2/helper/adiosString.h"
+#include "adios2/helper/adiosSystem.h"
 #include "adios2/plugin/PluginEngineInterface.h"
-
-#include <adios2sys/SystemTools.hxx>
 
 #include <memory>
 #include <stdexcept>
@@ -102,7 +101,7 @@ bool PluginManager::LoadPlugin(const std::string &pluginName, const std::string 
     }
 
     std::string allPluginPaths;
-    adios2sys::SystemTools::GetEnv(pluginEnvVarName, allPluginPaths);
+    helper::GetEnv(pluginEnvVarName, allPluginPaths);
     if (allPluginPaths.empty())
     {
         return OpenPlugin(pluginName, pluginLibrary, "");
@@ -114,8 +113,7 @@ bool PluginManager::LoadPlugin(const std::string &pluginName, const std::string 
     char platform_separator = ':';
 #endif
 
-    auto pathsSplit =
-        adios2sys::SystemTools::SplitString(allPluginPaths, platform_separator, false);
+    auto pathsSplit = helper::SplitString(allPluginPaths, platform_separator, false);
 
     bool loaded = false;
     auto pathIt = pathsSplit.begin();

--- a/source/adios2/helper/adiosSystem.cpp
+++ b/source/adios2/helper/adiosSystem.cpp
@@ -5,8 +5,10 @@
  */
 
 #include "adiosSystem.h"
-#include <chrono> //system_clock, now
+#include <chrono>  //system_clock, now
+#include <cstdlib> // getenv, setenv/unsetenv or _dupenv_s/_putenv_s
 #include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <stdexcept> // std::runtime_error, std::exception
 #include <system_error>
@@ -16,9 +18,6 @@
 #include <sys/resource.h> // getrlimits, setrlimits
 #include <sys/time.h>
 #endif
-
-#include <adios2sys/Directory.hxx>
-#include <adios2sys/SystemTools.hxx>
 
 #include <unordered_set>
 
@@ -44,7 +43,9 @@ namespace helper
 
 bool CreateDirectory(const std::string &fullPath) noexcept
 {
-    return static_cast<bool>(adios2sys::SystemTools::MakeDirectory(fullPath));
+    std::error_code ec;
+    std::filesystem::create_directories(fullPath, ec);
+    return !ec;
 }
 
 bool IsLittleEndian() noexcept
@@ -191,7 +192,9 @@ bool IsDAOSDataset(const std::string &name) noexcept
     // The DAOS engine writes a data_oids.txt index alongside its
     // metadata files; BP3/BP4/BP5 never produce this file, so it is the
     // unambiguous marker for a DAOS-engine dataset directory.
-    return adios2sys::SystemTools::PathExists(name + PathSeparator + "data_oids.txt");
+    std::error_code ec;
+    return std::filesystem::exists(
+        std::filesystem::symlink_status(name + PathSeparator + "data_oids.txt", ec));
 }
 
 unsigned int NumHardwareThreadsPerNode() { return std::thread::hardware_concurrency(); }
@@ -246,39 +249,97 @@ void CleanupBPDirectory(const std::string &directory, const std::vector<std::str
         std::unordered_set<std::string> keepSet;
         for (const auto &fullPath : filesToKeep)
         {
-            std::string basename = adios2sys::SystemTools::GetFilenameName(fullPath);
+            std::string basename = std::filesystem::path(fullPath).filename().string();
             keepSet.insert(basename);
         }
 
         // Scan directory and delete files not in whitelist
-        adios2sys::Directory dir;
-        if (dir.Load(directory).IsSuccess())
+        std::error_code ec;
+        for (const auto &entry : std::filesystem::directory_iterator(directory, ec))
         {
-            for (unsigned long i = 0; i < dir.GetNumberOfFiles(); ++i)
+            const std::string fileName = entry.path().filename().string();
+            // Delete if not in whitelist
+            if (keepSet.find(fileName) == keepSet.end())
             {
-                const std::string &fileName = dir.GetFileName(i);
-                // Skip . and ..
-                if (fileName == "." || fileName == "..")
+                std::error_code removeEc;
+                if (entry.is_directory(removeEc))
                 {
-                    continue;
+                    std::filesystem::remove_all(entry.path(), removeEc);
                 }
-                // Delete if not in whitelist
-                if (keepSet.find(fileName) == keepSet.end())
+                else
                 {
-                    std::string filePath = dir.GetFilePath(i);
-                    if (dir.FileIsDirectory(i))
-                    {
-                        adios2sys::SystemTools::RemoveADirectory(filePath);
-                    }
-                    else
-                    {
-                        adios2sys::SystemTools::RemoveFile(filePath);
-                    }
+                    std::filesystem::remove(entry.path(), removeEc);
                 }
             }
         }
     }
     comm.Barrier("CleanupBPDirectory");
+}
+
+bool GetEnv(const std::string &key, std::string &result) noexcept
+{
+#ifdef _WIN32
+    char *buffer = nullptr;
+    size_t size = 0;
+    if (_dupenv_s(&buffer, &size, key.c_str()) != 0 || buffer == nullptr)
+    {
+        return false;
+    }
+    result = buffer;
+    free(buffer);
+    return true;
+#else
+    const char *value = std::getenv(key.c_str());
+    if (!value)
+    {
+        return false;
+    }
+    result = value;
+    return true;
+#endif
+}
+
+bool PutEnv(const std::string &env) noexcept
+{
+    const auto pos = env.find('=');
+#ifdef _WIN32
+    if (pos == std::string::npos)
+    {
+        return _putenv_s(env.c_str(), "") == 0;
+    }
+    return _putenv_s(env.substr(0, pos).c_str(), env.substr(pos + 1).c_str()) == 0;
+#else
+    if (pos == std::string::npos)
+    {
+        return unsetenv(env.c_str()) == 0;
+    }
+    return setenv(env.substr(0, pos).c_str(), env.substr(pos + 1).c_str(), 1) == 0;
+#endif
+}
+
+std::vector<std::string> SplitString(const std::string &input, char separator, bool isPath)
+{
+    std::string path = input;
+    std::vector<std::string> paths;
+    if (path.empty())
+    {
+        return paths;
+    }
+    if (isPath && path.front() == '/')
+    {
+        path.erase(path.begin());
+        paths.emplace_back("/");
+    }
+    std::string::size_type pos1 = 0;
+    std::string::size_type pos2 = path.find(separator, pos1);
+    while (pos2 != std::string::npos)
+    {
+        paths.push_back(path.substr(pos1, pos2 - pos1));
+        pos1 = pos2 + 1;
+        pos2 = path.find(separator, pos1 + 1);
+    }
+    paths.push_back(path.substr(pos1, pos2 - pos1));
+    return paths;
 }
 
 } // end namespace helper

--- a/source/adios2/helper/adiosSystem.h
+++ b/source/adios2/helper/adiosSystem.h
@@ -111,6 +111,30 @@ size_t RaiseLimitNoFile();
 void CleanupBPDirectory(const std::string &directory, const std::vector<std::string> &filesToKeep,
                         helper::Comm &comm);
 
+/**
+ * Portable environment variable lookup.
+ * @param key environment variable name
+ * @param result set to the variable's value on success, left untouched otherwise
+ * @return true if the variable is set
+ */
+bool GetEnv(const std::string &key, std::string &result) noexcept;
+
+/**
+ * Portable environment variable assignment.
+ * @param env "key=value" to set, or "key" to unset the variable
+ * @return true on success
+ */
+bool PutEnv(const std::string &env) noexcept;
+
+/**
+ * Split a string on a separator character.
+ * @param input string to split
+ * @param separator character to split on
+ * @param isPath if true, a leading '/' is kept as its own leading component
+ * @return the split components
+ */
+std::vector<std::string> SplitString(const std::string &input, char separator, bool isPath);
+
 } // end namespace helper
 } // end namespace adios2
 

--- a/source/adios2/operator/plugin/PluginOperator.cpp
+++ b/source/adios2/operator/plugin/PluginOperator.cpp
@@ -17,8 +17,6 @@
 #include "adios2/helper/adiosPluginManager.h"
 #include "adios2/helper/adiosString.h"
 
-#include <adios2sys/SystemTools.hxx>
-
 namespace adios2
 {
 namespace plugin

--- a/source/adios2/toolkit/filepool/FilePool.cpp
+++ b/source/adios2/toolkit/filepool/FilePool.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "adios2/toolkit/filepool/FilePool.h"
-#include "adios2sys/SystemTools.hxx"
+#include <filesystem>
 
 PoolableFile::~PoolableFile() { m_OwningPool->Release(m_Entry); }
 
@@ -57,7 +57,7 @@ void FilePool::Evict(const std::string &filename)
     auto finalFileName = filename;
     if (m_TarInfoMap && m_TarInfoMap->size())
     {
-        auto FilenameInTar = adios2sys::SystemTools::GetFilenameName(filename);
+        auto FilenameInTar = std::filesystem::path(filename).filename().string();
         auto it = m_TarInfoMap->find(FilenameInTar);
         if (it != m_TarInfoMap->end())
         {
@@ -99,7 +99,7 @@ std::unique_ptr<PoolableFile> FilePool::Acquire(const std::string &filename, con
     size_t size = (size_t)-1;
     if (!skipTarInfo && m_TarInfoMap && m_TarInfoMap->size())
     {
-        auto FilenameInTar = adios2sys::SystemTools::GetFilenameName(filename);
+        auto FilenameInTar = std::filesystem::path(filename).filename().string();
         auto it = m_TarInfoMap->find(FilenameInTar);
         if (it != m_TarInfoMap->end())
         {

--- a/source/adios2/toolkit/transport/Transport.cpp
+++ b/source/adios2/toolkit/transport/Transport.cpp
@@ -6,8 +6,8 @@
 
 #include "Transport.h"
 #include "adios2/core/CoreTypes.h"
-#include <adios2sys/SystemTools.hxx>
 #include <algorithm> // max
+#include <filesystem>
 #include <map>
 
 #include "adios2/helper/adiosFunctions.h" //CreateDirectory
@@ -166,7 +166,7 @@ void Transport::ProfilerStop(const std::string process) noexcept
 #if ADIOS2_ENABLE_DELAYED_WRITE
         if (process == "write")
         {
-            std::string fname = adios2sys::SystemTools::GetFilenameName(m_Name);
+            std::string fname = std::filesystem::path(m_Name).filename().string();
             std::replace(fname.begin(), fname.end(), '.', '_');
             double writeDelayFraction = GetWriteDelay(fname);
             m_Profiler.m_Timers.at(process).Pause(writeDelayFraction);

--- a/source/adios2/toolkit/transport/file/FileHTTPS.cpp
+++ b/source/adios2/toolkit/transport/file/FileHTTPS.cpp
@@ -6,9 +6,9 @@
 
 #include "FileHTTPS.h"
 #include "adios2/helper/adiosString.h"
-#include <adios2sys/SystemTools.hxx>
 
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <stdexcept>
 
@@ -177,9 +177,10 @@ void FileHTTPS::CheckCache(const size_t fileSize)
             if (lastPathSeparator != std::string::npos)
             {
                 const std::string dirpath(m_CacheFilePath.substr(0, lastPathSeparator));
-                adios2sys::SystemTools::MakeDirectory(dirpath);
-                // Cannot call this on Windows because it confuses it with CreateDirectoryA()
-                // helper::CreateDirectory(dirpath);
+                std::error_code ec;
+                std::filesystem::create_directories(dirpath, ec);
+                // Cannot call helper::CreateDirectory() on Windows because it confuses it
+                // with CreateDirectoryA()
             }
             m_CacheFileWrite = new FileFStream(m_Comm);
             m_CacheFileWrite->Open(m_CacheFilePath, Mode::Write);

--- a/source/adios2/toolkit/transportman/TransportMan.cpp
+++ b/source/adios2/toolkit/transportman/TransportMan.cpp
@@ -12,7 +12,7 @@
 
 #include "adios2/helper/adiosFunctions.h" //CreateDirectory
 #include "adios2/toolkit/transport/OpenFile.h"
-#include <adios2sys/SystemTools.hxx>
+#include <filesystem>
 
 #ifdef _WIN32
 #pragma warning(disable : 4503) // length of std::function inside std::async
@@ -149,7 +149,7 @@ std::vector<std::string> TransportMan::GetTransportsNames() noexcept
     for (const auto &transportPair : m_Transports)
     {
         const std::shared_ptr<Transport> &transport = transportPair.second;
-        names.push_back(adios2sys::SystemTools::GetFilenameName(transport->m_Name));
+        names.push_back(std::filesystem::path(transport->m_Name).filename().string());
     }
     return names;
 }

--- a/source/utils/bpls/bpls.cpp
+++ b/source/utils/bpls/bpls.cpp
@@ -58,7 +58,7 @@
 #include "adios2/helper/adiosString.h" // EndsWith
 #include "adios2/helper/adiosSystem.h" //isHDF5File
 #include <adios2sys/CommandLineArguments.hxx>
-#include <adios2sys/SystemTools.hxx>
+#include <filesystem>
 #include <pugixml.hpp>
 
 namespace adios2
@@ -492,7 +492,8 @@ bool introspectAsBPDir(const std::string &name) noexcept
 
 void introspect_file(const char *filename) noexcept
 {
-    if (adios2sys::SystemTools::FileIsDirectory(filename))
+    std::error_code fileIsDirEc;
+    if (std::filesystem::is_directory(filename, fileIsDirEc))
     {
         if (!introspectAsBPDir(filename))
         {
@@ -1700,11 +1701,11 @@ int doList(std::string path)
     }
     else
     {
-        bool exists = adios2sys::SystemTools::FileExists(path);
+        bool exists = std::filesystem::exists(path);
         if (!exists && !userOptions.campaign.campaignstorepath.empty() && path[0] != PathSeparator)
         {
             std::string path2 = userOptions.campaign.campaignstorepath + PathSeparator + path;
-            exists = adios2sys::SystemTools::FileExists(path2);
+            exists = std::filesystem::exists(path2);
             if (exists)
             {
                 ; // path = path2.c_str();
@@ -1713,7 +1714,7 @@ int doList(std::string path)
             {
                 std::string path3 =
                     userOptions.campaign.campaignstorepath + PathSeparator + path + ".aca";
-                exists = adios2sys::SystemTools::FileExists(path3);
+                exists = std::filesystem::exists(path3);
                 if (exists)
                 {
                     path += ".aca"; // path = path3.c_str();

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -136,7 +136,6 @@ gtest_add_tests_helper(WriteReadFlatten MPI_ONLY BP Engine.BP. .BP5 WORKING_DIRE
 if(UNIX AND CMAKE_SIZEOF_VOID_P GREATER_EQUAL 8)
   gtest_add_tests_helper(LargeBlocks MPI_NONE BP Engine.BP. .BP5 WORKING_DIRECTORY ${BP5_DIR} EXTRA_ARGS "BP5" )
   set_tests_properties(Engine.BP.LargeBlocks.MultiBlock.BP5.Serial PROPERTIES SKIP_REGULAR_EXPRESSION "SKIP:" RUN_SERIAL TRUE)
-  target_link_libraries(Test.Engine.BP.LargeBlocks.Serial adios2sys)
 endif()
 
 # Interleaved reads from two files open at once (also run remotely below)

--- a/testing/adios2/engine/bp/TestBPLargeBlocks.cpp
+++ b/testing/adios2/engine/bp/TestBPLargeBlocks.cpp
@@ -12,8 +12,8 @@
 #include <sys/statvfs.h>
 
 #include <adios2.h>
-#include <adios2sys/SystemTools.hxx>
 
+#include <filesystem>
 #include <gtest/gtest.h>
 
 // Detect sanitizers - test is too slow due to ~4GB allocation
@@ -140,7 +140,8 @@ TEST_F(LargeBlocks, MultiBlock)
         }
         reader.Close();
     }
-    adios2sys::SystemTools::RemoveADirectory(fname);
+    std::error_code ec;
+    std::filesystem::remove_all(fname, ec);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Replace adios2sys::SystemTools file/path operations and Directory
listing with std::filesystem across core, engines, and toolkit
transports. Replace GetEnv/PutEnv/SplitString with small
adios2::helper equivalents. Replace DynamicLoader/ConvertToOutputPath
in adiosDynamicBinder.cpp with direct dlopen/LoadLibraryExW calls.

kwsys is not removed: bpls still uses CommandLineArguments (next PR),
and MD5 (BP5Helper.cpp, KVCacheCommon.cpp) is untouched.