### PR TITLE
Bp5 truncated/corrupt file recovery

### DIFF
--- a/docs/user_guide/source/engines/bp5.rst
+++ b/docs/user_guide/source/engines/bp5.rst
@@ -58,6 +58,8 @@ This engine allows the user to fine tune the buffering operations through the fo
 
    1. **OpenTimeoutSecs**: (Streaming mode) Reader may want to wait for the creation of the file in ``io.Open()``. By default the Open() function returns with an error if file is not found.
 
+   1. **EOFWaitSecs**: How long a read of data the metadata refers to may wait on an end-of-file before failing, once the writer is known to be gone. The wait absorbs shared-filesystem consistency lag; on a file truncated by an interrupted writer, reads of the missing bytes fail cleanly after roughly 1.5x this many seconds. Recovery tools can set it low to fail fast.
+
    #. **BeginStepPollingFrequencySecs**: (Streaming mode) Reader can set how frequently to check the file (and file system) for new steps. Default is 1 seconds which may be stressful for the file system and unnecessary for the application.
 
 #. Aggregation
@@ -170,6 +172,7 @@ This engine allows the user to fine tune the buffering operations through the fo
 ================================ ===================== ===========================================================
  OpenTimeoutSecs                 float                 **0** for *ReadRandomAccess* mode, **3600** for *Read* mode, ``10.0``, ``5``
  BeginStepPollingFrequencySecs   float                 **1**, 10.0 
+ EOFWaitSecs                     float                 **30**, ``1.0``
  AggregationType                 string                **TwoLevelShm**, EveryoneWritesSerial, DataSizeBased, EveryoneWrites
  NumAggregators                  integer >= 1          **0 (one file per compute node)**
  AggregatorRatio                 integer >= 1          not used unless set

--- a/source/adios2/engine/bp5/BP5Engine.h
+++ b/source/adios2/engine/bp5/BP5Engine.h
@@ -140,6 +140,7 @@ public:
 
 #define BP5_FOREACH_PARAMETER_TYPE_4ARGS(MACRO)                                                    \
     MACRO(OpenTimeoutSecs, Float, float, -1.0f)                                                    \
+    MACRO(EOFWaitSecs, Float, float, 30.0f)                                                        \
     MACRO(BeginStepPollingFrequencySecs, Float, float, 1.0f)                                       \
     MACRO(StreamReader, Bool, bool, false)                                                         \
     MACRO(BurstBufferDrain, Bool, bool, true)                                                      \

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -930,18 +930,7 @@ void BP5Reader::PerformLocalGets(format::BP5Deserializer::BP5GetContext &ctx)
 
     std::call_once(m_InitialWriterActiveCheckFlag, [this]() {
         CheckWriterActive();
-        if (!m_WriterIsActive)
-        {
-            Params transportParameters;
-            transportParameters["FailOnEOF"] = "true";
-            m_DataFiles->SetParameters(transportParameters);
-            if (m_MDIndexFile)
-                m_MDIndexFile->SetParameters(transportParameters);
-            if (m_MDFile)
-                m_MDFile->SetParameters(transportParameters);
-            if (m_MetaMetadataFile)
-                m_MetaMetadataFile->SetParameters(transportParameters);
-        }
+        ApplyFailOnEOFPolicy();
     });
     // TP start = NOW();
     PERFSTUBS_SCOPED_TIMER("BP5Reader::PerformGets");
