### PR TITLE
campaign: prepare simple-file reads for XRootD

### DIFF
--- a/scripts/docker/spin-xrootd/xrootd-http.cfg
+++ b/scripts/docker/spin-xrootd/xrootd-http.cfg
@@ -22,8 +22,12 @@ oss.statlib -2 libXrdSsi.so
 # Load ADIOS2 SSI service plugin
 ssi.svclib /usr/local/lib64/libadios2_xrootd.so
 
-# Data directories served as plain files.  /data is the Spin mount; /srv is
-# where the hpc-campaign integration image places its campaign data.
+# Data directories served as plain files: /cfs is the NERSC community file
+# system as mounted on Spin (KSTAR data lives under /cfs/www), /data is the
+# image's generic mount point, /srv is where the hpc-campaign integration
+# image places its campaign data.
+ssi.fspath /cfs
+all.export /cfs r/o
 ssi.fspath /data
 all.export /data r/o
 ssi.fspath /srv

--- a/scripts/docker/spin-xrootd/xrootd-http.cfg
+++ b/scripts/docker/spin-xrootd/xrootd-http.cfg
@@ -6,8 +6,12 @@ all.adminpath /var/spool/xrootd
 all.pidpath /run/xrootd
 xrd.homepath /tmp
 
-# Enable SSI filesystem
-xrootd.fslib libXrdSsi.so
+# SSI stacked over the default file system ("default"): SSI requests go to
+# the ADIOS2 service, while paths listed under ssi.fspath are ordinary files
+# served by XRootD itself (HTTP Range, HEAD, stat).  Campaign image and text
+# replicas and tar archives are read that way; only ADIOS dataset queries
+# (URLs with an /_adios/ segment) reach the plugin.
+xrootd.fslib libXrdSsi.so default
 
 # Export path for SSI operations
 all.export /etc nolock r/w
@@ -17,6 +21,13 @@ oss.statlib -2 libXrdSsi.so
 
 # Load ADIOS2 SSI service plugin
 ssi.svclib /usr/local/lib64/libadios2_xrootd.so
+
+# Data directories served as plain files.  /data is the Spin mount; /srv is
+# where the hpc-campaign integration image places its campaign data.
+ssi.fspath /data
+all.export /data r/o
+ssi.fspath /srv
+all.export /srv r/o
 
 # Native XRootD protocol on 1094 (not exposed externally)
 xrd.port 1094
@@ -31,7 +42,8 @@ xrd.protocol http:8080 libXrdHttp.so
 http.cert /tmp/server.crt
 http.key /tmp/server.key
 
-# Load HTTP-to-SSI bridge handler for /ssi endpoint
-# This routes HTTP POST requests to the SSI service
-# Format: http.exthandler <name> <library> [<params>]
+# Load the HTTP-to-SSI bridge handler.  It claims URLs carrying the reserved
+# /_adios/ segment after a dataset path (and the older /adios prefix form);
+# everything else falls through to regular file serving.
+# Format: http.exthandler <name> <library> [<param>]  (one parameter word)
 http.exthandler adios2ssi /usr/local/lib64/libadios2_xrootd_http.so ssilib=/usr/local/lib64/libadios2_xrootd.so

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -10,8 +10,6 @@
 #include "adios2/helper/adiosFunctions.h" // CSVToVector
 #include "adios2/helper/adiosNetwork.h"   // GetFQDN
 #include "adios2/helper/adiosSystem.h"    // CreateDirectory
-#include "adios2/toolkit/remote/EVPathRemote.h"
-#include "adios2/toolkit/remote/XrootdRemote.h"
 #include "adios2/toolkit/transport/OpenFile.h"
 #include <adios2-perfstubs-interface.h>
 #include <adios2sys/SystemTools.hxx>
@@ -1578,34 +1576,51 @@ void CampaignReader::GetVariableFromDB(std::string name, size_t dsIdx, size_t re
 void CampaignReader::ReadRemoteFile(const std::string &remoteHost, const std::string &remotePath,
                                     const size_t offset, const size_t size, void *data)
 {
-    std::unique_ptr<Remote> remote = nullptr;
-#ifdef ADIOS2_HAVE_XROOTD
-    if (getenv("DoXRootD"))
+    const RemoteSetup rs = GetRemoteSetup(remoteHost);
+    if (rs.protocol != HostAccessProtocol::XRootD && rs.protocol != HostAccessProtocol::SSH)
     {
-        const RemoteSetup rs = GetRemoteSetup("localhost");
-        remote = std::make_unique<XrootdRemote>(rs);
-        remote->Open("localhost", 1094, m_Name, m_OpenMode, true);
+        helper::Throw<std::invalid_argument>(
+            "Engine", "CampaignReader", "ReadRemoteFile",
+            "No SSH or XRootD access configuration found for host " + remoteHost +
+                ". Add a valid entry in ~/.config/hpc-campaign/hosts.yaml");
     }
-    else
-#endif
-#ifdef ADIOS2_HAVE_SST
-    {
-        const RemoteSetup rs = GetRemoteSetup(remoteHost);
-        remote = std::make_unique<EVPathRemote>(rs);
-        int localPort = remote->LaunchRemoteServerViaConnectionManager(remoteHost);
-        remote->OpenSimpleFile("localhost", localPort, remotePath);
-    }
-#endif
+
+    // Both SSH/EVPath and XRootD open the replica as an unstructured byte
+    // stream.  Transport selection and connection setup are handled by the
+    // common remote factory.
+    std::shared_ptr<Remote> remote = GetRemoteSimpleFile(rs, remotePath);
+
     // evaluate validity of object, not just that the pointer is non-NULL
     if (remote == nullptr || !(*remote))
     {
-        helper::Throw<std::ios_base::failure>(
-            "Engine", "CampaignReader", "ReadRemoteFile",
-            "Cannot get remote connection to read file " + remoteHost + ":" + remotePath +
-                ". Make sure connection manager is running, and the server specification for the "
-                "host is valid.");
+        const std::string advice =
+            (rs.protocol == HostAccessProtocol::XRootD)
+                ? ". Make sure the configured XRootD transport is enabled in this ADIOS2 build "
+                  "and the host entry is valid."
+                : ". Make sure connection manager is running, and the server specification for "
+                  "the host is valid.";
+        helper::Throw<std::ios_base::failure>("Engine", "CampaignReader", "ReadRemoteFile",
+                                              "Cannot get remote connection to read file " +
+                                                  remoteHost + ":" + remotePath + advice);
     }
-    remote->Read(offset, size, data);
+
+    Remote::GetHandle handle = remote->Read(offset, size, data);
+    if (rs.protocol == HostAccessProtocol::XRootD)
+    {
+        if (handle == nullptr)
+        {
+            helper::Throw<std::ios_base::failure>(
+                "Engine", "CampaignReader", "ReadRemoteFile",
+                "The configured XRootD transport does not support raw file reads for " +
+                    remoteHost + ":" + remotePath);
+        }
+        if (!remote->WaitForGet(handle))
+        {
+            helper::Throw<std::ios_base::failure>("Engine", "CampaignReader", "ReadRemoteFile",
+                                                  "The XRootD raw file read failed for " +
+                                                      remoteHost + ":" + remotePath);
+        }
+    }
 }
 
 void CampaignReader::ReadRemoteFile(const std::string &remoteHost, const std::string &remotePath,

--- a/source/adios2/engine/campaign/CampaignReader.cpp
+++ b/source/adios2/engine/campaign/CampaignReader.cpp
@@ -1604,23 +1604,22 @@ void CampaignReader::ReadRemoteFile(const std::string &remoteHost, const std::st
                                                   remoteHost + ":" + remotePath + advice);
     }
 
+    // The SSH/EVPath lane completes the read inside Read(); the XRootD lanes
+    // issue it asynchronously and WaitForGet() throws with detail on failure.
     Remote::GetHandle handle = remote->Read(offset, size, data);
     if (rs.protocol == HostAccessProtocol::XRootD)
     {
         if (handle == nullptr)
         {
-            helper::Throw<std::ios_base::failure>(
-                "Engine", "CampaignReader", "ReadRemoteFile",
-                "The configured XRootD transport does not support raw file reads for " +
-                    remoteHost + ":" + remotePath);
-        }
-        if (!remote->WaitForGet(handle))
-        {
             helper::Throw<std::ios_base::failure>("Engine", "CampaignReader", "ReadRemoteFile",
-                                                  "The XRootD raw file read failed for " +
+                                                  "Could not issue the XRootD raw file read for " +
                                                       remoteHost + ":" + remotePath);
         }
+        remote->WaitForGet(handle);
     }
+    // Release the server-side file handle (the SSH lane keeps one open per
+    // OpenSimpleFile until told otherwise).
+    remote->Close();
 }
 
 void CampaignReader::ReadRemoteFile(const std::string &remoteHost, const std::string &remotePath,

--- a/source/adios2/engine/campaign/CampaignReader.tcc
+++ b/source/adios2/engine/campaign/CampaignReader.tcc
@@ -103,7 +103,7 @@ void CampaignReader::GetSyncTCC(Variable<T> &variable, T *data)
 {
     auto lf_CheckStartCount = [&](const std::string &name, const size_t length, const size_t start,
                                   const size_t count) {
-        if (start + count > length)
+        if (start > length || count > length - start)
         {
             helper::Throw<std::invalid_argument>(
                 "Engine", "CampaignReader", "Get(Sync)",

--- a/source/adios2/toolkit/remote/EVPathRemote.cpp
+++ b/source/adios2/toolkit/remote/EVPathRemote.cpp
@@ -186,7 +186,7 @@ void EVPathRemote::Open(const std::string hostname, const int32_t port, const st
 }
 
 void EVPathRemote::OpenSimpleFile(const std::string hostname, const int32_t port,
-                                  const std::string filename)
+                                  const std::string filename, const Params & /*params*/)
 {
 
     EVPathRemoteCommon::_OpenSimpleFileMsg open_msg;
@@ -449,7 +449,7 @@ void EVPathRemote::Open(const std::string hostname, const int32_t port, const st
                         const Mode mode, bool RowMajorOrdering){};
 
 void EVPathRemote::OpenSimpleFile(const std::string hostname, const int32_t port,
-                                  const std::string filename){};
+                                  const std::string filename, const Params &params){};
 
 EVPathRemote::GetHandle EVPathRemote::Get(char *VarName, size_t Step, size_t BlockID, Dims &Count,
                                           Dims &Start, void *dest)

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -52,7 +52,8 @@ public:
     void Open(const std::string hostname, const int32_t port, const std::string filename,
               const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
-    void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename);
+    void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename,
+                        const Params &params = Params()) override;
 
     /*
      * OpenReadSimpleFile() is a synchronous call that returns the

--- a/source/adios2/toolkit/remote/EVPathRemote.h
+++ b/source/adios2/toolkit/remote/EVPathRemote.h
@@ -36,9 +36,9 @@ public:
      * @param comm passed to m_Comm
      */
     EVPathRemote(const RemoteSetup &remoteSetup);
-    ~EVPathRemote();
+    ~EVPathRemote() override;
 
-    explicit operator bool() const { return m_Active; }
+    explicit operator bool() const override { return m_Active; }
 
     /*
      * Open() and OpenSimpleFile() are synchronous calls that
@@ -50,7 +50,7 @@ public:
      * EVPathRemote object.
      */
     void Open(const std::string hostname, const int32_t port, const std::string filename,
-              const Mode mode, bool RowMajorOrdering, const Params &params = Params());
+              const Mode mode, bool RowMajorOrdering, const Params &params = Params()) override;
 
     void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename,
                         const Params &params = Params()) override;
@@ -62,14 +62,14 @@ public:
      * an open file on the server.
      */
     void OpenReadSimpleFile(const std::string hostname, const int32_t port,
-                            const std::string filename, std::vector<char> &contents);
+                            const std::string filename, std::vector<char> &contents) override;
 
     GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
