### PR TITLE
testing: make XRootD HTTPS cleanup reliable

### DIFF
--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -338,7 +338,7 @@ if (ADIOS2_HAVE_XRootD AND ADIOS2_HAVE_CURL)
    set_tests_properties(remoteXRHttpsServerSetup PROPERTIES FIXTURES_SETUP XRHttpsServer WORKING_DIRECTORY ${XROOTD_HTTPS_DIR} TIMEOUT 60)
    set_tests_properties(remoteXRHttpsServerSetup PROPERTIES DEPENDS "generateXRootDHttpConfig")
 
-   add_test(NAME remoteXRHttpsServerCleanup COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/kill_xrootd_http.sh)
+   add_test(NAME remoteXRHttpsServerCleanup COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/kill_xrootd_http.sh /tmp/xrootd-http-${XROOTD_HTTP_PORT}.pid)
    set_tests_properties(remoteXRHttpsServerCleanup PROPERTIES FIXTURES_CLEANUP XRHttpsServer)
 
    ##### add HTTPS remote tests below this line

--- a/testing/adios2/engine/bp/kill_xrootd_http.sh
+++ b/testing/adios2/engine/bp/kill_xrootd_http.sh
@@ -5,6 +5,80 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Kill XRootD HTTP server
-kill -2 "$(cat /tmp/xrootd-http.pid)"
-#rm /tmp/xrootd-http.pid
-exit 0
+
+PID_FILE="${1:-/tmp/xrootd-http.pid}"
+SHUTDOWN_WAIT_SECONDS=2
+
+process_is_running()
+{
+    if ! kill -0 "$1" 2>/dev/null; then
+        return 1
+    fi
+
+    PROCESS_STATE=$(ps -p "$1" -o stat= 2>/dev/null)
+    case "${PROCESS_STATE}" in
+        ''|Z*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+if [ ! -f "${PID_FILE}" ]; then
+    echo "XRootD HTTP PID file does not exist: ${PID_FILE}"
+    exit 0
+fi
+
+PID=$(cat "${PID_FILE}")
+case "${PID}" in
+    ''|*[!0-9]*)
+        echo "ERROR: Invalid XRootD HTTP PID in ${PID_FILE}: ${PID}"
+        exit 1
+        ;;
+esac
+
+if ! process_is_running "${PID}"; then
+    echo "Removing stale XRootD HTTP PID file for process ${PID}"
+    rm -f "${PID_FILE}"
+    exit 0
+fi
+
+COMMAND=$(ps -p "${PID}" -o comm= 2>/dev/null)
+case "${COMMAND##*/}" in
+    xrootd*) ;;
+    *)
+        echo "ERROR: Refusing to stop non-XRootD process ${PID}: ${COMMAND}"
+        exit 1
+        ;;
+esac
+
+echo "Stopping XRootD HTTP server process ${PID}"
+if ! kill -TERM "${PID}"; then
+    echo "ERROR: Failed to signal XRootD HTTP server process ${PID}"
+    exit 1
+fi
+
+for ((i = 0; i < SHUTDOWN_WAIT_SECONDS * 10; ++i)); do
+    if ! process_is_running "${PID}"; then
+        rm -f "${PID_FILE}"
+        echo "XRootD HTTP server process ${PID} stopped"
+        exit 0
+    fi
+    sleep 0.1
+done
+
+echo "XRootD HTTP server process ${PID} did not stop within ${SHUTDOWN_WAIT_SECONDS}s; sending SIGKILL"
+if ! kill -KILL "${PID}"; then
+    echo "ERROR: Failed to kill XRootD HTTP server process ${PID}"
+    exit 1
+fi
+
+for ((i = 0; i < 50; ++i)); do
+    if ! process_is_running "${PID}"; then
+        rm -f "${PID_FILE}"
+        echo "XRootD HTTP server process ${PID} killed"
+        exit 0
+    fi
+    sleep 0.1
+done
+
+echo "ERROR: XRootD HTTP server process ${PID} is still present after SIGKILL"
+exit 1