@@ -1620,14 +1609,27 @@ void BP5Reader::InitTransports()
 void BP5Reader::InstallMetaMetaData(format::BufferSTL buffer)
 {
     size_t Position = m_MetaMetaDataFileAlreadyProcessedSize;
-    while (Position < buffer.m_Buffer.size())
+    const size_t size = buffer.m_Buffer.size();
+    while (Position < size)
     {
         format::BP5Base::MetaMetaInfoBlock MMI;
 
+        // A record cut short by a killed writer (or one still being appended
+        // in streaming) must not be installed: stop at the last complete
+        // record and leave Position there so a later, longer read retries it.
+        const size_t savedPosition = Position;
+        if (size - Position < 2 * sizeof(uint64_t))
+            break;
         MMI.MetaMetaIDLen =
             helper::ReadValue<uint64_t>(buffer.m_Buffer, Position, m_Minifooter.IsLittleEndian);
         MMI.MetaMetaInfoLen =
             helper::ReadValue<uint64_t>(buffer.m_Buffer, Position, m_Minifooter.IsLittleEndian);
+        if (MMI.MetaMetaIDLen > size - Position || MMI.MetaMetaInfoLen > size - Position ||
+            MMI.MetaMetaIDLen + MMI.MetaMetaInfoLen > size - Position)
+        {
+            Position = savedPosition;
+            break;
+        }
         MMI.MetaMetaID = buffer.Data() + Position;
         MMI.MetaMetaInfo = buffer.Data() + Position + MMI.MetaMetaIDLen;
         m_BP5Deserializer->InstallMetaMetaData(MMI);
@@ -1693,6 +1695,17 @@ void BP5Reader::UpdateBuffer(const TimePoint &timeoutInstant, const Seconds &pol
     // broadcast metadata index buffer to all ranks from zero
     m_Comm.BroadcastVector(m_MetadataIndex.m_Buffer);
     newIdxSize = m_MetadataIndex.m_Buffer.size();
+
+    if (newIdxSize == 0 && m_OpenMode == Mode::ReadRandomAccess && !m_MDIndexFileAlreadyReadSize)
+    {
+        // The index file exists but is empty: a writer was interrupted before
+        // it produced anything. In random access the file is final, so this
+        // cannot resolve by waiting.
+        helper::Throw<std::runtime_error>("Engine", "BP5Reader", "UpdateBuffer",
+                                          "metadata index file of " + m_Name +
+                                              " is empty; the file was likely truncated by an "
+                                              "interrupted writer and contains no readable data");
+    }
 
     size_t parsedIdxSize = 0;
     const auto stepsBefore = m_StepsCount;
@@ -1877,6 +1890,21 @@ size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t 
 
     if (hasHeader)
     {
+        if (buffer.size() < m_IndexHeaderSize)
+        {
+            // A file shorter than its own 64-byte header. In streaming mode a
+            // just-created file can transiently look like this, so report
+            // nothing parsed and let the poll loop retry; in random access
+            // the file is final and unusable.
+            if (m_OpenMode == Mode::ReadRandomAccess)
+                helper::Throw<std::runtime_error>(
+                    "Engine", "BP5Reader", "ParseMetadataIndex",
+                    "metadata index file is smaller than its header (" +
+                        std::to_string(buffer.size()) +
+                        " bytes); the file is truncated or corrupt, possibly by an "
+                        "interrupted writer");
+            return 0;
+        }
         // Read header (64 bytes)
         // long version string
         position = m_VersionTagPosition;
@@ -2108,6 +2136,28 @@ bool BP5Reader::ReadActiveFlag(std::vector<char> &buffer)
     return m_WriterIsActive;
 }
 
+void BP5Reader::ApplyFailOnEOFPolicy()
+{
+    // Once the writer is known inactive, no file can legitimately be shorter
+    // than its metadata promises: make transport-level EOF a bounded wait and
+    // then a clean error instead of an indefinite wait for a writer to append.
+    if (m_WriterIsActive || m_FailOnEOFApplied)
+        return;
+    m_FailOnEOFApplied = true;
+    Params transportParameters;
+    transportParameters["FailOnEOF"] = "true";
+    if (m_DataFiles)
+        m_DataFiles->SetParameters(transportParameters);
+    if (m_MetadataFiles && m_MetadataFiles != m_DataFiles)
+        m_MetadataFiles->SetParameters(transportParameters);
+    if (m_MDIndexFile)
+        m_MDIndexFile->SetParameters(transportParameters);
+    if (m_MDFile)
+        m_MDFile->SetParameters(transportParameters);
+    if (m_MetaMetadataFile)
+        m_MetaMetadataFile->SetParameters(transportParameters);
+}
+
 bool BP5Reader::CheckWriterActive()
 {
     if (m_ReadMetadataFromFile && m_WriterIsActive)
@@ -2131,6 +2181,7 @@ bool BP5Reader::CheckWriterActive()
     {
         m_WriterIsActive = false;
     }
+    ApplyFailOnEOFPolicy();
     return m_WriterIsActive;
 }
 
@@ -2237,7 +2288,12 @@ void BP5Reader::DoGetStructDeferred(VariableStruct &variable, void *data)
 void BP5Reader::DoClose(const int transportIndex)
 {
     PERFSTUBS_SCOPED_TIMER("BP5Reader::Close");
-    if (m_OpenMode == Mode::ReadRandomAccess)
+    if (!m_BP5Deserializer)
+    {
+        // Open never got far enough to build the deserializer (e.g. the
+        // metadata index was empty or unusable); nothing to flush.
+    }
+    else if (m_OpenMode == Mode::ReadRandomAccess)
     {
         PerformGets();
     }
@@ -2338,6 +2394,11 @@ size_t BP5Reader::DoSteps() const
 
 void BP5Reader::NotifyEngineNoVarsQuery()
 {
+    // In random access an empty-but-valid (or truncated-to-empty) file is
+    // simply a file with no variables; InquireVariable returning nullptr is
+    // the right answer. The advice below is for streaming misuse only.
+    if (m_OpenMode == Mode::ReadRandomAccess)
+        return;
     if (!m_BetweenStepPairs)
     {
         helper::Throw<std::logic_error>(

--- a/source/adios2/engine/bp5/BP5Reader.cpp
+++ b/source/adios2/engine/bp5/BP5Reader.cpp
@@ -193,8 +193,44 @@ void BP5Reader::ProcessMetadataFromMemory(const char *md)
     }
 }
 
-void BP5Reader::InstallMetadataForTimestep(size_t Step)
+bool BP5Reader::StepMetadataFormatsKnown(size_t Step)
 {
+    // Can every writer rank's metadata block for this step be decoded, i.e.
+    // is each block's format among the (possibly truncated) mmd.0 records
+    // installed so far? Checked before any block is installed so a step is
+    // either fully available or not present at all.
+    size_t pgstart = m_MetadataIndexTable[Step][0];
+    size_t Position = pgstart + sizeof(uint64_t); // skip total data size
+    const uint64_t WriterCount = m_WriterMap[m_WriterMapIndex[Step]].WriterCount;
+    size_t MDPosition = Position + 2 * sizeof(uint64_t) * WriterCount;
+    for (size_t WriterRank = 0; WriterRank < WriterCount; WriterRank++)
+    {
+        size_t ThisMDSize =
+            helper::ReadValue<uint64_t>(m_Metadata.Data(), Position, m_Minifooter.IsLittleEndian);
+        char *ThisMD = m_Metadata.Data() + MDPosition;
+        if (!m_BP5Deserializer->MetadataFormatKnown(ThisMD))
+        {
+            return false;
+        }
+        MDPosition += ThisMDSize;
+    }
+    return true;
+}
+
+bool BP5Reader::InstallMetadataForTimestep(size_t Step)
+{
+    if (!StepMetadataFormatsKnown(Step))
+    {
+        if (m_OpenMode != Mode::ReadRandomAccess)
+        {
+            helper::Throw<std::runtime_error>(
+                "Engine", "BP5Reader", "InstallMetadataForTimestep",
+                "step metadata references data formats missing from a truncated "
+                "meta-metadata (mmd.0) file; the file was likely cut short by an "
+                "interrupted writer");
+        }
+        return false;
+    }
     size_t pgstart = m_MetadataIndexTable[Step][0];
     size_t Position = pgstart + sizeof(uint64_t); // skip total data size
     const uint64_t WriterCount = m_WriterMap[m_WriterMapIndex[Step]].WriterCount;
@@ -222,7 +258,24 @@ void BP5Reader::InstallMetadataForTimestep(size_t Step)
             helper::ReadValue<uint64_t>(m_Metadata.Data(), Position, m_Minifooter.IsLittleEndian);
         char *ThisAD = m_Metadata.Data() + MDPosition;
         if (ThisADSize > 0)
-            m_BP5Deserializer->InstallAttributeData(ThisAD, ThisADSize);
+        {
+            if (m_BP5Deserializer->MetadataFormatKnown(ThisAD))
+            {
+                m_BP5Deserializer->InstallAttributeData(ThisAD, ThisADSize);
+            }
+            else if (!m_AttrFormatWarned)
+            {
+                // format lost to a truncated mmd.0: variables may still be
+                // fully readable, so degrade to serving them without attributes
+                m_AttrFormatWarned = true;
+                if (m_Comm.Rank() == 0)
+                    std::cerr << "ADIOS2 BP5 reader WARNING: " << m_Name
+                              << " attribute metadata references a data format missing from "
+                                 "the meta-metadata file (truncated by an interrupted "
+                                 "writer?); attributes will be unavailable"
+                              << std::endl;
+            }
+        }
         MDPosition += ThisADSize;
     }
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
@@ -230,10 +283,23 @@ void BP5Reader::InstallMetadataForTimestep(size_t Step)
     // attributes (installed above, after variable metadata) are available.
     m_BP5Deserializer->InstallReaderDerivedVariables();
 #endif
+    return true;
 }
 
-void BP5Reader::ParallelInstallMetadataForTimestep(size_t Step)
+bool BP5Reader::ParallelInstallMetadataForTimestep(size_t Step)
 {
+    if (!StepMetadataFormatsKnown(Step))
+    {
+        if (m_OpenMode != Mode::ReadRandomAccess)
+        {
+            helper::Throw<std::runtime_error>(
+                "Engine", "BP5Reader", "ParallelInstallMetadataForTimestep",
+                "step metadata references data formats missing from a truncated "
+                "meta-metadata (mmd.0) file; the file was likely cut short by an "
+                "interrupted writer");
+        }
+        return false;
+    }
     const uint64_t WriterCount = m_WriterMap[m_WriterMapIndex[Step]].WriterCount;
     size_t m_MetadataThreads = m_Parameters.MetadataThreads;
     size_t nThreads = (m_MetadataThreads < WriterCount ? m_MetadataThreads : WriterCount);
@@ -331,7 +397,24 @@ void BP5Reader::ParallelInstallMetadataForTimestep(size_t Step)
             helper::ReadValue<uint64_t>(m_Metadata.Data(), Position, m_Minifooter.IsLittleEndian);
         char *ThisAD = m_Metadata.Data() + MDPosition;
         if (ThisADSize > 0)
-            m_BP5Deserializer->InstallAttributeData(ThisAD, ThisADSize);
+        {
+            if (m_BP5Deserializer->MetadataFormatKnown(ThisAD))
+            {
+                m_BP5Deserializer->InstallAttributeData(ThisAD, ThisADSize);
+            }
+            else if (!m_AttrFormatWarned)
+            {
+                // format lost to a truncated mmd.0: variables may still be
+                // fully readable, so degrade to serving them without attributes
+                m_AttrFormatWarned = true;
+                if (m_Comm.Rank() == 0)
+                    std::cerr << "ADIOS2 BP5 reader WARNING: " << m_Name
+                              << " attribute metadata references a data format missing from "
+                                 "the meta-metadata file (truncated by an interrupted "
+                                 "writer?); attributes will be unavailable"
+                              << std::endl;
+            }
+        }
         MDPosition += ThisADSize;
     }
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
@@ -339,6 +422,7 @@ void BP5Reader::ParallelInstallMetadataForTimestep(size_t Step)
     // attributes (installed above, after variable metadata) are available.
     m_BP5Deserializer->InstallReaderDerivedVariables();
 #endif
+    return true;
 }
 
 StepStatus BP5Reader::BeginStep(StepMode mode, const float timeoutSeconds)
@@ -493,7 +577,22 @@ double BP5Reader::ReadData(PoolableFile *DataFile, const size_t WriterRank, cons
             helper::Throw<std::overflow_error>("Engine", "BP5Reader", "ReadData",
                                                "file offset exceeds size_t on this platform");
         }
-        DataFile->Read(Destination, Length, static_cast<size_t>(base + offset));
+        try
+        {
+            DataFile->Read(Destination, Length, static_cast<size_t>(base + offset));
+        }
+        catch (std::ios_base::failure &e)
+        {
+            if (m_WriterIsActive)
+            {
+                helper::Throw<std::ios_base::failure>(
+                    "Engine", "BP5Reader", "ReadData",
+                    std::string(e.what()) +
+                        " -- the file is still marked as actively written; if its writer no "
+                        "longer exists, run adios2_deactivate_bp on it to mark it final");
+            }
+            throw;
+        }
     };
     size_t InfoStartPos = DataPosPos + (WriterRank * (2 * FlushCount + 1) * sizeof(uint64_t));
     uint64_t SumDataSize = 0; // count in contiguous space
@@ -1696,6 +1795,15 @@ void BP5Reader::UpdateBuffer(const TimePoint &timeoutInstant, const Seconds &pol
     m_Comm.BroadcastVector(m_MetadataIndex.m_Buffer);
     newIdxSize = m_MetadataIndex.m_Buffer.size();
 
+    // md.0's actual size bounds which index records are usable: a step whose
+    // metadata extent is not (yet) backed by md.0 bytes is not readable
+    size_t mdActualSize = 0;
+    if (m_Comm.Rank() == 0 && m_MDFile)
+    {
+        mdActualSize = m_MDFile->GetSize();
+    }
+    mdActualSize = m_Comm.BroadcastValue(mdActualSize, 0);
+
     if (newIdxSize == 0 && m_OpenMode == Mode::ReadRandomAccess && !m_MDIndexFileAlreadyReadSize)
     {
         // The index file exists but is empty: a writer was interrupted before
@@ -1713,7 +1821,20 @@ void BP5Reader::UpdateBuffer(const TimePoint &timeoutInstant, const Seconds &pol
     {
         /* Parse metadata index table */
         const bool hasHeader = (!m_MDIndexFileAlreadyReadSize);
-        parsedIdxSize = ParseMetadataIndex(m_MetadataIndex, 0, hasHeader);
+        m_MDTrimmedSteps = false;
+        parsedIdxSize = ParseMetadataIndex(m_MetadataIndex, 0, hasHeader, mdActualSize);
+        if (m_MDTrimmedSteps && m_OpenMode == Mode::ReadRandomAccess && m_Comm.Rank() == 0)
+        {
+            std::cerr << "ADIOS2 BP5 reader WARNING: " << m_Name
+                      << " lists steps whose metadata the md.0 file does not contain; the "
+                         "file appears truncated by an interrupted writer. Serving the "
+                      << m_StepsCount << " complete step(s)."
+                      << (m_WriterIsActive
+                              ? " The file is still marked as actively written; if its writer "
+                                "is gone, run adios2_deactivate_bp on it to mark it final."
+                              : "")
+                      << std::endl;
+        }
         // now we are sure the index header has been parsed,
         // first step parsing done
         // m_FilteredMetadataInfo is created
@@ -1789,9 +1910,12 @@ void BP5Reader::UpdateBuffer(const TimePoint &timeoutInstant, const Seconds &pol
                         " metadata size = " + std::to_string(actualFileSize) +
                         " expected size = " + std::to_string(expectedMinFileSize) +
                         ". One reason could be if the reader finds old "
-                        "data "
-                        "while "
-                        "the writer is creating the new files.");
+                        "data while the writer is creating the new files." +
+                        std::string(m_WriterIsActive
+                                        ? " The file is marked as actively written; if its "
+                                          "writer no longer exists, run adios2_deactivate_bp "
+                                          "on it to mark it final."
+                                        : ""));
             }
 
             /* Read new meta-meta-data into memory and append to existing one in
@@ -1838,13 +1962,36 @@ void BP5Reader::UpdateBuffer(const TimePoint &timeoutInstant, const Seconds &pol
             {
                 m_BP5Deserializer->SetupForStep(Step,
                                                 m_WriterMap[m_WriterMapIndex[Step]].WriterCount);
+                bool ok;
                 if (m_Parameters.MetadataThreads > 1)
                 {
-                    ParallelInstallMetadataForTimestep(Step);
+                    ok = ParallelInstallMetadataForTimestep(Step);
                 }
                 else
                 {
-                    InstallMetadataForTimestep(Step);
+                    ok = InstallMetadataForTimestep(Step);
+                }
+                if (!ok)
+                {
+                    // This step's metadata needs formats beyond what a
+                    // truncated mmd.0 still describes; it and all later
+                    // steps are unreadable. Serve the complete prefix.
+                    if (m_Comm.Rank() == 0)
+                    {
+                        std::cerr << "ADIOS2 BP5 reader WARNING: " << m_Name << " step " << Step
+                                  << " and beyond reference data formats missing from the "
+                                     "meta-metadata file; the file appears truncated by an "
+                                     "interrupted writer. Serving the first "
+                                  << Step << " step(s)."
+                                  << (m_WriterIsActive
+                                          ? " The file is still marked as actively written; "
+                                            "if its writer is gone, run adios2_deactivate_bp "
+                                            "on it to mark it final."
+                                          : "")
+                                  << std::endl;
+                    }
+                    m_StepsCount = Step;
+                    break;
                 }
             }
         }
@@ -1883,7 +2030,7 @@ void BP5Reader::UpdateBuffer(const TimePoint &timeoutInstant, const Seconds &pol
 }
 
 size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t absoluteStartPos,
-                                     const bool hasHeader)
+                                     const bool hasHeader, const size_t mdFileSize)
 {
     const auto &buffer = bufferSTL.m_Buffer;
     size_t &position = bufferSTL.m_Position;
@@ -1996,6 +2143,7 @@ size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t 
         }
 
         const size_t savedPosition = position;
+        bool stopParsing = false;
         const unsigned char recordID =
             helper::ReadValue<unsigned char>(buffer, position, m_Minifooter.IsLittleEndian);
         const uint64_t recordLength =
@@ -2041,6 +2189,19 @@ size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t 
                 helper::ReadValue<uint64_t>(buffer, position, m_Minifooter.IsLittleEndian);
             const uint64_t FlushCount =
                 helper::ReadValue<uint64_t>(buffer, position, m_Minifooter.IsLittleEndian);
+
+            if (MetadataPos + MetadataSize > mdFileSize)
+            {
+                /* The index promises metadata that md.0 does not (yet) hold.
+                   Streaming: the writer's md flush may just not be visible
+                   yet; stop here and let the next poll retry from this
+                   record. A killed writer never delivers it, and the steps
+                   before this one remain fully readable. */
+                m_MDTrimmedSteps = true;
+                position = savedPosition;
+                stopParsing = true;
+                break;
+            }
 
             if (!n)
             {
@@ -2100,6 +2261,10 @@ size_t BP5Reader::ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t 
             break;
         }
         }
+        if (stopParsing)
+        {
+            break;
+        }
         // dbg
         if ((position - dbgRecordStartPosition) != (size_t)recordLength)
         {
@@ -2141,11 +2306,12 @@ void BP5Reader::ApplyFailOnEOFPolicy()
     // Once the writer is known inactive, no file can legitimately be shorter
     // than its metadata promises: make transport-level EOF a bounded wait and
     // then a clean error instead of an indefinite wait for a writer to append.
-    if (m_WriterIsActive || m_FailOnEOFApplied)
+    if (m_FailOnEOFApplied || (m_WriterIsActive && m_OpenMode != Mode::ReadRandomAccess))
         return;
     m_FailOnEOFApplied = true;
     Params transportParameters;
     transportParameters["FailOnEOF"] = "true";
+    transportParameters["EOFWaitSecs"] = std::to_string(m_Parameters.EOFWaitSecs);
     if (m_DataFiles)
         m_DataFiles->SetParameters(transportParameters);
     if (m_MetadataFiles && m_MetadataFiles != m_DataFiles)

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -209,6 +209,11 @@ private:
      */
     bool CheckWriterActive();
 
+    /** set FailOnEOF on all read transports once the writer is known
+     * inactive; idempotent */
+    void ApplyFailOnEOFPolicy();
+    bool m_FailOnEOFApplied = false;
+
     /** Check for a step that is already in memory but haven't
      * been processed yet.
      *  @return true: if new step has been found and processed, false otherwise

--- a/source/adios2/engine/bp5/BP5Reader.h
+++ b/source/adios2/engine/bp5/BP5Reader.h
@@ -196,7 +196,7 @@ private:
      *   m_FilteredMetadataInfo
      */
     size_t ParseMetadataIndex(format::BufferSTL &bufferSTL, const size_t absoluteStartPos,
-                              const bool hasHeader);
+                              const bool hasHeader, const size_t mdFileSize = adios2::MaxSizeT);
 
     /** Process the new metadata coming in (in UpdateBuffer)
      *  @param newIdxSize: the size of the new content from Index Table
@@ -213,6 +213,13 @@ private:
      * inactive; idempotent */
     void ApplyFailOnEOFPolicy();
     bool m_FailOnEOFApplied = false;
+
+    /** ParseMetadataIndex stopped before index records whose metadata extents
+     * exceed md.0's actual size (truncated or not yet flushed) */
+    bool m_MDTrimmedSteps = false;
+
+    /** warned once that attributes are unreadable (format lost to truncation) */
+    bool m_AttrFormatWarned = false;
 
     /** Check for a step that is already in memory but haven't
      * been processed yet.
@@ -276,8 +283,11 @@ private:
     format::BufferMalloc m_Metadata;
 
     void InstallMetaMetaData(format::BufferSTL MetaMetadata);
-    void InstallMetadataForTimestep(size_t Step);
-    void ParallelInstallMetadataForTimestep(size_t Step);
+    /** false = the step references formats a truncated mmd.0 no longer
+     * describes (random access only; streaming throws instead) */
+    bool InstallMetadataForTimestep(size_t Step);
+    bool ParallelInstallMetadataForTimestep(size_t Step);
+    bool StepMetadataFormatsKnown(size_t Step);
     double ReadData(PoolableFile *DataFile, const size_t WriterRank, const size_t Timestep,
                     const uint64_t StartOffset, const size_t Length, char *Destination);
 

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.cpp
@@ -823,6 +823,11 @@ void BP5Deserializer::InstallMetaData(void *MetadataBlock, size_t BlockLen, size
     InstallMetadataBuffer(BaseData, WriterRank, Step, FFSformat);
 }
 
+bool BP5Deserializer::MetadataFormatKnown(void *MetadataBlock)
+{
+    return FFSTypeHandle_from_encode(ReaderFFSContext, (char *)MetadataBlock) != nullptr;
+}
+
 FFSTypeHandle BP5Deserializer::BufferMetaMetaPrep(void *MetadataBlock)
 {
     FFSTypeHandle FFSformat = FFSTypeHandle_from_encode(ReaderFFSContext, (char *)MetadataBlock);

--- a/source/adios2/toolkit/format/bp5/BP5Deserializer.h
+++ b/source/adios2/toolkit/format/bp5/BP5Deserializer.h
@@ -56,6 +56,10 @@ public:
     void InstallMetaData(void *MetadataBlock, size_t BlockLen, size_t WriterRank,
                          size_t Step = SIZE_MAX);
     void InstallAttributeData(void *AttributeBlock, size_t BlockLen, size_t Step = SIZE_MAX);
+    /** is the FFS format this metadata block was encoded with already
+     * installed? False means the describing mmd.0 record is absent (e.g.
+     * truncated away), so the block cannot be decoded. */
+    bool MetadataFormatKnown(void *MetadataBlock);
 #ifdef ADIOS2_HAVE_DERIVED_VARIABLE
     // Retry resolution of pending reader-derived variables. Idempotent and
     // cheap once none remain; also called after attribute install, since

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -517,13 +517,27 @@ void FilePOSIX::Read(char *buffer, size_t size, size_t start)
                     // reaches 30 seconds (nearly 45 seconds total
                     // wait time) and we still don't have data, treat
                     // this as a real failure and throw an exception.
+                    // One full wait per file suffices: once EOF has been
+                    // confirmed past the consistency window, further reads
+                    // of this (truncated) file fail immediately rather
+                    // than each re-waiting the full window.
+                    if (m_EOFConfirmed)
+                        helper::Throw<std::ios_base::failure>(
+                            "Toolkit", "transport::file::FilePOSIX", "Read",
+                            "file " + m_Name + " ends " + std::to_string(size) +
+                                " bytes before data that its metadata refers to; it was "
+                                "likely truncated by an interrupted writer");
                     std::this_thread::sleep_for(std::chrono::nanoseconds(backoff_ns));
                     backoff_ns *= 2;
                     if (std::chrono::nanoseconds(backoff_ns) > std::chrono::seconds(30))
+                    {
+                        m_EOFConfirmed = true;
                         helper::Throw<std::ios_base::failure>(
                             "Toolkit", "transport::file::FilePOSIX", "Read",
-                            "Read past end of file on " + m_Name + " trying to read " +
-                                std::to_string(size) + " bytes " + SysErrMsg(localErrno));
+                            "file " + m_Name + " ends " + std::to_string(size) +
+                                " bytes before data that its metadata refers to; it was "
+                                "likely truncated by an interrupted writer");
+                    }
                 }
                 else
                 {
@@ -735,7 +749,10 @@ void FilePOSIX::SetParameters(const Params &params)
     // Otherwise, they are set from environment if present
     // Otherwise, they remain at their default value
 
+    // key arrives verbatim from direct SetParameters calls but lowercased
+    // through the OpenFile path (LowerCaseParams); accept both
     helper::GetParameter(params, "FailOnEOF", m_FailOnEOF);
+    helper::GetParameter(params, "failoneof", m_FailOnEOF);
 }
 
 } // end namespace transport

