### PR TITLE
ci: automate backporting with korthout/backport-action

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -50,15 +50,23 @@ git checkout -b release_@MAJOR@@MINOR@ origin/master
 # Use the following command with care
 git push origin release_@MAJOR@@MINOR@:release_@MAJOR@@MINOR@
 ```
+- [ ] Create the `backport release_@MAJOR@@MINOR@` label so PRs can be
+  backported to the new branch (see
+  [backporting docs](https://adios2.readthedocs.io/en/latest/advice/backporting.html)):
+```
+gh label create "backport release_@MAJOR@@MINOR@" --description "Backport to release_@MAJOR@@MINOR@" --color e99695
+```
 <!-- else -->
 - [ ] Remove older patch releases for @MAJOR@.@MINOR@.X in ReadTheDocs.
-- [ ] Create merge -sours commit in master:
+<!-- endif -->
+<!-- If this is the FINAL planned release for release_@MAJOR@@MINOR@ (not a patch release) -->
+- [ ] Merge release_@MAJOR@@MINOR@ back into master, since this release line is complete:
 ```
 git fetch origin
 git checkout master
 git reset --hard origin/master
-# We do not want the changes master from the release branch
-git -s ours release_@MAJOR@@MINOR@
+git merge release_@MAJOR@@MINOR@
+# Resolve any conflicts, then:
 # Be very careful here
 git push origin master
 ```

--- a/.github/workflows/backport-manual.yml
+++ b/.github/workflows/backport-manual.yml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Backport PR (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull Request number
+        required: true
+      target_branch:
+        description: Branch to backport to
+        required: true
+
+permissions: {}
+
+jobs:
+  backport:
+    environment: backport
+    runs-on: ubuntu-latest
+    name: Backport
+    env:
+      GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+      BRANCH: ${{ github.event.inputs.target_branch }}
+      PR: ${{ github.event.inputs.pr }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BACKPORT_TOKEN }}
+      - name: Create backport
+        run: |
+          commit_hash=$(gh pr view "${PR}" --repo ornladios/ADIOS2 --json mergeCommit --jq '.mergeCommit.oid')
+          if [ -z "$commit_hash" ] || [ "$commit_hash" = "null" ]; then
+            echo "Error: PR ${PR} is not merged yet"
+            exit 1
+          fi
+
+          git config user.name "ornladios-robot"
+          git config user.email "ornladios-robot[bot]@users.noreply.github.com"
+          gh auth setup-git
+
+          git checkout --track "origin/${BRANCH}"
+          git checkout -b "backport-to-${BRANCH}-${PR}"
+          gh pr view --json commits --jq '.commits[].oid' "${PR}" | xargs -n1 git cherry-pick --mainline 1 -x
+          git push -f https://github.com/ornladios-robot/ADIOS2.git "backport-to-${BRANCH}-${PR}"
+          gh api repos/ornladios/ADIOS2/pulls \
+            --method POST \
+            -f head="ornladios-robot:backport-to-${BRANCH}-${PR}" \
+            -f base="${BRANCH}" \
+            -f title="Backport #${PR} to ${BRANCH}" \
+            -f body="Backports #${PR}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,50 +5,23 @@
 name: Backport PR
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr:
-        description: Pull Request number
-        required: true
-      target_branch:
-        description: Branch to backport to
-        required: true
+  pull_request_target:
+    types: [closed, labeled]
 
-permissions: {}
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   backport:
-    environment: backport
+    name: Backport pull request
     runs-on: ubuntu-latest
-    name: Backport
-    env:
-      GH_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
-      BRANCH: ${{ github.event.inputs.target_branch }}
-      PR: ${{ github.event.inputs.pr }}
+    # Only run on merged PRs carrying a "backport <branch>" label, e.g.
+    # "backport master" or "backport release_212".
+    if: >
+      github.event.pull_request.merged
+      && contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.BACKPORT_TOKEN }}
-      - name: Create backport
-        run: |
-          commit_hash=$(gh pr view "${PR}" --repo ornladios/ADIOS2 --json mergeCommit --jq '.mergeCommit.oid')
-          if [ -z "$commit_hash" ] || [ "$commit_hash" = "null" ]; then
-            echo "Error: PR ${PR} is not merged yet"
-            exit 1
-          fi
-
-          git config user.name "ornladios-robot"
-          git config user.email "ornladios-robot[bot]@users.noreply.github.com"
-          gh auth setup-git
-
-          git checkout --track "origin/${BRANCH}"
-          git checkout -b "backport-to-${BRANCH}-${PR}"
-          gh pr view --json commits --jq '.commits[].oid' "${PR}" | xargs -n1 git cherry-pick --mainline 1 -x 
-          git push -f https://github.com/ornladios-robot/ADIOS2.git "backport-to-${BRANCH}-${PR}"
-          gh api repos/ornladios/ADIOS2/pulls \
-            --method POST \
-            -f head="ornladios-robot:backport-to-${BRANCH}-${PR}" \
-            -f base="${BRANCH}" \
-            -f title="Backport #${PR} to ${BRANCH}" \
-            -f body="Backports #${PR}"
+      - name: Create backport pull request
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0

--- a/docs/user_guide/source/advice/backporting.rst
+++ b/docs/user_guide/source/advice/backporting.rst
@@ -22,6 +22,12 @@ The workflow is defined in ``.github/workflows/backport.yml``. It cherry-picks
 the merged PR's commits with ``-x`` and opens a new PR against the target
 branch for review; nothing is pushed directly.
 
+A manual fallback, ``.github/workflows/backport-manual.yml``, is also
+available via ``workflow_dispatch`` (PR number and target branch as inputs)
+for cases where the label-driven workflow cannot be used. Like the
+label-driven workflow, it only ever pushes to a new branch and opens a PR
+for review; it never pushes or merges directly into the target branch.
+
 When cutting a new release branch, create its ``backport release_X.Y`` label.
 See the release checklist in ``.github/ISSUE_TEMPLATE/new_release.md``.
 

--- a/docs/user_guide/source/advice/backporting.rst
+++ b/docs/user_guide/source/advice/backporting.rst
@@ -1,0 +1,32 @@
+***********
+Backporting
+***********
+
+ADIOS2 uses the `korthout/backport-action <https://github.com/korthout/backport-action>`_
+GitHub Action to automate backporting merged pull requests. Labeling a merged
+PR with ``backport <branch>`` opens a cherry-pick PR against ``<branch>``,
+for example:
+
+- ``backport release_212`` — backports to the ``release_212`` branch.
+- ``backport master`` — backports to ``master``. Use this for fixes merged
+  directly into a release branch that also apply to ``master``.
+
+Any target branch works, not just the currently active release line: apply
+``backport release_28`` to send a fix to an older, still-maintained release
+branch. Labels for ``master`` and the currently supported release branches
+already exist; create a new ``backport release_X.Y`` label
+(``gh label create "backport release_X.Y"``) the first time you need to
+target a branch that doesn't have one yet.
+
+The workflow is defined in ``.github/workflows/backport.yml``. It cherry-picks
+the merged PR's commits with ``-x`` and opens a new PR against the target
+branch for review; nothing is pushed directly.
+
+When cutting a new release branch, create its ``backport release_X.Y`` label.
+See the release checklist in ``.github/ISSUE_TEMPLATE/new_release.md``.
+
+While a release line is active, its branch only receives forward
+cherry-picks via ``backport release_X.Y`` labels; patch releases do not
+merge anything back into ``master``. When a release line reaches its
+final release, it is merged back into ``master`` with a normal
+``git merge release_X.Y`` (see the release checklist).