-                  Dims &Start, Accuracy &accuracy, void *dest, size_t destSize);
+                  Dims &Start, Accuracy &accuracy, void *dest, size_t destSize) override;
 
-    bool WaitForGet(GetHandle handle);
+    bool WaitForGet(GetHandle handle) override;
 
-    GetHandle Read(size_t Start, size_t Size, void *Dest);
+    GetHandle Read(size_t Start, size_t Size, void *Dest) override;
 
     /*
      * EVPathRemote::Close is an active synchronous operation that
@@ -81,7 +81,7 @@ public:
      * This is a passive asynchronous operation that will happen
      * sometime after the EVPathRemote object is destroyed.
      */
-    void Close();
+    void Close() override;
 
     int64_t m_ID;
 

--- a/source/adios2/toolkit/remote/LibcurlBackend.cpp
+++ b/source/adios2/toolkit/remote/LibcurlBackend.cpp
@@ -133,7 +133,10 @@ private:
                         long httpCode = 0;
                         curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &httpCode);
 
-                        if (httpCode == 200 || httpCode == 201)
+                        // 206 is the ranged-read success; a server that ignored
+                        // the Range and sent 200 with the whole file fails the
+                        // size check below.
+                        if (httpCode == 200 || httpCode == 201 || httpCode == 206)
                         {
                             // Reject a response that would overrun dest; 0 = caller
                             // gave no expected size.
@@ -280,6 +283,13 @@ CURL *CreateEasyHandle(const RemoteHttpBackend::Config &config, AsyncGet *asyncO
 
     curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
     curl_easy_setopt(easy, CURLOPT_HTTPGET, 1L);
+    if (asyncOp->rangeRead)
+    {
+        // Byte range of a plain file: "first-last", inclusive.
+        const std::string range = std::to_string(asyncOp->rangeOffset) + "-" +
+                                  std::to_string(asyncOp->rangeOffset + asyncOp->expectedSize - 1);
+        curl_easy_setopt(easy, CURLOPT_RANGE, range.c_str());
+    }
     curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, WriteCallback);
     curl_easy_setopt(easy, CURLOPT_WRITEDATA, &asyncOp->responseData);
     curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT, config.connectTimeout);

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -36,7 +36,7 @@ void Remote::Open(const std::string hostname, const int32_t port, const std::str
 };
 
 void Remote::OpenSimpleFile(const std::string hostname, const int32_t port,
-                            const std::string filename)
+                            const std::string filename, const Params &params)
 {
     ThrowUp("RemoteSimpleOpen");
 };
@@ -317,10 +317,19 @@ RemoteSetup GetRemoteSetup(const std::string &remoteHost)
     return rs;
 }
 