--- a/source/adios2/toolkit/transport/file/FilePOSIX.cpp
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.cpp
@@ -529,7 +529,8 @@ void FilePOSIX::Read(char *buffer, size_t size, size_t start)
                                 "likely truncated by an interrupted writer");
                     std::this_thread::sleep_for(std::chrono::nanoseconds(backoff_ns));
                     backoff_ns *= 2;
-                    if (std::chrono::nanoseconds(backoff_ns) > std::chrono::seconds(30))
+                    if (std::chrono::duration<double, std::nano>((double)backoff_ns) >
+                        std::chrono::duration<double>(m_EOFWaitSecs))
                     {
                         m_EOFConfirmed = true;
                         helper::Throw<std::ios_base::failure>(
@@ -749,10 +750,12 @@ void FilePOSIX::SetParameters(const Params &params)
     // Otherwise, they are set from environment if present
     // Otherwise, they remain at their default value
 
-    // key arrives verbatim from direct SetParameters calls but lowercased
+    // keys arrive verbatim from direct SetParameters calls but lowercased
     // through the OpenFile path (LowerCaseParams); accept both
     helper::GetParameter(params, "FailOnEOF", m_FailOnEOF);
     helper::GetParameter(params, "failoneof", m_FailOnEOF);
+    helper::GetParameter(params, "EOFWaitSecs", m_EOFWaitSecs);
+    helper::GetParameter(params, "eofwaitsecs", m_EOFWaitSecs);
 }
 
 } // end namespace transport

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -71,6 +71,9 @@ private:
     /** POSIX file handle returned by Open */
     int m_FileDescriptor = -1;
     bool m_FailOnEOF = false; // default to false for historic reasons
