### PR TITLE
Python: accept int8 or uint8 buffers for char variables in Get

### DIFF
--- a/bindings/Python/nbEngine.cpp
+++ b/bindings/Python/nbEngine.cpp
@@ -175,6 +175,24 @@ void Engine::PerformDataWrite()
     m_Engine->PerformDataWrite();
 }
 
+namespace
+{
+// numpy has no char dtype. char is signed on x86 and unsigned on aarch64 Linux, so
+// nb::dtype<char>() is int8 on one and uint8 on the other. Accept either 8-bit integer
+// buffer for char variables so the Python-side int8 mapping works on both.
+template <class T>
+bool DtypeMatches(const nb::dlpack::dtype &dtype)
+{
+    return dtype == nb::dtype<T>();
+}
+
+template <>
+bool DtypeMatches<char>(const nb::dlpack::dtype &dtype)
+{
+    return dtype == nb::dtype<int8_t>() || dtype == nb::dtype<uint8_t>();
+}
+}
+
 void Engine::Get(Variable variable, nb::ndarray<nb::numpy> &array, const Mode launch)
 {
     helper::CheckForNullptr(m_Engine, "for engine, in call to Engine::Get a numpy array");
@@ -190,7 +208,7 @@ void Engine::Get(Variable variable, nb::ndarray<nb::numpy> &array, const Mode la
 #define declare_type(T)                                                                            \
     else if (type == helper::GetDataType<T>())                                                     \
     {                                                                                              \
-        if (array.dtype() != nb::dtype<T>())                                                       \
+        if (!DtypeMatches<T>(array.dtype()))                                                       \
         {                                                                                          \
             throw std::invalid_argument("In ADIOS2 Get - Type mismatch between Python buffer and " \
                                         "incoming data.");                                         \

--- a/testing/adios2/python/TestStream.py
+++ b/testing/adios2/python/TestStream.py
@@ -48,6 +48,30 @@ class TestStream(unittest.TestCase):
                 self.assertEqual(s.read("Coords", block_id=0)[1], -46)
                 self.assertEqual(s.read("humidity", block_id=0).ndim, 2)
 
+    def test_8bit_types(self):
+        # int8 and uint8 arrays written through the high-level API come back
+        # byte for byte through read().  This exercises the binding's buffer
+        # type check for the `char` ADIOS type: numpy has no char dtype, and
+        # char is signed on x86 but unsigned on aarch64 Linux, so a char
+        # variable must accept either 8-bit buffer.  (Which of the two numpy
+        # types lands as `char` differs by platform, so the returned dtype is
+        # not asserted; the bytes are.)
+        print("===========   test_8bit_types ==================")
+        i8 = np.array([0, 1, -2, 3, -128, 127, -6, 7], dtype=np.int8)
+        u8 = np.array([0, 1, 2, 3, 128, 255, 254, 7], dtype=np.uint8)
+        with Stream("pythonstream8bit.bp", "w") as s:
+            s.write("i8", i8, [len(i8)], [0], [len(i8)])
+            s.write("u8", u8, [len(u8)], [0], [len(u8)])
+
+        with Stream("pythonstream8bit.bp", "r") as s:
+            for _ in s.steps():
+                got_i8 = s.read("i8")
+                got_u8 = s.read("u8")
+                self.assertEqual(got_i8.itemsize, 1)
+                self.assertEqual(got_u8.itemsize, 1)
+                self.assertEqual(got_i8.tobytes(), i8.tobytes())
+                self.assertEqual(got_u8.tobytes(), u8.tobytes())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
On aarch64 Linux char is unsigned, so nanobind's dtype<char> is uint8 there while stream.py maps char to int8. Every read() of a char variable on that platform failed with "Type mismatch between Python buffer and incoming data". Seen on the hpc-campaign integration image (arm64): all TEXT datasets unreadable on every transport.

numpy has no char dtype and the bytes are identical either way, so Get now accepts either 8-bit integer buffer for char; all other types still require an exact match.

Adds a serial Stream test that round-trips int8 and uint8 arrays. The existing 8-bit round-trip tests are MPI-only and never ran on the aarch64 CI job, which is why this went unnoticed.