--- a/testing/adios2/engine/bp/start_xrootd_http.sh
+++ b/testing/adios2/engine/bp/start_xrootd_http.sh
@@ -13,8 +13,21 @@ XROOTD_BINARY="$1"
 CONFIG_BASE="$2"
 HTTP_PORT="${3:-8443}"
 CONFIG_FILE="${CONFIG_BASE}/xroot-http/etc/xrootd/xrootd-http-ssi.cfg"
-LOG_FILE="/tmp/xroot-http.log"
-PID_FILE="/tmp/xrootd-http.pid"
+LOG_FILE="/tmp/xroot-http-${HTTP_PORT}.log"
+PID_FILE="/tmp/xrootd-http-${HTTP_PORT}.pid"
+
+process_is_running()
+{
+    if ! kill -0 "$1" 2>/dev/null; then
+        return 1
+    fi
+
+    PROCESS_STATE=$(ps -p "$1" -o stat= 2>/dev/null)
+    case "${PROCESS_STATE}" in
+        ''|Z*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
 
 echo "Starting XRootD HTTP server..."
 echo "Binary: ${XROOTD_BINARY}"
@@ -36,6 +49,23 @@ echo "=== End config ==="
 if [ ! -f "${CONFIG_BASE}/xroot-http/certs/server.crt" ]; then
     echo "ERROR: SSL certificate not found"
     exit 1
+fi
+
+# Do not let XRootD overwrite the PID of a server that is still running.
+if [ -f "${PID_FILE}" ]; then
+    OLD_PID=$(cat "${PID_FILE}")
+    case "${OLD_PID}" in
+        ''|*[!0-9]*)
+            echo "ERROR: Invalid XRootD HTTP PID in ${PID_FILE}: ${OLD_PID}"
+            exit 1
+            ;;
+    esac
+    if process_is_running "${OLD_PID}"; then
+        echo "ERROR: XRootD HTTP server process ${OLD_PID} is already running"
+        exit 1
+    fi
+    echo "Removing stale XRootD HTTP PID file for process ${OLD_PID}"
+    rm -f "${PID_FILE}"
 fi
 
 if [ "$(id -u)" -eq 0 ]; then
@@ -73,6 +103,24 @@ if [ $START_RESULT -ne 0 ]; then
     echo "ERROR: XRootD failed to start (exit code: $START_RESULT)"
     echo "=== Server log (on failure) ==="
     cat "${LOG_FILE}" 2>/dev/null || echo "No log file created"
+    if [ -f "${PID_FILE}" ]; then
+        FAILED_PID=$(cat "${PID_FILE}")
+        if ! process_is_running "${FAILED_PID}"; then
+            rm -f "${PID_FILE}"
+        fi
+    fi
+    exit 1
+fi
+
+if [ ! -f "${PID_FILE}" ]; then
+    echo "ERROR: XRootD started without creating PID file ${PID_FILE}"
+    exit 1
+fi
+
+PID=$(cat "${PID_FILE}")
+if ! process_is_running "${PID}"; then
+    echo "ERROR: XRootD server process ${PID} is not running after startup"
+    rm -f "${PID_FILE}"
     exit 1
 fi
 
@@ -89,7 +137,7 @@ for i in $(seq 1 ${MAX_WAIT}); do
     # Fall back: if the process died, bail out immediately
     if [ -f "${PID_FILE}" ]; then
         PID=$(cat "${PID_FILE}")
-        if ! kill -0 "${PID}" 2>/dev/null; then
+        if ! process_is_running "${PID}"; then
             echo "ERROR: Server process (PID ${PID}) died during startup"
             echo "=== Server log ==="
             cat "${LOG_FILE}" 2>/dev/null || echo "No log file"
@@ -100,6 +148,7 @@ for i in $(seq 1 ${MAX_WAIT}); do
         echo "ERROR: HTTPS listener not ready after ${MAX_WAIT}s"
         echo "=== Server log ==="
         cat "${LOG_FILE}" 2>/dev/null || echo "No log file"
+        "$(dirname "${BASH_SOURCE[0]}")/kill_xrootd_http.sh" "${PID_FILE}"
         exit 1
     fi
     sleep 1


### PR DESCRIPTION
codex found that the current script does not properly stop the xrootd server and I could not run the "Https" tests twice. 