### PR TITLE
Add configurable HTTPS campaign access

### DIFF
--- a/source/adios2/common/ADIOSTypes.h
+++ b/source/adios2/common/ADIOSTypes.h
@@ -392,7 +392,8 @@ enum class HostAccessProtocol
     SSH,
     XRootD,
     S3,
-    LocalHost
+    LocalHost,
+    HTTPS
 };
 
 /** Host authentication protocols */
@@ -428,8 +429,13 @@ struct HostConfig
     /* xrootd only parameters */
     XRootDTransferProtocol transfer_protocol = XRootDTransferProtocol::XRootD;
 
-    /* s3 parameters */
+    /* s3 and https parameters */
     std::string endpoint = "";
+
+    /* https parameters */
+    std::string caFile = "";
+
+    /* s3 parameters */
     std::string awsProfile = "default"; // profile name in ~/.aws/credentials
     bool isAWS_EC2 = false;
     bool recheckMetadata = true;

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -620,16 +620,51 @@ std::string CampaignReader::SaveRemoteMD(size_t dsIdx, size_t repIdx, adios2::co
         }
         else if (m_CampaignData.hosts[rep.hostIdx].defaultProtocol == "https")
         {
-            std::string url =
-                "https://" + m_CampaignData.hosts[rep.hostIdx].longhostname + "/" + remotePath;
+            const CampaignHost &campaignHost = m_CampaignData.hosts[rep.hostIdx];
+            const HostConfig *httpsConfig = nullptr;
+            auto hostOptions = ADIOS::GetHostOptions().find(campaignHost.hostname);
+            if (hostOptions != ADIOS::GetHostOptions().end())
+            {
+                for (const HostConfig &hostConfig : hostOptions->second)
+                {
+                    if (hostConfig.protocol == HostAccessProtocol::HTTPS)
+                    {
+                        httpsConfig = &hostConfig;
+                        break;
+                    }
+                }
+            }
+
+            std::string endpoint = "https://" + campaignHost.longhostname;
+            if (httpsConfig)
+            {
+                endpoint = httpsConfig->endpoint;
+            }
+
+            std::string url = endpoint;
+            if (!url.empty() && url.back() != '/')
+            {
+                url += '/';
+            }
+            if (!remotePath.empty() && remotePath.front() == '/')
+            {
+                url += remotePath.substr(1);
+            }
+            else
+            {
+                url += remotePath;
+            }
+
             Params p;
             p.emplace("library", "https");
-            // p.emplace("hostname", m_CampaignData.hosts[rep.hostIdx].longhostname);
-            // p.emplace("path", m_CampaignData.directory[rep.dirIdx].path + "/" + tarpath +
-            // rep.name);
             p.emplace("cache", cachePath);
-            p.emplace("verbose", std::to_string(m_Options.verbose));
+            p.emplace("verbose",
+                      std::to_string(httpsConfig ? httpsConfig->verbose : m_Options.verbose));
             p.emplace("recheck_metadata", "false");
+            if (httpsConfig && !httpsConfig->caFile.empty())
+            {
+                p.emplace("ca_file", httpsConfig->caFile);
+            }
             if (cvii)
             {
                 cvii->params = p;

--- a/source/adios2/helper/adiosNetwork.cpp
+++ b/source/adios2/helper/adiosNetwork.cpp
@@ -492,9 +492,26 @@ void NetworkSocket::Close()
 struct SSLData
 {
     NetworkSocket m_Socket;
-    SSL *m_SSL;
+    SSL *m_SSL = nullptr;
     SSL_CTX *m_sslCtx = nullptr;
 };
+
+namespace
+{
+
+std::string LastSSLError()
+{
+    const unsigned long error = ERR_get_error();
+    if (error == 0)
+    {
+        return "unknown OpenSSL error";
+    }
+    char buffer[256];
+    ERR_error_string_n(error, buffer, sizeof(buffer));
+    return buffer;
+}
+
+} // end anonymous namespace
 
 SSLSocket::SSLSocket()
 {
@@ -513,10 +530,13 @@ SSLSocket::SSLSocket()
         helper::Throw<std::ios_base::failure>("Helper", "helper::adiosNetwork::SSLSocket",
                                               "SSLSocket", "cannot create SSL context");
     }
+    SSL_CTX_set_verify(m_Data->m_sslCtx, SSL_VERIFY_PEER, nullptr);
+    SSL_CTX_set_default_verify_paths(m_Data->m_sslCtx);
 };
 
 SSLSocket::~SSLSocket()
 {
+    Close();
     if (m_Data->m_sslCtx)
     {
         SSL_CTX_free(m_Data->m_sslCtx);
@@ -530,17 +550,72 @@ bool SSLSocket::valid() const
     return (m_Data->m_Socket.valid() && m_Data->m_sslCtx != nullptr && m_Data->m_SSL != nullptr);
 };
 
+void SSLSocket::SetCAFile(const std::string &caFile)
+{
+    if (caFile.empty())
+    {
+        return;
+    }
+    ERR_clear_error();
+    if (SSL_CTX_load_verify_locations(m_Data->m_sslCtx, caFile.c_str(), nullptr) != 1)
+    {
+        helper::Throw<std::ios_base::failure>(
+            "Helper", "helper::adiosNetwork::SSLSocket", "SetCAFile",
+            "cannot load certificate authority file " + caFile + ": " + LastSSLError());
+    }
+}
+
 void SSLSocket::Connect(const std::string &hostname, uint16_t port, std::string protocol)
 {
     m_Data->m_Socket.Connect(hostname, port);
     m_Data->m_SSL = SSL_new(m_Data->m_sslCtx);
+    if (!m_Data->m_SSL)
+    {
+        m_Data->m_Socket.Close();
+        helper::Throw<std::ios_base::failure>("Helper", "helper::adiosNetwork::SSLSocket",
+                                              "Connect", "cannot create SSL connection");
+    }
     SSL_set_fd(m_Data->m_SSL, m_Data->m_Socket.GetSocket());
 
+    unsigned char address[sizeof(struct in6_addr)];
+    const bool isIPAddress = inet_pton(AF_INET, hostname.c_str(), address) == 1 ||
+                             inet_pton(AF_INET6, hostname.c_str(), address) == 1;
+    X509_VERIFY_PARAM *verifyParameters = SSL_get0_param(m_Data->m_SSL);
+    int configured = 0;
+    if (isIPAddress)
+    {
+        configured = X509_VERIFY_PARAM_set1_ip_asc(verifyParameters, hostname.c_str());
+    }
+    else
+    {
+        configured = SSL_set_tlsext_host_name(m_Data->m_SSL, hostname.c_str()) == 1 &&
+                     X509_VERIFY_PARAM_set1_host(verifyParameters, hostname.c_str(), 0) == 1;
+    }
+    if (!configured)
+    {
+        Close();
+        helper::Throw<std::ios_base::failure>(
+            "Helper", "helper::adiosNetwork::SSLSocket", "Connect",
+            "cannot configure TLS hostname verification for " + hostname);
+    }
+
+    ERR_clear_error();
     if (SSL_connect(m_Data->m_SSL) <= 0)
     {
-        ERR_print_errors_fp(stderr);
-        helper::Throw<std::ios_base::failure>("Helper", "helper::adiosNetwork::SSLSocket",
-                                              "Connect", "SSL handshake failed");
+        const std::string error = LastSSLError();
+        Close();
+        helper::Throw<std::ios_base::failure>(
+            "Helper", "helper::adiosNetwork::SSLSocket", "Connect",
+            "TLS handshake or certificate verification failed for " + hostname + ": " + error);
+    }
+    const long verificationResult = SSL_get_verify_result(m_Data->m_SSL);
+    if (verificationResult != X509_V_OK)
+    {
+        const std::string error = X509_verify_cert_error_string(verificationResult);
+        Close();
+        helper::Throw<std::ios_base::failure>(
+            "Helper", "helper::adiosNetwork::SSLSocket", "Connect",
+            "certificate verification failed for " + hostname + ": " + error);
     }
 }
 

--- a/source/adios2/helper/adiosNetwork.h
+++ b/source/adios2/helper/adiosNetwork.h
@@ -89,6 +89,7 @@ public:
 
     bool valid() const;
 
+    void SetCAFile(const std::string &caFile);
     void Connect(const std::string &hostname, uint16_t port, std::string protocol = "tcp");
     int Write(const char *buffer, int size);
     int Read(char *buffer, int size);

--- a/source/adios2/helper/adiosYAML.cpp
+++ b/source/adios2/helper/adiosYAML.cpp
@@ -326,6 +326,10 @@ HostAccessProtocol GetHostAccessProtocol(std::string valueStr)
     {
         return HostAccessProtocol::XRootD;
     }
+    else if (valueStr == "https")
+    {
+        return HostAccessProtocol::HTTPS;
+    }
     return HostAccessProtocol::Invalid;
 }
 
@@ -477,6 +481,12 @@ void ParseHostOptionsFile(Comm &comm, const std::string &configFileYAML, HostOpt
                 SetOption(hc.endpoint, "endpoint", hostmap, hint, isMandatory);
                 SetOption(hc.isAWS_EC2, "aws_ec2_metadata", hostmap, hint);
                 SetOption(hc.recheckMetadata, "recheck_metadata", hostmap, hint);
+                break;
+            }
+            case HostAccessProtocol::HTTPS: {
+                SetOption(hc.endpoint, "endpoint", hostmap, hint, isMandatory);
+                SetOption(hc.caFile, "ca_file", hostmap, hint);
+                FixHomePath(hc.caFile, homePath);
                 break;
             }
             default:

--- a/source/adios2/toolkit/transport/file/FileHTTPS.cpp
+++ b/source/adios2/toolkit/transport/file/FileHTTPS.cpp
@@ -10,6 +10,7 @@
 
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <stdexcept>
 
 namespace adios2
@@ -17,27 +18,100 @@ namespace adios2
 namespace transport
 {
 
-void ParseURL(const std::string &url, std::string &hostname, std::string &path)
+void ParseURL(const std::string &url, std::string &hostname, uint16_t &port,
+              std::string &hostHeader, std::string &path)
 {
     const std::string httpsPrefix = "https://";
-    size_t pos = 0;
-
-    // Skip scheme if present
-    if (url.rfind(httpsPrefix, 0) == 0)
-        pos = httpsPrefix.size();
-
-    // Find first '/' after hostname
-    size_t slashPos = url.find('/', pos);
-    if (slashPos == std::string::npos)
+    if (url.rfind(httpsPrefix, 0) != 0)
     {
-        hostname = url.substr(pos);
-        path = "";
+        helper::Throw<std::invalid_argument>("Toolkit", "transport::file::FileHTTPS", "ParseURL",
+                                             "expected an https:// URL, got " + url);
+    }
+
+    const size_t authorityBegin = httpsPrefix.size();
+    const size_t pathBegin = url.find('/', authorityBegin);
+    const std::string authority =
+        url.substr(authorityBegin,
+                   pathBegin == std::string::npos ? std::string::npos : pathBegin - authorityBegin);
+    if (authority.empty())
+    {
+        helper::Throw<std::invalid_argument>("Toolkit", "transport::file::FileHTTPS", "ParseURL",
+                                             "URL has no hostname: " + url);
+    }
+
+    std::string portString;
+    if (authority.front() == '[')
+    {
+        const size_t closeBracket = authority.find(']');
+        if (closeBracket == std::string::npos)
+        {
+            helper::Throw<std::invalid_argument>(
+                "Toolkit", "transport::file::FileHTTPS", "ParseURL",
+                "URL has an invalid bracketed IPv6 address: " + url);
+        }
+        hostname = authority.substr(1, closeBracket - 1);
+        if (closeBracket + 1 < authority.size())
+        {
+            if (authority[closeBracket + 1] != ':')
+            {
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "transport::file::FileHTTPS", "ParseURL",
+                    "URL has invalid text after its IPv6 address: " + url);
+            }
+            portString = authority.substr(closeBracket + 2);
+        }
     }
     else
     {
-        hostname = url.substr(pos, slashPos - pos);
-        path = url.substr(slashPos);
+        const size_t colon = authority.rfind(':');
+        if (colon != std::string::npos)
+        {
+            if (authority.find(':') != colon)
+            {
+                helper::Throw<std::invalid_argument>(
+                    "Toolkit", "transport::file::FileHTTPS", "ParseURL",
+                    "IPv6 addresses in HTTPS URLs must be enclosed in brackets: " + url);
+            }
+            hostname = authority.substr(0, colon);
+            portString = authority.substr(colon + 1);
+        }
+        else
+        {
+            hostname = authority;
+        }
     }
+
+    if (hostname.empty())
+    {
+        helper::Throw<std::invalid_argument>("Toolkit", "transport::file::FileHTTPS", "ParseURL",
+                                             "URL has no hostname: " + url);
+    }
+
+    port = 443;
+    if (!portString.empty())
+    {
+        size_t parsedCharacters = 0;
+        unsigned long parsedPort = 0;
+        try
+        {
+            parsedPort = std::stoul(portString, &parsedCharacters);
+        }
+        catch (const std::exception &)
+        {
+            helper::Throw<std::invalid_argument>("Toolkit", "transport::file::FileHTTPS",
+                                                 "ParseURL", "URL has an invalid port: " + url);
+        }
+        if (parsedCharacters != portString.size() || parsedPort == 0 ||
+            parsedPort > std::numeric_limits<uint16_t>::max())
+        {
+            helper::Throw<std::invalid_argument>("Toolkit", "transport::file::FileHTTPS",
+                                                 "ParseURL", "URL has an invalid port: " + url);
+        }
+        port = static_cast<uint16_t>(parsedPort);
+    }
+
+    hostHeader = authority;
+    path = pathBegin == std::string::npos ? "/" : url.substr(pathBegin);
 }
 
 std::string ExtractHeaderValue(const std::string &headers, const std::string &key)
@@ -62,12 +136,14 @@ void FileHTTPS::SetParameters(const Params &params)
     helper::SetParameterValue("cache", params, m_CachePath);
     helper::SetParameterValue("hostname", params, m_hostname);
     helper::SetParameterValue("path", params, m_path);
+    helper::SetParameterValue("ca_file", params, m_CAFile);
     helper::SetParameterValueInt("verbose", params, m_Verbose, "");
     helper::SetParameterValue("filenameintar", params, m_FileNameInTar);
 
     std::string recheckStr = "true";
     helper::SetParameterValue("recheck_metadata", params, recheckStr);
     m_RecheckMetadata = helper::StringTo<bool>(recheckStr, "");
+    m_ssl.SetCAFile(m_CAFile);
 
     if (m_Verbose > 0)
     {
@@ -197,11 +273,16 @@ void FileHTTPS::Open(const std::string &name, const Mode openMode, const bool as
 {
     if (m_hostname.empty())
     {
-        ParseURL(name, m_hostname, m_path);
+        ParseURL(name, m_hostname, m_server_port, m_HostHeader, m_path);
+    }
+    else if (m_HostHeader.empty())
+    {
+        m_HostHeader = m_hostname;
     }
     if (m_Verbose)
     {
-        std::cout << "FileHTTPS::Open( hostname = " << m_hostname << ", path = " << m_path << ")\n";
+        std::cout << "FileHTTPS::Open( hostname = " << m_hostname << ", port = " << m_server_port
+                  << ", path = " << m_path << ")\n";
     }
     // GetSize();
     m_OpenMode = openMode;
@@ -251,7 +332,7 @@ void FileHTTPS::Read(char *buffer, size_t size, size_t start)
     }
 
     const size_t BUF_SIZE = 8192;
-    std::string request = "GET " + m_path + " HTTP/1.1\r\nHost: " + m_hostname +
+    std::string request = "GET " + m_path + " HTTP/1.1\r\nHost: " + m_HostHeader +
                           "\r\nRange: bytes=" + std::to_string(start + m_BaseOffset) + "-" +
                           std::to_string(start + m_BaseOffset + size - 1) + "\r\n\r\n";
 
@@ -330,7 +411,7 @@ size_t FileHTTPS::GetSize()
     m_ssl.Connect(m_hostname, m_server_port);
 
     std::string request =
-        "HEAD " + m_path + " HTTP/1.1\r\nHost: " + m_hostname + "\r\nConnection: close\r\n\r\n";
+        "HEAD " + m_path + " HTTP/1.1\r\nHost: " + m_HostHeader + "\r\nConnection: close\r\n\r\n";
 
     if (m_Verbose > 1)
     {

--- a/source/adios2/toolkit/transport/file/FileHTTPS.h
+++ b/source/adios2/toolkit/transport/file/FileHTTPS.h
@@ -63,7 +63,7 @@ public:
     void MkDir(const std::string &fileName) final;
 
 private:
-    std::string m_hostname, m_path;
+    std::string m_hostname, m_path, m_HostHeader;
     uint16_t m_server_port = 443; // HTTPS default
     helper::SSLSocket m_ssl;
 
@@ -92,6 +92,7 @@ private:
     FileFStream *m_CacheFileRead;
     std::string m_CacheFilePath; // full path to file in cache
     std::string m_FileNameInTar; // original file name if we work inside a TAR file
+    std::string m_CAFile;
 };
 
 } // end namespace transport

--- a/testing/adios2/yaml/CMakeLists.txt
+++ b/testing/adios2/yaml/CMakeLists.txt
@@ -17,6 +17,12 @@ endforeach()
 #  "YAML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
 #)
 
+gtest_add_tests_helper(YAMLHostOptions MPI_NONE "" "" "")
+foreach(tgt IN LISTS Test.YAMLHostOptions-TARGETS)
+  target_compile_definitions(${tgt} PRIVATE
+    "YAML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+endforeach()
 
 gtest_add_tests_helper(YAMLConfig MPI_ALLOW "" "" "")
 
@@ -25,4 +31,3 @@ foreach(tgt IN LISTS Test.YAMLConfig-TARGETS)
     "YAML_CONFIG_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
   )
 endforeach()
-

--- a/testing/adios2/yaml/TestYAMLHostOptions.cpp
+++ b/testing/adios2/yaml/TestYAMLHostOptions.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdexcept>
+#include <string>
+
+#include <adios2.h>
+#include <adios2/helper/adiosCommDummy.h>
+#include <adios2/helper/adiosYAML.h>
+
+#include <gtest/gtest.h>
+
+#define str_helper(X) #X
+#define str(X) str_helper(X)
+
+namespace
+{
+
+std::string ConfigPath(const std::string &name)
+{
+    return str(YAML_CONFIG_DIR) + std::string(&adios2::PathSeparator, 1) + name;
+}
+
+} // end anonymous namespace
+
+TEST(YAMLHostOptions, HTTPS)
+{
+    adios2::helper::Comm comm = adios2::helper::CommDummy();
+    adios2::HostOptions hosts;
+    std::string homePath = "/home/campaign-user";
+
+    EXPECT_NO_THROW(adios2::helper::ParseHostOptionsFile(comm, ConfigPath("hosts-https.yaml"),
+                                                         hosts, homePath));
+
+    ASSERT_EQ(hosts.size(), 1);
+    const auto host = hosts.find("docker-https");
+    ASSERT_NE(host, hosts.end());
+    ASSERT_EQ(host->second.size(), 1);
+
+    const adios2::HostConfig &config = host->second.front();
+    EXPECT_EQ(config.name, "docker-https-loopback");
+    EXPECT_EQ(config.protocol, adios2::HostAccessProtocol::HTTPS);
+    EXPECT_EQ(config.endpoint, "https://127.0.0.1:8443");
+    EXPECT_EQ(config.caFile, "/home/campaign-user/certs/hpc-campaign-test.crt");
+    EXPECT_EQ(config.verbose, 2);
+}
+
+TEST(YAMLHostOptions, HTTPSEndpointIsRequired)
+{
+    adios2::helper::Comm comm = adios2::helper::CommDummy();
+    adios2::HostOptions hosts;
+    std::string homePath = "/home/campaign-user";
+
+    EXPECT_THROW(adios2::helper::ParseHostOptionsFile(
+                     comm, ConfigPath("hosts-https-missing-endpoint.yaml"), hosts, homePath),
+                 std::invalid_argument);
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/testing/adios2/yaml/hosts-https-missing-endpoint.yaml
+++ b/testing/adios2/yaml/hosts-https-missing-endpoint.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+docker-https:
+  docker-https-loopback:
+    protocol: https

--- a/testing/adios2/yaml/hosts-https.yaml
+++ b/testing/adios2/yaml/hosts-https.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+docker-https:
+  docker-https-loopback:
+    protocol: https
+    endpoint: https://127.0.0.1:8443
+    ca_file: ~/certs/hpc-campaign-test.crt
+    verbose: 2


### PR DESCRIPTION
Teach hosts.yaml and CampaignReader to select HTTPS endpoints and CA files, parse non-default ports, and verify TLS peers. This lets one campaign archive use Docker DNS internally and a trusted loopback endpoint from WSL without hostname aliases.

This was created for testing campaigns in hpc-campaign's container from the host environment, which exposed the simplicity of the current solution.