+    /** EOF persisted through a full backoff window once already; the file is
+     * truncated and later reads past its end fail without re-waiting */
+    bool m_EOFConfirmed = false;
     bool m_IsOpening = false;
     std::future<std::pair<int, int>> m_OpenFuture;
     bool m_DirectIO = false;

--- a/source/adios2/toolkit/transport/file/FilePOSIX.h
+++ b/source/adios2/toolkit/transport/file/FilePOSIX.h
@@ -74,6 +74,10 @@ private:
     /** EOF persisted through a full backoff window once already; the file is
      * truncated and later reads past its end fail without re-waiting */
     bool m_EOFConfirmed = false;
+    /** how long an EOF read on promised data may wait for filesystem
+     * consistency before failing (FailOnEOF mode); backoff doubling makes
+     * total wait roughly 1.5x this */
+    float m_EOFWaitSecs = 30.0f;
     bool m_IsOpening = false;
     std::future<std::pair<int, int>> m_OpenFuture;
     bool m_DirectIO = false;

--- a/testing/crash-recovery/crashreader.cpp
+++ b/testing/crash-recovery/crashreader.cpp
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Verifier for crash-recovery testing. Opens a (possibly truncated) BP5 file
+ * and reads every step it can, verifying content against the writer's
+ * deterministic pattern.
+ *
+ * Exit codes: 0 = recovered cleanly (prints RECOVERED <n>), 2 = data
+ * mismatch (silent corruption!), 3 = clean ADIOS exception (acceptable),
+ * signals = the bug class we hunt. Modes: ra (random access) | stream.
+ */
+#include <adios2.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+static float pattern(size_t step, size_t rank, size_t i)
+{
+    return (float)(step * 1000003 + rank * 10007 + i * 7 + 1);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 3)
+    {
+        fprintf(stderr, "usage: crashreader <file.bp> ra|stream\n");
+        return 1;
+    }
+    const char *fname = argv[1];
+    bool ra = (strcmp(argv[2], "ra") == 0);
+    size_t recovered = 0;
+    try
+    {
+        adios2::ADIOS adios;
+        adios2::IO io = adios.DeclareIO("r");
+        io.SetEngine("BP5");
+        if (!ra)
+        {
+            // bound the streaming Open: a writer killed before producing a
+            // usable header would otherwise block Open indefinitely
+            io.SetParameter("OpenTimeoutSecs", "2");
+        }
+        adios2::Engine r = io.Open(fname, ra ? adios2::Mode::ReadRandomAccess : adios2::Mode::Read);
+        if (ra)
+        {
+            auto va = io.InquireVariable<float>("a");
+            if (!va)
+            {
+                printf("RECOVERED 0 (no variable)\n");
+                r.Close();
+                return 0;
+            }
+            const size_t nsteps = va.Steps();
+            const size_t n = va.Shape()[0];
+            std::vector<float> buf(n);
+            for (size_t s = 0; s < nsteps; s++)
+            {
+                va.SetStepSelection({s, 1});
+                r.Get(va, buf.data(), adios2::Mode::Sync);
+                for (size_t i = 0; i < n; i++)
+                    if (buf[i] != pattern(s, 0, i))
+                    {
+                        printf("MISMATCH step %zu elem %zu: %g vs %g\n", s, i, buf[i],
+                               pattern(s, 0, i));
+                        return 2;
+                    }
+                recovered++;
+            }
+            r.Close();
+        }
+        else
+        {
+            // bounded BeginStep: a dead writer's file never gets EndOfStream,
+            // so a correct application polls with a timeout and gives up
+            adios2::StepStatus st;
+            while ((st = r.BeginStep(adios2::StepMode::Read, 1.0f)) !=
+                   adios2::StepStatus::EndOfStream)
+            {
+                if (st == adios2::StepStatus::NotReady)
+                {
+                    printf("GAVE_UP (NotReady) after %zu steps\n", recovered);
+                    break;
+                }
+                auto va = io.InquireVariable<float>("a");
+                auto vs = io.InquireVariable<uint64_t>("stepnum");
+                if (!va || !vs)
+                {
+                    r.EndStep();
+                    continue;
+                }
+                const size_t n = va.Shape()[0];
+                std::vector<float> buf(n);
+                uint64_t stepnum = ~0ull;
+                r.Get(va, buf.data());
+                r.Get(vs, &stepnum);
+                r.EndStep();
+                for (size_t i = 0; i < n; i++)
+                    if (buf[i] != pattern(stepnum, 0, i))
+                    {
+                        printf("MISMATCH step %llu elem %zu: %g vs %g\n",
+                               (unsigned long long)stepnum, i, buf[i], pattern(stepnum, 0, i));
+                        return 2;
+                    }
+                recovered++;
+            }
+            r.Close();
+        }
+    }
+    catch (std::exception &e)
+    {
+        printf("CLEAN_ERROR after %zu steps: %s\n", recovered, e.what());
+        return 3;
+    }
+    printf("RECOVERED %zu\n", recovered);
+    return 0;
+}

