### PR TITLE
Fix bug related to campaigns, metadata from BP5 stored as in-memory-…

### DIFF
--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -879,7 +879,8 @@ void CampaignReader::InitTransports()
                 {
                     if (m_Options.verbose > 0)
                     {
-                        std::cout << "      " << tsorder << ". " << ds.name << " Skipping \n";
+                        std::cout << "      " << tsorder << ". " << ds.name
+                                  << " No local metadata available. Skipping \n";
                     }
                 }
             }
@@ -935,7 +936,7 @@ void CampaignReader::InitTransports()
             localPath = SaveRemoteMD(dsIdx, repIdx, io, false);
             if (!localPath.empty())
             {
-                if (m_Options.verbose > 0)
+                if (m_Options.verbose > 0 && !in_memory_object.size())
                 {
                     std::cout << "    " << ds.name << " local file " << localPath << "\n";
                 }
@@ -944,8 +945,9 @@ void CampaignReader::InitTransports()
             {
                 if (m_Options.verbose > 0)
                 {
-                    std::cout << "    " << ds.name << " Skipping \n";
+                    std::cout << "    " << ds.name << " No local metadata available. Skipping \n";
                 }
+                continue;
             }
         }
         else
@@ -1159,18 +1161,19 @@ void CampaignReader::OpenDatasetWithADIOS(std::string prefixName, FileFormat for
                                           adios2::core::IO &io, std::string &localPath)
 {
     auto lf_Open = [&]() -> adios2::core::Engine & {
-        if (localPath.empty())
+        if (in_memory_object.size())
         {
             std::string engineName(in_memory_object.data(), 8);
+            std::string name = (localPath.empty() ? prefixName : localPath);
             helper::RightTrim(engineName);
             // in memory ADIOS metadata
             if (m_Options.verbose > 0)
             {
-                std::cout << "     Open in-memory for " << prefixName << " using engine ["
-                          << engineName << "] \n";
+                std::cout << "     Open in-memory for " << name << " using engine [" << engineName
+                          << "] \n";
             }
             io.SetEngine(engineName);
-            auto &e = io.Open(prefixName, m_OpenMode, m_Comm.Duplicate(), in_memory_object.data(),
+            auto &e = io.Open(name, m_OpenMode, m_Comm.Duplicate(), in_memory_object.data(),
                               in_memory_object.size());
             in_memory_object.clear();
             return e;


### PR DESCRIPTION
…metadata, and using HTTPS for remote access.

If a campaign file is created with hpc-campaign 0.7.1, and add a BP5 file, metadata is stored as in-memory object. If then that file is only accessible with HTTPS, the read will segfault as the https transport still expects metadata files on disk prepared by the campaing reader.  

Now, campaign reader calls BP5 with in-memory metadata but keep filename as the full URL so that the https transport knows where to read data from.

Demo of the issue. Make sure in `~/.config/hpc-campaign/hosts.yaml` there is no definition for either `NERSC.UEDGE` or `NERSC.UEDGE.Spin`. 
```
$ wget https://portal.nersc.gov/cfs/m3976/campaign-store/KSTAR24/Ip300_p0.5_d1.0.aca
$ bpls -l ./Ip300_p0.5_d1.0.aca
```
this will segfault with older bpls, and work now with this fix. 