-std::shared_ptr<adios2::Remote> GetRemote(const RemoteSetup &remoteSetup,
-                                          const std::string &RemoteFileName,
-                                          const adios2::Mode openMode, const bool rowMajorOrdering,
-                                          const Params &remoteParams)
+namespace
+{
+
+enum class RemoteOpenKind
+{
+    ADIOS,
+    SimpleFile
+};
+
+std::shared_ptr<adios2::Remote>
+GetRemoteCommon(const RemoteSetup &remoteSetup, const std::string &RemoteFileName,
+                const adios2::Mode openMode, const bool rowMajorOrdering,
+                const Params &remoteParams, const RemoteOpenKind openKind)
 {
 #if defined(ADIOS2_HAVE_CURL) || defined(ADIOS2_HAVE_XROOTD)
     auto lf_getXRootDHostPort = [&](int defaultPort) -> std::tuple<std::string, int> {
@@ -375,6 +384,17 @@ std::shared_ptr<adios2::Remote> GetRemote(const RemoteSetup &remoteSetup,
     if (!fileuuid.empty())
         params["FileUUID"] = fileuuid;
 
+    auto lf_OpenRemote = [&](const std::string &hostname, const int32_t port) {
+        if (openKind == RemoteOpenKind::SimpleFile)
+        {
+            remote->OpenSimpleFile(hostname, port, RemoteFileName, params);
+        }
+        else
+        {
+            remote->Open(hostname, port, RemoteFileName, openMode, rowMajorOrdering, params);
+        }
+    };
+
 #if defined(ADIOS2_HAVE_CURL) || defined(ADIOS2_HAVE_XROOTD)
     if (remoteSetup.protocol == HostAccessProtocol::XRootD &&
         (remoteSetup.xrootdTransferProtocol == XRootDTransferProtocol::HTTP ||
@@ -408,8 +428,7 @@ std::shared_ptr<adios2::Remote> GetRemote(const RemoteSetup &remoteSetup,
         {
             params["VerifySSL"] = "false";
         }
-        remote->Open(std::get<0>(tup), std::get<1>(tup), RemoteFileName, openMode, rowMajorOrdering,
-                     params);
+        lf_OpenRemote(std::get<0>(tup), std::get<1>(tup));
         return remote;
     }
 #endif
@@ -419,8 +438,7 @@ std::shared_ptr<adios2::Remote> GetRemote(const RemoteSetup &remoteSetup,
     {
         auto tup = lf_getXRootDHostPort(1094);
         remote = std::make_unique<XrootdRemote>(remoteSetup);
-        remote->Open(std::get<0>(tup), std::get<1>(tup), RemoteFileName, openMode, rowMajorOrdering,
-                     params);
+        lf_OpenRemote(std::get<0>(tup), std::get<1>(tup));
         return remote;
     }
 #endif
@@ -432,13 +450,31 @@ std::shared_ptr<adios2::Remote> GetRemote(const RemoteSetup &remoteSetup,
         int localPort = pair.second;
         if (remote && localPort > -1)
         {
-            remote->Open("localhost", localPort, RemoteFileName, openMode, rowMajorOrdering,
-                         params);
+            lf_OpenRemote("localhost", localPort);
         }
         return remote;
     }
 #endif
     return remote;
+}
+
+} // end anonymous namespace
+
+std::shared_ptr<adios2::Remote> GetRemote(const RemoteSetup &remoteSetup,
+                                          const std::string &RemoteFileName,
+                                          const adios2::Mode openMode, const bool rowMajorOrdering,
+                                          const Params &remoteParams)
+{
+    return GetRemoteCommon(remoteSetup, RemoteFileName, openMode, rowMajorOrdering, remoteParams,
+                           RemoteOpenKind::ADIOS);
+}
+
+std::shared_ptr<adios2::Remote> GetRemoteSimpleFile(const RemoteSetup &remoteSetup,
+                                                    const std::string &remoteFileName,
+                                                    const Params &remoteParams)
+{
+    return GetRemoteCommon(remoteSetup, remoteFileName, Mode::ReadRandomAccess, true, remoteParams,
+                           RemoteOpenKind::SimpleFile);
 }
 
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/Remote.cpp
+++ b/source/adios2/toolkit/remote/Remote.cpp
@@ -273,6 +273,12 @@ RemoteSetup GetRemoteSetup(const std::string &remoteHost)
                 }
             }
         }
+        if (rs.protocol == HostAccessProtocol::Invalid && rs.hostName == "localhost")
+        {
+            // No hosts.yaml entry needed for a remote server on this machine
+            // (the SSH lane connects to its default port without a tunnel).
+            rs.protocol = HostAccessProtocol::SSH;
+        }
     }
     else
     {
@@ -411,10 +417,11 @@ GetRemoteCommon(const RemoteSetup &remoteSetup, const std::string &RemoteFileNam
         params["UseHttps"] = useHttps ? "true" : "false";
         if (useXrdCl)
             params["Backend"] = "XrdCl";
-        // URL path prefix that routes requests to the ADIOS handler on the
-        // server: hosts.yaml `serverpath` (XRootDServerPath env in the
-        // env-var lane), default "/adios".  A Pelican deployment sets this
-        // to the namespace the federation exports.
+        // Optional path prefix placed before the dataset path in URLs:
+        // hosts.yaml `serverpath` (XRootDServerPath env in the env-var
+        // lane), none by default.  A Pelican deployment sets this to the
+        // namespace the federation exports.  Routing to the ADIOS handler
+        // is by the `_adios` segment, not by this prefix.
         if (remoteSetup.hostConfig && !remoteSetup.hostConfig->remoteServerPath.empty())
         {
             params["ServerPath"] = remoteSetup.hostConfig->remoteServerPath;

--- a/source/adios2/toolkit/remote/Remote.h
+++ b/source/adios2/toolkit/remote/Remote.h
@@ -51,7 +51,7 @@ public:
                       const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
     virtual void OpenSimpleFile(const std::string hostname, const int32_t port,
-                                const std::string filename);
+                                const std::string filename, const Params &params = Params());
 
     virtual void OpenReadSimpleFile(const std::string hostname, const int32_t port,
                                     const std::string filename, std::vector<char> &contents);
@@ -111,6 +111,12 @@ std::shared_ptr<adios2::Remote> GetRemote(const RemoteSetup &remoteSetup,
                                           const std::string &RemoteFileName,
                                           const adios2::Mode openMode, const bool rowMajorOrdering,
                                           const Params &remoteParams);
+
+/* Create/Get a Remote object and open a read-only, unstructured byte stream.
+   Unlike GetRemote(), this does not open an ADIOS dataset on the remote side. */
+std::shared_ptr<adios2::Remote> GetRemoteSimpleFile(const RemoteSetup &remoteSetup,
+                                                    const std::string &remoteFileName,
+                                                    const Params &remoteParams = Params());
 
 } // end namespace adios2
 

--- a/source/adios2/toolkit/remote/RemoteHttpBackend.h
+++ b/source/adios2/toolkit/remote/RemoteHttpBackend.h
@@ -28,9 +28,15 @@ struct AsyncGet
 {
     std::promise<bool> promise;
     std::string errorMsg;
-    void *destBuffer = nullptr;     ///< single-get dest; null for batch
-    size_t destSize = 0;            ///< bytes delivered to destBuffer on success
-    size_t expectedSize = 0;        ///< expected response bytes; 0 = unchecked
+    void *destBuffer = nullptr; ///< single-get dest; null for batch
+    size_t destSize = 0;        ///< bytes delivered to destBuffer on success
+    size_t expectedSize = 0;    ///< expected response bytes; 0 = unchecked
+    bool exactSize = false;     ///< a body shorter than expectedSize is an error
+    /** Plain-file byte range: the URL names a file, not a query, and the
+     *  backend asks for [rangeOffset, rangeOffset + expectedSize) with the
+     *  transport's own range mechanism (HTTP Range, XrdCl offset read). */
+    bool rangeRead = false;
+    size_t rangeOffset = 0;
     std::vector<char> responseData; ///< full response body
 };
 

--- a/source/adios2/toolkit/remote/XrdClBackend.cpp
+++ b/source/adios2/toolkit/remote/XrdClBackend.cpp
@@ -23,22 +23,28 @@ namespace
 // through a (void) cast; deliberately-ignored statuses are routed here.
 void IgnoreStatus(const XrdCl::XRootDStatus &) {}
 
-// Fetch one URL synchronously into op: Open(url) then a single Read(0,
-// expectedSize) of the whole response into the destination buffer (single Get)
-// or into responseData (batch, which the caller then frames/parses).  Returns
-// true on success; on failure sets op->errorMsg and returns false.  Does not
-// touch op->promise -- RunGet sets it exactly once, so the many exit paths here
-// cannot forget to.
+// Fetch one URL synchronously into op: Open(url) then a single Read of
+// expectedSize bytes into the destination buffer (single Get) or into
+// responseData (batch, which the caller then frames/parses).  A query URL is
+// read from offset 0 in full-download mode; a plain-file range read
+// (op->rangeRead) is an ordinary XrdCl offset read, which the curl plugin
+// turns into an HTTP Range request.  Returns true on success; on failure sets
+// op->errorMsg and returns false.  Does not touch op->promise -- RunGet sets it
+// exactly once, so the many exit paths here cannot forget to.
 bool Fetch(const std::string &url, AsyncGet *op)
 {
     XrdCl::File file;
 
-    // The xrdcl-curl plugin fetches the whole response in one GET (full_download
-    // mode; the origin returns a complete body per GET).  This no-op Open
-    // (Compress/None) is the plugin's documented hook to instantiate itself so
-    // the following SetProperty reaches the plugin object; then the real Open runs.
-    IgnoreStatus(file.Open(url, XrdCl::OpenFlags::Compress, XrdCl::Access::None, nullptr, 0));
-    (void)file.SetProperty("XrdClCurlFullDownload", "true");
+    if (!op->rangeRead)
+    {
+        // The xrdcl-curl plugin fetches the whole response in one GET
+        // (full_download mode; the origin returns a complete body per GET).
+        // This no-op Open (Compress/None) is the plugin's documented hook to
+        // instantiate itself so the following SetProperty reaches the plugin
+        // object; then the real Open runs.
+        IgnoreStatus(file.Open(url, XrdCl::OpenFlags::Compress, XrdCl::Access::None, nullptr, 0));
+        (void)file.SetProperty("XrdClCurlFullDownload", "true");
+    }
 
     XrdCl::XRootDStatus status = file.Open(url, XrdCl::OpenFlags::Read);
     if (!status.IsOK())
@@ -78,7 +84,8 @@ bool Fetch(const std::string &url, AsyncGet *op)
     }
 
     uint32_t bytesRead = 0;
-    status = file.Read(0, size, target, bytesRead);
+    const uint64_t offset = op->rangeRead ? op->rangeOffset : 0;
+    status = file.Read(offset, size, target, bytesRead);
     IgnoreStatus(file.Close());
 
     if (!status.IsOK())

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
@@ -206,6 +206,12 @@ void XrootdHttpRemote::Open(const std::string hostname, const int32_t port,
     m_OpenSuccess = true;
 }
 
+void XrootdHttpRemote::OpenSimpleFile(const std::string hostname, const int32_t port,
+                                      const std::string filename, const Params &params)
+{
+    Open(hostname, port, filename, Mode::ReadRandomAccess, true, params);
+}
+
 void XrootdHttpRemote::Close() { m_OpenSuccess = false; }
 
 // ---------------------------------------------------------------------

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.cpp
@@ -126,9 +126,9 @@ void XrootdHttpRemote::Open(const std::string hostname, const int32_t port,
     if (it != params.end())
         m_FileUUID = static_cast<uint32_t>(std::stoul(it->second));
 
-    // URL path prefix that routes requests to the ADIOS handler on the
-    // server; must match the prefix the server's HTTP handler was configured
-    // with (default "/adios" on both ends).  "/" or "" means no prefix.
+    // Optional path prefix placed before the dataset path in every URL (a
+    // federation namespace, for example).  Routing to the ADIOS handler no
+    // longer depends on it; "/" or "" means none.
     it = params.find("ServerPath");
     if (it != params.end())
     {
@@ -217,18 +217,21 @@ void XrootdHttpRemote::Close() { m_OpenSuccess = false; }
 // ---------------------------------------------------------------------
 // Path-encoded URL builders (Pelican/XCache-friendly form).
 //
-// Full URL: <scheme>://<host>:<port><serverpath><filename>/<file-config>/<request>
+// Full URL: <scheme>://<host>:<port><serverpath><filename>/_adios/<file-config>/<request>
 //
-// <serverpath> is the prefix that routes the request to the ADIOS handler
-// on the server ("/adios" unless hosts.yaml `serverpath` overrides it).
+// The reserved `_adios` segment after the dataset path is what routes the
+// request to the ADIOS handler on the server; a URL without it is a plain
+// file, served by XRootD itself (Read() below uses that for byte ranges).
+// <serverpath> is an optional prefix before the dataset path (hosts.yaml
+// `serverpath`, e.g. a federation namespace); it plays no routing role.
 //
 // The filename keeps its literal slashes (it is not URL-encoded), so
-// it occupies multiple path segments.  The server identifies the last
-// two segments as file-config and request and rejoins everything
-// before them as the filename.
+// it occupies multiple path segments.  The server splits at the last
+// `/_adios/` and takes the two segments after it as file-config and
+// request.
 //
 // Per-segment grammar:
-//   file-config:   r<digit>(p<base64url-EP>)?       (always at least r0/r1)
+//   file-config:   v1r<digit>(u<uuid>)?(e1)?(p<base64url-EP>)?  (wire version first)
 //   single get:    g~<base64url-var>~<paramstring>  (`_` if no params)
 //   batch get:     b~N~<v1>~<p1>~<v2>~<p2>~...~<vN>~<pN>
 //
@@ -243,6 +246,9 @@ void XrootdHttpRemote::Close() { m_OpenSuccess = false; }
 std::string XrootdHttpRemote::BuildFileConfigSegment()
 {
     std::ostringstream s;
+    // Wire-format version of the marker form (v1); the server rejects a
+    // version newer than it knows.  Must come first.
+    s << "v" << kWireVersion;
     // Always emit RMOrder so the server doesn't have to guess the default.
     s << "r" << (m_RowMajorOrdering ? "1" : "0");
     // File id for the identity check (omit when 0). Must precede the greedy `p`.
@@ -377,7 +383,7 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
         std::vector<BatchGetRequest> subRequests(requests.begin() + startIdx,
                                                  requests.begin() + startIdx + count);
         std::string url =
-            m_BaseUrl + "/" + m_FileConfigSegment + "/" + BuildBatchGetSegment(subRequests);
+            m_BaseUrl + "/_adios/" + m_FileConfigSegment + "/" + BuildBatchGetSegment(subRequests);
 
         AsyncGet *asyncOp = new AsyncGet();
         asyncOp->expectedSize = ExpectedBatchResponseSize(subRequests);
@@ -411,8 +417,8 @@ bool XrootdHttpRemote::BatchGet(const std::vector<BatchGetRequest> &requests)
 
                 std::vector<BatchGetRequest> subRequests(requests.begin() + sb.startIdx,
                                                          requests.begin() + sb.startIdx + sb.count);
-                std::string url =
-                    m_BaseUrl + "/" + m_FileConfigSegment + "/" + BuildBatchGetSegment(subRequests);
+                std::string url = m_BaseUrl + "/_adios/" + m_FileConfigSegment + "/" +
+                                  BuildBatchGetSegment(subRequests);
 
                 AsyncGet *retryOp = new AsyncGet();
                 retryOp->expectedSize = ExpectedBatchResponseSize(subRequests);
@@ -514,7 +520,7 @@ Remote::GetHandle XrootdHttpRemote::Get(const char *VarName, size_t Step, size_t
     asyncOp->expectedSize = destSize;
 
     std::string url =
-        m_BaseUrl + "/" + m_FileConfigSegment + "/" +
+        m_BaseUrl + "/_adios/" + m_FileConfigSegment + "/" +
         BuildSingleGetSegment(VarName, Step, StepCount, BlockID, Count, Start, accuracy);
     m_Backend->SubmitGet(url, asyncOp);
     return static_cast<GetHandle>(asyncOp);
@@ -534,9 +540,34 @@ bool XrootdHttpRemote::WaitForGet(GetHandle handle)
         helper::Throw<std::runtime_error>("Remote", "XrootdHttpRemote", "WaitForGet",
                                           "request failed for file " + m_Filename + ": " + detail);
     }
+    if (asyncOp->exactSize && asyncOp->destSize != asyncOp->expectedSize)
+    {
+        helper::Throw<std::runtime_error>("Remote", "XrootdHttpRemote", "WaitForGet",
+                                          "short response for file " + m_Filename + ": received " +
+                                              std::to_string(asyncOp->destSize) + " of " +
+                                              std::to_string(asyncOp->expectedSize) + " bytes");
+    }
     return true;
 }
 
-Remote::GetHandle XrootdHttpRemote::Read(size_t Start, size_t Size, void *Dest) { return nullptr; }
+Remote::GetHandle XrootdHttpRemote::Read(size_t Start, size_t Size, void *Dest)
+{
+    if (!m_OpenSuccess)
+    {
+        return nullptr;
+    }
+
+    AsyncGet *asyncOp = new AsyncGet();
+    asyncOp->destBuffer = Dest;
+    asyncOp->expectedSize = Size;
+    asyncOp->exactSize = true;
+    asyncOp->rangeRead = true;
+    asyncOp->rangeOffset = Start;
+
+    // A byte range of the file itself: the bare path, no `_adios` segment,
+    // served by XRootD's own file handling (and cacheable as such).
+    m_Backend->SubmitGet(m_BaseUrl, asyncOp);
+    return static_cast<GetHandle>(asyncOp);
+}
 
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.h
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.h
@@ -40,6 +40,9 @@ public:
     void Open(const std::string hostname, const int32_t port, const std::string filename,
               const Mode mode, bool RowMajorOrdering, const Params &params = Params()) override;
 
+    void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename,
+                        const Params &params = Params()) override;
+
     GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
                   Dims &Start, Accuracy &accuracy, void *dest, size_t destSize) override;
 

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.h
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.h
@@ -33,7 +33,7 @@ public:
     profiling::IOChrono m_Profiler;
 
     XrootdHttpRemote(const RemoteSetup &remoteSetup);
-    ~XrootdHttpRemote();
+    ~XrootdHttpRemote() override;
 
     explicit operator bool() const override { return m_OpenSuccess; }
 

--- a/source/adios2/toolkit/remote/XrootdHttpRemote.h
+++ b/source/adios2/toolkit/remote/XrootdHttpRemote.h
@@ -61,11 +61,16 @@ public:
     void SetVerifySSL(bool verify) { m_VerifySSL = verify; }
 
 private:
-    /** Path-encoded request builders.  Each produces one URL path segment.
-     *  See developer notes for the wire grammar; summary:
-     *    file-config:  r0?p<base64url-EP>?    (`_` placeholder if empty)
+    /** Wire-format version emitted in every query's file-config segment. */
+    static constexpr unsigned kWireVersion = 1;
+
+    /** Path-encoded request builders.  Each produces one URL path segment,
+     *  placed after the reserved `_adios` segment that follows the dataset
+     *  path.  See developer notes for the wire grammar; summary:
+     *    file-config:  v1r0?u<uuid>?e1?p<base64url-EP>?
      *    single get:   g~<base64url-var>~<paramstring>     (`_` if no params)
      *    batch get:    b~N~<v1>~<p1>~…~<vN>~<pN>
+     *  Byte ranges of plain files (Read()) use the bare path with no marker.
      *  Varnames and EngineParams are base64url-encoded (RFC 4648 §5).
      *  Paramstring fields are letter-prefixed and self-delimiting; vector
      *  elements use `,`; outer delimiter is `~`; floats use `.` as decimal. */
@@ -85,10 +90,9 @@ private:
 
     std::string m_BaseUrl;
     std::string m_Filename;
-    /** URL path prefix that routes requests to the ADIOS handler on the
-     *  server (hosts.yaml `serverpath`); must match the prefix the server's
-     *  HTTP handler was configured with. */
-    std::string m_ServerPath = "/adios";
+    /** Optional path prefix before the dataset path (hosts.yaml
+     *  `serverpath`, e.g. a federation namespace); none by default. */
+    std::string m_ServerPath;
     std::string m_EngineParams;
     /** File id from the reader's metadata, sent for the server's staleness check;
      *  0 = none (legacy file). */

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -339,6 +339,12 @@ void XrootdRemote::Open(const std::string hostname, const int32_t port, const st
     return;
 }
 
+void XrootdRemote::OpenSimpleFile(const std::string hostname, const int32_t port,
+                                  const std::string filename, const Params &params)
+{
+    Open(hostname, port, filename, Mode::ReadRandomAccess, true, params);
+}
+
 bool XrootdRemote::WaitForGet(GetHandle handle)
 {
     std::promise<bool> *p = (std::promise<bool> *)handle;

--- a/source/adios2/toolkit/remote/XrootdRemote.cpp
+++ b/source/adios2/toolkit/remote/XrootdRemote.cpp
@@ -12,6 +12,7 @@
 #include "adios2/helper/adiosString.h"
 #include "adios2/helper/adiosSystem.h"
 #ifdef ADIOS2_HAVE_XROOTD
+#include "XrdCl/XrdClFile.hh"
 #include "XrdSsi/XrdSsiProvider.hh"
 #include "XrdSsi/XrdSsiRequest.hh"
 #include "XrdSsi/XrdSsiService.hh"
@@ -244,15 +245,8 @@ void myRequest::ProcessResponseData(const XrdSsiErrInfo &eInfo, char *buff, int 
         return;
     }
 
-    // Now we check if we need to ask for more data. If last is false, we do!
-    //
-    if (!last && !clUI.doOnce)
-    {
-        GetResponseData(rspBuff, readSZ);
-        return;
-    }
-
-    // fill in destination buffer; reject a response that would overrun dest
+    // Append this chunk to the destination; a response larger than readSZ
+    // arrives in several calls.  Reject a response that would overrun dest
     // (stale metadata, wrong-size reply). 0 = caller gave no expected size.
     //
     if (expectedSize != 0 &&
@@ -265,8 +259,16 @@ void myRequest::ProcessResponseData(const XrdSsiErrInfo &eInfo, char *buff, int 
         delete this;
         return;
     }
+    memcpy(dest + totbytes, buff, dlen);
     totbytes += dlen;
-    memcpy(dest, buff, dlen);
+
+    // Now we check if we need to ask for more data. If last is false, we do!
+    //
+    if (!last && !clUI.doOnce)
+    {
+        GetResponseData(rspBuff, readSZ);
+        return;
+    }
 
     // We are done with our request. We avoid calling Finished if we got here
     // because we were cancelled.
@@ -326,6 +328,8 @@ void XrootdRemote::Open(const std::string hostname, const int32_t port, const st
     m_Mode = mode;
     m_RowMajorOrdering = RowMajorOrdering;
 
+    m_Host = hostname;
+    m_Port = port;
     const std::string contact = hostname + ":" + std::to_string(port);
     clUI.cmdName = strdup("adios:");
     clUI.contact = strdup(contact.c_str());
@@ -333,6 +337,8 @@ void XrootdRemote::Open(const std::string hostname, const int32_t port, const st
     {
         fprintf(XrdSsiCl::outErr, "Unable to get service object for %s; %s\n", clUI.contact,
                 eInfo.Get().c_str());
+        m_OpenSuccess = false;
+        return;
     }
     m_OpenSuccess = true;
 #endif
@@ -342,16 +348,26 @@ void XrootdRemote::Open(const std::string hostname, const int32_t port, const st
 void XrootdRemote::OpenSimpleFile(const std::string hostname, const int32_t port,
                                   const std::string filename, const Params &params)
 {
-    Open(hostname, port, filename, Mode::ReadRandomAccess, true, params);
+    // A plain file is read with XrdCl over the xroot protocol (Read() below);
+    // no SSI service is involved, so nothing is contacted until the read.
+    m_Host = hostname;
+    m_Port = port;
+    m_Filename = filename;
+    m_Mode = Mode::ReadRandomAccess;
+    m_OpenSuccess = true;
 }
 
 bool XrootdRemote::WaitForGet(GetHandle handle)
 {
     std::promise<bool> *p = (std::promise<bool> *)handle;
     bool result = p->get_future().get();
-    if (!result)
-        throw std::runtime_error("XRootD - Get failed for file " + m_Filename);
     delete p;
+    if (!result)
+    {
+        std::string detail = m_LastError.empty() ? "" : ": " + m_LastError;
+        m_LastError.clear();
+        throw std::runtime_error("XRootD - Get failed for file " + m_Filename + detail);
+    }
     return true;
 }
 
@@ -361,9 +377,6 @@ Remote::GetHandle XrootdRemote::Get(const char *VarName, size_t Step, size_t Ste
 {
 // FIXME: StepCount is not implemented here yet
 #ifdef ADIOS2_HAVE_XROOTD
-    char rName[512] = "/etc";
-    XrdSsiResource rSpec((std::string)rName);
-    myRequest *reqP;
     std::string reqData = "get Filename=" + std::string(m_Filename) + std::string("&RMOrder=") +
                           std::to_string(m_RowMajorOrdering) + std::string("&Varname=") +
                           std::string(VarName);
@@ -381,6 +394,73 @@ Remote::GetHandle XrootdRemote::Get(const char *VarName, size_t Step, size_t Ste
     {
         reqData += "&Start=" + std::to_string(s);
     }
+
+    return SubmitRequest(reqData, dest, destSize);
+#else
+    return (GetHandle)(intptr_t)0;
+#endif
+}
+
+XrootdRemote::GetHandle XrootdRemote::Read(size_t Start, size_t Size, void *Dest)
+{
+#ifdef ADIOS2_HAVE_XROOTD
+    if (!m_OpenSuccess)
+        return static_cast<GetHandle>(0);
+    // A byte range of a plain file, read the ordinary XRootD way: XrdCl over
+    // the xroot protocol against the same server (which must pass the data
+    // path through to its file system with `ssi.fspath`).  Synchronous; the
+    // handle carries the outcome for WaitForGet().
+    auto *promise = new std::promise<bool>();
+    if (Size > static_cast<size_t>(INT32_MAX))
+    {
+        m_LastError = "range of " + std::to_string(Size) + " bytes exceeds a single XrdCl read";
+        promise->set_value(false);
+        return (GetHandle)(intptr_t)promise;
+    }
+    const std::string url = "root://" + m_Host + ":" + std::to_string(m_Port) + "/" + m_Filename;
+    XrdCl::File file;
+    XrdCl::XRootDStatus status = file.Open(url, XrdCl::OpenFlags::Read);
+    if (!status.IsOK())
+    {
+        m_LastError = "open " + url + ": " + status.ToString();
+        promise->set_value(false);
+        return (GetHandle)(intptr_t)promise;
+    }
+    uint32_t bytesRead = 0;
+    status = file.Read(Start, static_cast<uint32_t>(Size), Dest, bytesRead);
+    XrdCl::XRootDStatus closeStatus = file.Close();
+    (void)closeStatus;
+    if (!status.IsOK())
+    {
+        m_LastError = "read " + url + ": " + status.ToString();
+        promise->set_value(false);
+    }
+    else if (bytesRead != Size)
+    {
+        m_LastError = "read " + url + ": got " + std::to_string(bytesRead) + " of " +
+                      std::to_string(Size) + " bytes";
+        promise->set_value(false);
+    }
+    else
+    {
+        promise->set_value(true);
+    }
+    return (GetHandle)(intptr_t)promise;
+#else
+    return static_cast<GetHandle>(0);
+#endif
+};
+
+#ifdef ADIOS2_HAVE_XROOTD
+// Hand one ASCII request to the SSI service; the response is copied into dest
+// (checked against destSize) by the request's callbacks, which then set the
+// promise returned here as the handle.
+XrootdRemote::GetHandle XrootdRemote::SubmitRequest(const std::string &reqData, void *dest,
+                                                    size_t destSize)
+{
+    char rName[512] = "/etc";
+    XrdSsiResource rSpec((std::string)rName);
+    myRequest *reqP;
 
     // The first step is to define the resource we will be using. So, just
     // initialize a resource object. It need only to exist during ProcessRequest()
@@ -411,14 +491,7 @@ Remote::GetHandle XrootdRemote::Get(const char *VarName, size_t Step, size_t Ste
     clUI.ssiService->ProcessRequest(*reqP, rSpec);
     // thread synchronization
     return (GetHandle)(intptr_t)(reqP->promise);
-#else
-    return (GetHandle)(intptr_t)0;
-#endif
 }
-
-XrootdRemote::GetHandle XrootdRemote::Read(size_t Start, size_t Size, void *Dest)
-{
-    return static_cast<GetHandle>(0);
-};
+#endif
 
 }

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -96,21 +96,21 @@ public:
     bool m_OpenSuccess = false;
 
     XrootdRemote(const RemoteSetup &remoteSetup);
-    ~XrootdRemote();
+    ~XrootdRemote() override;
 
-    explicit operator bool() const { return m_OpenSuccess; }
+    explicit operator bool() const override { return m_OpenSuccess; }
 
     void Open(const std::string hostname, const int32_t port, const std::string filename,
-              const Mode mode, bool RowMajorOrdering, const Params &params = Params());
+              const Mode mode, bool RowMajorOrdering, const Params &params = Params()) override;
 
     void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename,
                         const Params &params = Params()) override;
 
     GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
-                  Dims &Start, Accuracy &accuracy, void *dest, size_t destSize);
+                  Dims &Start, Accuracy &accuracy, void *dest, size_t destSize) override;
 
-    GetHandle Read(size_t Start, size_t Size, void *Dest);
-    bool WaitForGet(GetHandle handle);
+    GetHandle Read(size_t Start, size_t Size, void *Dest) override;
+    bool WaitForGet(GetHandle handle) override;
 };
 
 } // end namespace adios2

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -103,6 +103,9 @@ public:
     void Open(const std::string hostname, const int32_t port, const std::string filename,
               const Mode mode, bool RowMajorOrdering, const Params &params = Params());
 
+    void OpenSimpleFile(const std::string hostname, const int32_t port, const std::string filename,
+                        const Params &params = Params()) override;
+
     GetHandle Get(const char *VarName, size_t Step, size_t StepCount, size_t BlockID, Dims &Count,
                   Dims &Start, Accuracy &accuracy, void *dest, size_t destSize);
 

--- a/source/adios2/toolkit/remote/XrootdRemote.h
+++ b/source/adios2/toolkit/remote/XrootdRemote.h
@@ -91,6 +91,10 @@ public:
 #endif
     int reqLen;
     std::string m_Filename;
+    std::string m_Host;
+    int32_t m_Port = 1094;
+    /** Failure detail from the last Read(), reported by WaitForGet(). */
+    std::string m_LastError;
     Mode m_Mode;
     bool m_RowMajorOrdering;
     bool m_OpenSuccess = false;
@@ -111,6 +115,14 @@ public:
 
     GetHandle Read(size_t Start, size_t Size, void *Dest) override;
     bool WaitForGet(GetHandle handle) override;
+
+    /* Nothing is held on the server between requests. */
+    void Close() override { m_OpenSuccess = false; }
+
+private:
+#ifdef ADIOS2_HAVE_XROOTD
+    GetHandle SubmitRequest(const std::string &reqData, void *dest, size_t destSize);
+#endif
 };
 
 } // end namespace adios2

--- a/source/utils/xrootd-plugin/README.md
+++ b/source/utils/xrootd-plugin/README.md
@@ -16,34 +16,50 @@ This document covers operator-facing configuration. Other operational knobs
 (file-pool FD/metadata limits, the admin HTTP interface) are described in the
 release notes and will be folded in here over time.
 
-## URL path prefix
+## Request routing
 
-The HTTP handler answers only requests whose URL path starts with a configured
-prefix; everything else falls through to XRootD's regular HTTP file serving.
-The prefix defaults to `/adios` and is set server-side via the exthandler
-parameters in the XRootD config:
+The HTTP handler claims a URL when it carries the reserved `_adios` segment
+after the dataset path:
 
 ```
-http.exthandler xrdhttpssi /path/to/libadios2_xrootd_http.so "ssilib=/path/to/libadios2_xrootd.so prefix=/my/namespace"
+GET /<dataset path>/_adios/<file-config>/<request>
 ```
 
-The client must build URLs with the same prefix. It defaults to `/adios` and is
-set per host in `hosts.yaml` with the `serverpath` key of an `xrootd` protocol
-entry (or the `XRootDServerPath` environment variable when using the
-`DoXRootDHttps`/`DoXRootDXrdCl` env-var access path):
+Every other URL falls through to XRootD's regular file serving, so campaign
+image and text replicas, and whole tar archives, are read as plain files with
+ordinary `Range` requests, `HEAD`, and `stat`, and any HTTP or Pelican cache
+handles them as files. `_adios` is therefore a reserved name: no served
+dataset or file may use it as a path component.
 
-```yaml
-myserver:
-  remote:
-      protocol: xrootd
-      host: myserver.example.org
-      port: 8443
-      transfer_protocol: https
-      serverpath: /my/namespace
+For that fall-through to work the xrootd instance must serve files as well as
+SSI requests. Stack SSI over the default file system and list the data
+directories:
+
+```
+xrootd.fslib libXrdSsi.so default
+oss.statlib -2 libXrdSsi.so
+ssi.svclib /path/to/libadios2_xrootd.so
+ssi.fspath /data
+all.export /data r/o
+http.exthandler xrdhttpssi /path/to/libadios2_xrootd_http.so ssilib=/path/to/libadios2_xrootd.so
 ```
 
-This matters for Pelican-style deployments, where the path prefix is a
-federation namespace rather than a fixed string.
+Without `default` on the `fslib` line SSI is the only file system and plain
+reads return nothing. The same stacking lets the native xroot-protocol client
+read plain files from the same server with XrdCl.
+
+Older clients put a `/adios` prefix in front of the dataset path instead of
+the marker (`/adios/<dataset path>/<file-config>/<request>`, and before that a
+query-string form). The handler still answers those; the prefix it recognises
+is the `prefix=` handler parameter, `/adios` by default. Note that XRootD
+passes only the first word after the library name as handler parameters, so
+`ssilib=` and `prefix=` cannot both be given.
+
+The client-side `serverpath` key in `hosts.yaml` (or the `XRootDServerPath`
+environment variable in the env-var access lane) is now an optional prefix
+placed before the dataset path, for deployments such as a Pelican federation
+whose URL namespace does not begin at the server's file system root. It plays
+no part in routing.
 
 ## HEAD requests
 

--- a/source/utils/xrootd-plugin/XrdHttpSsiHandler.cpp
+++ b/source/utils/xrootd-plugin/XrdHttpSsiHandler.cpp
@@ -55,9 +55,16 @@ std::string UrlEncode(const std::string &s)
 // Wire grammar matches the client encoder in
 // source/adios2/toolkit/remote/XrootdHttpRemote.cpp:
 //
-//   /adios/<urlenc-filename>/<file-config>/<request>
+//   <filename>/_adios/<file-config>/<request>          (v1, current clients)
+//   /adios/<filename>/<file-config>/<request>          (v0, prefix form)
 //
-//   file-config:   r<digit>?p<base64url-EP>?    (or `_` placeholder)
+// The reserved `_adios` segment after the dataset path is what marks a
+// request for this handler; a path without it is a plain file and never
+// reaches here.  The prefix form is what clients emitted before the
+// marker and is still accepted (the prefix is the handler's `prefix=`
+// parameter, "/adios" by default).
+//
+//   file-config:   v<n>?r<digit>?u<n>?e<n>?p<base64url-EP>?  (or `_`)
 //   single get:    g~<base64url-var>~<paramstring>     (or `_` if no params)
 //   batch get:     b~N~<v1>~<p1>~<v2>~<p2>~...~<vN>~<pN>
 //
@@ -251,9 +258,13 @@ bool DecodeFileConfigSegment(const std::string &fileConfig, std::ostringstream &
     return i == n;
 }
 
-// Top-level decoder.  Strips the route prefix, splits the path, and
-// composes the legacy ssiCommand from the three segments.  On parse
-// error returns false with an explanation in `errorOut`.
+// The reserved segment that separates the dataset path from the request.
+const char kMarker[] = "/_adios/";
+
+// Top-level decoder.  Locates the dataset path, file-config, and request
+// segments (marker form first, prefix form as the fallback) and composes
+// the ssiCommand from them.  On parse error returns false with an
+// explanation in `errorOut`.
 bool DecodePathEncodedRequest(const std::string &fullresource, const std::string &pathPrefix,
                               std::string &ssiCommandOut, std::string &resourceOut,
                               std::string &errorOut)
@@ -265,34 +276,49 @@ bool DecodePathEncodedRequest(const std::string &fullresource, const std::string
     if (qpos != std::string::npos)
         path = path.substr(0, qpos);
 
-    const std::string fullPrefix = pathPrefix + "/";
-    if (path.compare(0, fullPrefix.size(), fullPrefix) != 0)
-    {
-        errorOut = "URL does not start with " + fullPrefix;
-        return false;
-    }
-    path = path.substr(fullPrefix.size());
-
-    // Three segments after the prefix: filename, file-config, request.
     // The filename's slashes are literal path separators (not encoded),
-    // so it spans multiple segments.  The last two are file-config and
-    // request; everything before them is the filename.
-    std::vector<std::string> segments = SplitOn(path, '/');
-    if (segments.size() < 3)
+    // so it spans multiple segments.  In the marker form everything before
+    // the last `/_adios/` is the filename and exactly two segments follow.
+    // In the prefix form the last two segments are file-config and request
+    // and everything between the prefix and them is the filename.
+    std::string encodedFilename, fileConfigSeg, requestSeg;
+    const size_t marker = path.rfind(kMarker);
+    if (marker != std::string::npos && marker > 0)
     {
-        errorOut = "URL must have filename, file-config, and request segments";
-        return false;
+        encodedFilename = path.substr(0, marker);
+        std::vector<std::string> tail = SplitOn(path.substr(marker + strlen(kMarker)), '/');
+        if (tail.size() != 2 || tail[0].empty() || tail[1].empty())
+        {
+            errorOut = "Expected <file-config>/<request> after /_adios/";
+            return false;
+        }
+        fileConfigSeg = tail[0];
+        requestSeg = tail[1];
     }
-    const std::string requestSeg = segments.back();
-    segments.pop_back();
-    const std::string fileConfigSeg = segments.back();
-    segments.pop_back();
-    std::string encodedFilename;
-    for (size_t i = 0; i < segments.size(); ++i)
+    else
     {
-        if (i > 0)
-            encodedFilename += "/";
-        encodedFilename += segments[i];
+        const std::string fullPrefix = pathPrefix + "/";
+        if (path.compare(0, fullPrefix.size(), fullPrefix) != 0)
+        {
+            errorOut = "URL has no /_adios/ segment and does not start with " + fullPrefix;
+            return false;
+        }
+        std::vector<std::string> segments = SplitOn(path.substr(fullPrefix.size()), '/');
+        if (segments.size() < 3)
+        {
+            errorOut = "URL must have filename, file-config, and request segments";
+            return false;
+        }
+        requestSeg = segments.back();
+        segments.pop_back();
+        fileConfigSeg = segments.back();
+        segments.pop_back();
+        for (size_t i = 0; i < segments.size(); ++i)
+        {
+            if (i > 0)
+                encodedFilename += "/";
+            encodedFilename += segments[i];
+        }
     }
 
     // Ensure leading '/' so the resource matches the legacy form
@@ -662,31 +688,34 @@ bool XrdHttpSsiHandler::ObtainSSIService()
     return true;
 }
 
+// XrdHttp asks this before it considers serving the path as a file, so a
+// "yes" here is what turns a URL into an ADIOS request; everything else
+// under the same namespace stays a plain file served by XRootD itself.
 bool XrdHttpSsiHandler::MatchesPath(const char *verb, const char *path)
 {
     if (!verb || !path)
     {
         return false;
     }
-
-    // HEAD is answered for ADIOS data requests only (headers-only response,
-    // so caches can size a response without fetching it).
-    if (strcmp(verb, "HEAD") == 0)
-    {
-        return strncmp(path, m_pathPrefix.c_str(), m_pathPrefix.length()) == 0;
-    }
-
-    // Accept POST and GET
-    if (strcmp(verb, "POST") != 0 && strcmp(verb, "GET") != 0)
+    const bool isHead = (strcmp(verb, "HEAD") == 0);
+    if (!isHead && strcmp(verb, "GET") != 0 && strcmp(verb, "POST") != 0)
     {
         return false;
     }
 
-    // Match admin paths or prefix
+    // Admin endpoints live at the root (/_adios/stats ...); no HEAD there.
     if (strncmp(path, "/_adios", 7) == 0)
+    {
+        return !isHead;
+    }
+    // A data request: the reserved `_adios` segment after the dataset path.
+    // HEAD is answered for these (headers-only, so caches can size a
+    // response without fetching it).
+    if (strstr(path, kMarker) != nullptr)
     {
         return true;
     }
+    // Prefix form from earlier clients.
     if (strncmp(path, m_pathPrefix.c_str(), m_pathPrefix.length()) == 0)
     {
         return true;
@@ -728,12 +757,13 @@ int XrdHttpSsiHandler::ProcessReq(XrdHttpExtReq &req)
         resource = "/";
     }
 
-    // The handler accepts two GET wire forms while old clients are
+    // The handler accepts three GET wire forms while old clients are
     // still being phased out:
-    //   - path-encoded GET (new, cache-friendly):
+    //   - marker form (current, cache-friendly):
+    //       <filename>/_adios/<file-config>/<request>
+    //   - prefix form (path-encoded clients before the marker):
     //       /adios/<filename>/<file-config>/<request>
-    //     Distinguished by the absence of any '?' in the URL.
-    //   - legacy query-string GET (old client form):
+    //   - legacy query-string GET (v2.12.0 clients):
     //       /adios/<filename>?<verb>&<key>=<val>&...
     // POST is no longer supported (legacy POST builds are out of
     // circulation).  HEAD runs the request as a size-only query: the SSI

--- a/source/utils/xrootd-plugin/XrdSsiSvService.cpp
+++ b/source/utils/xrootd-plugin/XrdSsiSvService.cpp
@@ -83,9 +83,10 @@ void *SvAdiosGet(void *svP)
     return 0;
 }
 
-// Highest request wire-format version we accept (clients emit none yet, absent ==
-// 0). Policing it gives a future newer client a clear error, not a parse failure.
-constexpr uint32_t kMaxWireVersion = 0;
+// Highest request wire-format version we accept: 0 = the original prefix and
+// query-string forms (no version field), 1 = the `_adios` marker form. Policing
+// it gives a future newer client a clear error, not a parse failure.
+constexpr uint32_t kMaxWireVersion = 1;
 
 // Record a rejected request in the access log (the normal entry is logged only
 // after a successful read, which a rejection never reaches).

--- a/testing/adios2/engine/bp/CMakeLists.txt
+++ b/testing/adios2/engine/bp/CMakeLists.txt
@@ -234,9 +234,16 @@ if (ADIOS2_HAVE_XRootD)
    add_test(NAME remoteXRServerCleanup COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/kill_xrootd.sh )
    set_tests_properties(remoteXRServerCleanup         PROPERTIES FIXTURES_CLEANUP    XRServer)
 
+   # Raw byte-range reads (campaign image/text replicas) through
+   # GetRemoteSimpleFile(); registered once per XRootD lane below.
+   add_executable(Test.Engine.BP.XRootDSimpleFile.Serial TestBPXRootDSimpleFile.cpp)
+   target_link_libraries(Test.Engine.BP.XRootDSimpleFile.Serial
+      adios2::cxx adios2_core adios2::thirdparty::gtest)
+
    ##### add remote tests below this line
    add_get_xrremote_tests_helper(WriteReadADIOS2Transport)
    add_get_xrremote_tests_helper(WriteMemorySelectionRead)
+   add_get_xrremote_tests_helper(XRootDSimpleFile)
 endif()
 
 # HTTPS-based remote tests (requires both XRootD for server and CURL for client)
@@ -344,8 +351,10 @@ if (ADIOS2_HAVE_XRootD AND ADIOS2_HAVE_CURL)
    ##### add HTTPS remote tests below this line
    add_get_xrhttps_tests_helper(WriteReadADIOS2Transport)
    add_get_xrhttps_tests_helper(WriteMemorySelectionRead)
+   add_get_xrhttps_tests_helper(XRootDSimpleFile)
    add_get_xrhttps_xrdcl_tests_helper(WriteReadADIOS2Transport)
    add_get_xrhttps_xrdcl_tests_helper(WriteMemorySelectionRead)
+   add_get_xrhttps_xrdcl_tests_helper(XRootDSimpleFile)
 endif()
 
 if(ADIOS2_HAVE_MPI)

--- a/testing/adios2/engine/bp/TestBPXRootDHttpHead.cpp
+++ b/testing/adios2/engine/bp/TestBPXRootDHttpHead.cpp
@@ -6,11 +6,14 @@
 
 // HEAD support on the path-encoded wire form: a data-request URL must answer
 // HEAD with the exact Content-Length the corresponding GET would carry and no
-// body, so an HTTP cache can size a response without fetching it.
+// body, so an HTTP cache can size a response without fetching it.  Plain files
+// next to the dataset (campaign image/text replicas) are served by XRootD
+// itself with Range and HEAD; those are checked here too.
 
 #include <array>
 #include <climits>
 #include <cstring>
+#include <fstream>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -33,7 +36,10 @@ size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
 }
 
 constexpr long kHttpOK = 200;
-constexpr size_t kNElems = 16; // elements in the test variable
+constexpr size_t kNElems = 16;     // elements in the test variable
+constexpr size_t kRawSize = 4096;  // bytes in the plain test file
+constexpr size_t kRawOffset = 100; // range used by the plain-file tests
+constexpr size_t kRawCount = 200;
 
 struct FetchResult
 {
@@ -42,8 +48,9 @@ struct FetchResult
     std::vector<char> body;
 };
 
-// Synchronous GET or HEAD; returns false only on curl-level failure.
-bool Fetch(const std::string &url, bool head, FetchResult &out)
+// Synchronous GET or HEAD, optionally with a byte range ("first-last");
+// returns false only on curl-level failure.
+bool Fetch(const std::string &url, bool head, FetchResult &out, const char *range = nullptr)
 {
     CURL *curl = curl_easy_init();
     if (!curl)
@@ -51,6 +58,10 @@ bool Fetch(const std::string &url, bool head, FetchResult &out)
         return false;
     }
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    if (range)
+    {
+        curl_easy_setopt(curl, CURLOPT_RANGE, range);
+    }
     if (head)
     {
         curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
@@ -101,15 +112,28 @@ protected:
         std::array<char, PATH_MAX> cwd{};
         ASSERT_NE(getcwd(cwd.data(), cwd.size()), nullptr);
         s_GetUrl =
-            "https://" + std::string(host) + "/adios" + cwd.data() + "/headtest.bp/r1/g~dA~c16o0";
+            "https://" + std::string(host) + cwd.data() + "/headtest.bp/_adios/v1r1/g~dA~c16o0";
+
+        // A plain file next to the dataset, served by XRootD, not the handler.
+        s_RawData.resize(kRawSize);
+        for (size_t i = 0; i < kRawSize; ++i)
+            s_RawData[i] = static_cast<char>((i * 7 + 3) & 0xFF);
+        std::ofstream raw("headtest.bin", std::ios::binary | std::ios::trunc);
+        raw.write(s_RawData.data(), static_cast<std::streamsize>(s_RawData.size()));
+        ASSERT_TRUE(raw.good());
+        s_RawUrl = "https://" + std::string(host) + cwd.data() + "/headtest.bin";
     }
 
     static std::vector<double> s_Expected;
     static std::string s_GetUrl;
+    static std::vector<char> s_RawData;
+    static std::string s_RawUrl;
 };
 
 std::vector<double> XRootDHttpHead::s_Expected;
 std::string XRootDHttpHead::s_GetUrl;
+std::vector<char> XRootDHttpHead::s_RawData;
+std::string XRootDHttpHead::s_RawUrl;
 
 // HEAD: 200, Content-Length of the would-be body, no body bytes.
 TEST_F(XRootDHttpHead, Head)
@@ -152,6 +176,50 @@ TEST_F(XRootDHttpHead, HeadError)
     ASSERT_TRUE(Fetch(badUrl, true, r));
     EXPECT_NE(r.httpCode, kHttpOK);
     EXPECT_TRUE(r.body.empty());
+}
+
+// Plain file HEAD: XRootD reports the file size, no body.
+TEST_F(XRootDHttpHead, PlainFileHead)
+{
+    FetchResult r;
+    ASSERT_TRUE(Fetch(s_RawUrl, true, r));
+    EXPECT_EQ(r.httpCode, kHttpOK);
+    EXPECT_EQ(r.contentLength, (long long)kRawSize);
+    EXPECT_TRUE(r.body.empty());
+}
+
+// Plain file byte range: 206 with exactly the requested bytes.
+TEST_F(XRootDHttpHead, PlainFileRange)
+{
+    const std::string range =
+        std::to_string(kRawOffset) + "-" + std::to_string(kRawOffset + kRawCount - 1);
+    FetchResult r;
+    ASSERT_TRUE(Fetch(s_RawUrl, false, r, range.c_str()));
+    EXPECT_EQ(r.httpCode, 206);
+    ASSERT_EQ(r.body.size(), kRawCount);
+    EXPECT_EQ(memcmp(r.body.data(), s_RawData.data() + kRawOffset, kRawCount), 0);
+}
+
+// A range starting past EOF is refused (416), not answered short.
+TEST_F(XRootDHttpHead, PlainFileRangePastEnd)
+{
+    const std::string range =
+        std::to_string(kRawSize + 10) + "-" + std::to_string(kRawSize + 10 + kRawCount - 1);
+    FetchResult r;
+    ASSERT_TRUE(Fetch(s_RawUrl, false, r, range.c_str()));
+    EXPECT_EQ(r.httpCode, 416);
+}
+
+// A plain path never reaches the handler even when it looks query-like:
+// only the reserved /_adios/ segment routes there.
+TEST_F(XRootDHttpHead, MarkerRoutesOnlyMarkedPaths)
+{
+    FetchResult r;
+    ASSERT_TRUE(Fetch(s_RawUrl + "/v1r1/g~dA~c16o0", false, r));
+    EXPECT_NE(r.httpCode, kHttpOK); // no such file; ADIOS never saw it
+    ASSERT_TRUE(
+        Fetch(s_RawUrl.substr(0, s_RawUrl.rfind('/')) + "/headtest.bp/_adios/v1r1", false, r));
+    EXPECT_NE(r.httpCode, kHttpOK); // handler: request segment missing
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPXRootDHttpLegacyWire.cpp
+++ b/testing/adios2/engine/bp/TestBPXRootDHttpLegacyWire.cpp
@@ -4,19 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// REGRESSION TEST FOR THE LEGACY XROOTD-HTTP WIRE FORMAT.
+// REGRESSION TEST FOR THE LEGACY XROOTD-HTTP WIRE FORMATS.
 //
-// Released clients up through v2.12.x encode remote-read requests as a URL
-// query string:
+// Released clients up through v2.12.0 encode remote-read requests as a URL
+// query string under the /adios prefix:
 //     /adios/<filename>?get&Varname=<v>&Count=...&Start=...
 //     /adios/<filename>?batchget&NVars=<n>&Varname=...&Varname=...
-// The current client speaks the path-encoded form instead, but the server
-// must keep answering the legacy form until those clients age out.  This
-// test hand-builds requests exactly as the v2.12.0 client did and verifies
-// the bytes that come back.
+// Later 2.12.x clients used the path-encoded form under the same prefix:
+//     /adios/<filename>/<file-config>/<request>
+// The current client puts a reserved /_adios/ segment after the dataset path
+// instead, but the server must keep answering both older forms until those
+// clients age out.  This test hand-builds the old requests and verifies the
+// bytes that come back.
 //
-// REMOVE this test (and its registration in CMakeLists.txt) when legacy
-// query-string support is retired from the server.
+// REMOVE this test (and its registration in CMakeLists.txt) when support for
+// the prefix forms is retired from the server.
 
 #include <array>
 #include <climits>
@@ -136,6 +138,16 @@ TEST_F(XRootDHttpLegacyWire, BatchGet)
     const char *chunk1 = chunk0 + chunkBytes;
     EXPECT_EQ(memcmp(chunk0, &s_Expected[0], chunkBytes), 0);
     EXPECT_EQ(memcmp(chunk1, &s_Expected[12], chunkBytes), 0);
+}
+
+// Path-encoded form under the /adios prefix (2.12.x clients after the
+// query-string form): same variable, same bytes.
+TEST_F(XRootDHttpLegacyWire, PrefixPathForm)
+{
+    std::vector<char> body;
+    ASSERT_TRUE(LegacyFetch(s_BaseUrl + "/r1/g~dA~c16o0", body));
+    ASSERT_EQ(body.size(), s_Expected.size() * sizeof(double));
+    EXPECT_EQ(memcmp(body.data(), s_Expected.data(), body.size()), 0);
 }
 
 int main(int argc, char **argv)

--- a/testing/adios2/engine/bp/TestBPXRootDServerPath.cpp
+++ b/testing/adios2/engine/bp/TestBPXRootDServerPath.cpp
@@ -4,17 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Verifies the client-side `serverpath` URL-prefix plumbing (hosts.yaml
-// `serverpath`, or the XRootDServerPath environment variable in the env-var
-// access lane): the reader must build request URLs with the configured prefix
-// in place of the built-in "/adios".
+// Verifies the client-side `serverpath` plumbing (hosts.yaml `serverpath`,
+// or the XRootDServerPath environment variable in the env-var access lane):
+// the reader must place the configured prefix before the dataset path in
+// every request URL.  The prefix no longer routes to the ADIOS handler (the
+// reserved /_adios/ segment does); it exists for deployments whose URL
+// namespace does not start at the server's file system root.
 //
-// Runs against the standard HTTPS test server, whose handler answers at the
-// default "/adios" prefix:
-//   - prefix explicitly set to "/adios": reads succeed with correct data,
-//     proving the configured value produces working URLs;
-//   - prefix set to anything else: requests miss the ADIOS handler and the
-//     read throws, proving the setting actually reaches the URL.
+// Runs against the standard HTTPS test server, which serves the test tree
+// at its real path:
+//   - prefix "/" (none): reads succeed with correct data;
+//   - prefix set to anything else: the dataset path in the URL no longer
+//     exists on the server and the read throws, proving the setting reaches
+//     the URL.
 
 #include <cstdlib>
 #include <exception>
@@ -77,17 +79,18 @@ protected:
 
 std::vector<double> XRootDServerPath::s_Expected;
 
-// A configured prefix matching the server's works end to end.
-TEST_F(XRootDServerPath, MatchingPrefix)
+// An explicit "no prefix" works end to end.
+TEST_F(XRootDServerPath, NoPrefix)
 {
-    setenv("XRootDServerPath", "/adios", 1);
+    setenv("XRootDServerPath", "/", 1);
     EXPECT_EQ(ReadRemote(), s_Expected);
 }
 
-// A non-matching prefix must land in the URL and miss the handler.
+// A prefix must land in the URL: the dataset then lives at a path the
+// server does not have.
 TEST_F(XRootDServerPath, WrongPrefix)
 {
-    setenv("XRootDServerPath", "/not-the-adios-handler", 1);
+    setenv("XRootDServerPath", "/not-a-real-namespace", 1);
     EXPECT_THROW(ReadRemote(), std::exception);
 }
 

--- a/testing/adios2/engine/bp/TestBPXRootDSimpleFile.cpp
+++ b/testing/adios2/engine/bp/TestBPXRootDSimpleFile.cpp
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Oak Ridge National Laboratory and Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Raw byte-range reads of an arbitrary file through the XRootD remote lanes,
+// the path the campaign reader takes for image and text replicas.  Runs
+// against whichever server the environment selects (DoXRootD for native SSI,
+// DoXRootDHttps for the HTTPS bridge, DoXRootDXrdCl for the XrdCl client) via
+// the same GetRemoteSimpleFile() factory the campaign reader uses.  The server
+// must return exactly the requested range and reject anything else.
+
+#include <array>
+#include <climits>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <unistd.h> // getcwd; the server plugin is POSIX-only
+
+#include "adios2/toolkit/remote/Remote.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+// Larger than the native client's 1 MiB receive chunk, so a response that
+// arrives in several pieces is exercised.
+constexpr size_t kFileSize = 3 * 1024 * 1024 + 517;
+
+// One campaign-style read: open the file as a byte stream, read a range,
+// close.  Throws on any failure, as the campaign reader would.
+std::vector<char> ReadRange(const std::string &path, size_t offset, size_t count)
+{
+    adios2::RemoteSetup rs = adios2::GetRemoteSetup("");
+    std::shared_ptr<adios2::Remote> remote = adios2::GetRemoteSimpleFile(rs, path);
+    if (!remote || !(*remote))
+    {
+        throw std::runtime_error("no usable remote for " + path);
+    }
+    std::vector<char> buffer(count);
+    adios2::Remote::GetHandle handle = remote->Read(offset, count, buffer.data());
+    if (handle == nullptr)
+    {
+        throw std::runtime_error("Read() returned no handle for " + path);
+    }
+    remote->WaitForGet(handle);
+    remote->Close();
+    return buffer;
+}
+} // anonymous namespace
+
+class XRootDSimpleFile : public ::testing::Test
+{
+protected:
+    // Write one file of pseudo-random bytes; every test reads ranges of it.
+    static void SetUpTestSuite()
+    {
+        ASSERT_TRUE(getenv("DoXRootD") || getenv("DoXRootDHttps") || getenv("DoXRootDXrdCl"))
+            << "one of DoXRootD, DoXRootDHttps, DoXRootDXrdCl must select the server lane";
+
+        s_Data.resize(kFileSize);
+        uint32_t x = 0x9E3779B9u;
+        for (char &c : s_Data)
+        {
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            c = static_cast<char>(x);
+        }
+
+        std::array<char, PATH_MAX> cwd{};
+        ASSERT_NE(getcwd(cwd.data(), cwd.size()), nullptr);
+        s_Path = std::string(cwd.data()) + "/simplefile.bin";
+        std::ofstream out(s_Path, std::ios::binary | std::ios::trunc);
+        out.write(s_Data.data(), static_cast<std::streamsize>(s_Data.size()));
+        ASSERT_TRUE(out.good());
+    }
+
+    static void ExpectRange(const std::vector<char> &got, size_t offset)
+    {
+        ASSERT_LE(offset + got.size(), s_Data.size());
+        EXPECT_EQ(memcmp(got.data(), s_Data.data() + offset, got.size()), 0)
+            << "bytes differ in range [" << offset << ", " << offset + got.size() << ")";
+    }
+
+    static std::vector<char> s_Data;
+    static std::string s_Path;
+};
+
+std::vector<char> XRootDSimpleFile::s_Data;
+std::string XRootDSimpleFile::s_Path;
+
+TEST_F(XRootDSimpleFile, WholeFile)
+{
+    std::vector<char> got = ReadRange(s_Path, 0, kFileSize);
+    ASSERT_EQ(got.size(), kFileSize);
+    ExpectRange(got, 0);
+}
+
+// A range that straddles the 1 MiB and 2 MiB chunk boundaries.
+TEST_F(XRootDSimpleFile, MiddleRange)
+{
+    const size_t offset = 1024 * 1024 - 7;
+    const size_t count = 1024 * 1024 + 99;
+    std::vector<char> got = ReadRange(s_Path, offset, count);
+    ASSERT_EQ(got.size(), count);
+    ExpectRange(got, offset);
+}
+
+// A short range at the very end (the common image/text case: small files).
+TEST_F(XRootDSimpleFile, TailRange)
+{
+    const size_t count = 100;
+    const size_t offset = kFileSize - count;
+    std::vector<char> got = ReadRange(s_Path, offset, count);
+    ASSERT_EQ(got.size(), count);
+    ExpectRange(got, offset);
+}
+
+// A range running past EOF is an error, not a short read: the campaign
+// recorded a byte range this replica does not have.
+TEST_F(XRootDSimpleFile, RangePastEndFails)
+{
+    EXPECT_THROW(ReadRange(s_Path, kFileSize - 10, 20), std::exception);
+}
+
+TEST_F(XRootDSimpleFile, MissingFileFails)
+{
+    EXPECT_THROW(ReadRange(s_Path + ".missing", 0, 16), std::exception);
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/testing/adios2/engine/bp/generateXRootDConfig.sh
+++ b/testing/adios2/engine/bp/generateXRootDConfig.sh
@@ -8,13 +8,20 @@ echo "Generating config for XRootD with plugin library at $1"
 mkdir -p xroot/var/spool
 mkdir -p xroot/run/xrootd
 mkdir -p xroot/etc/xrootd
+BASEDIR="$(pwd)"
 {
-    echo "xrootd.fslib libXrdSsi.so";
+    # SSI stacked over the default file system: SSI requests go to the ADIOS
+    # service; paths under ssi.fspath are ordinary files (byte-range reads of
+    # campaign image/text replicas use them).
+    echo "xrootd.fslib libXrdSsi.so default";
     echo ""
     echo "all.export /etc nolock r/w";
     echo ""
     echo "oss.statlib -2 libXrdSsi.so";
     echo ""
     echo "ssi.svclib $1";
+    echo ""
+    echo "ssi.fspath ${BASEDIR}";
+    echo "all.export ${BASEDIR} r/o";
     echo ""
 } > xroot/etc/xrootd/xrootd-ssi.cfg

--- a/testing/adios2/engine/bp/generateXRootDHttpConfig.sh
+++ b/testing/adios2/engine/bp/generateXRootDHttpConfig.sh
@@ -50,8 +50,10 @@ if [ ! -f xroot-http/certs/server.crt ]; then
 fi
 
 {
-    # Enable SSI filesystem
-    echo "xrootd.fslib libXrdSsi.so"
+    # SSI stacked over the default file system: SSI requests go to the ADIOS
+    # service; paths under ssi.fspath are ordinary files served by XRootD
+    # (byte-range reads of campaign image/text replicas use them).
+    echo "xrootd.fslib libXrdSsi.so default"
     echo ""
     echo "all.export /etc nolock r/w"
     echo ""
@@ -59,6 +61,9 @@ fi
     echo ""
     # Load SSI service plugin
     echo "ssi.svclib $1"
+    echo ""
+    echo "ssi.fspath ${BASEDIR}"
+    echo "all.export ${BASEDIR} r/o"
     echo ""
     # Disable native xrootd protocol (use port 0 to disable or a different port)
     echo "xrd.port ${XRD_PORT}"

--- a/testing/adios2/unit/TestRemote.cpp
+++ b/testing/adios2/unit/TestRemote.cpp
@@ -54,9 +54,11 @@ TEST(Remote, OpenRead)
     }
 
     {
-        std::unique_ptr<Remote> remote = nullptr;
-        remote = std::make_unique<EVPathRemote>(rs);
-        remote->OpenSimpleFile("localhost", localPort, FNAME);
+        RemoteSetup simpleFileSetup = rs;
+        simpleFileSetup.hostName = "localhost";
+        simpleFileSetup.protocol = HostAccessProtocol::SSH;
+        std::shared_ptr<Remote> remote = GetRemoteSimpleFile(simpleFileSetup, FNAME);
+        ASSERT_NE(remote, nullptr);
         std::cout << "Contents size is " << remote->m_Size << std::endl;
         contents.resize(remote->m_Size); // should be unnecessary
         remote->Read(0, remote->m_Size, contents.data());


### PR DESCRIPTION
This PR adds the plumbing for reading arbitrary byte ranges through XRootD, but deliberately leaves the actual XRootD reader unimplemented.

Key changes:

- Adds Remote::OpenSimpleFile(..., Params) and the GetRemoteSimpleFile() factory for opening unstructured files rather than ADIOS datasets. The factory   supports native XRootD, HTTP/HTTPS/XrdCl, and SSH/EVPath using the existing host configuration logic. See source/adios2/toolkit/remote/Remote.cpp:323    and source/adios2/toolkit/remote/Remote.h:51.
- Refactors CampaignReader to use that factory. It now calls Read(offset, size, data), requires XRootD to return a non-null asynchronous handle, and   completes it with WaitForGet(). Unsupported raw reads produce an explicit error. See source/adios2/engine/campaign/CampaignReader.cpp:1576.
- Keeps SSH/EVPath behavior working and updates its unit test to go through the new factory. See testing/adios2/unit/TestRemote.cpp:56.
- Adds an unrelated safety improvement to campaign selection validation by avoiding overflow in start + count. See source/adios2/engine/campaign/CampaignReader.tcc:104.

For the XRootD implementer:

- Both XRootD classes now expose OpenSimpleFile(), currently just delegating to their normal Open().
- Both raw-read methods are still stubs returning nullptr:
    - Native SSI: source/adios2/toolkit/remote/XrootdRemote.cpp:419
    - HTTP/HTTPS/XrdCl: source/adios2/toolkit/remote/XrootdHttpRemote.cpp:540
- No files under source/utils/xrootd-plugin/ were changed. Therefore the server plugin still needs a proper range-read operation accepting a filename,  byte offset, and byte count.
- The native client should submit that operation similarly to Get(), set the destination and expected size, and return its promise as the handle.
- The HTTP client needs a matching URL/request encoding and an AsyncGet with expectedSize = Size.
- The HTTP-to-SSI decoder currently recognizes only get and batchget, so it must be extended for the new raw-read operation. See source/utils/xrootd-plugin/XrdHttpSsiHandler.cpp:305.
- Server-side validation should cover offset/count overflow, reads beyond EOF, short reads, file-open failures, and the existing single-response size  limit.
- Add native XRootD and HTTP/XrdCl tests; the commit only tests the SSH path.

In short: this commit defines the end-to-end API and consumer expectations. The remaining work is the XRootD client request construction, server/plugin  range-read handler, HTTP request encoding/decoding, and tests.