--- a/testing/crash-recovery/crashreader.cpp
+++ b/testing/crash-recovery/crashreader.cpp
@@ -39,6 +39,8 @@ int main(int argc, char **argv)
         adios2::ADIOS adios;
         adios2::IO io = adios.DeclareIO("r");
         io.SetEngine("BP5");
+        if (const char *w = getenv("CR_EOF_WAIT"))
+            io.SetParameter("EOFWaitSecs", w);
         if (!ra)
         {
             // bound the streaming Open: a writer killed before producing a

--- a/testing/crash-recovery/crashwriter.cpp
+++ b/testing/crash-recovery/crashwriter.cpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Writer for crash-recovery testing: writes deterministic per-step data so a
+ * reader can verify integrity of whatever survives. Designed to be killed.
+ */
+#include <adios2.h>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+// data[i] at (step, rank) = pattern(step, rank, i): recomputable by the reader
+static float pattern(size_t step, size_t rank, size_t i)
+{
+    return (float)(step * 1000003 + rank * 10007 + i * 7 + 1);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 4)
+    {
+        fprintf(stderr, "usage: crashwriter <file.bp> <steps> <elems> [sleep_ms_per_step]\n");
+        return 1;
+    }
+    const char *fname = argv[1];
+    size_t steps = strtoul(argv[2], nullptr, 10);
+    size_t n = strtoul(argv[3], nullptr, 10);
+    int sleep_ms = argc > 4 ? atoi(argv[4]) : 0;
+
+    adios2::ADIOS adios;
+    adios2::IO io = adios.DeclareIO("w");
+    io.SetEngine("BP5");
+    auto va = io.DefineVariable<float>("a", {n}, {0}, {n});
+    auto vstep = io.DefineVariable<uint64_t>("stepnum");
+    io.DefineAttribute<int>("meaning", 42);
+    adios2::Engine w = io.Open(fname, adios2::Mode::Write);
+    std::vector<float> buf(n);
+    for (size_t s = 0; s < steps; s++)
+    {
+        w.BeginStep();
+        for (size_t i = 0; i < n; i++)
+            buf[i] = pattern(s, 0, i);
+        w.Put(va, buf.data());
+        w.Put(vstep, (uint64_t)s);
+        w.EndStep();
+        // stdout marker: harness learns how many EndSteps definitely completed
+        printf("ENDSTEP %zu\n", s);
+        fflush(stdout);
+        if (sleep_ms)
+            std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+    }
+    w.Close();
+    printf("CLOSED\n");
+    return 0;
+}