--- a/docs/user_guide/source/index.rst
+++ b/docs/user_guide/source/index.rst
@@ -67,6 +67,7 @@ Funded by the `Exascale Computing Project (ECP) <https://www.exascaleproject.org
 
    faq/faq
    advice/advice
+   advice/backporting
 
 
 * :ref:`search`


### PR DESCRIPTION
## Summary
- Replace the manual `workflow_dispatch` backport script in `.github/workflows/backport.yml` with `korthout/backport-action`. Any `backport <branch>` label on a merged PR (e.g. `backport release_212`, `backport master`) opens a cherry-pick PR against that branch, fully automated: no repo variable to keep updated, and any previous release line can be targeted, not just the active one.
- In `.github/ISSUE_TEMPLATE/new_release.md`: patch releases no longer merge anything back into `master`. Only the final release of a minor line does a normal `git merge release_X.Y` into `master` (previously this used `-s ours` on every release, patch included).
- Add a succinct doc page at `docs/user_guide/source/advice/backporting.rst` explaining the automation and the merge-back policy.

Labels `backport master`, `backport release_210`, `backport release_211`, and `backport release_212` already exist in the repo. New ones (e.g. for an older release line) can be created ad hoc with `gh label create "backport release_X.Y"`.

## Test plan
- [ ] Merge a small test PR labeled `backport release_212`, confirm a cherry-pick PR opens against `release_212`
- [ ] Merge a small test PR (base = a release branch) labeled `backport master`, confirm a cherry-pick PR opens against `master`