### PR TITLE
Avoid linking to uninstalled TARGET_OBJECTS

### DIFF
--- a/thirdparty/KWSys/CMakeLists.txt
+++ b/thirdparty/KWSys/CMakeLists.txt
@@ -11,11 +11,11 @@ if(WIN32)
 else()
   set(KWSYS_BUILD_SHARED ${BUILD_SHARED_LIBS})
 endif()
-set(KWSYS_SPLIT_OBJECTS_FROM_INTERFACE ON)
+set(KWSYS_SPLIT_OBJECTS_FROM_INTERFACE OFF)
 set(KWSYS_INSTALL_EXPORT_NAME adios2Exports)
 set(KWSYS_INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR})
 
 add_subdirectory(adios2sys)
-add_library(adios2sys_interface ALIAS adios2sys_private)
+add_library(adios2sys_interface ALIAS adios2sys)
 
 message_end_thirdparty()


### PR DESCRIPTION
As reported in https://github.com/ornladios/ADIOS2/issues/5105, the KWSys third-party module was installing a target with files in the `INTERFACE_SOURCES` property that were not installed. Even though this target was never used, CMake was failing simply because the target with a bad property existed.

This change modifies how the KWSys module is used. Rather than split objects from the interface, the module creates a single `adios2sys` target and avoids adding target objects.

Fixes #5105