--- a/testing/crash-recovery/harness.py
+++ b/testing/crash-recovery/harness.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Crash-recovery harness for BP5.
+
+Two modes:
+  sweep: write a good file once, then truncate each constituent file at many
+         offsets and require readers to recover or fail cleanly -- never crash.
+  kill:  run the writer, SIGKILL it at a random moment, verify that at least
+         the steps whose EndStep completed are recovered bit-exact.
+
+Outcome classes per reader run:
+  OK(n)        recovered n steps, content verified
+  CLEAN_ERROR  ADIOS threw a catchable exception (acceptable)
+  MISMATCH     reader returned wrong data with no error (silent corruption)
+  SIGNAL       reader died on a signal (segfault etc. -- the 5162 class)
+  TIMEOUT      reader hung
+"""
+
+import argparse
+import os
+import random
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BPLS = os.path.expanduser("~/prog/ADIOS2/build/bin/bpls")
+WRITER = os.path.join(HERE, "crashwriter")
+READER = os.path.join(HERE, "crashreader")
+TIMEOUT_S = int(os.environ.get("HARNESS_TIMEOUT", "2"))
+
+
+def classify(cmd, cwd=None):
+    """Run cmd, return (class, detail)."""
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=TIMEOUT_S, cwd=cwd)
+    except subprocess.TimeoutExpired:
+        return ("TIMEOUT", "")
+    if p.returncode < 0:
+        return ("SIGNAL", signal.Signals(-p.returncode).name)
+    out = p.stdout.strip().splitlines()
+    last = out[-1] if out else ""
+    if p.returncode == 0:
+        if last.startswith("RECOVERED"):
+            return ("OK", last)
+        return ("OK", last[:80])
+    if p.returncode == 2:
+        return ("MISMATCH", last[:120])
+    if p.returncode == 3:
+        return ("CLEAN_ERROR", last[:120])
+    # bpls returns 1 with an error message on stderr for clean failures
+    err = p.stderr.strip().splitlines()
+    return ("CLEAN_ERROR", (err[-1] if err else last)[:120])
+
+
+def readers_for(bpdir):
+    return [
+        ("bpls", [BPLS, "-la", bpdir]),
+        ("ra", [READER, bpdir, "ra"]),
+        ("stream", [READER, bpdir, "stream"]),
+    ]
+
+
+def sweep(args):
+    src = os.path.join(HERE, "sweep_master.bp")
+    shutil.rmtree(src, ignore_errors=True)
+    subprocess.run(
+        [WRITER, src, str(args.steps), str(args.elems), "0"], check=True, capture_output=True
+    )
+    work = os.path.join(HERE, "sweep_work.bp")
+    bad = []
+    total = 0
+    files = sorted(f for f in os.listdir(src) if f != "profiling.json")
+    for fn in files:
+        size = os.path.getsize(os.path.join(src, fn))
+        # sample truncation points: all of small files, stride through big ones
+        if size <= args.dense_limit:
+            points = range(0, size)
+        else:
+            stride = max(1, size // args.samples)
+            points = sorted(set(list(range(0, size, stride)) + [size - 1, size - 2]))
+        streak = {}  # rname -> (class, count); skip a reader after 3 identical fails
+        for cut in points:
+            shutil.rmtree(work, ignore_errors=True)
+            shutil.copytree(src, work)
+            with open(os.path.join(work, fn), "r+b") as f:
+                f.truncate(cut)
+            for rname, cmd in readers_for(work):
+                pc, n = streak.get(rname, (None, 0))
+                if n >= 3:
+                    continue  # established failure class for this file/reader
+                total += 1
+                cls, detail = classify(cmd)
+                if cls in ("SIGNAL", "TIMEOUT", "MISMATCH"):
+                    bad.append((fn, cut, size, rname, cls, detail))
+                    print(f"BAD {fn} cut={cut}/{size} {rname}: {cls} {detail}")
+                    streak[rname] = (cls, n + 1) if pc == cls else (cls, 1)
+                else:
+                    streak[rname] = (None, 0)
+        for rname, (pc, n) in streak.items():
+            if n >= 3:
+                print(f"SKIPPED rest of {fn} for {rname}: consistent {pc}")
+    print(f"\nsweep done: {total} reader runs, {len(bad)} bad")
+    summarize(bad)
+    return 1 if bad else 0
+
+
+def kill_loop(args):
+    rng = random.Random(args.seed)
+    bad = []
+    for it in range(args.iters):
+        bpdir = os.path.join(HERE, "kill_work.bp")
+        shutil.rmtree(bpdir, ignore_errors=True)
+        proc = subprocess.Popen(
+            [WRITER, bpdir, str(args.steps), str(args.elems), str(args.sleep_ms)],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        delay = rng.uniform(0, args.steps * (args.sleep_ms / 1000.0))
+        time.sleep(delay)
+        proc.kill()
+        out, _ = proc.communicate()
+        endsteps = sum(1 for line in out.splitlines() if line.startswith("ENDSTEP"))
+        if "CLOSED" in out:
+            continue  # writer finished before the kill landed; not interesting
+        for rname, cmd in readers_for(bpdir):
+            cls, detail = classify(cmd)
+            fail = cls in ("SIGNAL", "TIMEOUT", "MISMATCH")
+            if cls == "OK" and detail.startswith("RECOVERED"):
+                n = int(detail.split()[1])
+                if n < endsteps:
+                    fail, cls, detail = True, "LOST_STEPS", f"recovered {n} < completed {endsteps}"
+            if fail:
+                bad.append((f"iter{it}", f"{delay:.3f}s", endsteps, rname, cls, detail))
+                print(
+                    f"BAD iter={it} delay={delay:.3f}s endsteps={endsteps} {rname}: {cls} {detail}"
+                )
+        if not any(b[0] == f"iter{it}" for b in bad):
+            print(f"ok  iter={it} delay={delay:.3f}s endsteps={endsteps}")
+    print(f"\nkill loop done: {args.iters} iters, {len(bad)} bad (seed={args.seed})")
+    summarize(bad)
+    return 1 if bad else 0
+
+
+def summarize(bad):
+    from collections import Counter
+
+    c = Counter((b[0] if not b[0].startswith("iter") else "kill", b[3], b[4]) for b in bad)
+    for k, v in sorted(c.items()):
+        print(f"  {k[0]:8s} {k[1]:7s} {k[2]:12s} x{v}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="mode", required=True)
+    sp = sub.add_parser("sweep")
+    sp.add_argument("--steps", type=int, default=5)
+    sp.add_argument("--elems", type=int, default=1000)
+    sp.add_argument("--samples", type=int, default=64, help="truncation points per big file")
+    sp.add_argument(
+        "--dense-limit",
+        type=int,
+        default=2048,
+        help="files at or below this size get every truncation point",
+    )
+    kp = sub.add_parser("kill")
+    kp.add_argument("--iters", type=int, default=20)
+    kp.add_argument("--steps", type=int, default=50)
+    kp.add_argument("--elems", type=int, default=100000)
+    kp.add_argument("--sleep-ms", type=int, default=20)
+    kp.add_argument("--seed", type=int, default=1)
+    args = ap.parse_args()
+    sys.exit(sweep(args) if args.mode == "sweep" else kill_loop(args))

--- a/testing/crash-recovery/harness.py
+++ b/testing/crash-recovery/harness.py
@@ -58,6 +58,7 @@ def classify(cmd, cwd=None):
 
 
 def readers_for(bpdir):
+    os.environ.setdefault("CR_EOF_WAIT", "1")
     return [
         ("bpls", [BPLS, "-la", bpdir]),
         ("ra", [READER, bpdir, "ra"]),


### PR DESCRIPTION
This PR adds some truncation/corruption recovery testing tools.  These are not part of CI, but added here so they can be rerun occasionally if formats or methods change.  There are also bug-fixes for the issues that these tools uncovered.  Detections of truncated files, attempts at recovering what data can be provided to the user, exceptions when appropriate.  It also cleans up a bunch of hangs.  Turns out that when a writer dies without closing, the active flag is left on, so a reader will assume it's in a streaming-through-file situation and wait, used to be pretty much forever.  Now we're going to be more actively trying to detect that the file is really truncated, remember that we've determined that so that the next time we read we don't wait again, etc.  These fixes *may* fix issue #5162.  Can't really know without being able to duplicate it.